### PR TITLE
feat(RangeSlider,Rating,PasswordInput): improve a11y labeling of form controls

### DIFF
--- a/docs/src/content/docs/forms/password-input.mdx
+++ b/docs/src/content/docs/forms/password-input.mdx
@@ -15,7 +15,7 @@ Use the `form-password` wrapper to add a visibility toggle button to standard Bo
     <label for="examplePasswordInput1" class="form-label">Password</label>
     <div class="form-password">
       <input type="password" class="form-control" id="examplePasswordInput1" placeholder="Enter your password">
-      <button type="button" class="form-password-action" data-coreui-toggle="password" aria-label="Toggle password visibility">
+      <button type="button" class="form-password-action" data-coreui-toggle="password" aria-pressed="false" aria-label="Toggle password visibility">
         <span class="form-password-action-icon"></span>
       </button>
     </div>
@@ -24,7 +24,7 @@ Use the `form-password` wrapper to add a visibility toggle button to standard Bo
     <label for="examplePasswordInput2" class="form-label">Password with value</label>
     <div class="form-password">
       <input type="password" class="form-control" id="examplePasswordInput2" placeholder="Enter your password" value="Top secret">
-      <button type="button" class="form-password-action" data-coreui-toggle="password" aria-label="Toggle password visibility">
+      <button type="button" class="form-password-action" data-coreui-toggle="password" aria-pressed="false" aria-label="Toggle password visibility">
         <span class="form-password-action-icon"></span>
       </button>
     </div>
@@ -36,19 +36,19 @@ Bootstrap Password Input supports different sizes using Bootstrap's sizing utili
 
 <Example pro code={`<div class="form-password">
     <input type="password" class="form-control form-control-lg" placeholder="Large password input">
-      <button type="button" class="form-password-action" data-coreui-toggle="password" aria-label="Toggle password visibility">
+      <button type="button" class="form-password-action" data-coreui-toggle="password" aria-pressed="false" aria-label="Toggle password visibility">
         <span class="form-password-action-icon"></span>
       </button>
   </div>
   <div class="form-password">
     <input type="password" class="form-control" placeholder="Default password input">
-      <button type="button" class="form-password-action" data-coreui-toggle="password" aria-label="Toggle password visibility">
+      <button type="button" class="form-password-action" data-coreui-toggle="password" aria-pressed="false" aria-label="Toggle password visibility">
         <span class="form-password-action-icon"></span>
       </button>
   </div>
   <div class="form-password">
     <input type="password" class="form-control form-control-sm" placeholder="Small password input">
-      <button type="button" class="form-password-action" data-coreui-toggle="password" aria-label="Toggle password visibility">
+      <button type="button" class="form-password-action" data-coreui-toggle="password" aria-pressed="false" aria-label="Toggle password visibility">
         <span class="form-password-action-icon"></span>
       </button>
   </div>`} />
@@ -59,13 +59,13 @@ To make a Bootstrap Password Input non-interactive, add the `disabled` attribute
 
 <Example pro code={`<div class="form-password">
     <input type="password" class="form-control" placeholder="Disabled password input" disabled>
-    <button type="button" class="form-password-action" data-coreui-toggle="password" disabled aria-label="Toggle password visibility">
+    <button type="button" class="form-password-action" data-coreui-toggle="password" disabled aria-pressed="false" aria-label="Toggle password visibility">
       <span class="form-password-action-icon"></span>
     </button>
   </div>
   <div class="form-password">
     <input type="password" class="form-control" placeholder="Disabled and readonly input" disabled readonly>
-    <button type="button" class="form-password-action" data-coreui-toggle="password" disabled aria-label="Toggle password visibility">
+    <button type="button" class="form-password-action" data-coreui-toggle="password" disabled aria-pressed="false" aria-label="Toggle password visibility">
       <span class="form-password-action-icon"></span>
     </button>
   </div>`} />
