### PR TITLE
fix(Autocomplete): expose options as ARIA options and wire aria-controls

### DIFF
--- a/js/src/autocomplete.js
+++ b/js/src/autocomplete.js
@@ -631,6 +631,7 @@ class Autocomplete extends BaseComponent {
     inputEl.setAttribute('aria-autocomplete', 'list')
     inputEl.setAttribute('aria-expanded', 'false')
     inputEl.setAttribute('aria-haspopup', 'listbox')
+    inputEl.setAttribute('aria-controls', `${this._uniqueId}-listbox`)
 
     if (this._config.disabled) {
       inputEl.setAttribute('disabled', true)
@@ -767,6 +768,11 @@ class Autocomplete extends BaseComponent {
 
       const optionDiv = document.createElement('div')
       optionDiv.classList.add(CLASS_NAME_OPTION)
+      optionDiv.setAttribute('role', 'option')
+      optionDiv.setAttribute(
+        'aria-selected',
+        this._selected.some(selected => selected.value === option.value) ? 'true' : 'false'
+      )
 
       if (option.disabled) {
         optionDiv.classList.add(CLASS_NAME_DISABLED)

--- a/js/tests/unit/autocomplete.spec.js
+++ b/js/tests/unit/autocomplete.spec.js
@@ -98,6 +98,22 @@ describe('Autocomplete', () => {
       expect(autocomplete._inputElement.getAttribute('role')).toBe('combobox')
       expect(autocomplete._inputElement.getAttribute('aria-autocomplete')).toBe('list')
       expect(autocomplete._inputElement.getAttribute('aria-haspopup')).toBe('listbox')
+      expect(autocomplete._inputElement.getAttribute('aria-controls')).toBe(`${autocomplete._uniqueId}-listbox`)
+    })
+
+    it('should render each option with role="option"', () => {
+      fixtureEl.innerHTML = '<div class="autocomplete"></div>'
+      const autocompleteEl = fixtureEl.querySelector('.autocomplete')
+      const autocomplete = new Autocomplete(autocompleteEl, {
+        options: [{ value: 1, label: 'One' }, { value: 2, label: 'Two' }]
+      })
+
+      const optionEls = autocomplete._optionsElement.querySelectorAll('.autocomplete-option')
+      expect(optionEls.length).toBe(2)
+      for (const optionEl of optionEls) {
+        expect(optionEl.getAttribute('role')).toBe('option')
+        expect(optionEl.getAttribute('aria-selected')).toBe('false')
+      }
     })
 
     it('should create autocomplete with cleaner button when cleaner option is true', () => {


### PR DESCRIPTION
Fixes a11y audit high-priority #1 ("autocomplete options are not options").

- Each option now has `role="option"` + `aria-selected` (`aria-disabled` when disabled). Previously `aria-selected` sat on roleless divs (invalid).
- The combobox input gets `aria-controls` pointing at the listbox id — **portal/teleport-safe** because it is id-based (works when the menu is rendered outside the input's subtree).

Regression tests added.

Vanilla is the spec; ports follow in coreui-react-pro / coreui-vue-pro. Local validation: lint 0 errors, `js-test` (karma) 2995 SUCCESS.