### PR TITLE
fix(Autocomplete): escape option labels in highlight to prevent XSS

### DIFF
--- a/js/src/autocomplete.js
+++ b/js/src/autocomplete.js
@@ -10,7 +10,7 @@ import BaseComponent from './base-component.js'
 import Data from './dom/data.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { DefaultAllowlist, sanitizeHtml } from './util/sanitizer.js'
+import { DefaultAllowlist, escapeHtml, sanitizeHtml } from './util/sanitizer.js'
 import {
   defineJQueryPlugin,
   getNextActiveElement,
@@ -320,8 +320,16 @@ class Autocomplete extends BaseComponent {
   }
 
   _highlightOption(label) {
-    const regex = new RegExp(this._search, 'gi')
-    return label.replace(regex, string => `<strong>${string}</strong>`)
+    if (!this._search) {
+      return escapeHtml(label)
+    }
+
+    const escapedSearch = this._search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const regex = new RegExp(`(${escapedSearch})`, 'gi')
+    return String(label)
+      .split(regex)
+      .map((part, index) => (index % 2 === 0 ? escapeHtml(part) : `<strong>${escapeHtml(part)}</strong>`))
+      .join('')
   }
 
   _isExternalSearch() {

--- a/js/tests/unit/autocomplete.spec.js
+++ b/js/tests/unit/autocomplete.spec.js
@@ -894,6 +894,37 @@ describe('Autocomplete', () => {
 
       expect(highlighted).toBe('<strong>O</strong>pti<strong>o</strong>n <strong>O</strong>ne')
     })
+
+    it('should escape HTML in the label to prevent XSS', () => {
+      fixtureEl.innerHTML = '<div class="autocomplete"></div>'
+      const autocompleteEl = fixtureEl.querySelector('.autocomplete')
+      const autocomplete = new Autocomplete(autocompleteEl, { options: [] })
+
+      autocomplete._search = 'img'
+      const highlighted = autocomplete._highlightOption('<img src=x onerror=alert(1)> img')
+
+      expect(highlighted).not.toContain('<img')
+      expect(highlighted).toBe('&lt;<strong>img</strong> src=x onerror=alert(1)&gt; <strong>img</strong>')
+    })
+
+    it('should not throw on regex-special characters in the search', () => {
+      fixtureEl.innerHTML = '<div class="autocomplete"></div>'
+      const autocompleteEl = fixtureEl.querySelector('.autocomplete')
+      const autocomplete = new Autocomplete(autocompleteEl, { options: [] })
+
+      autocomplete._search = '('
+      expect(() => autocomplete._highlightOption('a (b) c')).not.toThrow()
+      expect(autocomplete._highlightOption('a (b) c')).toBe('a <strong>(</strong>b) c')
+    })
+
+    it('should return the escaped label when the search is empty', () => {
+      fixtureEl.innerHTML = '<div class="autocomplete"></div>'
+      const autocompleteEl = fixtureEl.querySelector('.autocomplete')
+      const autocomplete = new Autocomplete(autocompleteEl, { options: [] })
+
+      autocomplete._search = ''
+      expect(autocomplete._highlightOption('<b>x</b>')).toBe('&lt;b&gt;x&lt;/b&gt;')
+    })
   })
 
   describe('_isExternalSearch', () => {


### PR DESCRIPTION
## Security fix — Autocomplete highlight XSS + regex injection

Option labels rendered by `highlightOptionsOnSearch` were wrapped in `<strong>` and written to `innerHTML` **without escaping**. With external search, options come from API data, so a label such as `<img src=x onerror=…>` executed — bypassing the `sanitize: true` default.

The highlight regex was also built directly from the raw search string, so characters like `(` or `[` threw a `SyntaxError` (broken render) and crafted input enabled catastrophic backtracking (ReDoS).

### Fix
- Escape the search string before building the `RegExp`.
- HTML-escape every label segment before wrapping matches in `<strong>` (split-on-match so highlighting still works and ampersands stay readable).

Regression tests added.