### PR TITLE
refactor(MultiSelect): reduce duplicated lookups and redundant queries

### DIFF
--- a/js/src/multi-select.js
+++ b/js/src/multi-select.js
@@ -932,9 +932,7 @@ class MultiSelect extends BaseComponent {
         optionDiv.setAttribute('aria-selected', option.selected === true ? 'true' : 'false')
 
         if (typeof this._config.optionsTemplate === 'function') {
-          optionDiv.innerHTML = this._config.sanitize ?
-            sanitizeHtml(this._config.optionsTemplate(option), this._config.allowList, this._config.sanitizeFn) :
-            this._config.optionsTemplate(option)
+          optionDiv.innerHTML = this._maybeSanitize(this._config.optionsTemplate(option))
         } else {
           optionDiv.textContent = option.text
         }
@@ -949,9 +947,7 @@ class MultiSelect extends BaseComponent {
         const optgrouplabel = document.createElement('div')
 
         if (typeof this._config.optionsGroupsTemplate === 'function') {
-          optgrouplabel.innerHTML = this._config.sanitize ?
-            sanitizeHtml(this._config.optionsGroupsTemplate(option), this._config.allowList, this._config.sanitizeFn) :
-            this._config.optionsGroupsTemplate(option)
+          optgrouplabel.innerHTML = this._maybeSanitize(this._config.optionsGroupsTemplate(option))
         } else {
           optgrouplabel.textContent = option.label
         }
@@ -1135,6 +1131,12 @@ class MultiSelect extends BaseComponent {
   _getDisplayedItems() {
     return SelectorEngine.find(SELECTOR_VISIBLE_ITEMS, this._menu)
       .filter(element => this._isOptionDisplayed(element))
+  }
+
+  _maybeSanitize(content) {
+    return this._config.sanitize ?
+      sanitizeHtml(content, this._config.allowList, this._config.sanitizeFn) :
+      content
   }
 
   _selectOption(value, text, { refresh = true } = {}) {
@@ -1499,9 +1501,7 @@ class MultiSelect extends BaseComponent {
     if (result instanceof Node) {
       this._headerElement.replaceChildren(result)
     } else {
-      this._headerElement.innerHTML = this._config.sanitize ?
-        sanitizeHtml(result, this._config.allowList, this._config.sanitizeFn) :
-        result
+      this._headerElement.innerHTML = this._maybeSanitize(result)
     }
   }
 

--- a/js/src/multi-select.js
+++ b/js/src/multi-select.js
@@ -368,8 +368,7 @@ class MultiSelect extends BaseComponent {
   }
 
   selectFiltered() {
-    const items = SelectorEngine.find(SELECTOR_VISIBLE_ITEMS, this._menu)
-      .filter(element => this._isOptionDisplayed(element))
+    const items = this._getDisplayedItems()
 
     let limitReached = false
     for (const item of items) {
@@ -393,8 +392,7 @@ class MultiSelect extends BaseComponent {
   }
 
   deselectFiltered() {
-    const items = SelectorEngine.find(SELECTOR_VISIBLE_ITEMS, this._menu)
-      .filter(element => this._isOptionDisplayed(element))
+    const items = this._getDisplayedItems()
 
     for (const item of items) {
       const value = String(item.dataset.value)
@@ -933,7 +931,7 @@ class MultiSelect extends BaseComponent {
         optionDiv.setAttribute('role', 'option')
         optionDiv.setAttribute('aria-selected', option.selected === true ? 'true' : 'false')
 
-        if (this._config.optionsTemplate && typeof this._config.optionsTemplate === 'function') {
+        if (typeof this._config.optionsTemplate === 'function') {
           optionDiv.innerHTML = this._config.sanitize ?
             sanitizeHtml(this._config.optionsTemplate(option), this._config.allowList, this._config.sanitizeFn) :
             this._config.optionsTemplate(option)
@@ -950,7 +948,7 @@ class MultiSelect extends BaseComponent {
 
         const optgrouplabel = document.createElement('div')
 
-        if (this._config.optionsGroupsTemplate && typeof this._config.optionsGroupsTemplate === 'function') {
+        if (typeof this._config.optionsGroupsTemplate === 'function') {
           optgrouplabel.innerHTML = this._config.sanitize ?
             sanitizeHtml(this._config.optionsGroupsTemplate(option), this._config.allowList, this._config.sanitizeFn) :
             this._config.optionsGroupsTemplate(option)
@@ -1126,6 +1124,19 @@ class MultiSelect extends BaseComponent {
     }
   }
 
+  _getNativeOption(value) {
+    return SelectorEngine.findOne(`option[value="${CSS.escape(value)}"]`, this._element)
+  }
+
+  _getOptionElement(value) {
+    return SelectorEngine.findOne(`[data-value="${CSS.escape(value)}"]`, this._optionsElement)
+  }
+
+  _getDisplayedItems() {
+    return SelectorEngine.find(SELECTOR_VISIBLE_ITEMS, this._menu)
+      .filter(element => this._isOptionDisplayed(element))
+  }
+
   _selectOption(value, text, { refresh = true } = {}) {
     if (!this._config.multiple) {
       this.deselectAll()
@@ -1145,13 +1156,13 @@ class MultiSelect extends BaseComponent {
       })
     }
 
-    const nativeOption = SelectorEngine.findOne(`option[value="${CSS.escape(value)}"]`, this._element)
+    const nativeOption = this._getNativeOption(value)
 
     if (nativeOption) {
       nativeOption.selected = true
     }
 
-    const option = SelectorEngine.findOne(`[data-value="${CSS.escape(value)}"]`, this._optionsElement)
+    const option = this._getOptionElement(value)
     if (option) {
       option.classList.add(CLASS_NAME_SELECTED)
       option.setAttribute('aria-selected', 'true')
@@ -1172,12 +1183,12 @@ class MultiSelect extends BaseComponent {
   _deselectOption(value, { refresh = true } = {}) {
     this._selected = this._selected.filter(option => option.value !== String(value))
 
-    const nativeOption = SelectorEngine.findOne(`option[value="${CSS.escape(value)}"]`, this._element)
+    const nativeOption = this._getNativeOption(value)
     if (nativeOption) {
       nativeOption.selected = false
     }
 
-    const option = SelectorEngine.findOne(`[data-value="${CSS.escape(value)}"]`, this._optionsElement)
+    const option = this._getOptionElement(value)
     if (option) {
       option.classList.remove(CLASS_NAME_SELECTED)
       option.setAttribute('aria-selected', 'false')
@@ -1575,23 +1586,23 @@ class MultiSelect extends BaseComponent {
     this._updateHeader()
     this._updateMasterCheckbox()
 
+    const emptyMessage = SelectorEngine.findOne(SELECTOR_OPTIONS_EMPTY, this._menu)
+
     if (visibleOptions > 0) {
-      if (SelectorEngine.findOne(SELECTOR_OPTIONS_EMPTY, this._menu)) {
-        SelectorEngine.findOne(SELECTOR_OPTIONS_EMPTY, this._menu).remove()
+      if (emptyMessage) {
+        emptyMessage.remove()
       }
 
       return
     }
 
-    if (visibleOptions === 0) {
+    if (visibleOptions === 0 && !emptyMessage) {
       const placeholder = document.createElement('div')
       placeholder.classList.add(CLASS_NAME_OPTIONS_EMPTY)
       placeholder.setAttribute('role', 'status')
       placeholder.textContent = this._config.searchNoResultsLabel
 
-      if (!SelectorEngine.findOne(SELECTOR_OPTIONS_EMPTY, this._menu)) {
-        SelectorEngine.findOne(SELECTOR_OPTIONS, this._menu).append(placeholder)
-      }
+      SelectorEngine.findOne(SELECTOR_OPTIONS, this._menu).append(placeholder)
     }
   }
 


### PR DESCRIPTION
## Summary

Pure cleanup of the MultiSelect source — no behavior change, covered by the existing unit tests.

## Changes
- Add `_getNativeOption(value)` / `_getOptionElement(value)` for the value lookups duplicated across `_selectOption` and `_deselectOption`.
- Add `_getDisplayedItems()` for the shared "find visible items + filter by display" query in `selectFiltered` / `deselectFiltered`.
- Cache the single `SELECTOR_OPTIONS_EMPTY` lookup in `_filterOptionsList` instead of re-querying it up to three times.
- Drop the redundant `xTemplate &&` guard before the `typeof === 'function'` checks (the config type is already `function|null`, matching how `headerTemplate` is checked).

## Notes
- Build artifacts (`dist/`, `js/dist/`) intentionally not committed.
- Tests: 2909 passing; lint/stylelint clean.
