### PR TITLE
fix: avoid Array.prototype.at() to support the declared browser range

### DIFF
--- a/js/src/chip-input.js
+++ b/js/src/chip-input.js
@@ -166,7 +166,7 @@ class ChipInput extends ChipSet {
       // direction is mirrored in RTL.
       if (event.key === (isRTL() ? 'ArrowLeft' : 'ArrowRight')) {
         const chips = this._getFocusableChips()
-        if (chips.length > 0 && chips.at(-1).contains(event.target)) {
+        if (chips.length > 0 && chips[chips.length - 1].contains(event.target)) {
           event.preventDefault()
           this._input.focus()
           return
@@ -271,7 +271,7 @@ class ChipInput extends ChipSet {
           const chips = this._getChipElements()
 
           if (chips.length > 0) {
-            chips.at(-1).focus()
+            chips[chips.length - 1].focus()
           }
         }
 
@@ -292,7 +292,7 @@ class ChipInput extends ChipSet {
           const chips = this._getChipElements()
 
           if (chips.length > 0) {
-            chips.at(-1).focus()
+            chips[chips.length - 1].focus()
           }
         }
 
@@ -323,7 +323,7 @@ class ChipInput extends ChipSet {
         this.add(part.trim())
       }
 
-      this._input.value = parts.at(-1)
+      this._input.value = parts[parts.length - 1]
     }
 
     this._setInputSize()

--- a/js/src/chip-set.js
+++ b/js/src/chip-set.js
@@ -428,7 +428,7 @@ class ChipSet extends BaseComponent {
 
   _navigateToEdge(targetIndex) {
     const chips = this._getFocusableChips()
-    chips.at(targetIndex)?.focus()
+    chips[targetIndex < 0 ? chips.length + targetIndex : targetIndex]?.focus()
   }
 
   _handleSelectionChange(event) {

--- a/js/src/util/calendar.js
+++ b/js/src/util/calendar.js
@@ -859,13 +859,13 @@ export const getMonthDetails = (year, month, firstDayOfWeek) => {
 
     if ((index + 1) % 7 === 0) {
       const { weekNumber, year } = getISOWeekNumberAndYear(day.date)
-      const lastWeek = weeks.at(-1)
+      const lastWeek = weeks[weeks.length - 1]
       if (lastWeek) {
         lastWeek.week = { number: weekNumber, year }
       }
     }
 
-    const lastWeek = weeks.at(-1)
+    const lastWeek = weeks[weeks.length - 1]
     if (lastWeek) {
       lastWeek.days.push(day)
     }


### PR DESCRIPTION
Completes #565.

`Array.prototype.at()` requires **Chrome 92 / Safari 15.4 / iOS 15.4**, but the committed `.browserslistrc` declares **Chrome >= 60, Safari >= 12, iOS >= 12**, and the build only transpiles syntax — it does not polyfill (`.babelrc.js` has no `useBuiltIns`). So on the supported older browsers `.at()` is `undefined` and throws.

#565 fixed only the two calendar usages. This replaces **all** `.at()` calls in `js/src`:

- `util/calendar.js` — `weeks.at(-1)` → `weeks[weeks.length - 1]` (×2)
- `chip-input.js` — `chips.at(-1)` / `parts.at(-1)` → index access (×4)
- `chip-set.js` — `chips.at(targetIndex)` → `chips[targetIndex < 0 ? chips.length + targetIndex : targetIndex]` (preserves negative-index semantics; `_navigateToEdge` is called with `0` and `-1`)

Behavior is unchanged; existing chip/calendar suites pass (2994). Original calendar fix by @vladrusu (#565).