### PR TITLE
feat(Autocomplete,MultiSelect): Home/End keys focus first/last option (a11y)

### DIFF
--- a/docs/src/content/docs/forms/autocomplete.mdx
+++ b/docs/src/content/docs/forms/autocomplete.mdx
@@ -359,6 +359,8 @@ The Autocomplete component includes several accessibility features:
 | --- | --- |
 | <kbd>Arrow Down</kbd> | Navigate to the next option or open dropdown |
 | <kbd>Arrow Up</kbd> | Navigate to the previous option |
+| <kbd>Home</kbd> | Focus the first option |
+| <kbd>End</kbd> | Focus the last option |
 | <kbd>Enter</kbd> | Select the highlighted option |
 | <kbd>Escape</kbd> | Close the dropdown and clear focus |
 | <kbd>Tab</kbd> | Accept hint completion (when hints are enabled) |

--- a/docs/src/content/docs/forms/multi-select.mdx
+++ b/docs/src/content/docs/forms/multi-select.mdx
@@ -538,6 +538,20 @@ myMutliSelect.addEventListener('changed.coreui.multi-select', event => {
 })
 ```
 
+## Accessibility
+
+### Keyboard shortcuts
+
+| Key | Action |
+| --- | --- |
+| <kbd>Tab</kbd> | Navigate to/from the component |
+| <kbd>Enter</kbd>/<kbd>Space</kbd> | Open dropdown or select focused option |
+| <kbd>Arrow Up</kbd>/<kbd>Arrow Down</kbd> | Navigate through options |
+| <kbd>Home</kbd> | Focus the first option |
+| <kbd>End</kbd> | Focus the last option |
+| <kbd>Escape</kbd> | Close the dropdown |
+| <kbd>Backspace</kbd>/<kbd>Delete</kbd> | Remove last selected item (when search is empty) |
+
 ## Customizing
 
 ### CSS variables

--- a/js/src/autocomplete.js
+++ b/js/src/autocomplete.js
@@ -35,8 +35,10 @@ const ARROW_UP_KEY = 'ArrowUp'
 const ARROW_DOWN_KEY = 'ArrowDown'
 const BACKSPACE_KEY = 'Backspace'
 const DELETE_KEY = 'Delete'
+const END_KEY = 'End'
 const ENTER_KEY = 'Enter'
 const ESCAPE_KEY = 'Escape'
+const HOME_KEY = 'Home'
 const TAB_KEY = 'Tab'
 const RIGHT_MOUSE_BUTTON = 2 // MouseEvent.button value for the secondary button, usually the right button
 
@@ -525,6 +527,11 @@ class Autocomplete extends BaseComponent {
         event.preventDefault()
         this._selectMenuItem(event)
       }
+
+      if ([HOME_KEY, END_KEY].includes(event.key)) {
+        event.preventDefault()
+        this._selectFirstOrLastMenuItem(event.key === HOME_KEY)
+      }
     })
   }
 
@@ -963,6 +970,17 @@ class Autocomplete extends BaseComponent {
     // if target isn't included in items (e.g. when expanding the dropdown)
     // allow cycling to get the last item in case key equals ARROW_UP_KEY
     getNextActiveElement(items, target, key === ARROW_DOWN_KEY, !items.includes(target)).focus()
+  }
+
+  _selectFirstOrLastMenuItem(first) {
+    const items = SelectorEngine.find(SELECTOR_VISIBLE_ITEMS, this._menu).filter(element => isVisible(element))
+
+    if (!items.length) {
+      return
+    }
+
+    const item = first ? items[0] : items[items.length - 1]
+    item.focus()
   }
 
   _configAfterMerge(config) {

--- a/js/src/multi-select.js
+++ b/js/src/multi-select.js
@@ -37,8 +37,10 @@ const ARROW_UP_KEY = 'ArrowUp'
 const ARROW_DOWN_KEY = 'ArrowDown'
 const BACKSPACE_KEY = 'Backspace'
 const DELETE_KEY = 'Delete'
+const END_KEY = 'End'
 const ENTER_KEY = 'Enter'
 const ESCAPE_KEY = 'Escape'
+const HOME_KEY = 'Home'
 const SPACE_KEY = ' '
 const TAB_KEY = 'Tab'
 const RIGHT_MOUSE_BUTTON = 2 // MouseEvent.button value for the secondary button, usually the right button
@@ -544,6 +546,11 @@ class MultiSelect extends BaseComponent {
           event.preventDefault()
           this._selectMenuItem(event)
         }
+
+        if ([HOME_KEY, END_KEY].includes(event.key)) {
+          event.preventDefault()
+          this._selectFirstOrLastMenuItem(event.key === HOME_KEY)
+        }
       })
     }
 
@@ -563,6 +570,11 @@ class MultiSelect extends BaseComponent {
       if ([ARROW_UP_KEY, ARROW_DOWN_KEY].includes(event.key)) {
         event.preventDefault()
         this._selectMenuItem(event)
+      }
+
+      if ([HOME_KEY, END_KEY].includes(event.key)) {
+        event.preventDefault()
+        this._selectFirstOrLastMenuItem(event.key === HOME_KEY)
       }
     })
   }
@@ -1637,6 +1649,17 @@ class MultiSelect extends BaseComponent {
     // if target isn't included in items (e.g. when expanding the dropdown)
     // allow cycling to get the last item in case key equals ARROW_UP_KEY
     getNextActiveElement(items, target, key === ARROW_DOWN_KEY, !items.includes(target)).focus()
+  }
+
+  _selectFirstOrLastMenuItem(first) {
+    const items = SelectorEngine.find(SELECTOR_NAVIGABLE_ITEMS, this._menu).filter(element => isVisible(element))
+
+    if (!items.length) {
+      return
+    }
+
+    const item = first ? items[0] : items[items.length - 1]
+    item.focus()
   }
 
   _configAfterMerge(config) {

--- a/js/tests/unit/autocomplete.spec.js
+++ b/js/tests/unit/autocomplete.spec.js
@@ -1050,6 +1050,37 @@ describe('Autocomplete', () => {
       })
     })
 
+    it('should focus the first/last option on Home/End keys', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div class="autocomplete"></div>'
+        const autocompleteEl = fixtureEl.querySelector('.autocomplete')
+        const autocomplete = new Autocomplete(autocompleteEl, {
+          options: [
+            { label: 'Option 1', value: '1' },
+            { label: 'Option 2', value: '2' },
+            { label: 'Option 3', value: '3' }
+          ]
+        })
+
+        autocompleteEl.addEventListener('shown.coreui.autocomplete', () => {
+          const options = autocomplete._optionsElement.querySelectorAll('.autocomplete-option')
+
+          const endEvent = createEvent('keydown')
+          endEvent.key = 'End'
+          autocomplete._optionsElement.dispatchEvent(endEvent)
+          expect(document.activeElement).toBe(options[options.length - 1])
+
+          const homeEvent = createEvent('keydown')
+          homeEvent.key = 'Home'
+          autocomplete._optionsElement.dispatchEvent(homeEvent)
+          expect(document.activeElement).toBe(options[0])
+          resolve()
+        })
+
+        autocomplete.show()
+      })
+    })
+
     it('should open dropdown on Enter key', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<div class="autocomplete"></div>'

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -2878,6 +2878,31 @@ describe('MultiSelect', () => {
       expect(multiSelect._optionsElement.querySelectorAll('.form-multi-select-option').length).toBe(2)
     })
 
+    it('should focus the first/last navigable item on Home/End keys', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [
+          { value: '1', text: 'Option 1' },
+          { value: '2', text: 'Option 2' },
+          { value: '3', text: 'Option 3' }
+        ],
+        selectAll: false
+      })
+
+      multiSelect.show()
+
+      const items = multiSelect._optionsElement.querySelectorAll('.form-multi-select-option')
+
+      const endEvent = new KeyboardEvent('keydown', { key: 'End', bubbles: true })
+      multiSelect._optionsElement.dispatchEvent(endEvent)
+      expect(document.activeElement).toBe(items[items.length - 1])
+
+      const homeEvent = new KeyboardEvent('keydown', { key: 'Home', bubbles: true })
+      multiSelect._optionsElement.dispatchEvent(homeEvent)
+      expect(document.activeElement).toBe(items[0])
+    })
+
     it('should focus the select all button during arrow navigation', () => {
       fixtureEl.innerHTML = '<select></select>'
       const selectEl = fixtureEl.querySelector('select')


### PR DESCRIPTION
Adds **Home / End** keyboard support to the **Autocomplete** and **MultiSelect** option lists, aligning them with the WAI-ARIA APG combobox/listbox pattern: **Home** focuses the first enabled option, **End** the last (skipping disabled options; in vanilla MultiSelect the navigation ring also includes the select-all header item, matching arrow-key behavior).

**Virtual scroller aware (React/Vue):** with `virtualScroller` only a window of options is mounted in the DOM, so a naive query would land on the edge of the rendered window instead of the true first/last option. Home/End scroll the virtualized viewport to its edge and focus once the window has re-rendered (double rAF). The non-virtualized path stays synchronous. Applies to both option and group-label keydown handlers in MultiSelect.

Uniform gap — verified none of vanilla/React/Vue had Home/End in either component (the a11y audit's claim that Vue/Angular already had them was inaccurate). Not Bootstrap-inherited (Bootstrap has neither component).

Docs: Home/End added to each edition's keyboard table; the vanilla MultiSelect page gains an Accessibility → Keyboard shortcuts section (parity with React/Vue). Regression tests per edition and component (plain + virtualScroller paths; verified failing without the fix). Vanilla karma: 3009/3009.