### PR TITLE
fix(DatePicker): disable the Today button when today's date is disabled

### DIFF
--- a/js/src/date-range-picker.js
+++ b/js/src/date-range-picker.js
@@ -882,6 +882,11 @@ class DateRangePicker extends BaseComponent {
       todayButtonEl.classList.add(...this._getButtonClasses(this._config.todayButtonClasses))
       todayButtonEl.type = 'button'
       todayButtonEl.textContent = this._config.todayButton
+
+      if (isDateDisabled(new Date(), this._config.minDate, this._config.maxDate, this._config.disabledDates)) {
+        todayButtonEl.disabled = true
+      }
+
       todayButtonEl.addEventListener('click', () => {
         const date = new Date()
         this._calendarDate = date

--- a/js/tests/unit/date-range-picker.spec.js
+++ b/js/tests/unit/date-range-picker.spec.js
@@ -832,6 +832,35 @@ describe('DateRangePicker', () => {
       expect(dateRangePicker._endDate.toDateString()).toBe(today.toDateString())
     })
 
+    it('should disable today button when today is a disabled date', () => {
+      fixtureEl.innerHTML = '<div></div>'
+      const div = fixtureEl.querySelector('div')
+      const yesterday = new Date()
+      yesterday.setDate(yesterday.getDate() - 1)
+      const dateRangePicker = new DateRangePicker(div, { // eslint-disable-line no-unused-vars
+        footer: true,
+        todayButton: 'Today',
+        maxDate: yesterday
+      })
+
+      const footer = div.querySelector('.date-picker-footer')
+      const todayBtn = Array.from(footer.querySelectorAll('button')).find(b => b.innerHTML === 'Today')
+      expect(todayBtn.disabled).toBeTrue()
+    })
+
+    it('should not disable today button when today is selectable', () => {
+      fixtureEl.innerHTML = '<div></div>'
+      const div = fixtureEl.querySelector('div')
+      const dateRangePicker = new DateRangePicker(div, { // eslint-disable-line no-unused-vars
+        footer: true,
+        todayButton: 'Today'
+      })
+
+      const footer = div.querySelector('.date-picker-footer')
+      const todayBtn = Array.from(footer.querySelectorAll('button')).find(b => b.innerHTML === 'Today')
+      expect(todayBtn.disabled).toBeFalse()
+    })
+
     it('should not set end date on today click when range is false', () => {
       fixtureEl.innerHTML = '<div></div>'
       const div = fixtureEl.querySelector('div')


### PR DESCRIPTION
## Problem

In the Date Picker, clicking the **Today** button selected today's date even when today was a disabled date (excluded by `minDate`/`maxDate` or `disabledDates`). The disabled-date guard only ran on the text-input path, not on the Today button, so users could pick a disabled date.

## Fix

Disable the Today button when `isDateDisabled(new Date(), minDate, maxDate, disabledDates)` is true — the same check already used on the input path. Applies to both DatePicker and DateRangePicker (they share the footer).

## Tests

Added specs asserting the Today button is disabled when today is out of range and enabled otherwise.

Cross-framework parity: same fix ported to coreui-react-pro and coreui-vue-pro. Angular has no built-in Today button (consumer-supplied footer template), so it is not affected.