### PR TITLE
Various Bootstrap-version JS generation fixes

### DIFF
--- a/build/rollup.config.mjs
+++ b/build/rollup.config.mjs
@@ -23,8 +23,7 @@ const plugins = [
   })
 ]
 const globals = {
-  '@popperjs/core': 'Popper',
-  'date-fns': 'dateFns'
+  '@popperjs/core': 'Popper'
 }
 
 if (BUNDLE) {
@@ -32,20 +31,27 @@ if (BUNDLE) {
   // Remove last entry in external array to bundle Popper
   external.pop()
   delete globals['@popperjs/core']
-  // Remove last entry in external array to bundle dateFns
-  external.pop()
-  delete globals['date-fns']
-  plugins.push(
-    replace({
-      'process.env.NODE_ENV': '"production"',
-      preventAssignment: true,
-      ...BOOTSTRAP && {
-        'coreui.': 'bs.'
-      }
-    }),
-    nodeResolve()
-  )
+  plugins.push(nodeResolve())
 }
+
+plugins.push(
+  replace({
+    'process.env.NODE_ENV': '"production"',
+    preventAssignment: true,
+    ...BOOTSTRAP && {
+      delimiters: ['', ''], // disable word boundaries
+      '/coreui': '/coreui', // prevents https://coreui.io being replaced with https://bs.io
+      'coreui.': 'bs.',
+      '.coreui': '.bs',
+      'coreui-': 'bs-',
+      '-coreui': '-bs',
+      "'coreui'": "'bs'",         // key.startsWith('coreui') => key.startsWith('bs')
+      'coreuiConfig': 'bsConfig', // key.startsWith('coreuiConfig')) => key.startsWith('bsConfig'))
+      '^coreui': '^bs',           // key.replace(/^coreui/, ''); => key.replace(/^bs/, '');
+      'coreui=': 'bs=',           // [data-coreui="navigation"] => [data-bs="navigation"] (workaround for preventAssignment being true)
+    }
+  })
+)
 
 const rollupConfig = {
   input: path.resolve(__dirname, `../js/index.${ESM ? 'esm' : 'umd'}.js`),


### PR DESCRIPTION
In the current state, Core UI Bootstrap JS is not really Bootstrap compatible.

All data attributes are expected to be data-coreui instead of data-bs, as with Bootstrap. This basically breaked a lot of Boostrap code.
Fixed this. Basically, with my fixes, CoreUI Bootstrap version becomes more or less 100% drop-in Bootstrap replacement.

Also fixed coreui.io website being written wrong in the source as bs.io.

Not in the least, the coreui -> bs replace was made only for the bundle versions. The regular Boostrap (non-Popper bundled) version was totally avoided.