### PR TITLE
test(visual): mark the floating-label page as having no linguistic content

### DIFF
--- a/js/tests/visual/floating-label.html
+++ b/js/tests/visual/floating-label.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="zxx">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
`js/tests/visual/floating-label.html` is Lorem ipsum with `lang="en"`, so the HTML validator's language detector reports:

> This document appears to be written in Lorem ipsum text but the "html" start tag has "lang=en". Consider using "lang=zxx" (or variant) instead.

`docs-vnu` runs with `--Werror`, so that info warning fails the Docs job. It fired on some runs and not others with byte-identical input — the Docs job passed on `v6-dev` and failed minutes later on a PR that changed only an `.mdx` file — which made it read as a random CI failure rather than a real one.

`lang="zxx"` ("no linguistic content") is what the validator's own message suggests for placeholder text, so this makes the check deterministic without touching the filter list. It is the only page in the repo with Lorem ipsum.