### PR TITLE
refactor(MultiSelect): rename _updateOptionsList to _selectInitialOptions

### DIFF
--- a/js/src/multi-select.js
+++ b/js/src/multi-select.js
@@ -735,7 +735,7 @@ class MultiSelect extends BaseComponent {
 
     this._createOptionsContainer()
     this._hideNativeSelect()
-    this._updateOptionsList()
+    this._selectInitialOptions()
   }
 
   _createSelection() {
@@ -1263,7 +1263,7 @@ class MultiSelect extends BaseComponent {
     }
   }
 
-  _updateOptionsList() {
+  _selectInitialOptions() {
     // `_selected` is already fully populated by `_getOptions()` before this runs,
     // so iterate it directly (no tree walk) and batch the DOM refresh into one call.
     for (const option of this._selected) {


### PR DESCRIPTION
## Summary

Rename `_updateOptionsList()` to `_selectInitialOptions()`. The method selects the preselected options once at init and refreshes — it does not update or filter the options list (`_filterOptionsList` does that), so the old name was misleading. Internal-only method, single call site. No behavior change.

## Notes
- Tests: 2910 passing; lint/stylelint clean.
