### PR TITLE
feat(MultiSelect): accessibility improvements (aria-selected, live regions, Space, search labeling)

### DIFF
--- a/docs/content/forms/multi-select.md
+++ b/docs/content/forms/multi-select.md
@@ -467,6 +467,7 @@ const mulitSelectList = mulitSelectElementList.map(mulitSelectEl => {
 | --- | --- | --- | --- |
 | `allowList` | object | `DefaultAllowlist` | Object containing allowed tags and attributes for HTML sanitization when using custom templates. |
 | `ariaCleanerLabel`| string | `Clear all selections` | A string that provides an accessible label for the cleaner button. This label is read by screen readers to describe the action associated with the button. |
+| `ariaSearchLabel`| string | `Search` | Accessible label for the search input (when `search` is enabled). |
 | `ariaTagDeleteLabel`| string | `Remove` | Accessible label prefix for a tag's delete button (selection type `tags`). The selected option's text is appended, so screen readers announce e.g. "Remove Angular". |
 | `cleaner`| boolean | `true` | Enables selection cleaner element. |
 | `clearSearchOnSelect`| boolean | `false` | Clear current search on selecting an item. |

--- a/js/src/multi-select.js
+++ b/js/src/multi-select.js
@@ -738,6 +738,10 @@ class MultiSelect extends BaseComponent {
     togglerEl.setAttribute('aria-owns', `${this._uniqueId}-listbox`)
     this._togglerElement = togglerEl
 
+    if (this._config.disabled) {
+      togglerEl.setAttribute('aria-disabled', 'true')
+    }
+
     if (!this._config.search && !this._config.disabled) {
       togglerEl.tabIndex = 0
     }

--- a/js/src/multi-select.js
+++ b/js/src/multi-select.js
@@ -102,6 +102,7 @@ const Default = {
   allowList: DefaultAllowlist,
   ariaCleanerLabel: 'Clear all selections',
   ariaIndicatorLabel: 'Toggle visibility of options menu',
+  ariaSearchLabel: 'Search',
   ariaTagDeleteLabel: 'Remove',
   cleaner: true,
   clearSearchOnSelect: false,
@@ -143,6 +144,7 @@ const DefaultType = {
   allowList: 'object',
   ariaCleanerLabel: 'string',
   ariaIndicatorLabel: 'string',
+  ariaSearchLabel: 'string',
   ariaTagDeleteLabel: 'string',
   cleaner: 'boolean',
   clearSearchOnSelect: 'boolean',
@@ -827,6 +829,9 @@ class MultiSelect extends BaseComponent {
 
     input.setAttribute('id', `search-${this._uniqueId}`)
     input.setAttribute('name', `search-${this._uniqueName}`)
+    input.setAttribute('aria-label', this._config.ariaSearchLabel)
+    input.setAttribute('aria-autocomplete', 'list')
+    input.setAttribute('aria-controls', `${this._uniqueId}-listbox`)
 
     this._searchElement = input
     this._updateSearchSize()

--- a/js/src/multi-select.js
+++ b/js/src/multi-select.js
@@ -748,6 +748,7 @@ class MultiSelect extends BaseComponent {
 
     const selectionEl = document.createElement('div')
     selectionEl.classList.add(CLASS_NAME_SELECTION)
+    selectionEl.setAttribute('aria-live', 'polite')
 
     if (this._config.multiple && this._config.selectionType === 'tags') {
       selectionEl.classList.add(CLASS_NAME_SELECTION_TAGS)
@@ -1571,6 +1572,7 @@ class MultiSelect extends BaseComponent {
     if (visibleOptions === 0) {
       const placeholder = document.createElement('div')
       placeholder.classList.add(CLASS_NAME_OPTIONS_EMPTY)
+      placeholder.setAttribute('role', 'status')
       placeholder.textContent = this._config.searchNoResultsLabel
 
       if (!SelectorEngine.findOne(SELECTOR_OPTIONS_EMPTY, this._menu)) {

--- a/js/src/multi-select.js
+++ b/js/src/multi-select.js
@@ -912,6 +912,7 @@ class MultiSelect extends BaseComponent {
         optionDiv.dataset.value = String(option.value)
         optionDiv.tabIndex = 0
         optionDiv.setAttribute('role', 'option')
+        optionDiv.setAttribute('aria-selected', option.selected === true ? 'true' : 'false')
 
         if (this._config.optionsTemplate && typeof this._config.optionsTemplate === 'function') {
           optionDiv.innerHTML = this._config.sanitize ?

--- a/js/src/multi-select.js
+++ b/js/src/multi-select.js
@@ -738,7 +738,7 @@ class MultiSelect extends BaseComponent {
     togglerEl.setAttribute('role', 'combobox')
     togglerEl.setAttribute('aria-expanded', 'false')
     togglerEl.setAttribute('aria-haspopup', 'listbox')
-    togglerEl.setAttribute('aria-owns', `${this._uniqueId}-listbox`)
+    togglerEl.setAttribute('aria-controls', `${this._uniqueId}-listbox`)
     this._togglerElement = togglerEl
 
     if (this._config.disabled) {

--- a/js/src/multi-select.js
+++ b/js/src/multi-select.js
@@ -39,6 +39,7 @@ const BACKSPACE_KEY = 'Backspace'
 const DELETE_KEY = 'Delete'
 const ENTER_KEY = 'Enter'
 const ESCAPE_KEY = 'Escape'
+const SPACE_KEY = ' '
 const TAB_KEY = 'Tab'
 const RIGHT_MOUSE_BUTTON = 2 // MouseEvent.button value for the secondary button, usually the right button
 
@@ -549,7 +550,9 @@ class MultiSelect extends BaseComponent {
     })
 
     EventHandler.on(this._optionsElement, EVENT_KEYDOWN, event => {
-      if (event.key === ENTER_KEY) {
+      if (event.key === ENTER_KEY || event.key === SPACE_KEY) {
+        // Space would otherwise scroll the options list.
+        event.preventDefault()
         this._onOptionsClick(event.target)
       }
 

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -4437,6 +4437,23 @@ describe('MultiSelect', () => {
       expect(optionEl.getAttribute('role')).toBe('option')
     })
 
+    it('should set aria-selected on options at creation', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [
+          { value: '1', text: 'Opt 1', selected: true },
+          { value: '2', text: 'Opt 2' }
+        ]
+      })
+
+      const selectedOption = multiSelect._optionsElement.querySelector('[data-value="1"]')
+      const unselectedOption = multiSelect._optionsElement.querySelector('[data-value="2"]')
+
+      expect(selectedOption.getAttribute('aria-selected')).toBe('true')
+      expect(unselectedOption.getAttribute('aria-selected')).toBe('false')
+    })
+
     it('should set aria-label on cleaner button', () => {
       fixtureEl.innerHTML = '<select></select>'
       const selectEl = fixtureEl.querySelector('select')

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -4407,6 +4407,22 @@ describe('MultiSelect', () => {
       expect(multiSelect._togglerElement.getAttribute('aria-haspopup')).toBe('listbox')
     })
 
+    it('should set aria-disabled on the toggler when disabled', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, { options: [], disabled: true })
+
+      expect(multiSelect._togglerElement.getAttribute('aria-disabled')).toBe('true')
+    })
+
+    it('should not set aria-disabled on the toggler when enabled', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, { options: [] })
+
+      expect(multiSelect._togglerElement.getAttribute('aria-disabled')).toBeNull()
+    })
+
     it('should set aria-owns referencing listbox id', () => {
       fixtureEl.innerHTML = '<select id="test-select"></select>'
       const selectEl = fixtureEl.querySelector('select')

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -4429,6 +4429,25 @@ describe('MultiSelect', () => {
       expect(multiSelect._togglerElement.getAttribute('aria-haspopup')).toBe('listbox')
     })
 
+    it('should give the search input an accessible label and combobox-supporting attributes', () => {
+      fixtureEl.innerHTML = '<select id="test-select"></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, { options: [], search: true })
+      const input = multiSelect._searchElement
+
+      expect(input.getAttribute('aria-label')).toBe('Search')
+      expect(input.getAttribute('aria-autocomplete')).toBe('list')
+      expect(input.getAttribute('aria-controls')).toBe('test-select-listbox')
+    })
+
+    it('should use a custom ariaSearchLabel', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, { options: [], search: true, ariaSearchLabel: 'Szukaj' })
+
+      expect(multiSelect._searchElement.getAttribute('aria-label')).toBe('Szukaj')
+    })
+
     it('should mark the selection as an aria-live region', () => {
       fixtureEl.innerHTML = '<select></select>'
       const selectEl = fixtureEl.querySelector('select')

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -2134,6 +2134,7 @@ describe('MultiSelect', () => {
       const emptyMessage = multiSelect._menu.querySelector('.form-multi-select-options-empty')
       expect(emptyMessage).not.toBeNull()
       expect(emptyMessage.textContent).toBe('No results found')
+      expect(emptyMessage.getAttribute('role')).toBe('status')
     })
 
     it('should remove "no results" message when results are found again', () => {
@@ -4405,6 +4406,14 @@ describe('MultiSelect', () => {
       const multiSelect = new MultiSelect(selectEl, { options: [] })
 
       expect(multiSelect._togglerElement.getAttribute('aria-haspopup')).toBe('listbox')
+    })
+
+    it('should mark the selection as an aria-live region', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, { options: [], selectionType: 'counter' })
+
+      expect(multiSelect._selectionElement.getAttribute('aria-live')).toBe('polite')
     })
 
     it('should set aria-disabled on the toggler when disabled', () => {

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -2993,6 +2993,27 @@ describe('MultiSelect', () => {
       expect(multiSelect._selected[0].value).toBe('1')
     })
 
+    it('should select option on Space key in options list', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [
+          { value: '1', text: 'Option 1' },
+          { value: '2', text: 'Option 2' }
+        ]
+      })
+
+      multiSelect.show()
+
+      const optionEl = multiSelect._optionsElement.querySelector('[data-value="1"]')
+      const spaceEvent = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true })
+      optionEl.dispatchEvent(spaceEvent)
+
+      expect(spaceEvent.defaultPrevented).toBe(true)
+      expect(multiSelect._selected.length).toBe(1)
+      expect(multiSelect._selected[0].value).toBe('1')
+    })
+
     it('should navigate options with ArrowDown in options list', () => {
       fixtureEl.innerHTML = '<select></select>'
       const selectEl = fixtureEl.querySelector('select')

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -4453,12 +4453,12 @@ describe('MultiSelect', () => {
       expect(multiSelect._togglerElement.getAttribute('aria-disabled')).toBeNull()
     })
 
-    it('should set aria-owns referencing listbox id', () => {
+    it('should set aria-controls referencing listbox id', () => {
       fixtureEl.innerHTML = '<select id="test-select"></select>'
       const selectEl = fixtureEl.querySelector('select')
       const multiSelect = new MultiSelect(selectEl, { options: [] })
 
-      expect(multiSelect._togglerElement.getAttribute('aria-owns')).toBe('test-select-listbox')
+      expect(multiSelect._togglerElement.getAttribute('aria-controls')).toBe('test-select-listbox')
     })
 
     it('should set listbox role on the options element', () => {


### PR DESCRIPTION
## Summary

Accessibility improvements for the MultiSelect listbox/combobox. Stacked on #570 (native validation) — base branch is `feat/multi-select-native-validation`; retarget to `main` once #570 merges.

## Changes
- **`aria-selected` from the start** — options expose `aria-selected="true|false"` at creation, not only after a select/deselect.
- **`aria-disabled`** on the combobox toggler when `disabled: true`.
- **Live regions** — `role="status"` on the "no results" message and `aria-live="polite"` on the selection container, so filtering-empty and selection/counter changes are announced.
- **Space activates an option** in the listbox (alongside Enter), with default scroll prevented.
- **`aria-controls`** instead of `aria-owns` for the combobox→listbox relationship.
- **Search input labeling** — adds the `ariaSearchLabel` option (default `'Search'`) as `aria-label`, plus `aria-autocomplete="list"` and `aria-controls`. The `combobox` role stays on the toggler, which is always present (there is no input when search is disabled).

## Notes
- Build artifacts (`dist/`, `js/dist/`) intentionally not committed.
- Tests: 2908 passing; lint/stylelint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
