### PR TITLE
chore: ignore node_modules in every directory, not just the root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ Thumbs.db
 # Folders to ignore
 /dist-sass/
 /js/coverage/
-/node_modules/
+node_modules/


### PR DESCRIPTION
`.gitignore` anchors the pattern at the repository root:

```
/node_modules/
```

The docs are a standalone project, not a workspace of the root, so `npm install` there creates `docs/node_modules` — which that pattern does not cover. It shows up as untracked in `git status` and is one `git add -A` away from being committed to a public repository.

Nothing has ever been committed there, so this only closes the hole. Unanchoring the pattern also covers any future nested project.

The same applies to `coreui` (free), where the pattern is identical.