### PR TITLE
Fix 2 CSS lint errors

### DIFF
--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -211,8 +211,8 @@
 .nav-justified {
   > .nav-link,
   .nav-item {
-    flex-basis: 0;
     flex-grow: 1;
+    flex-basis: 0;
     text-align: center;
   }
 }

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -139,8 +139,8 @@
 // the default flexbox row orientation. Requires the use of `flex-wrap: wrap`
 // on the `.navbar` parent.
 .navbar-collapse {
-  flex-basis: 100%;
   flex-grow: 1;
+  flex-basis: 100%;
   // For always expanded or extra full navbars, ensure content aligns itself
   // properly vertically. Can be easily overridden with flex utilities.
   align-items: center;


### PR DESCRIPTION
Currently, running `npm run css-lint` results in two errors.