### PR TITLE
Fix dark theme optgroup color in Firefox

### DIFF
--- a/scss/themes/dark.scss
+++ b/scss/themes/dark.scss
@@ -56,7 +56,7 @@ $theme-prefix: "dark" !default;
 
   // Fix Firefox option color
   @-moz-document url-prefix("") {
-    select:not([multiple]) option {
+    select:not([multiple]) option, select optgroup {
       color: initial;
     }
   }


### PR DESCRIPTION
Opt groups have same issue as options themselves.