### PR TITLE
fix(MultiSelect): refresh native multiple/required on update()

### DIFF
--- a/js/src/multi-select.js
+++ b/js/src/multi-select.js
@@ -347,6 +347,7 @@ class MultiSelect extends BaseComponent {
     this._wrapperElement.before(this._element)
     this._wrapperElement.remove()
     this._element.innerHTML = ''
+    this._configureNativeSelect()
     this._createNativeOptions(this._element, this._options)
     this._createSelect()
     this._addEventListeners()
@@ -661,12 +662,17 @@ class MultiSelect extends BaseComponent {
   _configureNativeSelect() {
     this._element.classList.add(CLASS_NAME_SELECT)
 
+    // Set or clear so update() can flip these on or off.
     if (this._config.multiple) {
       this._element.setAttribute('multiple', true)
+    } else {
+      this._element.removeAttribute('multiple')
     }
 
     if (this._config.required) {
       this._element.setAttribute('required', true)
+    } else {
+      this._element.removeAttribute('required')
     }
   }
 

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -3546,6 +3546,29 @@ describe('MultiSelect', () => {
       expect(multiSelect._options[0].value).toBe('new1')
     })
 
+    it('should refresh multiple and required on the native select', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [{ value: '1', text: 'Option 1' }],
+        multiple: true,
+        required: true
+      })
+
+      expect(selectEl.getAttribute('multiple')).toBe('true')
+      expect(selectEl.getAttribute('required')).toBe('true')
+
+      multiSelect.update({ multiple: false, required: false })
+
+      expect(selectEl.hasAttribute('multiple')).toBe(false)
+      expect(selectEl.hasAttribute('required')).toBe(false)
+
+      multiSelect.update({ multiple: true, required: true })
+
+      expect(selectEl.getAttribute('multiple')).toBe('true')
+      expect(selectEl.getAttribute('required')).toBe('true')
+    })
+
     it('should deselect all when value is provided in update config', () => {
       fixtureEl.innerHTML = '<select></select>'
       const selectEl = fixtureEl.querySelector('select')


### PR DESCRIPTION
## Summary

`update()` rebuilt the component but never re-ran `_configureNativeSelect()`, so changing `multiple` or `required` through `update(config)` left the native `<select>`'s attributes stale (e.g. updating `multiple: false` kept the `multiple` attribute).

## Changes
- Call `_configureNativeSelect()` during `update()`.
- Make `_configureNativeSelect()` set **and** clear `multiple`/`required` (it only added them before), so the flip works in both directions.

## Notes
- Build artifacts (`dist/`, `js/dist/`) intentionally not committed.
- Tests: 2909 passing (added a flip-both-ways update test); lint/stylelint clean.
