### PR TITLE
docs: fix CSS Grid intro and drop React reference from templates page

### DIFF
--- a/docs/src/content/docs/layout/css-grid.mdx
+++ b/docs/src/content/docs/layout/css-grid.mdx
@@ -6,27 +6,9 @@ description: "Learn how to enable, use, and customize our alternate layout syste
 
 CoreUI for Bootstrap's default grid system represents the culmination of over a decade of CSS layout techniques, tried and tested by millions of people. But, it was also created without many of the modern CSS features and techniques we're seeing in browsers like the new CSS Grid.
 
-CoreUI Bootstrap's grid system uses a series of containers, rows, and columns to layout and align content. It's built with [flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) and is fully responsive. Below is an example and an in-depth explanation for how the grid system comes together.
-
-<Callout color="info">
-**New to or unfamiliar with flexbox?** [Read this CSS Tricks flexbox guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/#flexbox-background) for background, terminology, guidelines, and code snippets.
+<Callout color="warning">
+**Heads up—our CSS Grid system is experimental and opt-in as of v4.1.0!** We included it in our documentation's CSS to demonstrate it for you, but it's disabled by default. Keep reading to learn how to enable it in your projects.
 </Callout>
-
-<Example class="bd-example-row" code={`<div class="container">
-    <div class="row">
-      <div class="col">
-        Column
-      </div>
-      <div class="col">
-        Column
-      </div>
-      <div class="col">
-        Column
-      </div>
-    </div>
-  </div>`} />
-
-The above example creates three equal-width columns across all devices and viewports using our predefined grid classes. Those columns are centered in the page with the parent `.container`.
 
 ## How it works
 

--- a/docs/src/content/docs/templates/admin-dashboard.mdx
+++ b/docs/src/content/docs/templates/admin-dashboard.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Bootstrap Templates"
-description: "Develop modern, beautiful, and responsive applications in half the time with high-performing and easy-to-customize react admin panels to cover any requirement."
+description: "Develop modern, beautiful, and responsive applications in half the time with high-performing and easy-to-customize Bootstrap admin panels to cover any requirement."
 ---
 
 ## Bootstrap Admin & Dashboard Templates


### PR DESCRIPTION
Two docs-only fixes found while comparing the free and PRO Bootstrap docs.

### CSS Grid page
`layout/css-grid.mdx` had a stale flexbox-grid intro spliced in from `layout/grid.mdx` ("CoreUI Bootstrap's grid system uses a series of containers, rows, and columns…" plus a three-column example). That block also displaced the **"Heads up—our CSS Grid system is experimental and opt-in as of v4.1.0!"** warning, so the page never told readers the feature is off by default. The section now matches `coreui`; the rest of the file was already identical.

### Templates page
The meta description advertised "easy-to-customize **react** admin panels". Companion fix in coreui/coreui#1140.

`npm run docs-build` passes (133 pages, no broken links); `js-lint` and `css-lint` are clean.

Note: `npm run js-test-karma` exits non-zero with "Some of your tests did a full page reload!" while reporting 3010/3010 SUCCESS. The same happens on a clean `main` in both `coreui` and `coreui-pro`, so it is unrelated to this change.