### PR TITLE
data-coreui-toggle="loading-button" prevents submitting action

### DIFF
--- a/js/src/loading-button.js
+++ b/js/src/loading-button.js
@@ -176,7 +176,8 @@ class LoadingButton extends BaseComponent {
  */
 
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, event => {
-  event.preventDefault()
+  // commented because otherwise this won't trigger submit: <button type="submit" data-coreui-toggle="loading-button">Save</button>
+  //event.preventDefault()
   const button = event.target.closest(SELECTOR_DATA_TOGGLE)
   const data = LoadingButton.getOrCreateInstance(button)
 

--- a/js/src/loading-button.js
+++ b/js/src/loading-button.js
@@ -176,8 +176,6 @@ class LoadingButton extends BaseComponent {
  */
 
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, event => {
-  // commented because otherwise this won't trigger submit: <button type="submit" data-coreui-toggle="loading-button">Save</button>
-  //event.preventDefault()
   const button = event.target.closest(SELECTOR_DATA_TOGGLE)
   const data = LoadingButton.getOrCreateInstance(button)
 


### PR DESCRIPTION
Consider the following code:

```
<form>
...
<button type="submit" class="btn btn-primary" data-coreui-toggle="loading-button">Save</button>
</form>
```

Pressing Save button never submits the form. I don't think that adding data-coreui-toggle="loading-button" should prevent default action.

Added pull request.