### PR TITLE
chore(docs): bump @coreui/astro-docs to 0.1.0-beta.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@astrojs/mdx": "^6.0.3",
         "@babel/core": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
-        "@coreui/astro-docs": "^0.1.0-beta.10",
+        "@coreui/astro-docs": "^0.1.0-beta.11",
         "@eslint/markdown": "^7.5.1",
         "@popperjs/core": "^2.11.8",
         "@rollup/plugin-babel": "^7.1.0",
@@ -1885,9 +1885,9 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.0-beta.10.tgz",
-      "integrity": "sha512-PcelygXXNWq8el5SPG5mSOUzzoShQ9lqdvah63nbuNtbidm2C8rEo3uT1wtde5fSCoEuxBCrmGgtp4Yh5JNk6Q==",
+      "version": "0.1.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.0-beta.11.tgz",
+      "integrity": "sha512-ZqHvHDVzbpulQHQB5igfYW+skXcFUlN9j6D+n5jITVkZ4Rl4FU8EgzQK6zlp+aAXiS22zhXfFLMc2W4KvKOQTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@astrojs/mdx": "^6.0.3",
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
-    "@coreui/astro-docs": "^0.1.0-beta.10",
+    "@coreui/astro-docs": "^0.1.0-beta.11",
     "@eslint/markdown": "^7.5.1",
     "@popperjs/core": "^2.11.8",
     "@rollup/plugin-babel": "^7.1.0",


### PR DESCRIPTION
Bumps the shared docs engine `@coreui/astro-docs` `0.1.0-beta.10` → `0.1.0-beta.11`, which adds the prerendered `/api.json` route. After deploy, `…/docs/api.json` exposes every component's structured API (props/events/slots), consumed by the `@coreui/docs-mcp` server.