### PR TITLE
fix(Tooltip): dismiss on Escape key (WCAG 1.4.13)

### DIFF
--- a/docs/src/content/docs/components/popovers.mdx
+++ b/docs/src/content/docs/components/popovers.mdx
@@ -107,6 +107,8 @@ You can customize the appearance of popovers using [CSS variables](#variables). 
 
 Use the `focus` trigger to dismiss popovers on the user's next click of a different element than the toggle element.
 
+A shown popover can also be dismissed by pressing the <kbd>Escape</kbd> key. As with dropdown menus, a popover shown inside a dialog is dismissed on its own: the first <kbd>Escape</kbd> closes the popover and a subsequent one closes the dialog.
+
 <Callout color="danger">
 #### Specific markup required for dismiss-on-next-click
 

--- a/docs/src/content/docs/components/tooltips.mdx
+++ b/docs/src/content/docs/components/tooltips.mdx
@@ -136,6 +136,8 @@ The markup needed for a tooltip consists solely of a `data` attribute and a `tit
 Only add tooltips to HTML elements that are inherently keyboard-focusable and interactive, like links or form controls. While it is possible to make arbitrary HTML elements like `<span>`s focusable by using the `tabindex="0"` attribute, doing so may create confusing tab stops on non-interactive elements for keyboard users. Moreover, most assistive technologies typically do not announce tooltips in these cases. Additionally, avoid depending solely on `hover` to trigger your tooltips, as this approach renders them inaccessible for keyboard users.
 </Callout>
 
+A shown tooltip can be dismissed by pressing the <kbd>Escape</kbd> key, helping satisfy the [WCAG 1.4.13 "Content on Hover or Focus"](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) success criterion.
+
 ```html
 <!-- HTML to write -->
 <a href="#" data-coreui-toggle="tooltip" title="Some tooltip text!">Hover over me</a>

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -25,6 +25,8 @@ import TemplateFactory from './util/template-factory.js'
 const NAME = 'tooltip'
 const DISALLOWED_ATTRIBUTES = new Set(['sanitize', 'allowList', 'sanitizeFn'])
 
+const ESCAPE_KEY = 'Escape'
+
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_MODAL = 'modal'
 const CLASS_NAME_SHOW = 'show'
@@ -33,6 +35,7 @@ const SELECTOR_TOOLTIP_INNER = '.tooltip-inner'
 const SELECTOR_MODAL = `.${CLASS_NAME_MODAL}`
 
 const EVENT_MODAL_HIDE = 'hide.coreui.modal'
+const EVENT_KEYDOWN = 'keydown'
 
 const TRIGGER_HOVER = 'hover'
 const TRIGGER_FOCUS = 'focus'
@@ -125,6 +128,9 @@ class Tooltip extends BaseComponent {
     // Protected
     this.tip = null
 
+    // Private
+    this._keydownHandler = null
+
     this._setListeners()
 
     if (!this._config.selector) {
@@ -174,6 +180,8 @@ class Tooltip extends BaseComponent {
   dispose() {
     clearTimeout(this._timeout)
 
+    this._removeEscapeListener()
+
     EventHandler.off(this._element.closest(SELECTOR_MODAL), EVENT_MODAL_HIDE, this._hideModalHandler)
 
     if (this._element.getAttribute('data-coreui-original-title')) {
@@ -219,6 +227,8 @@ class Tooltip extends BaseComponent {
 
     tip.classList.add(CLASS_NAME_SHOW)
 
+    this._setEscapeListener()
+
     // If this is a touch-enabled device we add extra
     // empty mouseover listeners to the body's immediate children;
     // only needed because of broken event delegation on iOS
@@ -254,6 +264,8 @@ class Tooltip extends BaseComponent {
 
     const tip = this._getTipElement()
     tip.classList.remove(CLASS_NAME_SHOW)
+
+    this._removeEscapeListener()
 
     // If this is a touch-enabled device we remove the extra
     // empty mouseover listeners we added for iOS support
@@ -371,6 +383,33 @@ class Tooltip extends BaseComponent {
 
   _isShown() {
     return this.tip && this.tip.classList.contains(CLASS_NAME_SHOW)
+  }
+
+  _setEscapeListener() {
+    if (this._keydownHandler) {
+      return
+    }
+
+    this._keydownHandler = event => {
+      if (event.key !== ESCAPE_KEY || !this._isShown() || !this.tip.isConnected) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      this.hide()
+    }
+
+    this._element.ownerDocument.addEventListener(EVENT_KEYDOWN, this._keydownHandler, true)
+  }
+
+  _removeEscapeListener() {
+    if (!this._keydownHandler) {
+      return
+    }
+
+    this._element.ownerDocument.removeEventListener(EVENT_KEYDOWN, this._keydownHandler, true)
+    this._keydownHandler = null
   }
 
   _createPopper(tip) {

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -980,6 +980,77 @@ describe('Tooltip', () => {
       })
     })
 
+    it('should hide a tooltip when the Escape key is pressed', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip"></a>'
+
+        const tooltipEl = fixtureEl.querySelector('a')
+        const tooltip = new Tooltip(tooltipEl)
+
+        tooltipEl.addEventListener('shown.coreui.tooltip', () => {
+          expect(document.querySelector('.tooltip')).not.toBeNull()
+          const keydownEscape = createEvent('keydown', { bubbles: true })
+          keydownEscape.key = 'Escape'
+          document.dispatchEvent(keydownEscape)
+        })
+        tooltipEl.addEventListener('hidden.coreui.tooltip', () => {
+          expect(document.querySelector('.tooltip')).toBeNull()
+          expect(tooltipEl.getAttribute('aria-describedby')).toBeNull()
+          resolve()
+        })
+
+        tooltip.show()
+      })
+    })
+
+    it('should stop the Escape keystroke from reaching ancestor components', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip"></a>'
+
+        const tooltipEl = fixtureEl.querySelector('a')
+        const tooltip = new Tooltip(tooltipEl)
+        const ancestorSpy = jasmine.createSpy('ancestor keydown')
+        fixtureEl.addEventListener('keydown', ancestorSpy)
+
+        tooltipEl.addEventListener('shown.coreui.tooltip', () => {
+          const keydownEscape = createEvent('keydown', { bubbles: true, cancelable: true })
+          keydownEscape.key = 'Escape'
+          tooltipEl.dispatchEvent(keydownEscape)
+          expect(ancestorSpy).not.toHaveBeenCalled()
+          expect(keydownEscape.defaultPrevented).toBeTrue()
+        })
+        tooltipEl.addEventListener('hidden.coreui.tooltip', () => {
+          fixtureEl.removeEventListener('keydown', ancestorSpy)
+          resolve()
+        })
+
+        tooltip.show()
+      })
+    })
+
+    it('should not hide a tooltip when a non-Escape key is pressed', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip"></a>'
+
+        const tooltipEl = fixtureEl.querySelector('a')
+        const tooltip = new Tooltip(tooltipEl)
+
+        tooltipEl.addEventListener('shown.coreui.tooltip', () => {
+          const spy = spyOn(tooltip, 'hide').and.callThrough()
+          const keydownEnter = createEvent('keydown', { bubbles: true })
+          keydownEnter.key = 'Enter'
+          document.dispatchEvent(keydownEnter)
+          setTimeout(() => {
+            expect(spy).not.toHaveBeenCalled()
+            expect(document.querySelector('.tooltip')).not.toBeNull()
+            resolve()
+          }, 20)
+        })
+
+        tooltip.show()
+      })
+    })
+
     it('should hide a tooltip on mobile', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip"></a>'


### PR DESCRIPTION
Backports Bootstrap 6's tooltip Escape-key dismissal (a11y audit — WCAG 1.4.13 "Content on Hover or Focus"). Hover/focus tooltips (and popovers, which extend Tooltip) couldn't be dismissed by keyboard.

- On show, `_setEscapeListener()` adds a `keydown` listener on `element.ownerDocument` in the **capture phase**; on `Escape` (while shown) it `preventDefault()` + `stopPropagation()` and `hide()`. Removed on hide/dispose via `_removeEscapeListener()`.
- Capture phase → the tooltip dismisses **before** an ancestor dialog's own Escape handler (nested dismissal).
- **Popover inherits** it (extends Tooltip, doesn't override show/hide).
- Ported Bootstrap 6's **three tests** (basic dismiss, ancestor-propagation-stop, non-Escape-ignored) and documented the behavior in the tooltip/popover docs (verbatim Bootstrap 6 wording).

Byte-identical to the future Bootstrap 6 rebase → conflict-free sync.

Local validation: lint 0 errors, js compile, **js-test 2999 SUCCESS** (via pre-push gate — including the 3 new Escape tests).