### PR TITLE
Bootstrap version fixes (as Bootstrap version is currently broken)

### DIFF
--- a/build/rollup.config.mjs
+++ b/build/rollup.config.mjs
@@ -22,12 +22,10 @@ const plugins = [
     babelHelpers: 'bundled'
   }),
   BOOTSTRAP && replace({
-    preventAssignment: true,
+    preventAssignment: false,
     delimiters: ['', ''],
     '/coreui': '/coreui', // prevents changes in URLs
-    coreui: 'bs',
-    '-coreui': '-bs',
-    'coreui=': 'bs=', // [data-coreui="navigation"] => [data-bs="navigation"] (workaround for `preventAssignment` being true),
+    'coreui': 'bs',
     '--cui-': '--bs-'
   })
 ]

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -91,7 +91,7 @@
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
     .dropdown-menu#{$infix}-start {
-      --cui-position: start;
+      --#{$prefix}position: start;
 
       &[data-coreui-popper] {
         @include ltr-rtl("right", auto);
@@ -100,7 +100,7 @@
     }
 
     .dropdown-menu#{$infix}-end {
-      --cui-position: end;
+      --#{$prefix}position: end;
 
       &[data-coreui-popper] {
         @include ltr-rtl("right", 0);


### PR DESCRIPTION
Hello,

Again with some Bootstrap version fixes. :-)

... as I noticed the latest version of CoreUI Pro gives "Uncaught ReferenceError: bsKeys is not defined" is console... basically the JS is broken in the Bootstrap version.

So: here are the changes:
1. "preventAssignment: true" broke Bootstrap version (Uncaught ReferenceError: bsKeys is not defined)
2. Fix for hardcoded "cui" prefix in _dropdown.scss (broked Boostrap version)