### PR TITLE
refactor(MultiSelect): unify group detection with _isOptionGroup

### DIFF
--- a/js/src/multi-select.js
+++ b/js/src/multi-select.js
@@ -575,7 +575,7 @@ class MultiSelect extends BaseComponent {
   _getOptionsFromConfig(options = this._config.options) {
     const _options = []
     for (const option of options) {
-      if (option.options && Array.isArray(option.options)) {
+      if (this._isOptionGroup(option)) {
         const customGroupProperties = { ...option }
 
         delete customGroupProperties.label
@@ -676,7 +676,12 @@ class MultiSelect extends BaseComponent {
 
   _createNativeOptions(parentElement, options) {
     for (const option of options) {
-      if ((typeof option.options === 'undefined')) {
+      if (this._isOptionGroup(option)) {
+        const optgroup = document.createElement('optgroup')
+        optgroup.label = option.label
+        this._createNativeOptions(optgroup, option.options)
+        parentElement.append(optgroup)
+      } else {
         const opt = document.createElement('OPTION')
         opt.value = option.value
 
@@ -690,11 +695,6 @@ class MultiSelect extends BaseComponent {
 
         opt.textContent = option.text
         parentElement.append(opt)
-      } else {
-        const optgroup = document.createElement('optgroup')
-        optgroup.label = option.label
-        this._createNativeOptions(optgroup, option.options)
-        parentElement.append(optgroup)
       }
     }
   }
@@ -914,7 +914,7 @@ class MultiSelect extends BaseComponent {
 
   _createOptions(parentElement, options) {
     for (const option of options) {
-      if (typeof option.value !== 'undefined') {
+      if (!this._isOptionGroup(option)) {
         const optionDiv = document.createElement('div')
         optionDiv.classList.add(CLASS_NAME_OPTION)
 
@@ -940,7 +940,7 @@ class MultiSelect extends BaseComponent {
         parentElement.append(optionDiv)
       }
 
-      if (typeof option.label !== 'undefined') {
+      if (this._isOptionGroup(option)) {
         const optgroup = document.createElement('div')
         optgroup.classList.add(CLASS_NAME_OPTGROUP)
 
@@ -1070,7 +1070,7 @@ class MultiSelect extends BaseComponent {
         return option
       }
 
-      if (option.options && Array.isArray(option.options)) {
+      if (this._isOptionGroup(option)) {
         const found = this._findOptionByValue(value, option.options)
         if (found) {
           return found
@@ -1087,7 +1087,7 @@ class MultiSelect extends BaseComponent {
         continue
       }
 
-      if (option.label) {
+      if (this._isOptionGroup(option)) {
         if (this._selectAllOptions(option.options)) {
           return true
         }
@@ -1111,7 +1111,7 @@ class MultiSelect extends BaseComponent {
         continue
       }
 
-      if (option.label) {
+      if (this._isOptionGroup(option)) {
         this._deselectAllOptions(option.options)
         continue
       }
@@ -1137,6 +1137,10 @@ class MultiSelect extends BaseComponent {
     return this._config.sanitize ?
       sanitizeHtml(content, this._config.allowList, this._config.sanitizeFn) :
       content
+  }
+
+  _isOptionGroup(option) {
+    return Array.isArray(option.options)
   }
 
   _selectOption(value, text, { refresh = true } = {}) {

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -3881,6 +3881,18 @@ describe('MultiSelect', () => {
     })
   })
 
+  describe('_isOptionGroup', () => {
+    it('should detect groups by their options array', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, { options: [] })
+
+      expect(multiSelect._isOptionGroup({ label: 'Group', options: [] })).toBe(true)
+      expect(multiSelect._isOptionGroup({ value: '1', text: 'Opt' })).toBe(false)
+      expect(multiSelect._isOptionGroup({ label: 'No options array' })).toBe(false)
+    })
+  })
+
   describe('_findOptionByValue', () => {
     it('should find option by value', () => {
       fixtureEl.innerHTML = '<select></select>'


### PR DESCRIPTION
## Summary

Pure refactor — unify how the option tree distinguishes a group from an option. No behavior change for valid data, covered by the existing group tests.

## Changes
Group-vs-option was detected three different ways across the walkers:
- `option.options && Array.isArray(option.options)`
- `option.label` / `typeof option.label !== 'undefined'`
- inverses like `typeof option.options === 'undefined'` / `typeof option.value !== 'undefined'`

Replace all seven sites with a single `_isOptionGroup(option)` predicate (`Array.isArray(option.options)`). A group always carries both `label` and an `options` array, so this is equivalent for valid data — and slightly safer in `_selectAllOptions` / `_deselectAllOptions`, which now confirm the array before recursing. `_createNativeOptions` flips its if/else so the group is the positive branch.

## Notes
- Build artifacts (`dist/`, `js/dist/`) intentionally not committed.
- Tests: 2910 passing (added a `_isOptionGroup` unit test); lint/stylelint clean.
