### PR TITLE
feat(MultiSelect): native select overlay for required validation + data attribute init

### DIFF
--- a/docs/content/forms/multi-select.md
+++ b/docs/content/forms/multi-select.md
@@ -22,7 +22,7 @@ snippets:
 A straightforward demonstration of how to implement a basic Bootstrap Multi Select dropdown, highlighting essential attributes and configurations.
 
 {{< example stackblitz_pro="true" >}}
-<select class="form-multi-select" id="ms1" multiple data-coreui-search="global">
+<select id="ms1" data-coreui-multi-select multiple data-coreui-search="global">
   <option value="0">Angular</option>
   <option value="1">Bootstrap</option>
   <option value="2">React.js</option>
@@ -36,7 +36,7 @@ A straightforward demonstration of how to implement a basic Bootstrap Multi Sele
 {{< /example >}}
 
 {{< example stackblitz_pro="true" >}}
-<select class="form-multi-select" multiple data-coreui-search="true">
+<select data-coreui-multi-select multiple data-coreui-search="true">
   <option value="0">Angular</option>
   <option value="1" disabled>Bootstrap</option>
   <option value="2">React.js</option>
@@ -58,7 +58,7 @@ Learn how to populate the multi-select component with data from various sources,
 If you want to create a multi-select dropdown with predefined options, use the `<option>` elements inside the `<select>` tag.
 
 {{< example stackblitz_pro="true" >}}
-<select class="form-multi-select" multiple data-coreui-search="true">
+<select data-coreui-multi-select multiple data-coreui-search="true">
   <option value="0" selected>Angular</option>
   <option value="1">Bootstrap</option>
   <option value="2">React.js</option>
@@ -88,7 +88,7 @@ We use the following JavaScript to set up our multi-select:
 You can configure the search functionality within the component. The `data-coreui-search` option determines how the search input element is enabled and behaves. It accepts multiple types to provide flexibility in configuring search behavior. By default is set to `false`.
 
 {{< example stackblitz_pro="true" >}}
-<select class="form-multi-select" multiple>
+<select data-coreui-multi-select multiple>
   <option value="0">Angular</option>
   <option value="1">Bootstrap</option>
   <option value="2">React.js</option>
@@ -106,7 +106,7 @@ You can configure the search functionality within the component. The `data-coreu
 To enable the default search input element with standard behavior, please add `data-coreui-search="true"` like in the example below:
 
 {{< example stackblitz_pro="true" >}}
-<select class="form-multi-select" multiple data-coreui-search="true">
+<select data-coreui-multi-select multiple data-coreui-search="true">
   <option value="0">Angular</option>
   <option value="1">Bootstrap</option>
   <option value="2">React.js</option>
@@ -126,7 +126,7 @@ To enable the default search input element with standard behavior, please add `d
 To enable the global search functionality within the Multi Select component, please add `data-coreui-search="global"`. When `data-coreui-search` is set to `'global'`, the user can perform searches across the entire component, regardless of where their focus is within the component. This allows for a more flexible and intuitive search experience, ensuring the search input is recognized from any point within the component.
 
 {{< example stackblitz_pro="true" >}}
-<select class="form-multi-select" multiple data-coreui-search="global">
+<select data-coreui-multi-select multiple data-coreui-search="global">
   <option value="0">Angular</option>
   <option value="1">Bootstrap</option>
   <option value="2">React.js</option>
@@ -149,7 +149,7 @@ Explore different selection modes, including single and multiple selections, all
 If you want to enable users to select multiple options as text entries, add the `data-coreui-selection-type="text"`. This configuration includes search functionality, making it easier to filter options by typing.
 
 {{< example stackblitz_pro="true" >}}
-<select class="form-multi-select" id="multiple-select-text" multiple data-coreui-selection-type="text" data-coreui-search="true">
+<select id="multiple-select-text" data-coreui-multi-select multiple data-coreui-selection-type="text" data-coreui-search="true">
   <option value="0">Angular</option>
   <option value="1">Bootstrap</option>
   <option value="2">React.js</option>
@@ -167,7 +167,7 @@ If you want to enable users to select multiple options as text entries, add the 
 If you want to display selected options as tags, add the `data-coreui-selection-type="tags"`. This mode is useful for visually grouping selected items. The search functionality is also enabled for better user experience.
 
 {{< example stackblitz_pro="true" >}}
-<select class="form-multi-select" id="multiple-select-tag" multiple data-coreui-selection-type="tags" data-coreui-search="true">
+<select id="multiple-select-tag" data-coreui-multi-select multiple data-coreui-selection-type="tags" data-coreui-search="true">
   <option value="0">Angular</option>
   <option value="1">Bootstrap</option>
   <option value="2">React.js</option>
