### PR TITLE
fix(Autocomplete): announce no-results via role="status" live region (a11y)

### DIFF
--- a/js/src/autocomplete.js
+++ b/js/src/autocomplete.js
@@ -947,6 +947,7 @@ class Autocomplete extends BaseComponent {
       if (this._config.searchNoResultsLabel) {
         const placeholder = document.createElement('div')
         placeholder.classList.add(CLASS_NAME_OPTIONS_EMPTY)
+        placeholder.setAttribute('role', 'status')
         placeholder.textContent = this._config.searchNoResultsLabel
 
         if (!SelectorEngine.findOne(SELECTOR_OPTIONS_EMPTY, this._menu)) {

--- a/js/tests/unit/autocomplete.spec.js
+++ b/js/tests/unit/autocomplete.spec.js
@@ -495,6 +495,22 @@ describe('Autocomplete', () => {
       expect(autocomplete._isShown()).toBe(true)
     })
 
+    it('should expose the no-results placeholder as a role="status" live region', () => {
+      fixtureEl.innerHTML = '<div class="autocomplete"></div>'
+      const autocompleteEl = fixtureEl.querySelector('.autocomplete')
+      const autocomplete = new Autocomplete(autocompleteEl, {
+        searchNoResultsLabel: 'No results',
+        options: [{ label: 'Option 1', value: '1' }]
+      })
+
+      autocomplete.show()
+      autocomplete._search = 'nonexistent'
+      autocomplete._filterOptionsList()
+
+      const placeholder = autocomplete._menu.querySelector('.autocomplete-options-empty')
+      expect(placeholder.getAttribute('role')).toBe('status')
+    })
+
     it('should render searchNoResultsLabel as text, not markup', () => {
       fixtureEl.innerHTML = '<div class="autocomplete"></div>'
       const autocompleteEl = fixtureEl.querySelector('.autocomplete')


### PR DESCRIPTION
Marks the Autocomplete 'no results' placeholder as a `role="status"` live region (implicit `aria-live="polite"`), so screen readers announce it when a search empties the option list. Previously it was a plain `div` — the visual change was silent to AT.

Uniform gap — verified none of vanilla/React/Vue had it on **autocomplete** (the a11y audit only flagged multi-select and mis-stated which editions were affected). **MultiSelect already does this** in vanilla/React/Vue, so this brings Autocomplete to parity. Regression test per edition. (Angular lacks it on both components → for @xidedix.)