### PR TITLE
date-picker / date-range-picker event fixes

### DIFF
--- a/js/src/date-picker.js
+++ b/js/src/date-picker.js
@@ -29,7 +29,6 @@ const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_SHOW = 'show'
 
-const SELECTOR_CALENDAR = '.calendar'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="date-picker"]:not(.disabled):not(:disabled)'
 const SELECTOR_DATA_TOGGLE_SHOWN = `${SELECTOR_DATA_TOGGLE}.${CLASS_NAME_SHOW}`
 
@@ -65,20 +64,14 @@ class DatePicker extends DateRangePicker {
   }
 
   // Overrides
-  _addCalendarEventListeners() {
-    super._addCalendarEventListeners()
-    for (const calendar of SelectorEngine.find(SELECTOR_CALENDAR, this._element)) {
-      EventHandler.on(calendar, 'startDateChange.coreui.calendar', event => {
-        this._startDate = event.date
-        this._startInput.value = this._setInputValue(event.date)
-        this._selectEndDate = false
-        this._calendar.update(this._getCalendarConfig())
+  _addEventListeners() {
+    super._addEventListeners()
 
+    EventHandler.on(this._element, 'startDateChange.coreui.date-range-picker', event => {
         EventHandler.trigger(this._element, EVENT_DATE_CHANGE, {
           date: event.date
         })
-      })
-    }
+    })
   }
 
   // Static

--- a/js/src/date-range-picker.js
+++ b/js/src/date-range-picker.js
@@ -315,11 +315,10 @@ class DateRangePicker extends BaseComponent {
     })
 
     EventHandler.on(this._startInput, EVENT_INPUT, event => {
-      const date = this._config.inputDateParse ?
-        this._config.inputDateParse(event.target.value) :
-        getLocalDateFromString(event.target.value, this._config.locale, this._config.timepicker)
+      const date = this._parseDate(event.target.value)
 
-      if (date instanceof Date && date.getTime()) {
+      // valid date or empty date
+      if ((date instanceof Date && !isNaN(date)) || (date === null)) {
         this._startDate = date
         this._calendarDate = date
         this._calendar.update(this._getCalendarConfig())
@@ -358,16 +357,16 @@ class DateRangePicker extends BaseComponent {
     })
 
     EventHandler.on(this._endInput, EVENT_INPUT, event => {
-      const date = this._config.inputDateParse ?
-        this._config.inputDateParse(event.target.value) :
-        getLocalDateFromString(event.target.value, this._config.locale, this._config.timepicker)
-      if (date instanceof Date && date.getTime()) {
+      const date = this._parseDate(event.target.value)
+
+      // valid date or empty date
+      if ((date instanceof Date && !isNaN(date)) || (date === null)) {
         this._endDate = date
         this._calendarDate = date
         this._calendar.update(this._getCalendarConfig())
 
         EventHandler.trigger(this._element, EVENT_END_DATE_CHANGE, {
-          date: value
+          date: date
         })
       }
     })
@@ -813,7 +812,19 @@ class DateRangePicker extends BaseComponent {
     this._popper = Popper.createPopper(this._togglerElement, this._menu, popperConfig)
   }
 
+  _parseDate(str) {
+    if (!str)
+      return null;
+
+    return this._config.inputDateParse ?
+      this._config.inputDateParse(str) :
+      getLocalDateFromString(str, this._config.locale, this._config.timepicker)
+  }
+
   _formatDate(date) {
+    if (!date)
+      return '';
+
     if (this._config.inputDateFormat) {
       return this._config.inputDateFormat(
         date instanceof Date ? new Date(date) : convertToDateObject(date, this._config.selectionType)

--- a/js/src/date-range-picker.js
+++ b/js/src/date-range-picker.js
@@ -323,6 +323,10 @@ class DateRangePicker extends BaseComponent {
         this._startDate = date
         this._calendarDate = date
         this._calendar.update(this._getCalendarConfig())
+
+        EventHandler.trigger(this._element, EVENT_START_DATE_CHANGE, {
+          date: date
+        })
       }
     })
 
@@ -361,6 +365,10 @@ class DateRangePicker extends BaseComponent {
         this._endDate = date
         this._calendarDate = date
         this._calendar.update(this._getCalendarConfig())
+
+        EventHandler.trigger(this._element, EVENT_END_DATE_CHANGE, {
+          date: value
+        })
       }
     })
 


### PR DESCRIPTION
Hi again,

I'm coming with another pull request, this time fixing the date picker components (Date Picker and its parent, Date Range Picker).

More specifically, there are two bugs in the current copoment:
1.  `dateChange.coreui.date-picker` never triggers due to a typo in the calendar selector (.calendar instead of .calendar**s**)
2. Again, the dateChange is not triggered when updating the date component via input, only when selecting the date with the mouse.
This also affects Date Range Picker, because an EVENT_INPUT does NOT trigger an EVENT_START_DATE_CHANGE (_startInput) or an EVENT_END_DATE_CHANGE (_endInput)

I fixed both bugs. I also rearchitectured a bit the Date Picker to listen to the EVENT_START_DATE_CHANGE triggered on the Date Range Picker it extends from and not the one from the Calendar, in order to capture also input events, as I said earlier.

Regards,
Vlad