@@ -185,7 +185,7 @@ If you want to display selected options as tags, add the `data-coreui-selection-
 If you prefer to show a counter indicating the number of selected options, add the `data-coreui-selection-type="tags"`. This helps users keep track of their selections and includes search functionality for filtering options.
 
 {{< example stackblitz_pro="true" >}}
-<select class="form-multi-select" id="multiple-select-counter" multiple data-coreui-selection-type="counter" data-coreui-search="true">
+<select id="multiple-select-counter" data-coreui-multi-select multiple data-coreui-selection-type="counter" data-coreui-search="true">
   <option value="0">Angular</option>
   <option value="1">Bootstrap</option>
   <option value="2">React.js</option>
@@ -205,7 +205,7 @@ When `multiple` is enabled, a **select all** button is rendered in the dropdown 
 With the default `selectAllStyle: 'checkbox'` the button shows a tri-state indicator that mirrors the overall selection — `none` when nothing is selected, `all` when everything is, and `indeterminate` in between. Set `selectAllStyle: 'text'` for a plain text toggle instead.
 
 {{< example stackblitz_pro="true" >}}
-<select class="form-multi-select" id="multiSelectSelectAll" multiple data-coreui-search="true">
+<select id="multiSelectSelectAll" data-coreui-multi-select multiple data-coreui-search="true">
   <option value="0">Angular</option>
   <option value="1">Bootstrap</option>
   <option value="2">React.js</option>
@@ -233,7 +233,7 @@ To avoid a misleading "Select all" while a filter is active, the label switches 
 Type into the search box below, then use select all — only the matching options are selected.
 
 {{< example stackblitz_pro="true" >}}
-<select class="form-multi-select" id="multiSelectSelectAllMode" multiple data-coreui-search="true" data-coreui-select-all-mode="filtered">
+<select id="multiSelectSelectAllMode" data-coreui-multi-select multiple data-coreui-search="true" data-coreui-select-all-mode="filtered">
   <option value="0">Angular</option>
   <option value="1">Bootstrap</option>
   <option value="2">React.js</option>
@@ -264,7 +264,7 @@ To surface these as buttons inside the dropdown, render them through the [custom
 Use `data-coreui-selection-limit` to limit how many options can be selected. The select all button stays enabled and selects options up to the limit, then toggles to deselect all once the limit is reached. The `selectionLimit.coreui.multi-select` event can be used to show feedback when a user tries to select more options than allowed.
 
 {{< example stackblitz_pro="true" stackblitz_add_js="multiSelectSelectionLimitSnippet">}}
-<select class="form-multi-select" id="multiSelectSelectionLimit" multiple data-coreui-search="true" data-coreui-selection-limit="3">
+<select id="multiSelectSelectionLimit" data-coreui-multi-select multiple data-coreui-search="true" data-coreui-selection-limit="3">
   <option value="0">Angular</option>
   <option value="1">Bootstrap</option>
   <option value="2">React.js</option>
@@ -286,7 +286,7 @@ We use the following JavaScript to show a toast when the selection limit is reac
 Add the `data-coreui-multiple="false"` boolean attribute to implement single-selection mode, enabling users to select only one option from the dropdown at a time.
 
 {{< example stackblitz_pro="true" >}}
-<select class="form-multi-select" id="single-select" data-coreui-multiple="false">
+<select id="single-select" data-coreui-multi-select data-coreui-multiple="false">
   <option value="0">Angular</option>
   <option value="1">Bootstrap</option>
   <option value="2">React.js</option>
@@ -304,7 +304,7 @@ Add the `data-coreui-multiple="false"` boolean attribute to implement single-sel
 Add the `data-coreui-disabled="true"` boolean attribute to give it a grayed out appearance, remove pointer events, and prevent focusing.
 
 {{< example stackblitz_pro="true" >}}
-<select class="form-multi-select" id="ms1" multiple data-coreui-search="true"  data-coreui-disabled="true">
+<select id="ms1" data-coreui-multi-select multiple data-coreui-search="true"  data-coreui-disabled="true">
   <option value="0">Angular</option>
   <option value="1">Bootstrap</option>
   <option value="2">React.js</option>
@@ -324,10 +324,10 @@ The CoreUI Bootstrap Multi Select Component provides the flexibility to personal
 {{< example stackblitz_pro="true" stackblitz_add_js="multiSelectCustomOptionsSnippet">}}
 <div class="row">
   <div class="col-md-6">
-    <select id="myMultiSelectCountries" class="form-multi-select"></select>
+    <select id="myMultiSelectCountries" data-coreui-multi-select></select>
   </div>
   <div class="col-md-6">
-    <select id="myMultiSelectCountriesAndCities" class="form-multi-select"></select>
+    <select id="myMultiSelectCountriesAndCities" data-coreui-multi-select></select>
   </div>
 </div>
 {{< /example >}}
@@ -341,7 +341,7 @@ We use the following JavaScript to set up our multi-select:
 Use the `headerTemplate` option to fully customize the dropdown header — the area above the options list — including rendering several action buttons. It renders independently of `selectAll`. The template function receives a `state` object (`{ selected, total, filtered, filteredSelected }`) and an `actions` object with bound component methods (`selectAll`, `selectFiltered`, `deselectFiltered`, `deselectAll`). Return an `HTMLElement` and wire your own listeners to the `actions`, or return an HTML string (sanitized) for simple custom content. The header re-renders on every selection change and search filter, so labels and `disabled` states stay up to date.
 
 {{< example stackblitz_pro="true" stackblitz_add_js="multiSelectHeaderSnippet">}}
-<select id="myMultiSelectHeader" class="form-multi-select"></select>
+<select id="myMultiSelectHeader" data-coreui-multi-select></select>
 {{< /example >}}
 
 We use the following JavaScript to set up our multi-select:
@@ -353,7 +353,7 @@ We use the following JavaScript to set up our multi-select:
 Enable `optionsGroupsSelectable` to turn each group label into its own tri-state checkbox that toggles the whole group. Because the indicator is rendered with CSS, it supports a third, `indeterminate` state — shown when only some of a group's options are selected — without any real `<input>` element. The same tri-state logic drives the header [select all](#select-all) button when `selectAllStyle: 'checkbox'`. Each section's indicator follows its own `*Style` option (`optionsStyle`, `optionsGroupsStyle`, `selectAllStyle`, all defaulting to `'checkbox'`) and requires `multiple`.
 
 {{< example stackblitz_pro="true" stackblitz_add_js="multiSelectIndeterminateSnippet">}}
-<select id="myMultiSelectIndeterminate" class="form-multi-select"></select>
+<select id="myMultiSelectIndeterminate" data-coreui-multi-select></select>
 {{< /example >}}
 
 We use the following JavaScript to set up our multi-select:
@@ -367,7 +367,7 @@ You may also choose from small and large multi selects to match our similarly si
 {{< example stackblitz_pro="true" >}}
 <div class="row">
   <div class="col-md-6">
-    <select class="form-multi-select form-multi-select-lg mb-3" id="multiple-select-counter" data-coreui-selection-type="counter" data-coreui-search="true">
+    <select id="multiple-select-counter" class="form-multi-select-lg mb-3" data-coreui-multi-select data-coreui-selection-type="counter" data-coreui-search="true">
       <option value="0">Angular</option>
       <option value="1">Bootstrap</option>
       <option value="2">React.js</option>
@@ -378,7 +378,7 @@ You may also choose from small and large multi selects to match our similarly si
         <option value="6">Node.js</option>
       </optgroup>
     </select>
-    <select class="form-multi-select form-multi-select-sm" id="multiple-select-counter" data-coreui-selection-type="counter" data-coreui-search="true">
+    <select id="multiple-select-counter" class="form-multi-select-sm" data-coreui-multi-select data-coreui-selection-type="counter" data-coreui-search="true">
       <option value="0">Angular</option>
       <option value="1">Bootstrap</option>
       <option value="2">React.js</option>
@@ -391,7 +391,7 @@ You may also choose from small and large multi selects to match our similarly si
     </select>
   </div>
   <div class="col-md-6">
-    <select class="form-multi-select form-multi-select-lg mb-3" id="multiple-select-counter" data-coreui-selection-type="tags" data-coreui-search="true">
+    <select id="multiple-select-counter" class="form-multi-select-lg mb-3" data-coreui-multi-select data-coreui-selection-type="tags" data-coreui-search="true">
       <option value="0">Angular</option>
       <option value="1">Bootstrap</option>
       <option value="2">React.js</option>
@@ -402,7 +402,7 @@ You may also choose from small and large multi selects to match our similarly si
         <option value="6">Node.js</option>
       </optgroup>
     </select>
-    <select class="form-multi-select form-multi-select-sm" id="multiple-select-counter" data-coreui-selection-type="tags" data-coreui-search="true">
+    <select id="multiple-select-counter" class="form-multi-select-sm" data-coreui-multi-select data-coreui-selection-type="tags" data-coreui-search="true">
       <option value="0">Angular</option>
       <option value="1">Bootstrap</option>
       <option value="2">React.js</option>
@@ -423,10 +423,10 @@ You may also choose from small and large multi selects to match our similarly si
 
 ### Via data attributes
 
-Add `form-multi-select` class to a `select` element.
+Add the `data-coreui-multi-select` attribute to a `select` element.
 
 ```html
-<select class="form-multi-select" id="ms1" multiple data-coreui-search="true">
+<select id="ms1" data-coreui-multi-select multiple data-coreui-search="true">
   <option value="0">Angular</option>
   <option value="1">Bootstrap</option>
   <option value="2">React.js</option>
