### PR TITLE
docs: use flex rows with spacing for toggle button examples

### DIFF
--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -192,27 +192,27 @@ Visually, these toggle buttons are identical to the [checkbox toggle buttons](/f
 
 Add `data-coreui-toggle="button"` to toggle a button's `active` state. If you're pre-toggling a button, you must manually add the `.active` class **and** `aria-pressed="true"` to the `<button>`.
 
-<Example code={`<p class="d-inline-flex gap-1">
+<Example code={`<div class="d-flex gap-1 mb-3">
     <button type="button" class="btn" data-coreui-toggle="button">Toggle button</button>
     <button type="button" class="btn active" data-coreui-toggle="button" aria-pressed="true">Active toggle button</button>
     <button type="button" class="btn" disabled data-coreui-toggle="button">Disabled toggle button</button>
-  </p>
-  <p class="d-inline-flex gap-1">
+  </div>
+  <div class="d-flex gap-1">
     <button type="button" class="btn btn-primary" data-coreui-toggle="button">Toggle button</button>
     <button type="button" class="btn btn-primary active" data-coreui-toggle="button" aria-pressed="true">Active toggle button</button>
     <button type="button" class="btn btn-primary" disabled data-coreui-toggle="button">Disabled toggle button</button>
-  </p>`} />
+  </div>`} />
 
-<Example code={`<p class="d-inline-flex gap-1">
+<Example code={`<div class="d-flex gap-1 mb-3">
     <a href="#" class="btn" role="button" data-coreui-toggle="button">Toggle link</a>
     <a href="#" class="btn active" role="button" data-coreui-toggle="button" aria-pressed="true">Active toggle link</a>
     <a class="btn disabled" aria-disabled="true" role="button" data-coreui-toggle="button">Disabled toggle link</a>
-  </p>
-  <p class="d-inline-flex gap-1">
+  </div>
+  <div class="d-flex gap-1">
     <a href="#" class="btn btn-primary" role="button" data-coreui-toggle="button">Toggle link</a>
     <a href="#" class="btn btn-primary active" role="button" data-coreui-toggle="button" aria-pressed="true">Active toggle link</a>
     <a class="btn btn-primary disabled" aria-disabled="true" role="button" data-coreui-toggle="button">Disabled toggle link</a>
-  </p>`} />
+  </div>`} />
 
 ### Methods
 


### PR DESCRIPTION
Port of coreui #1107.

The "Toggle states" examples on the Buttons page wrapped each row in `<p class="d-inline-flex gap-1">`. Switch to `<div class="d-flex gap-1">` and add `mb-3` to the first row so the two rows are spaced consistently with the rest of the docs. Markup/behavior of the toggle buttons themselves is unchanged.