### PR TITLE
fix(time-picker): label hour column by picker mode, not locale default

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "./dist/js/coreui.bundle.js",
-      "maxSize": "108.00 kB"
+      "maxSize": "108.25 kB"
     },
     {
       "path": "./dist/js/coreui.bundle.min.js",
@@ -42,7 +42,7 @@
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "92.50 kB"
+      "maxSize": "92.75 kB"
     },
     {
       "path": "./dist/js/coreui.esm.min.js",

--- a/js/src/util/time.js
+++ b/js/src/util/time.js
@@ -58,16 +58,21 @@ export const getAmPm = (date, locale) => {
  * @param {number[]} values An array of time values to format.
  * @param {string} locale The locale to use for formatting.
  * @param {('hour' | 'minute' | 'second')} partial The type of time value to format.
+ * @param {boolean} [hour12] Whether the hour labels should use the 12-hour cycle. When omitted the formatter falls back to the locale's default cycle.
  * @returns {Array} An array of objects with the original value and its localized label.
  */
-export const formatTimePartials = (values, locale, partial) => {
+export const formatTimePartials = (values, locale, partial, hour12) => {
   const date = new Date()
 
   const forceTwoDigit = shouldUseTwoDigitHour(locale)
+  // `hour12: false` lets ICU pick either h23 (00–23) or h24 (01–24), so older
+  // engines label midnight as "24"; pin the cycle explicitly to stay stable.
+  const hourCycle = hour12 === undefined ? undefined : (hour12 ? 'h12' : 'h23')
   const formatter = new Intl.DateTimeFormat(locale, {
     hour: forceTwoDigit ? '2-digit' : 'numeric',
     minute: '2-digit',
-    second: '2-digit'
+    second: '2-digit',
+    hourCycle
   })
 
   return values.map(value => {
@@ -138,7 +143,7 @@ export const getLocalizedTimePartials = (
         Array.from({ length: 60 }, (_, i) => i))
 
   return {
-    listOfHours: formatTimePartials(listOfHours, locale, 'hour'),
+    listOfHours: formatTimePartials(listOfHours, locale, 'hour', hour12),
     listOfMinutes: formatTimePartials(listOfMinutes, locale, 'minute'),
     listOfSeconds: formatTimePartials(listOfSeconds, locale, 'second'),
     hour12

--- a/js/tests/unit/util/time.spec.js
+++ b/js/tests/unit/util/time.spec.js
@@ -133,6 +133,17 @@ describe('Time Utilities', () => {
       expect(listOfHours[23].value).toBe(23)
     })
 
+    it('should label a 24-hour picker with 24-hour hours (00…23) in a 12-hour locale', () => {
+      // en-CA defaults to a 12-hour cycle, so without pinning the hour cycle a
+      // 24-hour picker rendered duplicated 12-hour labels (12,01,…,11,12,01,…)
+      // and older ICU labelled midnight "24".
+      const { listOfHours } = getLocalizedTimePartials('en-CA', false)
+      const labels = listOfHours.map(({ label }) => label)
+      expect(labels).toContain('00')
+      expect(labels).toContain('13')
+      expect(labels).toContain('23')
+    })
+
     it('should filter hours if a function is passed', () => {
       // For example, only even hours in 24-hour format
       const hoursFn = hour => hour % 2 === 0


### PR DESCRIPTION
`formatTimePartials` formatted the hour labels with the locale's **default** hour cycle, ignoring the picker's own 12/24-hour mode. Consequences:

- **24-hour picker in a 12-hour-default locale** (en-US, en-CA, …): the hour column showed duplicated 12-hour labels — `12,01,02,…,11,12,01,02,…,11` — instead of `00…23`. The underlying values were correct (0–23) but the visible labels were ambiguous (you couldn't tell 1:00 from 13:00).
- **Older ICU engines** (e.g. Node 20): midnight in a 24-hour picker was labelled `24` instead of `00`, because `hour12: false` leaves ICU free to pick the h24 cycle.

## Fix
Thread the picker's hour mode (`hour12`) into `formatTimePartials` and pin an explicit `hourCycle` — `h23` for 24-hour, `h12` for 12-hour — so the labels follow the picker mode on every engine. When `hour12` is omitted the formatter still falls back to the locale default (unchanged behaviour for minute/second partials).

## Test
Added a regression test in `util/time.spec.js`: a 24-hour picker in `en-CA` (a 12-hour-default locale) now labels hours `00…23` (asserts `00`, `13`, `23`). The existing tests only checked the numeric values, which is why the label bug went unnoticed.

Verified against the real module: `en-CA` 24h → `00,01,…,23`; `en-US` 12h → `1,…,12` (no `13`).