### PR TITLE
chore: bump bundlewatch JS thresholds to match current bundle sizes

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,27 +34,27 @@
     },
     {
       "path": "./dist/js/coreui.bundle.js",
-      "maxSize": "108.25 kB"
+      "maxSize": "109.50 kB"
     },
     {
       "path": "./dist/js/coreui.bundle.min.js",
-      "maxSize": "61.75 kB"
+      "maxSize": "62.50 kB"
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "92.75 kB"
+      "maxSize": "94.00 kB"
     },
     {
       "path": "./dist/js/coreui.esm.min.js",
-      "maxSize": "60.85 kB"
+      "maxSize": "61.75 kB"
     },
     {
       "path": "./dist/js/coreui.js",
-      "maxSize": "94.25 kB"
+      "maxSize": "95.50 kB"
     },
     {
       "path": "./dist/js/coreui.min.js",
-      "maxSize": "54.85 kB"
+      "maxSize": "55.50 kB"
     }
   ],
   "ci": {


### PR DESCRIPTION
The six JS bundle entries in \`.bundlewatch.config.json\` were slightly under the current gzipped sizes, so \`bundlewatch\` failed on every PR (e.g. \`coreui.bundle.js\` 108.5KB > 108.25KB). The growth is legitimate — accumulated component features — so the thresholds are raised to sit just above the current sizes with a small headroom:

| Bundle | Current (gzip) | Old max | New max |
| --- | --- | --- | --- |
| \`coreui.bundle.js\` | 108.5KB | 108.25 kB | 109.50 kB |
| \`coreui.bundle.min.js\` | 61.83KB | 61.75 kB | 62.50 kB |
| \`coreui.esm.js\` | 93KB | 92.75 kB | 94.00 kB |
| \`coreui.esm.min.js\` | 60.99KB | 60.85 kB | 61.75 kB |
| \`coreui.js\` | 94.61KB | 94.25 kB | 95.50 kB |
| \`coreui.min.js\` | 54.85KB | 54.85 kB | 55.50 kB |

CSS thresholds are unchanged (still passing). Verified locally with \`npm run dist && npm run bundlewatch\` → \`bundlewatch PASS\`.