### PR TITLE
chore: ban Array/String.prototype.at() via eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -90,6 +90,13 @@ export default [
       ],
       'no-console': 'error',
       'no-negated-condition': 'off',
+      'no-restricted-properties': [
+        'error',
+        {
+          property: 'at',
+          message: 'Avoid Array/String.prototype.at(): it is unsupported in the browsers declared in .browserslistrc (Chrome < 92, Safari < 15.4) and the build does not polyfill. Use index access, e.g. arr[arr.length - 1].'
+        }
+      ],
       'object-curly-spacing': ['error', 'always'],
       'operator-linebreak': ['error', 'after'],
       'prefer-object-has-own': 'off',


### PR DESCRIPTION
Follow-up to #602. Adds an eslint `no-restricted-properties` rule that forbids `.at()`:

```
'no-restricted-properties': ['error', { property: 'at', message: '…use index access, e.g. arr[arr.length - 1]' }]
```

`Array.prototype.at()` / `String.prototype.at()` require Chrome 92 / Safari 15.4 / iOS 15.4, but `.browserslistrc` declares Chrome >= 60 / Safari >= 12 and the build does not polyfill (`.babelrc.js` has no `useBuiltIns`). The rule guards against silently reintroducing it. `js/src` is already `.at()`-free, so lint is green.