### PR TITLE
fix(Autocomplete): select the clicked option with allowOnlyDefinedOptions

### DIFF
--- a/js/src/autocomplete.js
+++ b/js/src/autocomplete.js
@@ -48,6 +48,7 @@ const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_INPUT = `input${EVENT_KEY}`
 const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
 const EVENT_KEYUP = `keyup${EVENT_KEY}`
+const EVENT_MOUSEDOWN = `mousedown${EVENT_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
@@ -477,6 +478,12 @@ class Autocomplete extends BaseComponent {
           this._triggerChangeEvent(null)
         }
       }
+    })
+
+    EventHandler.on(this._optionsElement, EVENT_MOUSEDOWN, event => {
+      // Keep focus on the input so its blur handler doesn't clear the search
+      // (and re-render the list) before the click selects the option.
+      event.preventDefault()
     })
 
     EventHandler.on(this._optionsElement, EVENT_CLICK, event => {

--- a/js/tests/unit/autocomplete.spec.js
+++ b/js/tests/unit/autocomplete.spec.js
@@ -2202,6 +2202,71 @@ describe('Autocomplete', () => {
       expect(autocomplete._inputElement.value).toBe('')
     })
 
+    it('should prevent default on options mousedown so clicking a filtered option keeps focus', () => {
+      // Regression test for #484: clicking a filtered option must not be hijacked by
+      // the input blur clearing the search and re-rendering the full list. The fix
+      // prevents the option mousedown from blurring the input.
+      fixtureEl.innerHTML = '<div class="autocomplete"></div>'
+      const autocompleteEl = fixtureEl.querySelector('.autocomplete')
+      const autocomplete = new Autocomplete(autocompleteEl, {
+        allowOnlyDefinedOptions: true,
+        options: [
+          { label: 'Angular', value: 'angular' },
+          { label: 'Vue.js', value: 'vue' }
+        ]
+      })
+
+      autocomplete.show()
+      autocomplete._inputElement.value = 'vue'
+      autocomplete._search = 'vue'
+      autocomplete._filterOptionsList()
+
+      const visibleOption = Array.from(autocomplete._optionsElement.querySelectorAll('.autocomplete-option'))
+        .find(option => option.style.display !== 'none')
+      expect(visibleOption.textContent).toBe('Vue.js')
+
+      const mousedown = createEvent('mousedown', { bubbles: true, cancelable: true })
+      visibleOption.dispatchEvent(mousedown)
+
+      expect(mousedown.defaultPrevented).toBe(true)
+    })
+
+    it('should select the clicked option after filtering with allowOnlyDefinedOptions', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div class="autocomplete"></div>'
+        const autocompleteEl = fixtureEl.querySelector('.autocomplete')
+        const autocomplete = new Autocomplete(autocompleteEl, {
+          allowOnlyDefinedOptions: true,
+          options: [
+            { label: 'Angular', value: 'angular' },
+            { label: 'Vue.js', value: 'vue' }
+          ]
+        })
+
+        autocomplete.show()
+        autocomplete._inputElement.value = 'vue'
+        autocomplete._search = 'vue'
+        autocomplete._filterOptionsList()
+
+        const visibleOption = Array.from(autocomplete._optionsElement.querySelectorAll('.autocomplete-option'))
+          .find(option => option.style.display !== 'none')
+
+        autocompleteEl.addEventListener('changed.coreui.autocomplete', event => {
+          expect(event.value.label).toBe('Vue.js')
+          resolve()
+        })
+
+        // Model the real browser ordering: mousedown -> (blur unless prevented) -> click.
+        const mousedown = createEvent('mousedown', { bubbles: true, cancelable: true })
+        visibleOption.dispatchEvent(mousedown)
+        if (!mousedown.defaultPrevented) {
+          autocomplete._inputElement.dispatchEvent(createEvent('blur'))
+        }
+
+        visibleOption.dispatchEvent(createEvent('click', { bubbles: true }))
+      })
+    })
+
     it('should not clear on blur when there is exactly one case-insensitive match', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<div class="autocomplete"></div>'


### PR DESCRIPTION
## Summary

With `allowOnlyDefinedOptions`, clicking a filtered option failed to select it — the field ended up empty. Reproduced on the live docs "restricted selection" example: type `vue` to filter down to **Vue.js**, click it, and the input clears instead of selecting Vue.js.

## Root cause

Clicking an option first **blurs the input** (mousedown → blur → click). Under `allowOnlyDefinedOptions` the blur handler calls `clear()`, which empties the search and re-shows the full options list via `_filterOptionsList()`. The previously-hidden options reappear above the target, so by mouseup/click the pointer is no longer over the intended option and the selection misses — leaving the field empty.

## Fix

Add a `mousedown` listener on the options container that calls `preventDefault()`, so clicking an option no longer blurs the input. The search/filter state is preserved until the click selects the intended option. Outside clicks still clear as before.

## Tests

Two regression tests in `js/tests/unit/autocomplete.spec.js`:
- the options `mousedown` is default-prevented;
- after filtering to one option with `allowOnlyDefinedOptions`, clicking it selects that option (models the real mousedown → blur → click ordering).

Full Karma suite passes (2971).

Reported in coreui/coreui-react#484.