### PR TITLE
fix(LoadingButton): allow submit buttons to submit their form

### DIFF
--- a/js/src/loading-button.js
+++ b/js/src/loading-button.js
@@ -171,7 +171,6 @@ class LoadingButton extends BaseComponent {
  */
 
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, event => {
-  event.preventDefault()
   const button = event.target.closest(SELECTOR_DATA_TOGGLE)
   const data = LoadingButton.getOrCreateInstance(button)
 

--- a/js/tests/unit/loading-button.spec.js
+++ b/js/tests/unit/loading-button.spec.js
@@ -444,7 +444,7 @@ describe('LoadingButton', () => {
       })
     })
 
-    it('should prevent default behavior on click', () => {
+    it('should not prevent default behavior on click', () => {
       fixtureEl.innerHTML = '<button data-coreui-toggle="loading-button">Click me</button>'
       const button = fixtureEl.querySelector('[data-coreui-toggle="loading-button"]')
 
@@ -452,7 +452,26 @@ describe('LoadingButton', () => {
       spyOn(clickEvent, 'preventDefault')
       button.dispatchEvent(clickEvent)
 
-      expect(clickEvent.preventDefault).toHaveBeenCalled()
+      expect(clickEvent.preventDefault).not.toHaveBeenCalled()
+    })
+
+    it('should not prevent a submit button from submitting its form', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<form>',
+          '  <button type="submit" data-coreui-toggle="loading-button">Save</button>',
+          '</form>'
+        ].join('')
+        const form = fixtureEl.querySelector('form')
+        const button = fixtureEl.querySelector('[data-coreui-toggle="loading-button"]')
+
+        form.addEventListener('submit', event => {
+          event.preventDefault()
+          resolve()
+        })
+
+        button.click()
+      })
     })
 
     it('should work with nested elements', () => {


### PR DESCRIPTION
The data-api click handler for \`data-coreui-toggle="loading-button"\` called \`event.preventDefault()\`, so a \`<button type="submit" data-coreui-toggle="loading-button">\` inside a \`<form>\` never submitted the form. Adding the loading state should not suppress the button's default action.

## Fix

Remove the \`event.preventDefault()\` from the data-api handler. The loading state still starts on click; the default action (form submit, etc.) now runs as expected.

## Tests

- \`data-api\` › should not prevent default behavior on click (replaces the previous test that asserted the opposite)
- \`data-api\` › should not prevent a submit button from submitting its form

## Parity

Vanilla-only bug — it lives in the \`data-coreui-toggle\` auto-init handler. The React/Vue/Angular \`CLoadingButton\` components do not call \`preventDefault\` (they just invoke the user's \`onClick\`), so submit works there already. No cross-framework port needed.

Closes #546. Original fix by @vladrusu.