### PR TITLE
Update multi-select.js

### DIFF
--- a/js/src/multi-select.js
+++ b/js/src/multi-select.js
@@ -479,7 +479,7 @@ class MultiSelect extends BaseComponent {
 
     if (this._config.optionsMaxHeight !== 'auto') {
       optionsDiv.style.maxHeight = `${this._config.optionsMaxHeight}px`
-      optionsDiv.style.overflow = 'scroll'
+      optionsDiv.style.overflow = 'auto'
     }
 
     dropdownDiv.append(optionsDiv)


### PR DESCRIPTION
I believe the overflow properly of the multi-select should be set to 'auto', not 'scroll' when a height is specified. This is personal preference, but I believe it makes a better UX.