### PR TITLE
jQuery fixes (config was ignored, if given as parameter)

### DIFF
--- a/js/src/calendar.js
+++ b/js/src/calendar.js
@@ -853,7 +853,7 @@ class Calendar extends BaseComponent {
 
   static jQueryInterface(config) {
     return this.each(function () {
-      const data = Calendar.getOrCreateInstance(this)
+      const data = Calendar.getOrCreateInstance(this, config)
 
       if (typeof config !== 'string') {
         return

--- a/js/src/date-picker.js
+++ b/js/src/date-picker.js
@@ -96,7 +96,7 @@ class DatePicker extends DateRangePicker {
 
   static jQueryInterface(config) {
     return this.each(function () {
-      const data = DatePicker.getOrCreateInstance(this)
+      const data = DatePicker.getOrCreateInstance(this, config)
 
       if (typeof config !== 'string') {
         return

--- a/js/src/date-range-picker.js
+++ b/js/src/date-range-picker.js
@@ -866,7 +866,7 @@ class DateRangePicker extends BaseComponent {
 
   static jQueryInterface(config) {
     return this.each(function () {
-      const data = DateRangePicker.getOrCreateInstance(this)
+      const data = DateRangePicker.getOrCreateInstance(this, config)
 
       if (typeof config !== 'string') {
         return

--- a/js/src/rating.js
+++ b/js/src/rating.js
@@ -484,7 +484,7 @@ class Rating extends BaseComponent {
 
   static jQueryInterface(config) {
     return this.each(function () {
-      const data = Rating.getOrCreateInstance(this)
+      const data = Rating.getOrCreateInstance(this, config)
 
       if (typeof config !== 'string') {
         return

--- a/js/src/time-picker.js
+++ b/js/src/time-picker.js
@@ -813,7 +813,7 @@ class TimePicker extends BaseComponent {
 
   static jQueryInterface(config) {
     return this.each(function () {
-      const data = TimePicker.getOrCreateInstance(this)
+      const data = TimePicker.getOrCreateInstance(this, config)
 
       if (typeof config !== 'string') {
         return


### PR DESCRIPTION
For example, as of currently, passing config via jQuery to a rating component is ignored. For example `$('#myRating').rating({ name: 'rating' })` does the same as `$('#myRating').rating()`. Obviously a bug.

Affected components (you are free to check to see if there are more):
- Calendar
- DatePicker
- DateRangePicker
- Rating
- TimePicker
