### PR TITLE
Rating component fixes

### DIFF
--- a/js/src/rating.js
+++ b/js/src/rating.js
@@ -34,6 +34,7 @@ const EVENT_MOUSELEAVE = `mouseleave${EVENT_KEY}`
 
 const CLASS_NAME_ACTIVE = 'active'
 const CLASS_NAME_DISABLED = 'disabled'
+const CLASS_NAME_READONLY = 'readonly'
 const CLASS_NAME_RATING = 'rating'
 const CLASS_NAME_RATING_ITEM = 'rating-item'
 const CLASS_NAME_RATING_ITEM_ICON = 'rating-item-icon'
@@ -353,6 +354,10 @@ class Rating extends BaseComponent {
 
     if (this._config.disabled) {
       this._element.classList.add(CLASS_NAME_DISABLED)
+    }
+
+    if (this._config.readOnly) {
+      this._element.classList.add(CLASS_NAME_READONLY)
     }
 
     this._element.setAttribute('role', 'radiogroup')

--- a/js/src/rating.js
+++ b/js/src/rating.js
@@ -34,7 +34,6 @@ const EVENT_MOUSELEAVE = `mouseleave${EVENT_KEY}`
 
 const CLASS_NAME_ACTIVE = 'active'
 const CLASS_NAME_DISABLED = 'disabled'
-const CLASS_NAME_READONLY = 'readonly'
 const CLASS_NAME_RATING = 'rating'
 const CLASS_NAME_RATING_ITEM = 'rating-item'
 const CLASS_NAME_RATING_ITEM_ICON = 'rating-item-icon'
@@ -42,6 +41,7 @@ const CLASS_NAME_RATING_ITEM_CUSTOM_ICON = 'rating-item-custom-icon'
 const CLASS_NAME_RATING_ITEM_CUSTOM_ICON_ACTIVE = 'rating-item-custom-icon-active'
 const CLASS_NAME_RATING_ITEM_INPUT = 'rating-item-input'
 const CLASS_NAME_RATING_ITEM_LABEL = 'rating-item-label'
+const CLASS_NAME_READONLY = 'readonly'
 
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="rating"]'
 const SELECTOR_RATING_ITEM_INPUT = '.rating-item-input'

--- a/scss/_rating.scss
+++ b/scss/_rating.scss
@@ -17,14 +17,13 @@
   }
 
   &:not(.disabled):not(.readonly) {
-    .rating-item {
-      .rating-item-label {
-        cursor: pointer;
-      }
+    .rating-item:hover {
+      transform: var(--#{$prefix}rating-item-scale-transform);
+    }
 
-      &:hover {
-        transform: var(--#{$prefix}rating-item-scale-transform);
-      }
+    .rating-item-icon,
+    .rating-item-label {
+      cursor: pointer;
     }
   }
 }
@@ -49,7 +48,6 @@
   font-size: var(--#{$prefix}rating-item-height);
   line-height: 0;
   color: var(--#{$prefix}rating-item-color);
-  cursor: default;  // has cursor pointer only if the rating is not disabled or readonly (see above)
 
   * {
     pointer-events: none;
@@ -85,7 +83,6 @@
 .rating-item-icon {
   width: var(--#{$prefix}rating-item-height);
   height: var(--#{$prefix}rating-item-height);
-  //cursor: pointer;  // has the cursor of rating-item-label (parent)
   background-color: var(--#{$prefix}rating-item-color);
   mask: var(--#{$prefix}rating-item-icon) center / var(--#{$prefix}rating-item-height) no-repeat;
 }

--- a/scss/_rating.scss
+++ b/scss/_rating.scss
@@ -18,7 +18,9 @@
 
   &:not(.disabled):not(.readonly) {
     .rating-item {
-      cursor: pointer;
+      .rating-item-label {
+        cursor: pointer;
+      }
 
       &:hover {
         transform: var(--#{$prefix}rating-item-scale-transform);
@@ -47,7 +49,7 @@
   font-size: var(--#{$prefix}rating-item-height);
   line-height: 0;
   color: var(--#{$prefix}rating-item-color);
-  cursor: pointer;
+  cursor: default;  // has cursor pointer only if the rating is not disabled or readonly (see above)
 
   * {
     pointer-events: none;
@@ -83,7 +85,7 @@
 .rating-item-icon {
   width: var(--#{$prefix}rating-item-height);
   height: var(--#{$prefix}rating-item-height);
-  cursor: pointer;
+  //cursor: pointer;  // has the cursor of rating-item-label (parent)
   background-color: var(--#{$prefix}rating-item-color);
   mask: var(--#{$prefix}rating-item-icon) center / var(--#{$prefix}rating-item-height) no-repeat;
 }


### PR DESCRIPTION
This commit fixes 2 bugs on the Rating component:
1. readonly class is not added to a "readonly" .rating element, making the stars to grow when hovering
2. hovering over a readonly or disabled rating shows a pointer cursor, not default (arrow), thinking you can click on it