### PR TITLE
chore(docs): bump @coreui/astro-docs to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@astrojs/mdx": "^7.0.3",
         "@babel/core": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
-        "@coreui/astro-docs": "0.1.0",
+        "@coreui/astro-docs": "0.1.1",
         "@eslint/markdown": "^7.5.1",
         "@popperjs/core": "^2.11.8",
         "@rollup/plugin-babel": "^7.1.0",
@@ -2184,13 +2184,12 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.0.tgz",
-      "integrity": "sha512-pmi5f4qz90TqWUXwffjdDWEY3FCP1DIDXyw7bHhIHTy1AVWXM7aUU482UxnKH5zWDstKNx7b0dgZgS8aXMxl6g==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.1.tgz",
+      "integrity": "sha512-ucFQ2TzMi9iR35eZ3FRvyanIi+9P+TBTffnHrtuwQ2GKcCxKb38zeLs68iWo2sPDWPf7K28IZq2xNnpXzLA07Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@astrojs/markdown-remark": "^7.2.1",
         "@coreui/icons": "^3.1.0",
         "@coreui/internal-links": "^5.2.0",
         "@docsearch/css": "^4.6.3",
@@ -2205,6 +2204,7 @@
         "zod": "^4.4.3"
       },
       "peerDependencies": {
+        "@astrojs/markdown-remark": "^7.2.0",
         "@astrojs/mdx": "^7.0.0",
         "astro": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@astrojs/mdx": "^7.0.3",
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
-    "@coreui/astro-docs": "0.1.0",
+    "@coreui/astro-docs": "0.1.1",
     "@eslint/markdown": "^7.5.1",
     "@popperjs/core": "^2.11.8",
     "@rollup/plugin-babel": "^7.1.0",


### PR DESCRIPTION
0.1.1 moves @astrojs/markdown-remark to a peer dependency. Docs build verified: no broken links.