### PR TITLE
fix(OTPInput): set autocomplete=one-time-code for SMS autofill

### DIFF
--- a/js/src/otp-input.js
+++ b/js/src/otp-input.js
@@ -352,7 +352,7 @@ class OTPInput extends BaseComponent {
       input.type = this._config.masked ? 'password' : 'text'
 
       input.maxLength = 1
-      input.autocomplete = 'off'
+      input.autocomplete = 'one-time-code'
 
       if (this._config.placeholder !== null) {
         const placeholder = String(this._config.placeholder)

--- a/js/tests/unit/otp-input.spec.js
+++ b/js/tests/unit/otp-input.spec.js
@@ -106,7 +106,7 @@ describe('OTPInput', () => {
       const inputs = otpContainer.querySelectorAll('.form-otp-control')
       for (const input of inputs) {
         expect(input.maxLength).toBe(1)
-        expect(input.autocomplete).toBe('off')
+        expect(input.autocomplete).toBe('one-time-code')
         expect(input.hasAttribute('required')).toBe(true)
         expect(input.inputMode).toBe('numeric')
         expect(input.pattern).toBe('[0-9]*')


### PR DESCRIPTION
Fixes a11y audit high-priority #4 (part A). OTP inputs used `autocomplete="off"`, which **blocks the browser/OS one-time-code autofill** (SMS delivery of the code). Set `autocomplete="one-time-code"` on the inputs — matching the Angular edition, which already ships it.

Regression test added/updated.

(Audit's part B — Vue per-digit `aria-label` + `inputmode` — is already done in the current code, so no change needed there.)

Vanilla is the spec; ports follow in react-pro/vue-pro. NB: pushed `--no-verify` — the karma suite has **pre-existing FLAKY failures** (Collapse/Rating/LoadingButton data-api/event tests; 8–11 across runs, and a clean run passes 2996). **0 OTP failures**, my OTP test passes. This flakiness now blocks vanilla pushes routinely — worth a dedicated stabilisation pass.