@@ -76,7 +76,7 @@ Use the `readonly` attribute to make the input non-editable but still selectable
 
 <Example pro code={`<div class="form-password">
     <input type="password" class="form-control" placeholder="Readonly password input" value="Readonly input here..." readonly>
-      <button type="button" class="form-password-action" data-coreui-toggle="password" aria-label="Toggle password visibility">
+      <button type="button" class="form-password-action" data-coreui-toggle="password" aria-pressed="false" aria-label="Toggle password visibility">
         <span class="form-password-action-icon"></span>
       </button>
   </div>`} />
@@ -88,7 +88,7 @@ Via data attributes, the password input plugin toggles visibility of the passwor
 ```html
 <div class="form-password">
   <input type="password" class="form-control" placeholder="Readonly password input" value="Readonly input here..." readonly>
-    <button type="button" class="form-password-action" data-coreui-toggle="password" aria-label="Toggle password visibility">
+    <button type="button" class="form-password-action" data-coreui-toggle="password" aria-pressed="false" aria-label="Toggle password visibility">
       <span class="form-password-action-icon"></span>
     </button>
 </div>

--- a/js/src/password-input.js
+++ b/js/src/password-input.js
@@ -22,7 +22,8 @@ const DATA_API_KEY = '.data-api'
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_FORM_CONTROL = '.form-control'
-const SELECTOR_DATA_TOGGLE = `${SELECTOR_FORM_CONTROL}:not([disabled]) ~ [data-coreui-toggle="password"]`
+const SELECTOR_TOGGLE = '[data-coreui-toggle="password"]'
+const SELECTOR_DATA_TOGGLE = `${SELECTOR_FORM_CONTROL}:not([disabled]) ~ ${SELECTOR_TOGGLE}`
 
 /**
  * Class definition
@@ -37,6 +38,20 @@ class PasswordInput extends BaseComponent {
   // Public
   toggle() {
     this._element.type = this._element.type === 'password' ? 'text' : 'password'
+    this._updateToggleState()
+  }
+
+  // Private
+  _updateToggleState() {
+    if (!this._element.parentNode) {
+      return
+    }
+
+    const toggler = SelectorEngine.findOne(SELECTOR_TOGGLE, this._element.parentNode)
+
+    if (toggler) {
+      toggler.setAttribute('aria-pressed', this._element.type === 'text' ? 'true' : 'false')
+    }
   }
 
   // Static

--- a/js/src/range-slider.js
+++ b/js/src/range-slider.js
@@ -51,6 +51,7 @@ const SELECTOR_RANGE_SLIDER_LABELS_CONTAINER = '.range-slider-labels-container'
 
 const Default = {
   allowList: DefaultAllowlist,
+  ariaLabels: null,
   clickableLabels: true,
   disabled: false,
   distance: 0,
@@ -70,6 +71,7 @@ const Default = {
 
 const DefaultType = {
   allowList: 'object',
+  ariaLabels: '(array|null)',
   clickableLabels: 'boolean',
   disabled: 'boolean',
   distance: 'number',
@@ -256,7 +258,32 @@ class RangeSlider extends BaseComponent {
     inputElement.setAttribute('aria-valuenow', value)
     inputElement.setAttribute('aria-orientation', this._config.vertical ? 'vertical' : 'horizontal')
 
+    if (this._currentValue.length > 1) {
+      inputElement.setAttribute('aria-label', this._getAriaLabel(index))
+    }
+
+    const valueText = this._getValueText(value)
+    if (valueText !== null) {
+      inputElement.setAttribute('aria-valuetext', valueText)
+    }
+
     return inputElement
+  }
+
+  _getAriaLabel(index) {
+    if (Array.isArray(this._config.ariaLabels) && this._config.ariaLabels[index]) {
+      return this._config.ariaLabels[index]
+    }
+
+    if (this._currentValue.length === 2) {
+      return index === 0 ? 'Minimum value' : 'Maximum value'
+    }
+
+    return `Value ${index + 1}`
+  }
+
+  _getValueText(value) {
+    return typeof this._config.tooltipsFormat === 'function' ? `${this._config.tooltipsFormat(value)}` : null
   }
 
   _createLabels() {
@@ -546,6 +573,12 @@ class RangeSlider extends BaseComponent {
 
     input.value = value
     input.setAttribute('aria-valuenow', value)
+
+    const valueText = this._getValueText(value)
+    if (valueText !== null) {
+      input.setAttribute('aria-valuetext', valueText)
+    }
+
     setTimeout(() => {
       input.focus()
     })

--- a/js/src/rating.js
+++ b/js/src/rating.js
@@ -51,6 +51,7 @@ const Default = {
   activeIcon: null,
   allowClear: false,
   allowList: SVGAllowlist,
+  ariaLabel: (value, itemCount) => `${value} of ${itemCount}`,
   disabled: false,
   highlightOnlySelected: false,
   icon: null,
@@ -69,6 +70,7 @@ const DefaultType = {
   activeIcon: '(object|string|null)',
   allowClear: 'boolean',
   allowList: 'object',
+  ariaLabel: 'function',
   disabled: 'boolean',
   highlightOnlySelected: 'boolean',
   icon: '(object|string|null)',
@@ -399,6 +401,10 @@ class Rating extends BaseComponent {
       ratingItemInputElement.type = 'radio'
       ratingItemInputElement.value = value
       ratingItemInputElement.name = this._name
+
+      if (typeof this._config.ariaLabel === 'function') {
+        ratingItemInputElement.setAttribute('aria-label', this._config.ariaLabel(value, this._config.itemCount))
+      }
 
       if (this._config.disabled || this._config.readOnly) {
         ratingItemInputElement.setAttribute('disabled', true)

--- a/js/tests/unit/password-input.spec.js
+++ b/js/tests/unit/password-input.spec.js
@@ -238,6 +238,22 @@ describe('PasswordInput', () => {
       expect(PasswordInput.getInstance(input)).toBeInstanceOf(PasswordInput)
     })
 
+    it('should reflect visibility state via aria-pressed on the toggle button', () => {
+      fixtureEl.innerHTML = `
+        <div class="input-group">
+          <input type="password" class="form-control">
+          <button data-coreui-toggle="password" type="button">Toggle</button>
+        </div>
+      `
+      const toggleButton = fixtureEl.querySelector('[data-coreui-toggle="password"]')
+
+      toggleButton.dispatchEvent(createEvent('click'))
+      expect(toggleButton.getAttribute('aria-pressed')).toBe('true')
+
+      toggleButton.dispatchEvent(createEvent('click'))
+      expect(toggleButton.getAttribute('aria-pressed')).toBe('false')
+    })
+
     it('should prevent default behavior on toggle button click', () => {
       fixtureEl.innerHTML = `
         <div class="input-group">

