### PR TITLE
fix(Rating,RangeSlider,Calendar,DateRangePicker): close sanitize bypass via data attributes

### DIFF
--- a/js/src/calendar.js
+++ b/js/src/calendar.js
@@ -1071,7 +1071,7 @@ class Calendar extends BaseComponent {
       ...dataAttributes,
       ...(typeof config === 'object' && config ? config : {})
     }
-    config = this._mergeConfigObj(config, this._element)
+    config = this._mergeConfigObj(config)
     config = this._configAfterMerge(config)
     this._typeCheckConfig(config)
 

--- a/js/src/date-range-picker.js
+++ b/js/src/date-range-picker.js
@@ -1078,7 +1078,7 @@ class DateRangePicker extends BaseComponent {
       ...dataAttributes,
       ...(typeof config === 'object' && config ? config : {})
     }
-    config = this._mergeConfigObj(config, this._element)
+    config = this._mergeConfigObj(config)
     config = this._configAfterMerge(config)
     this._typeCheckConfig(config)
 

--- a/js/src/range-slider.js
+++ b/js/src/range-slider.js
@@ -615,7 +615,7 @@ class RangeSlider extends BaseComponent {
       ...dataAttributes,
       ...(typeof config === 'object' && config ? config : {})
     }
-    config = this._mergeConfigObj(config, this._element)
+    config = this._mergeConfigObj(config)
     config = this._configAfterMerge(config)
     this._typeCheckConfig(config)
 

--- a/js/src/rating.js
+++ b/js/src/rating.js
@@ -470,7 +470,7 @@ class Rating extends BaseComponent {
       ...dataAttributes,
       ...(typeof config === 'object' && config ? config : {})
     }
-    config = this._mergeConfigObj(config, this._element)
+    config = this._mergeConfigObj(config)
     config = this._configAfterMerge(config)
     this._typeCheckConfig(config)
 

--- a/js/tests/unit/rating.spec.js
+++ b/js/tests/unit/rating.spec.js
@@ -1484,4 +1484,25 @@ describe('Rating', () => {
       expect(div.querySelectorAll('.rating-item-label.active')).toHaveSize(3)
     })
   })
+
+  describe('sanitize', () => {
+    it('should strip event-handler attributes from a custom icon', () => {
+      fixtureEl.innerHTML = '<div></div>'
+      const div = fixtureEl.querySelector('div')
+      // eslint-disable-next-line no-new
+      new Rating(div, { readOnly: true, value: 1, icon: '<img src=x onerror="window.xss = true">' })
+
+      const icon = div.querySelector('.rating-item-custom-icon img')
+      expect(icon.hasAttribute('onerror')).toBeFalse()
+    })
+
+    it('should not disable sanitization via a data attribute', () => {
+      fixtureEl.innerHTML = '<div data-coreui-sanitize="false" data-coreui-read-only="true" data-coreui-value="1" data-coreui-icon="<img src=x onerror=alert(1)>"></div>'
+      const div = fixtureEl.querySelector('div')
+      const rating = new Rating(div)
+
+      expect(rating._config.sanitize).toBeTrue()
+      expect(div.querySelector('.rating-item-custom-icon img').hasAttribute('onerror')).toBeFalse()
+    })
+  })
 })


### PR DESCRIPTION
## Security fix — sanitize bypass via data attributes

`Rating`, `RangeSlider`, `Calendar` and `DateRangePicker` override `_getConfig` to strip `sanitize` / `allowList` / `sanitizeFn` from the element's data attributes — but then call `_mergeConfigObj(config, this._element)`, which re-reads **every** data attribute and re-introduced them. So `data-coreui-sanitize="false"` in markup re-enabled raw HTML injection, defeating the strip.

### Fix
Drop the element from the merge (`_mergeConfigObj(config)`), exactly as `tooltip.js` already does, so the strip sticks. JS-supplied config still overrides normally; no component in the suite relies on `data-coreui-config` here.

Found while fixing the Chip sanitizer (same class of bug, four more components). Regression tests added to `rating.spec.js`.