### PR TITLE
ci: bump stale (v10.4.0), checkout (v7.0.0), linkinator (v2.4.2)

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/css.yml
+++ b/.github/workflows/css.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -44,7 +44,7 @@ jobs:
         run: npm run docs-vnu
 
       - name: Run linkinator
-        uses: JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d # v1
+        uses: JustinBeckwith/linkinator-action@7b6b0bc671f6264e1a8daa4488a5bd91ce61dcd4 # v2.4.2
         with:
           paths: _site
           recurse: true

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Follow-up to the SHA-pin sweep — upgrades the actions that were stale or split across majors (all config inputs verified compatible):

- **actions/checkout → v7.0.0** everywhere. Was inconsistent: `v4.3.1` in codeql.yml, `v6.0.3` elsewhere. Unified to v7.0.0 (the version upstream **Bootstrap** uses).
- **actions/stale → v10.4.0** (coreui only) — was on **v3**, 7 majors behind. The config only uses `repo-token` + `stale-*-message`/`stale-*-label`, all stable across v3→v10.
- **JustinBeckwith/linkinator-action → v2.4.2** — was v1. Inputs (`paths`/`recurse`/`verbosity`/`skip`) unchanged in v2.
- **setup-node stays v6.5.0** (Bootstrap is also on v6), codeql-action stays v3 (current major), coverallsapp stays v2.3.7.

All pins remain full-SHA + `# vX.Y.Z`. Workflow YAML validated (13/13 parse). Dependabot maintains them going forward.