### PR TITLE
docs(ai-tools): list Angular among the editions the MCP server covers

### DIFF
--- a/docs/src/content/docs/ai-tools/mcp.mdx
+++ b/docs/src/content/docs/ai-tools/mcp.mdx
@@ -13,7 +13,7 @@ It provides:
 - **Component documentation** — pages, props, events, and slots.
 - **Live content** — read on demand from `coreui.io`, always matching the latest release.
 - **Cross-framework links** — where each component is documented for Angular, Bootstrap, React, and Vue.
-- **Coverage of Bootstrap, React, and Vue** from a single server.
+- **Coverage of Angular, Bootstrap, React, and Vue** from a single server.
 
 The server runs locally over stdio via `npx` — no global install required.
 
@@ -118,7 +118,7 @@ Once connected, your assistant can call the following tools:
 
 | Flag | Environment variable | Default | Description |
 | --- | --- | --- | --- |
-| `--framework <list>` | `COREUI_DOCS_FRAMEWORKS` | `bootstrap,react,vue` | Enabled editions (comma-separated). The first is the default for tools. |
+| `--framework <list>` | `COREUI_DOCS_FRAMEWORKS` | `angular,bootstrap,react,vue` | Enabled editions (comma-separated). The first is the default for tools. |
 | `--base-url <url>` | `COREUI_DOCS_BASE_URL` | `https://coreui.io` | Origin of the CoreUI site. The `/<framework>/docs` path is appended automatically — override only for a staging or self-hosted mirror. |
 | `--ttl <minutes>` | `COREUI_DOCS_TTL_MINUTES` | `360` | Cache freshness window. |
 | — | `COREUI_DOCS_CACHE_DIR` | OS cache directory | On-disk cache location. |


### PR DESCRIPTION
The MCP page says the server covers *Bootstrap, React, and Vue* and documents `bootstrap,react,vue` as the default. It accepts `--framework angular` today, and with the Angular docs moving onto the shared engine (which serves the Markdown and llms endpoints the server reads) Angular joins the default set — coreui/coreui-docs-mcp#14.

Both lines now name all four editions. Merge alongside that PR and the Angular docs cutover.