### PR TITLE
Date validation on input was broken

### DIFF
--- a/js/src/date-range-picker.js
+++ b/js/src/date-range-picker.js
@@ -346,7 +346,7 @@ class DateRangePicker extends BaseComponent {
       const date = this._parseDate(event.target.value)
 
       // valid date or empty date
-      if ((date instanceof Date && !Number.isNaN(date)) || (date === null)) {
+      if ((date instanceof Date && !isNaN(date)) || (date === null)) {
         this._startDate = date
         this._calendarDate = date
         this._calendar.update(this._getCalendarConfig())
@@ -388,7 +388,7 @@ class DateRangePicker extends BaseComponent {
       const date = this._parseDate(event.target.value)
 
       // valid date or empty date
-      if ((date instanceof Date && !Number.isNaN(date)) || (date === null)) {
+      if ((date instanceof Date && !isNaN(date)) || (date === null)) {
         this._endDate = date
         this._calendarDate = date
         this._calendar.update(this._getCalendarConfig())


### PR DESCRIPTION
Valid date validation on input is broken.

This is because Number.isNaN('Invalid Date') returns false (Number.isNaN returns true only if the parameter is NaN), unlike isNaN('Invalid Date').

See this for more information:
https://stackoverflow.com/questions/1353684/detecting-an-invalid-date-date-instance-in-javascript

Currently, if you dropdown a daterange, select a date and then manually modify it to an invalid date (say, deleting a digit from the month), the entire dropdown calendar will show invalid date or Inv...

This pull request fixes this.

![Screenshot from 2025-02-09 01-13-28](https://github.com/user-attachments/assets/4c5138d7-7569-47f0-8988-3d87cdcdf088)
