### PR TITLE
docs: restore Release Candidate banner on pre-release components

### DIFF
--- a/docs/src/content/docs/components/chip-set.mdx
+++ b/docs/src/content/docs/components/chip-set.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Bootstrap 5 Chip Set"
 name: "Chip set"
+preRelease: true
 description: "Bootstrap Chip set component for CoreUI — group chips into an accessible, keyboard-navigable container with single or multiple selection."
 ---
 

--- a/docs/src/content/docs/components/chip.mdx
+++ b/docs/src/content/docs/components/chip.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Bootstrap 5 Chip"
 name: "Chip"
+preRelease: true
 description: "Bootstrap Chip component for CoreUI — build removable tags, selectable labels, and filterable chips with icons, avatars, and full keyboard support."
 otherFrameworks:
   - chip

--- a/docs/src/content/docs/components/search-button.mdx
+++ b/docs/src/content/docs/components/search-button.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Bootstrap 5 Search Button"
 name: "Search Button"
+preRelease: true
 description: "Bootstrap Search Button for CoreUI is a keyboard-aware trigger component that can open search interfaces, modals, offcanvas panels, and custom flows from click or shortcut."
 otherFrameworks:
   - search-button

--- a/docs/src/content/docs/forms/chip-input.mdx
+++ b/docs/src/content/docs/forms/chip-input.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Bootstrap 5 Chip Input"
 name: "Chip input"
+preRelease: true
 description: "Bootstrap Chip Input component for CoreUI — create tag-like multi-value inputs for skills, categories, or recipients with keyboard support, selection, and form integration."
 otherFrameworks:
   - chip-input


### PR DESCRIPTION
The Astro docs migration dropped the old `preview_component` frontmatter flag, which the engine now exposes as `preRelease` (rendered as the "Release candidate (RC)" banner). It was preserved in the React and Vue editions but lost in the vanilla docs.

Re-adds `preRelease: true` to Chip, Chip Set, Search Button and Chip Input so the RC banner shows again. Verified by building the docs: the banner renders on all four pages.