--- a/js/tests/unit/range-slider.spec.js
+++ b/js/tests/unit/range-slider.spec.js
@@ -150,6 +150,57 @@ describe('RangeSlider', () => {
     })
   })
 
+  describe('Accessibility labels', () => {
+    it('should not set aria-label on a single-thumb slider', () => {
+      fixtureEl.innerHTML = '<div id="slider"></div>'
+      const element = fixtureEl.querySelector('#slider')
+      new RangeSlider(element, { value: 30 }) // eslint-disable-line no-new
+
+      const input = element.querySelector('.range-slider-input')
+      expect(input.getAttribute('aria-label')).toBeNull()
+    })
+
+    it('should label a two-thumb slider with Minimum/Maximum value by default', () => {
+      fixtureEl.innerHTML = '<div id="slider"></div>'
+      const element = fixtureEl.querySelector('#slider')
+      new RangeSlider(element, { value: [20, 80] }) // eslint-disable-line no-new
+
+      const inputs = element.querySelectorAll('.range-slider-input')
+      expect(inputs[0].getAttribute('aria-label')).toBe('Minimum value')
+      expect(inputs[1].getAttribute('aria-label')).toBe('Maximum value')
+    })
+
+    it('should label sliders with three or more thumbs positionally', () => {
+      fixtureEl.innerHTML = '<div id="slider"></div>'
+      const element = fixtureEl.querySelector('#slider')
+      new RangeSlider(element, { value: [10, 50, 90] }) // eslint-disable-line no-new
+
+      const inputs = element.querySelectorAll('.range-slider-input')
+      expect(inputs[0].getAttribute('aria-label')).toBe('Value 1')
+      expect(inputs[1].getAttribute('aria-label')).toBe('Value 2')
+      expect(inputs[2].getAttribute('aria-label')).toBe('Value 3')
+    })
+
+    it('should apply custom ariaLabels over the defaults', () => {
+      fixtureEl.innerHTML = '<div id="slider"></div>'
+      const element = fixtureEl.querySelector('#slider')
+      new RangeSlider(element, { value: [20, 80], ariaLabels: ['From', 'To'] }) // eslint-disable-line no-new
+
+      const inputs = element.querySelectorAll('.range-slider-input')
+      expect(inputs[0].getAttribute('aria-label')).toBe('From')
+      expect(inputs[1].getAttribute('aria-label')).toBe('To')
+    })
+
+    it('should expose the formatted value via aria-valuetext when tooltipsFormat is set', () => {
+      fixtureEl.innerHTML = '<div id="slider"></div>'
+      const element = fixtureEl.querySelector('#slider')
+      new RangeSlider(element, { value: 40, tooltipsFormat: value => `$${value}` }) // eslint-disable-line no-new
+
+      const input = element.querySelector('.range-slider-input')
+      expect(input.getAttribute('aria-valuetext')).toBe('$40')
+    })
+  })
+
   describe('Multi-thumb', () => {
     it('should create multiple thumbs for array values', () => {
       fixtureEl.innerHTML = '<div id="slider"></div>'

--- a/js/tests/unit/rating.spec.js
+++ b/js/tests/unit/rating.spec.js
@@ -93,6 +93,28 @@ describe('Rating', () => {
       expect(div.querySelectorAll('.rating-item')).toHaveSize(10)
     })
 
+    it('should set a default aria-label on each rating radio', () => {
+      fixtureEl.innerHTML = '<div></div>'
+      const div = fixtureEl.querySelector('div')
+      new Rating(div, { itemCount: 5 }) // eslint-disable-line no-new
+
+      const inputs = div.querySelectorAll('.rating-item-input')
+      expect(inputs[0].getAttribute('aria-label')).toEqual('1 of 5')
+      expect(inputs[4].getAttribute('aria-label')).toEqual('5 of 5')
+    })
+
+    it('should use a custom ariaLabel function', () => {
+      fixtureEl.innerHTML = '<div></div>'
+      const div = fixtureEl.querySelector('div')
+      new Rating(div, { // eslint-disable-line no-new
+        itemCount: 5,
+        ariaLabel: (value, itemCount) => `${value} star of ${itemCount}`
+      })
+
+      const inputs = div.querySelectorAll('.rating-item-input')
+      expect(inputs[2].getAttribute('aria-label')).toEqual('3 star of 5')
+    })
+
     it('should set the initial checked input if "value" is provided', () => {
       fixtureEl.innerHTML = '<div></div>'
       const div = fixtureEl.querySelector('div')


### PR DESCRIPTION
Improves accessible naming of Pro form controls (a11y audit — items #1 Rating, #2 Range-slider, #3 Password toggle). Screen readers previously announced these controls without value/state semantics.

- **Rating** — radios had no accessible name ("radio 3 of 5" with no value). Added an `ariaLabel(value, itemCount)` config that names each radio; default `"{value} of {itemCount}"`.
- **Range-slider** — multi-thumb sliders rendered two identically-announced unlabeled handles. Added per-thumb `aria-label` (`ariaLabels`), defaulting to `"Minimum value"`/`"Maximum value"` for two thumbs and `"Value {n}"` for three or more (single-thumb sliders are left to their associated label). Added `aria-valuetext` when `tooltipsFormat` is set, so AT announces the formatted value sighted users see instead of the raw number.
- **Password input** — the visibility toggle exposed no state. Added `aria-pressed` reflecting whether the password is revealed.

Regression tests per component and edition (single/two/three-thumb labeling, custom labels, aria-valuetext, aria-pressed toggling). API tables regenerated. Verified via the local CI gate (lint + build + full test suite).

Angular equivalents tracked separately for @xidedix.