@@ -444,11 +444,11 @@ Add `form-multi-select` class to a `select` element.
 Call the time picker via JavaScript:
 
 ```html
-<select class="form-multi-select"></select>
+<select data-coreui-multi-select></select>
 ```
 
 ```js
-const mulitSelectElementList = Array.prototype.slice.call(document.querySelectorAll('.form-multi-select'))
+const mulitSelectElementList = Array.prototype.slice.call(document.querySelectorAll('[data-coreui-multi-select]'))
 const mulitSelectList = mulitSelectElementList.map(mulitSelectEl => {
   return new coreui.MultiSelect(mulitSelectEl, {
     // options

--- a/js/src/multi-select.js
+++ b/js/src/multi-select.js
@@ -48,7 +48,9 @@ const SELECTOR_OPTION = '.form-multi-select-option'
 const SELECTOR_OPTIONS = '.form-multi-select-options'
 const SELECTOR_OPTIONS_EMPTY = '.form-multi-select-options-empty'
 const SELECTOR_SEARCH = '.form-multi-select-search'
-const SELECTOR_SELECT = '.form-multi-select'
+const SELECTOR_DATA_MULTI_SELECT = '[data-coreui-multi-select]'
+// TODO: remove the class-based selector in v6, use the data attribute instead
+const SELECTOR_SELECT = 'select.form-multi-select'
 const SELECTOR_SELECTION = '.form-multi-select-selection'
 const SELECTOR_TAG = '.form-multi-select-tag'
 const SELECTOR_TAG_DELETE = '.form-multi-select-tag-delete'
@@ -199,7 +201,7 @@ class MultiSelect extends BaseComponent {
     this._togglerElement = null
     this._optionsElement = null
 
-    this._clone = null
+    this._wrapperElement = null
     this._menu = null
     this._selected = []
     this._options = this._getOptions()
@@ -240,11 +242,11 @@ class MultiSelect extends BaseComponent {
     }
 
     EventHandler.trigger(this._element, EVENT_SHOW)
-    this._clone.classList.add(CLASS_NAME_SHOW)
-    this._clone.setAttribute('aria-expanded', 'true')
+    this._wrapperElement.classList.add(CLASS_NAME_SHOW)
+    this._togglerElement.setAttribute('aria-expanded', 'true')
 
     if (this._config.container) {
-      this._menu.style.minWidth = `${this._clone.offsetWidth}px`
+      this._menu.style.minWidth = `${this._wrapperElement.offsetWidth}px`
       this._menu.classList.add(CLASS_NAME_SHOW)
     }
 
@@ -253,14 +255,14 @@ class MultiSelect extends BaseComponent {
     this._createPopper()
 
     if (this._config.search) {
-      SelectorEngine.findOne(SELECTOR_SEARCH, this._clone).focus()
+      SelectorEngine.findOne(SELECTOR_SEARCH, this._wrapperElement).focus()
     }
   }
 
   hide() {
     EventHandler.trigger(this._element, EVENT_HIDE)
 
-    const refocusFromInside = this._clone.contains(document.activeElement) ||
+    const refocusFromInside = this._wrapperElement.contains(document.activeElement) ||
       this._menu.contains(document.activeElement)
 
     if (this._popper) {
@@ -272,8 +274,8 @@ class MultiSelect extends BaseComponent {
     }
 
     this._onSearchChange(this._searchElement)
-    this._clone.classList.remove(CLASS_NAME_SHOW)
-    this._clone.setAttribute('aria-expanded', 'false')
+    this._wrapperElement.classList.remove(CLASS_NAME_SHOW)
+    this._togglerElement.setAttribute('aria-expanded', 'false')
 
     if (this._config.container) {
       this._menu.classList.remove(CLASS_NAME_SHOW)
@@ -295,7 +297,7 @@ class MultiSelect extends BaseComponent {
     }
 
     for (const element of [
-      this._clone,
+      this._wrapperElement,
       this._menu,
       this._selectionElement,
       this._togglerElement,
@@ -314,11 +316,11 @@ class MultiSelect extends BaseComponent {
       this._menu.remove()
     }
 
-    if (this._clone) {
-      this._clone.remove()
+    if (this._wrapperElement) {
+      this._wrapperElement.before(this._element)
+      this._wrapperElement.remove()
     }
 
-    this._element.style.removeProperty('display')
     this._element.removeAttribute('tabindex')
 
     super.dispose()
@@ -339,7 +341,8 @@ class MultiSelect extends BaseComponent {
     this._selected = []
     this._options = this._getOptions()
     this._menu.remove()
-    this._clone.remove()
+    this._wrapperElement.before(this._element)
+    this._wrapperElement.remove()
     this._element.innerHTML = ''
     this._createNativeOptions(this._element, this._options)
     this._createSelect()
@@ -424,13 +427,13 @@ class MultiSelect extends BaseComponent {
       }
     })
 
-    EventHandler.on(this._clone, EVENT_CLICK, () => {
+    EventHandler.on(this._wrapperElement, EVENT_CLICK, () => {
       if (!this._config.disabled) {
         this.show()
       }
     })
 
-    EventHandler.on(this._clone, EVENT_KEYDOWN, event => {
+    EventHandler.on(this._wrapperElement, EVENT_KEYDOWN, event => {
       if (event.key === ESCAPE_KEY) {
         this.hide()
         return
@@ -457,6 +460,35 @@ class MultiSelect extends BaseComponent {
       if (this._isShown() && event.key === ARROW_DOWN_KEY) {
         event.preventDefault()
         this._selectMenuItem(event)
+      }
+    })
+
+    // Validation focuses the overlay select; hand its keystrokes to the custom control.
+    EventHandler.on(this._element, EVENT_KEYDOWN, event => {
+      if (event.key === TAB_KEY || event.key === ESCAPE_KEY) {
+        return
+      }
+
+      // Suppress the native select's own keyboard behavior (typeahead, value change).
+      event.preventDefault()
+
+      const isPrintable = event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey
+
+      if (!this._isShown() && (event.key === ENTER_KEY || event.key === ARROW_DOWN_KEY || (this._config.search && isPrintable))) {
+        this.show()
+      }
+
+      if (this._config.search) {
+        this._searchElement.focus()
+
+        // The keystroke can't be retargeted mid-event, so inject the character that
+        // would otherwise be lost and start filtering on this first press.
+        if (isPrintable) {
+          this._searchElement.value += event.key
+          this._onSearchChange(this._searchElement)
+        }
+      } else {
+        this._togglerElement.focus()
       }
     })
 
@@ -660,29 +692,27 @@ class MultiSelect extends BaseComponent {
 
   _hideNativeSelect() {
     this._element.tabIndex = '-1'
-    this._element.style.display = 'none'
   }
 
   _createSelect() {
-    const multiSelectEl = document.createElement('div')
-    multiSelectEl.classList.add(CLASS_NAME_SELECT)
-    multiSelectEl.classList.toggle('is-invalid', this._config.invalid)
-    multiSelectEl.classList.toggle('is-valid', this._config.valid)
-    multiSelectEl.setAttribute('role', 'combobox')
-    multiSelectEl.setAttribute('aria-expanded', 'false')
-    multiSelectEl.setAttribute('aria-haspopup', 'listbox')
-    multiSelectEl.setAttribute('aria-owns', `${this._uniqueId}-listbox`)
+    const wrapper = document.createElement('div')
+    wrapper.classList.add(CLASS_NAME_SELECT)
+    wrapper.classList.toggle('is-invalid', this._config.invalid)
+    wrapper.classList.toggle('is-valid', this._config.valid)
 
     if (this._config.disabled) {
       this._element.classList.add(CLASS_NAME_DISABLED)
     }
 
     for (const className of this._element.classList.value.split(' ')) {
-      multiSelectEl.classList.add(className)
+      wrapper.classList.add(className)
     }
 
-    this._clone = multiSelectEl
-    this._element.parentNode.insertBefore(multiSelectEl, this._element.nextSibling)
+    this._wrapperElement = wrapper
+    // The wrapper takes the native select's place, then the select moves inside it
+    // as an invisible overlay so native `required` validation anchors over the control.
+    this._element.parentNode.insertBefore(wrapper, this._element)
+    wrapper.prepend(this._element)
     this._createSelection()
     this._createButtons()
 
@@ -702,6 +732,10 @@ class MultiSelect extends BaseComponent {
   _createSelection() {
     const togglerEl = document.createElement('div')
     togglerEl.classList.add(CLASS_NAME_INPUT_GROUP)
+    togglerEl.setAttribute('role', 'combobox')
+    togglerEl.setAttribute('aria-expanded', 'false')
+    togglerEl.setAttribute('aria-haspopup', 'listbox')
+    togglerEl.setAttribute('aria-owns', `${this._uniqueId}-listbox`)
     this._togglerElement = togglerEl
 
     if (!this._config.search && !this._config.disabled) {
@@ -716,7 +750,7 @@ class MultiSelect extends BaseComponent {
     }
 
     togglerEl.append(selectionEl)
-    this._clone.append(togglerEl)
+    this._wrapperElement.append(togglerEl)
 
     this._updateSelection()
     this._selectionElement = selectionEl
@@ -850,7 +884,7 @@ class MultiSelect extends BaseComponent {
     if (container) {
       container.append(dropdownDiv)
     } else {
-      this._clone.append(dropdownDiv)
+      this._wrapperElement.append(dropdownDiv)
     }
 
     this._createOptions(optionsDiv, this._options)
@@ -1203,8 +1237,8 @@ class MultiSelect extends BaseComponent {
   }
 
   _updateSelection() {
-    const selection = SelectorEngine.findOne(SELECTOR_SELECTION, this._clone)
-    const search = SelectorEngine.findOne(SELECTOR_SEARCH, this._clone)
+    const selection = SelectorEngine.findOne(SELECTOR_SELECTION, this._wrapperElement)
+    const search = SelectorEngine.findOne(SELECTOR_SEARCH, this._wrapperElement)
 
     if (this._selected.length === 0 && !this._config.search) {
       const placeholder = document.createElement('span')
@@ -1252,7 +1286,7 @@ class MultiSelect extends BaseComponent {
     }
 
     if (this._selected.length > 0 && this._selectionCleanerElement === null) {
-      const buttons = SelectorEngine.findOne(`.${CLASS_NAME_BUTTONS}`, this._clone)
+      const buttons = SelectorEngine.findOne(`.${CLASS_NAME_BUTTONS}`, this._wrapperElement)
       const selectionCleaner = this._createSelectionCleaner()
 
       buttons.insertBefore(selectionCleaner, this._indicatorElement)
@@ -1477,7 +1511,7 @@ class MultiSelect extends BaseComponent {
   }
 
   _isShown() {
-    return this._clone.classList.contains(CLASS_NAME_SHOW)
+    return this._wrapperElement.classList.contains(CLASS_NAME_SHOW)
   }
 
   _hasSelectionLimit() {
@@ -1614,11 +1648,11 @@ class MultiSelect extends BaseComponent {
         continue
       }
 
-      if (!context._clone.classList.contains(CLASS_NAME_SHOW)) {
+      if (!context._wrapperElement.classList.contains(CLASS_NAME_SHOW)) {
         continue
       }
 
-      if (context._clone.contains(event.target)) {
+      if (context._wrapperElement.contains(event.target)) {
         continue
       }
 
@@ -1634,7 +1668,12 @@ class MultiSelect extends BaseComponent {
  */
 
 EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const ms of SelectorEngine.find(SELECTOR_SELECT)) {
+  const elements = new Set([
+    ...SelectorEngine.find(SELECTOR_DATA_MULTI_SELECT),
+    ...SelectorEngine.find(SELECTOR_SELECT)
+  ])
+
+  for (const ms of elements) {
     if (ms.tabIndex !== -1) {
       MultiSelect.multiSelectInterface(ms)
     }

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -84,9 +84,9 @@ describe('MultiSelect', () => {
       const selectEl = fixtureEl.querySelector('select')
       const multiSelect = new MultiSelect(selectEl, { options: [] })
 
-      expect(multiSelect._clone.classList.contains('form-multi-select')).toBe(true)
-      expect(multiSelect._clone.querySelector('.form-multi-select-input-group')).toBeTruthy()
-      expect(multiSelect._clone.querySelector('.form-multi-select-selection')).toBeTruthy()
+      expect(multiSelect._wrapperElement.classList.contains('form-multi-select')).toBe(true)
+      expect(multiSelect._wrapperElement.querySelector('.form-multi-select-input-group')).toBeTruthy()
+      expect(multiSelect._wrapperElement.querySelector('.form-multi-select-selection')).toBeTruthy()
     })
 
     it('should handle disabled state', () => {
@@ -196,10 +196,78 @@ describe('MultiSelect', () => {
     it('should hide native select', () => {
       fixtureEl.innerHTML = '<select></select>'
       const selectEl = fixtureEl.querySelector('select')
-      new MultiSelect(selectEl, { options: [] }) // eslint-disable-line no-new
+      const multiSelect = new MultiSelect(selectEl, { options: [] })
 
-      expect(selectEl.style.display).toBe('none')
+      // The native select stays in the DOM as an overlay inside the wrapper.
       expect(selectEl.tabIndex).toBe(-1)
+      expect(selectEl.parentNode).toBe(multiSelect._wrapperElement)
+    })
+
+    it('should keep the native select usable for required validation', () => {
+      fixtureEl.innerHTML = '<form><select required multiple></select></form>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [{ value: '1', text: 'Option 1' }],
+        multiple: true,
+        required: true
+      })
+
+      // Not removed from the DOM via inline display:none, so the browser can focus it
+      // to anchor the constraint-validation bubble over the control.
+      expect(selectEl.style.display).toBe('')
+      expect(selectEl.willValidate).toBe(true)
+      expect(selectEl.checkValidity()).toBe(false)
+
+      multiSelect.selectAll()
+
+      expect(selectEl.checkValidity()).toBe(true)
+    })
+
+    it('should hand native select keyboard interaction to the custom control', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [{ value: '1', text: 'Option 1' }]
+      })
+
+      // Simulate validation having focused the native overlay select.
+      const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true })
+      selectEl.dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
+      expect(document.activeElement).toBe(multiSelect._togglerElement)
+    })
+
+    it('should not intercept Tab on the native select', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      new MultiSelect(selectEl, { options: [{ value: '1', text: 'Option 1' }] }) // eslint-disable-line no-new
+
+      const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true })
+      selectEl.dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(false)
+    })
+
+    it('should open and start searching on the first printable key from the native select', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [
+          { value: '1', text: 'Apple' },
+          { value: '2', text: 'Banana' }
+        ],
+        search: true
+      })
+
+      const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true, cancelable: true })
+      selectEl.dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
+      expect(multiSelect._searchElement.value).toBe('a')
+      expect(document.activeElement).toBe(multiSelect._searchElement)
     })
 
     it('should use element id when provided', () => {
@@ -341,7 +409,7 @@ describe('MultiSelect', () => {
         invalid: true
       })
 
-      expect(multiSelect._clone.classList.contains('is-invalid')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('is-invalid')).toBe(true)
     })
 
     it('should set is-valid class when valid config is true', () => {
@@ -352,7 +420,7 @@ describe('MultiSelect', () => {
         valid: true
       })
 
-      expect(multiSelect._clone.classList.contains('is-valid')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('is-valid')).toBe(true)
     })
 
     it('should apply optionsMaxHeight when not auto', () => {
@@ -444,7 +512,7 @@ describe('MultiSelect', () => {
         placeholder: 'Choose...'
       })
 
-      const placeholder = multiSelect._clone.querySelector('.form-multi-select-placeholder')
+      const placeholder = multiSelect._wrapperElement.querySelector('.form-multi-select-placeholder')
       expect(placeholder).not.toBeNull()
       expect(placeholder.textContent).toBe('Choose...')
     })
@@ -616,7 +684,7 @@ describe('MultiSelect', () => {
         selectionTypeCounterText: 'items selected'
       })
 
-      const selection = multiSelect._clone.querySelector('.form-multi-select-selection')
+      const selection = multiSelect._wrapperElement.querySelector('.form-multi-select-selection')
       expect(selection.textContent).toContain('2')
       expect(selection.textContent).toContain('items selected')
     })
@@ -632,7 +700,7 @@ describe('MultiSelect', () => {
         selectionType: 'text'
       })
 
-      const selection = multiSelect._clone.querySelector('.form-multi-select-selection')
+      const selection = multiSelect._wrapperElement.querySelector('.form-multi-select-selection')
       expect(selection.textContent).toContain('Opt 1')
       expect(selection.textContent).toContain('Opt 2')
     })
@@ -648,7 +716,7 @@ describe('MultiSelect', () => {
         selectionType: 'tags'
       })
 
-      const tags = multiSelect._clone.querySelectorAll('.form-multi-select-tag')
+      const tags = multiSelect._wrapperElement.querySelectorAll('.form-multi-select-tag')
       expect(tags.length).toBe(2)
     })
 
@@ -662,7 +730,7 @@ describe('MultiSelect', () => {
         selectionType: 'tags'
       })
 
-      const tag = multiSelect._clone.querySelector('.form-multi-select-tag')
+      const tag = multiSelect._wrapperElement.querySelector('.form-multi-select-tag')
       expect(tag.querySelector('.form-multi-select-tag-delete')).not.toBeNull()
     })
 
@@ -677,7 +745,7 @@ describe('MultiSelect', () => {
         disabled: true
       })
 
-      const tag = multiSelect._clone.querySelector('.form-multi-select-tag')
+      const tag = multiSelect._wrapperElement.querySelector('.form-multi-select-tag')
       expect(tag.querySelector('.form-multi-select-tag-delete')).toBeNull()
     })
 
@@ -692,7 +760,7 @@ describe('MultiSelect', () => {
         multiple: false
       })
 
-      const selection = multiSelect._clone.querySelector('.form-multi-select-selection')
+      const selection = multiSelect._wrapperElement.querySelector('.form-multi-select-selection')
       expect(selection.textContent).toContain('Opt 1')
     })
 
@@ -701,8 +769,8 @@ describe('MultiSelect', () => {
       const selectEl = fixtureEl.querySelector('select')
       const multiSelect = new MultiSelect(selectEl, { options: [] })
 
-      expect(multiSelect._clone.classList.contains('custom-class')).toBe(true)
-      expect(multiSelect._clone.classList.contains('another-class')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('custom-class')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('another-class')).toBe(true)
     })
 
     it('should handle custom group properties', () => {
@@ -731,7 +799,7 @@ describe('MultiSelect', () => {
         })
 
         selectEl.addEventListener('shown.coreui.multi-select', () => {
-          expect(multiSelect._clone.classList.contains('show')).toBe(true)
+          expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
           resolve()
         })
 
@@ -765,7 +833,7 @@ describe('MultiSelect', () => {
       })
 
       multiSelect.show()
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
     })
 
     it('should not show if already shown', () => {
@@ -776,11 +844,11 @@ describe('MultiSelect', () => {
       })
 
       multiSelect.show()
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
 
       // Call show again - should not throw
       multiSelect.show()
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
     })
 
     it('should set aria-expanded to true', () => {
@@ -791,7 +859,7 @@ describe('MultiSelect', () => {
       })
 
       multiSelect.show()
-      expect(multiSelect._clone.getAttribute('aria-expanded')).toBe('true')
+      expect(multiSelect._togglerElement.getAttribute('aria-expanded')).toBe('true')
     })
 
     it('should focus search input when search is enabled', () => {
@@ -804,7 +872,7 @@ describe('MultiSelect', () => {
 
       multiSelect.show()
 
-      const searchInput = multiSelect._clone.querySelector('.form-multi-select-search')
+      const searchInput = multiSelect._wrapperElement.querySelector('.form-multi-select-search')
       expect(searchInput).not.toBeNull()
     })
 
@@ -847,7 +915,7 @@ describe('MultiSelect', () => {
         })
 
         selectEl.addEventListener('hidden.coreui.multi-select', () => {
-          expect(multiSelect._clone.classList.contains('show')).toBe(false)
+          expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
           resolve()
         })
 
@@ -885,7 +953,7 @@ describe('MultiSelect', () => {
 
       multiSelect.show()
       multiSelect.hide()
-      expect(multiSelect._clone.getAttribute('aria-expanded')).toBe('false')
+      expect(multiSelect._togglerElement.getAttribute('aria-expanded')).toBe('false')
     })
 
     it('should destroy popper', () => {
@@ -974,9 +1042,9 @@ describe('MultiSelect', () => {
         options: [{ value: '1', text: 'Option 1' }]
       })
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
       multiSelect.toggle()
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
     })
 
     it('should hide when shown', () => {
@@ -987,9 +1055,9 @@ describe('MultiSelect', () => {
       })
 
       multiSelect.show()
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
       multiSelect.toggle()
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
     })
   })
 
@@ -2378,7 +2446,7 @@ describe('MultiSelect', () => {
       const option = multiSelect._optionsElement.querySelector('[data-value="1"]')
       multiSelect._onOptionsClick(option)
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
     })
 
     it('should add form-multi-selected class on selected option', () => {
@@ -2554,7 +2622,7 @@ describe('MultiSelect', () => {
 
       expect(multiSelect._selected.length).toBe(2)
 
-      const tagDelete = multiSelect._clone.querySelector('.form-multi-select-tag-delete')
+      const tagDelete = multiSelect._wrapperElement.querySelector('.form-multi-select-tag-delete')
       tagDelete.click()
 
       expect(multiSelect._selected.length).toBe(1)
@@ -2568,12 +2636,12 @@ describe('MultiSelect', () => {
         selectionType: 'tags'
       })
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
 
-      multiSelect._clone.querySelector('.form-multi-select-tag-delete').click()
+      multiSelect._wrapperElement.querySelector('.form-multi-select-tag-delete').click()
 
       expect(multiSelect._selected.length).toBe(0)
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
     })
 
     it('should remove a tag created after initialization via delegation', () => {
@@ -2589,7 +2657,7 @@ describe('MultiSelect', () => {
 
       // This tag node did not exist when listeners were bound.
       multiSelect._selectOption('2', 'Opt 2')
-      const newTagDelete = multiSelect._clone
+      const newTagDelete = multiSelect._wrapperElement
         .querySelector('.form-multi-select-tag[data-value="2"] .form-multi-select-tag-delete')
 
       newTagDelete.click()
@@ -2633,7 +2701,7 @@ describe('MultiSelect', () => {
       })
 
       // The disabled option's tag should not have a delete button
-      const tags = multiSelect._clone.querySelectorAll('.form-multi-select-tag')
+      const tags = multiSelect._wrapperElement.querySelectorAll('.form-multi-select-tag')
       const disabledTag = Array.from(tags).find(t => t.dataset.value === '1')
       if (disabledTag) {
         expect(disabledTag.querySelector('.form-multi-select-tag-delete')).toBeNull()
@@ -2650,7 +2718,7 @@ describe('MultiSelect', () => {
         selectionType: 'tags'
       })
 
-      let tagDelete = multiSelect._clone.querySelector('.form-multi-select-tag-delete')
+      let tagDelete = multiSelect._wrapperElement.querySelector('.form-multi-select-tag-delete')
       expect(tagDelete.getAttribute('aria-label')).toBe('Remove Angular')
 
       multiSelect.dispose()
@@ -2662,7 +2730,7 @@ describe('MultiSelect', () => {
         ariaTagDeleteLabel: 'Usuń'
       })
 
-      tagDelete = multiSelect2._clone.querySelector('.form-multi-select-tag-delete')
+      tagDelete = multiSelect2._wrapperElement.querySelector('.form-multi-select-tag-delete')
       expect(tagDelete.getAttribute('aria-label')).toBe('Usuń Angular')
     })
 
@@ -2678,13 +2746,13 @@ describe('MultiSelect', () => {
         selectionType: 'tags'
       })
 
-      const firstTag = multiSelect._clone.querySelector('.form-multi-select-tag[data-value="1"]')
+      const firstTag = multiSelect._wrapperElement.querySelector('.form-multi-select-tag[data-value="1"]')
 
       multiSelect._selectOption('2', 'Opt 2')
 
       // The diff update keeps the already-rendered tag node instead of recreating it.
-      expect(multiSelect._clone.querySelector('.form-multi-select-tag[data-value="1"]')).toBe(firstTag)
-      expect(multiSelect._clone.querySelectorAll('.form-multi-select-tag').length).toBe(2)
+      expect(multiSelect._wrapperElement.querySelector('.form-multi-select-tag[data-value="1"]')).toBe(firstTag)
+      expect(multiSelect._wrapperElement.querySelectorAll('.form-multi-select-tag').length).toBe(2)
     })
 
     it('should remove the placeholder when the first tag is added', () => {
@@ -2697,12 +2765,12 @@ describe('MultiSelect', () => {
         selectionType: 'tags'
       })
 
-      expect(multiSelect._clone.querySelector('.form-multi-select-placeholder')).not.toBeNull()
+      expect(multiSelect._wrapperElement.querySelector('.form-multi-select-placeholder')).not.toBeNull()
 
       multiSelect._selectOption('1', 'Opt 1')
 
-      expect(multiSelect._clone.querySelector('.form-multi-select-placeholder')).toBeNull()
-      expect(multiSelect._clone.querySelectorAll('.form-multi-select-tag').length).toBe(1)
+      expect(multiSelect._wrapperElement.querySelector('.form-multi-select-placeholder')).toBeNull()
+      expect(multiSelect._wrapperElement.querySelectorAll('.form-multi-select-tag').length).toBe(1)
     })
 
     it('should keep tags ordered and before the search input', () => {
@@ -2722,7 +2790,7 @@ describe('MultiSelect', () => {
       multiSelect._selectOption('2', 'Opt 2')
       multiSelect._selectOption('1', 'Opt 1')
 
-      const selection = multiSelect._clone.querySelector('.form-multi-select-selection')
+      const selection = multiSelect._wrapperElement.querySelector('.form-multi-select-selection')
       const order = Array.from(selection.children).map(child => child.dataset.value || 'search')
 
       expect(order).toEqual(['2', '1', 'search'])
@@ -2740,7 +2808,7 @@ describe('MultiSelect', () => {
       const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
       multiSelect._togglerElement.dispatchEvent(event)
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
     })
 
     it('should open dropdown on ArrowDown key on toggler when closed', () => {
@@ -2753,7 +2821,7 @@ describe('MultiSelect', () => {
       const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })
       multiSelect._togglerElement.dispatchEvent(event)
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
     })
 
     it('should navigate to menu item on ArrowDown when already open', () => {
@@ -2845,12 +2913,12 @@ describe('MultiSelect', () => {
       })
 
       multiSelect.show()
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
 
       const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
-      multiSelect._clone.dispatchEvent(event)
+      multiSelect._wrapperElement.dispatchEvent(event)
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
     })
 
     it('should return focus to the toggler when closed from inside the component', () => {
@@ -2863,7 +2931,7 @@ describe('MultiSelect', () => {
       multiSelect.show()
       const option = multiSelect._optionsElement.querySelector('[data-value="1"]')
       option.focus()
-      expect(multiSelect._clone.contains(document.activeElement)).toBe(true)
+      expect(multiSelect._wrapperElement.contains(document.activeElement)).toBe(true)
 
       multiSelect.hide()
 
@@ -3036,12 +3104,12 @@ describe('MultiSelect', () => {
         search: true
       })
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
 
       const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true })
       multiSelect._searchElement.dispatchEvent(event)
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
     })
 
     it('should open dropdown on ArrowDown from search input', () => {
@@ -3055,7 +3123,7 @@ describe('MultiSelect', () => {
       const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })
       multiSelect._searchElement.dispatchEvent(event)
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
     })
 
     it('should not open on typing when ctrlKey is pressed', () => {
@@ -3069,7 +3137,7 @@ describe('MultiSelect', () => {
       const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true, ctrlKey: true })
       multiSelect._searchElement.dispatchEvent(event)
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
     })
 
     it('should not open on typing when metaKey is pressed', () => {
@@ -3083,7 +3151,7 @@ describe('MultiSelect', () => {
       const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true, metaKey: true })
       multiSelect._searchElement.dispatchEvent(event)
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
     })
 
     it('should focus search on global search keydown on clone', () => {
@@ -3097,7 +3165,7 @@ describe('MultiSelect', () => {
       multiSelect.show()
 
       const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true })
-      multiSelect._clone.dispatchEvent(event)
+      multiSelect._wrapperElement.dispatchEvent(event)
 
       // Should focus the search element (no error thrown)
       expect(multiSelect._searchElement).not.toBeNull()
@@ -3130,7 +3198,7 @@ describe('MultiSelect', () => {
       multiSelect.show()
 
       const event = new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true })
-      multiSelect._clone.dispatchEvent(event)
+      multiSelect._wrapperElement.dispatchEvent(event)
 
       expect(multiSelect._searchElement).not.toBeNull()
     })
@@ -3178,7 +3246,7 @@ describe('MultiSelect', () => {
         multiple: true
       })
 
-      const cleaner = multiSelect._clone.querySelector('.form-multi-select-cleaner')
+      const cleaner = multiSelect._wrapperElement.querySelector('.form-multi-select-cleaner')
       expect(cleaner).not.toBeNull()
     })
 
@@ -3196,16 +3264,16 @@ describe('MultiSelect', () => {
 
       // Empty the selection so the cleaner is removed, then re-create it.
       multiSelect.deselectAll()
-      expect(multiSelect._clone.querySelector('.form-multi-select-cleaner')).toBeNull()
+      expect(multiSelect._wrapperElement.querySelector('.form-multi-select-cleaner')).toBeNull()
 
       multiSelect._selectOption('2', 'Opt 2')
-      const cleaner = multiSelect._clone.querySelector('.form-multi-select-cleaner')
+      const cleaner = multiSelect._wrapperElement.querySelector('.form-multi-select-cleaner')
       expect(cleaner).not.toBeNull()
 
       cleaner.click()
 
       expect(multiSelect._selected.length).toBe(0)
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
     })
 
     it('should not insert cleaner when no items are selected', () => {
@@ -3217,7 +3285,7 @@ describe('MultiSelect', () => {
         multiple: true
       })
 
-      const cleaner = multiSelect._clone.querySelector('.form-multi-select-cleaner')
+      const cleaner = multiSelect._wrapperElement.querySelector('.form-multi-select-cleaner')
       expect(cleaner).toBeNull()
     })
 
@@ -3230,11 +3298,11 @@ describe('MultiSelect', () => {
         multiple: true
       })
 
-      expect(multiSelect._clone.querySelector('.form-multi-select-cleaner')).toBeNull()
+      expect(multiSelect._wrapperElement.querySelector('.form-multi-select-cleaner')).toBeNull()
 
       multiSelect._selectOption('1', 'Opt 1')
 
-      expect(multiSelect._clone.querySelector('.form-multi-select-cleaner')).not.toBeNull()
+      expect(multiSelect._wrapperElement.querySelector('.form-multi-select-cleaner')).not.toBeNull()
     })
 
     it('should insert cleaner and clear selection for single select', () => {
@@ -3246,13 +3314,13 @@ describe('MultiSelect', () => {
         multiple: false
       })
 
-      const cleaner = multiSelect._clone.querySelector('.form-multi-select-cleaner')
+      const cleaner = multiSelect._wrapperElement.querySelector('.form-multi-select-cleaner')
       expect(cleaner).not.toBeNull()
 
       cleaner.click()
 
       expect(multiSelect._selected.length).toBe(0)
-      expect(multiSelect._clone.querySelector('.form-multi-select-cleaner')).toBeNull()
+      expect(multiSelect._wrapperElement.querySelector('.form-multi-select-cleaner')).toBeNull()
     })
 
     it('should deselect all on cleaner click', () => {
@@ -3269,11 +3337,11 @@ describe('MultiSelect', () => {
 
       expect(multiSelect._selected.length).toBe(2)
 
-      const cleaner = multiSelect._clone.querySelector('.form-multi-select-cleaner')
+      const cleaner = multiSelect._wrapperElement.querySelector('.form-multi-select-cleaner')
       cleaner.click()
 
       expect(multiSelect._selected.length).toBe(0)
-      expect(multiSelect._clone.querySelector('.form-multi-select-cleaner')).toBeNull()
+      expect(multiSelect._wrapperElement.querySelector('.form-multi-select-cleaner')).toBeNull()
     })
 
     it('should not deselect on cleaner click when disabled', () => {
@@ -3312,9 +3380,9 @@ describe('MultiSelect', () => {
         options: [{ value: '1', text: 'Opt 1' }]
       })
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
       multiSelect._indicatorElement.click()
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
     })
 
     it('should set tabIndex -1 on indicator when disabled', () => {
@@ -3483,13 +3551,13 @@ describe('MultiSelect', () => {
         options: [{ value: '1', text: 'Option 1' }]
       })
 
-      const oldClone = multiSelect._clone
+      const oldClone = multiSelect._wrapperElement
 
       multiSelect.update({
         options: [{ value: '2', text: 'Option 2' }]
       })
 
-      expect(multiSelect._clone).not.toBe(oldClone)
+      expect(multiSelect._wrapperElement).not.toBe(oldClone)
     })
   })
 
@@ -3537,8 +3605,8 @@ describe('MultiSelect', () => {
         options: [{ value: '1', text: 'Option 1' }]
       })
 
-      multiSelect._clone.click()
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      multiSelect._wrapperElement.click()
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
     })
 
     it('should not show on clone click when disabled', () => {
@@ -3549,8 +3617,8 @@ describe('MultiSelect', () => {
         disabled: true
       })
 
-      multiSelect._clone.click()
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      multiSelect._wrapperElement.click()
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
     })
   })
 
@@ -3601,17 +3669,18 @@ describe('MultiSelect', () => {
         options: [{ value: '1', text: 'Option 1' }]
       })
 
-      const clone = multiSelect._clone
+      const wrapper = multiSelect._wrapperElement
       const menu = multiSelect._menu
 
       expect(fixtureEl.querySelector('.form-multi-select')).not.toBeNull()
-      expect(selectEl.style.display).toBe('none')
+      expect(selectEl.parentNode).toBe(wrapper)
 
       multiSelect.dispose()
 
-      expect(clone.isConnected).toBe(false)
+      expect(wrapper.isConnected).toBe(false)
       expect(menu.isConnected).toBe(false)
-      expect(selectEl.style.display).toBe('')
+      expect(selectEl.isConnected).toBe(true)
+      expect(selectEl.parentNode).toBe(fixtureEl)
       expect(selectEl.getAttribute('tabindex')).toBeNull()
     })
 
@@ -3645,7 +3714,7 @@ describe('MultiSelect', () => {
 
       multiSelect._selectOption('1', 'Option 1')
 
-      const clone = multiSelect._clone
+      const clone = multiSelect._wrapperElement
       const optionsElement = multiSelect._optionsElement
       const spy = spyOn(EventHandler, 'off').and.callThrough()
 
@@ -3666,7 +3735,7 @@ describe('MultiSelect', () => {
       })
 
       multiSelect.show()
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
 
       const outsideEl = fixtureEl.querySelector('#outside')
       const clickEvent = new Event('click', { bubbles: true })
@@ -3674,7 +3743,7 @@ describe('MultiSelect', () => {
 
       MultiSelect.clearMenus(clickEvent)
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
     })
 
     it('should not close on right mouse button click', () => {
@@ -3691,7 +3760,7 @@ describe('MultiSelect', () => {
 
       MultiSelect.clearMenus(event)
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
     })
 
     it('should not close on keyup that is not Tab', () => {
@@ -3708,7 +3777,7 @@ describe('MultiSelect', () => {
 
       MultiSelect.clearMenus(event)
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
     })
 
     it('should close on Tab keyup', () => {
@@ -3727,7 +3796,7 @@ describe('MultiSelect', () => {
 
       MultiSelect.clearMenus(event)
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
     })
 
     it('should not close when clicking inside the clone', () => {
@@ -3740,11 +3809,11 @@ describe('MultiSelect', () => {
       multiSelect.show()
 
       const clickEvent = new Event('click', { bubbles: true })
-      Object.defineProperty(clickEvent, 'target', { value: multiSelect._clone })
+      Object.defineProperty(clickEvent, 'target', { value: multiSelect._wrapperElement })
 
       MultiSelect.clearMenus(clickEvent)
 
-      expect(multiSelect._clone.classList.contains('show')).toBe(true)
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(true)
     })
   })
 
@@ -4004,6 +4073,26 @@ describe('MultiSelect', () => {
       const _multiSelect = new MultiSelect(selectEl, { options: [] })
       expect(MultiSelect.getInstance(selectEl)).toBeInstanceOf(MultiSelect)
     })
+
+    it('should auto-initialize on load via the data-coreui-multi-select attribute', () => {
+      fixtureEl.innerHTML = '<select data-coreui-multi-select><option value="1">One</option></select>'
+      const selectEl = fixtureEl.querySelector('select')
+
+      expect(MultiSelect.getInstance(selectEl)).toBeNull()
+
+      window.dispatchEvent(new Event('load'))
+
+      expect(MultiSelect.getInstance(selectEl)).toBeInstanceOf(MultiSelect)
+    })
+
+    it('should still auto-initialize on load via the form-multi-select class (backward compat)', () => {
+      fixtureEl.innerHTML = '<select class="form-multi-select"><option value="1">One</option></select>'
+      const selectEl = fixtureEl.querySelector('select')
+
+      window.dispatchEvent(new Event('load'))
+
+      expect(MultiSelect.getInstance(selectEl)).toBeInstanceOf(MultiSelect)
+    })
   })
 
   describe('_updateSelectionCleaner', () => {
@@ -4190,7 +4279,7 @@ describe('MultiSelect', () => {
         search: false
       })
 
-      const selection = multiSelect._clone.querySelector('.form-multi-select-selection')
+      const selection = multiSelect._wrapperElement.querySelector('.form-multi-select-selection')
       expect(selection.innerHTML).toContain('Select something')
     })
 
@@ -4205,7 +4294,7 @@ describe('MultiSelect', () => {
         search: false
       })
 
-      const selection = multiSelect._clone.querySelector('.form-multi-select-selection')
+      const selection = multiSelect._wrapperElement.querySelector('.form-multi-select-selection')
       expect(selection.textContent).toContain('Opt 1')
     })
 
@@ -4224,7 +4313,7 @@ describe('MultiSelect', () => {
         search: false
       })
 
-      const selection = multiSelect._clone.querySelector('.form-multi-select-selection')
+      const selection = multiSelect._wrapperElement.querySelector('.form-multi-select-selection')
       expect(selection.textContent).toContain('2')
       expect(selection.textContent).toContain('item(s) selected')
     })
@@ -4242,7 +4331,7 @@ describe('MultiSelect', () => {
         selectionType: 'text'
       })
 
-      const selection = multiSelect._clone.querySelector('.form-multi-select-selection')
+      const selection = multiSelect._wrapperElement.querySelector('.form-multi-select-selection')
       expect(selection.textContent).toContain('Apple')
       expect(selection.textContent).toContain('Banana')
     })
@@ -4257,8 +4346,8 @@ describe('MultiSelect', () => {
         disabled: true
       })
 
-      multiSelect._clone.click()
-      expect(multiSelect._clone.classList.contains('show')).toBe(false)
+      multiSelect._wrapperElement.click()
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
     })
 
     it('should add disabled class to element', () => {
@@ -4283,7 +4372,7 @@ describe('MultiSelect', () => {
         selectionType: 'tags'
       })
 
-      const selection = multiSelect._clone.querySelector('.form-multi-select-selection')
+      const selection = multiSelect._wrapperElement.querySelector('.form-multi-select-selection')
       expect(selection.classList.contains('form-multi-select-selection-tags')).toBe(true)
     })
 
@@ -4296,7 +4385,7 @@ describe('MultiSelect', () => {
         selectionType: 'counter'
       })
 
-      const selection = multiSelect._clone.querySelector('.form-multi-select-selection')
+      const selection = multiSelect._wrapperElement.querySelector('.form-multi-select-selection')
       expect(selection.classList.contains('form-multi-select-selection-tags')).toBe(false)
     })
   })
@@ -4307,7 +4396,7 @@ describe('MultiSelect', () => {
       const selectEl = fixtureEl.querySelector('select')
       const multiSelect = new MultiSelect(selectEl, { options: [] })
 
-      expect(multiSelect._clone.getAttribute('role')).toBe('combobox')
+      expect(multiSelect._togglerElement.getAttribute('role')).toBe('combobox')
     })
 
     it('should set aria-haspopup to listbox', () => {
@@ -4315,7 +4404,7 @@ describe('MultiSelect', () => {
       const selectEl = fixtureEl.querySelector('select')
       const multiSelect = new MultiSelect(selectEl, { options: [] })
 
-      expect(multiSelect._clone.getAttribute('aria-haspopup')).toBe('listbox')
+      expect(multiSelect._togglerElement.getAttribute('aria-haspopup')).toBe('listbox')
     })
 
     it('should set aria-owns referencing listbox id', () => {
@@ -4323,7 +4412,7 @@ describe('MultiSelect', () => {
       const selectEl = fixtureEl.querySelector('select')
       const multiSelect = new MultiSelect(selectEl, { options: [] })
 
-      expect(multiSelect._clone.getAttribute('aria-owns')).toBe('test-select-listbox')
+      expect(multiSelect._togglerElement.getAttribute('aria-owns')).toBe('test-select-listbox')
     })
 
     it('should set listbox role on the options element', () => {

--- a/scss/forms/_form-multi-select.scss
+++ b/scss/forms/_form-multi-select.scss
@@ -120,7 +120,7 @@
 
   position: relative;
 
-  .was-validated .form-multi-select:invalid + &,
+  .was-validated .form-multi-select:has(> select:invalid),
   &.is-invalid {
     $focus-box-shadow: 0 0 $input-btn-focus-blur $input-focus-width rgba($form-multi-select-invalid-border-color, $input-btn-focus-color-opacity);
 
@@ -130,7 +130,7 @@
 
   }
 
-  .was-validated .form-multi-select:valid + &,
+  .was-validated .form-multi-select:has(> select:valid),
   &.is-valid {
     $focus-box-shadow: 0 0 $input-btn-focus-blur $input-focus-width rgba($form-multi-select-valid-border-color, $input-btn-focus-color-opacity);
 
@@ -140,9 +140,21 @@
   }
 }
 
+// The native select stays in the DOM as an invisible overlay covering the control
+// so native `required` constraint validation focuses and anchors over the field.
 // stylelint-disable-next-line selector-no-qualifying-type
-select.form-multi-select {
-  display: none;
+select.form-multi-select,
+[data-coreui-multi-select] {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  pointer-events: none;
+  border: 0;
+  outline: 0;
+  opacity: 0;
 }
 
 .form-multi-select-input-group {
@@ -171,6 +183,7 @@ select.form-multi-select {
   }
 
   .form-multi-select.show &,
+  .form-multi-select:has(> select:focus) &,
   &:has(*:focus),
   &:focus {
     color: var(--#{$prefix}form-multi-select-focus-color);


### PR DESCRIPTION
## Summary

Make the native `<select>`'s `required` constraint validation work by keeping it in the DOM as an invisible overlay instead of `display:none`.

`.form-multi-select` becomes the wrapper; the native `<select>` moves inside it as a full-cover overlay (`position:absolute; inset:0; opacity:0; pointer-events:none`). The native control stays focusable, so `reportValidity()` focuses it and the validation bubble anchors over the control (verified in-browser across the open/select/search/validate flow).

## Changes
- **Combobox semantics** (`role`, `aria-expanded`, `aria-haspopup`, `aria-owns`) move onto the focusable `.form-multi-select-input-group` toggler (also fixes aria-expanded sitting on a non-focusable element).
- **Focus reflection**: the native select's focus is mirrored onto the visible toggler via `:has(> select:focus)`, and the overlay's own ring is suppressed with `outline:0` — so validation focus shows a ring on the control.
- **Keyboard handoff**: keystrokes on the validation-focused native select are handed to the custom control — open on Enter/ArrowDown (or any printable key with search), injecting that first character so filtering starts on the first press. Tab/Escape pass through.
- **Lifecycle**: `_clone` renamed to `_wrapperElement`; `update()`/`dispose()` move the native select out before removing the wrapper.
- **Validation styling** switches from sibling (`:invalid +`) to `:has(> select:..)`.
- **Init via `[data-coreui-multi-select]`** (data-api + pre-JS overlay hiding), keeping the `.form-multi-select` class as a deprecated fallback (TODO: remove in v6). Docs examples switched to the data attribute.

## Notes
- Dropping `display:none` keeps the native select in the a11y tree (deliberate trade-off for working validation).
- Build artifacts (`dist/`, `js/dist/`) intentionally not committed.
- Tests: 2901 passing; lint/stylelint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
