### PR TITLE
refactor: extract the shared anchored-position wiring into util/floating-ui

### DIFF
--- a/js/src/autocomplete.ts
+++ b/js/src/autocomplete.ts
@@ -5,24 +5,17 @@
  * --------------------------------------------------------------------------
  */
 
-import {
-  autoUpdate, computePosition, flip, offset, shift
-} from '@floating-ui/dom'
 import BaseComponent from './base-component.js'
 import Data from './dom/data.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
+import { createAnchoredPosition } from './util/floating-ui.js'
 import {
   DefaultAllowlist, escapeHtml, sanitizeHtml, type SanitizerAllowList
 } from './util/sanitizer.js'
 import {
-  defineJQueryPlugin,
-  getNextActiveElement,
-  getElement,
-  getUID,
-  isVisible,
-  isRTL
+  defineJQueryPlugin, getNextActiveElement, getElement, getUID, isVisible
 } from './util/index.js'
 
 /**
@@ -165,6 +158,7 @@ class Autocomplete extends BaseComponent {
   protected declare _selected: any
   protected declare _options: any
   protected declare _floatingCleanup: (() => void) | null
+  protected declare _anchoredPosition: ReturnType<typeof createAnchoredPosition> | null
   protected declare _search: any
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
@@ -181,6 +175,7 @@ class Autocomplete extends BaseComponent {
     this._selected = []
     this._options = this._getOptionsFromConfig()
     this._floatingCleanup = null
+    this._anchoredPosition = null
     this._search = ''
 
     this._createAutocomplete()
@@ -708,44 +703,19 @@ class Autocomplete extends BaseComponent {
   }
 
   _createFloating(): void {
-    this._updateFloatingPosition()
-
-    this._floatingCleanup = autoUpdate(
-      this._togglerElement,
-      this._menu,
-      () => this._updateFloatingPosition()
-    )
+    this._anchoredPosition = createAnchoredPosition(this._togglerElement, this._menu)
+    this._floatingCleanup = this._anchoredPosition.destroy
   }
 
   async _updateFloatingPosition(): Promise<void> {
-    if (!this._menu || !this._menu.isConnected) {
-      return
-    }
-
-    const { x, y } = await computePosition(this._togglerElement, this._menu, {
-      middleware: [
-        offset({ mainAxis: 2 }),
-        flip(),
-        shift({ boundary: 'clippingAncestors' })
-      ],
-      placement: isRTL() ? 'bottom-end' : 'bottom-start'
-    })
-
-    if (!this._menu || !this._menu.isConnected) {
-      return
-    }
-
-    Object.assign(this._menu.style, {
-      position: 'absolute',
-      left: `${x}px`,
-      top: `${y}px`
-    })
+    await this._anchoredPosition?.update()
   }
 
   _disposeFloating(): void {
     if (this._floatingCleanup) {
       this._floatingCleanup()
       this._floatingCleanup = null
+      this._anchoredPosition = null
     }
   }
 

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -5,9 +5,6 @@
  * --------------------------------------------------------------------------
  */
 
-import {
-  autoUpdate, computePosition, flip, offset, shift
-} from '@floating-ui/dom'
 import BaseComponent from './base-component.js'
 import Calendar from './calendar.js'
 import TimePicker from './time-picker.js'
@@ -15,11 +12,12 @@ import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { DefaultAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
-import { defineJQueryPlugin, getElement, isRTL } from './util/index.js'
+import { defineJQueryPlugin, getElement } from './util/index.js'
 import {
   convertToDateObject, getDateBySelectionType, getLocalDateFromString, isDateDisabled
 } from './util/calendar.js'
 import type { ComponentConfig } from './util/config.js'
+import { createAnchoredPosition } from './util/floating-ui.js'
 import FocusTrap from './util/focustrap.js'
 
 /**
@@ -219,6 +217,7 @@ class DateRangePicker extends BaseComponent {
   protected declare _initialEndDate: any
   protected declare _mobile: any
   protected declare _floatingCleanup: (() => void) | null
+  protected declare _anchoredPosition: ReturnType<typeof createAnchoredPosition> | null
   protected declare _selectEndDate: any
   protected declare _calendar: any
   protected declare _calendars: any
@@ -247,6 +246,7 @@ class DateRangePicker extends BaseComponent {
     this._initialEndDate = null
     this._mobile = window.innerWidth < 768
     this._floatingCleanup = null
+    this._anchoredPosition = null
     this._selectEndDate = this._config.selectEndDate
 
     this._calendar = null
@@ -1004,44 +1004,19 @@ class DateRangePicker extends BaseComponent {
   }
 
   _createFloating(): void {
-    this._updateFloatingPosition()
-
-    this._floatingCleanup = autoUpdate(
-      this._togglerElement,
-      this._menu,
-      () => this._updateFloatingPosition()
-    )
+    this._anchoredPosition = createAnchoredPosition(this._togglerElement, this._menu)
+    this._floatingCleanup = this._anchoredPosition.destroy
   }
 
   async _updateFloatingPosition(): Promise<void> {
-    if (!this._menu || !this._menu.isConnected) {
-      return
-    }
-
-    const { x, y } = await computePosition(this._togglerElement, this._menu, {
-      middleware: [
-        offset({ mainAxis: 2 }),
-        flip(),
-        shift({ boundary: 'clippingAncestors' })
-      ],
-      placement: isRTL() ? 'bottom-end' : 'bottom-start'
-    })
-
-    if (!this._menu || !this._menu.isConnected) {
-      return
-    }
-
-    Object.assign(this._menu.style, {
-      position: 'absolute',
-      left: `${x}px`,
-      top: `${y}px`
-    })
+    await this._anchoredPosition?.update()
   }
 
   _disposeFloating(): void {
     if (this._floatingCleanup) {
       this._floatingCleanup()
       this._floatingCleanup = null
+      this._anchoredPosition = null
     }
   }
 

--- a/js/src/multi-select.ts
+++ b/js/src/multi-select.ts
@@ -7,22 +7,15 @@
  * --------------------------------------------------------------------------
  */
 
-import {
-  autoUpdate, computePosition, flip, offset, shift
-} from '@floating-ui/dom'
 import BaseComponent from './base-component.js'
 import Data from './dom/data.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
+import { createAnchoredPosition } from './util/floating-ui.js'
 import { DefaultAllowlist, sanitizeHtml, type SanitizerAllowList } from './util/sanitizer.js'
 import {
-  defineJQueryPlugin,
-  getNextActiveElement,
-  getElement,
-  getUID,
-  isVisible,
-  isRTL
+  defineJQueryPlugin, getNextActiveElement, getElement, getUID, isVisible
 } from './util/index.js'
 
 /**
@@ -212,6 +205,7 @@ class MultiSelect extends BaseComponent {
   protected declare _selected: any
   protected declare _options: any
   protected declare _floatingCleanup: (() => void) | null
+  protected declare _anchoredPosition: ReturnType<typeof createAnchoredPosition> | null
   protected declare _search: any
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
@@ -235,6 +229,7 @@ class MultiSelect extends BaseComponent {
     this._selected = []
     this._options = this._getOptions()
     this._floatingCleanup = null
+    this._anchoredPosition = null
     this._search = ''
 
     if (this._config.options.length > 0) {
@@ -832,44 +827,19 @@ class MultiSelect extends BaseComponent {
   }
 
   _createFloating(): void {
-    this._updateFloatingPosition()
-
-    this._floatingCleanup = autoUpdate(
-      this._togglerElement,
-      this._menu,
-      () => this._updateFloatingPosition()
-    )
+    this._anchoredPosition = createAnchoredPosition(this._togglerElement, this._menu)
+    this._floatingCleanup = this._anchoredPosition.destroy
   }
 
   async _updateFloatingPosition(): Promise<void> {
-    if (!this._menu || !this._menu.isConnected) {
-      return
-    }
-
-    const { x, y } = await computePosition(this._togglerElement, this._menu, {
-      middleware: [
-        offset({ mainAxis: 2 }),
-        flip(),
-        shift({ boundary: 'clippingAncestors' })
-      ],
-      placement: isRTL() ? 'bottom-end' : 'bottom-start'
-    })
-
-    if (!this._menu || !this._menu.isConnected) {
-      return
-    }
-
-    Object.assign(this._menu.style, {
-      position: 'absolute',
-      left: `${x}px`,
-      top: `${y}px`
-    })
+    await this._anchoredPosition?.update()
   }
 
   _disposeFloating(): void {
     if (this._floatingCleanup) {
       this._floatingCleanup()
       this._floatingCleanup = null
+      this._anchoredPosition = null
     }
   }
 

--- a/js/src/time-picker.ts
+++ b/js/src/time-picker.ts
@@ -5,14 +5,12 @@
  * --------------------------------------------------------------------------
  */
 
-import {
-  autoUpdate, computePosition, flip, offset, shift
-} from '@floating-ui/dom'
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
+import { createAnchoredPosition } from './util/floating-ui.js'
 import {
   defineJQueryPlugin, getElement, getNextActiveElement, isRTL
 } from './util/index.js'
@@ -160,6 +158,7 @@ class TimePicker extends BaseComponent {
   protected declare _initialDate: any
   protected declare _ampm: any
   protected declare _floatingCleanup: (() => void) | null
+  protected declare _anchoredPosition: ReturnType<typeof createAnchoredPosition> | null
   protected declare _indicatorElement: any
   protected declare _input: any
   protected declare _menu: any
@@ -179,6 +178,7 @@ class TimePicker extends BaseComponent {
       getAmPm(new Date(this._date), this._config.locale) :
       'am'
     this._floatingCleanup = null
+    this._anchoredPosition = null
 
     this._indicatorElement = null
     this._input = null
@@ -895,44 +895,19 @@ class TimePicker extends BaseComponent {
   }
 
   _createFloating(): void {
-    this._updateFloatingPosition()
-
-    this._floatingCleanup = autoUpdate(
-      this._togglerElement,
-      this._menu,
-      () => this._updateFloatingPosition()
-    )
+    this._anchoredPosition = createAnchoredPosition(this._togglerElement, this._menu)
+    this._floatingCleanup = this._anchoredPosition.destroy
   }
 
   async _updateFloatingPosition(): Promise<void> {
-    if (!this._menu || !this._menu.isConnected) {
-      return
-    }
-
-    const { x, y } = await computePosition(this._togglerElement, this._menu, {
-      middleware: [
-        offset({ mainAxis: 2 }),
-        flip(),
-        shift({ boundary: 'clippingAncestors' })
-      ],
-      placement: isRTL() ? 'bottom-end' : 'bottom-start'
-    })
-
-    if (!this._menu || !this._menu.isConnected) {
-      return
-    }
-
-    Object.assign(this._menu.style, {
-      position: 'absolute',
-      left: `${x}px`,
-      top: `${y}px`
-    })
+    await this._anchoredPosition?.update()
   }
 
   _disposeFloating(): void {
     if (this._floatingCleanup) {
       this._floatingCleanup()
       this._floatingCleanup = null
+      this._anchoredPosition = null
     }
   }
 

--- a/js/src/util/floating-ui.ts
+++ b/js/src/util/floating-ui.ts
@@ -8,6 +8,9 @@
  * --------------------------------------------------------------------------
  */
 
+import {
+  autoUpdate, computePosition, flip, offset, shift
+} from '@floating-ui/dom'
 import { isRTL } from './index.js'
 
 /**
@@ -168,6 +171,56 @@ type FloatingOffsetValue = Exclude<FloatingOffsetInput, number[]>
  */
 export const toFloatingOffset = (value: FloatingOffsetInput): FloatingOffsetValue => {
   return Array.isArray(value) ? { mainAxis: value[1] || 0, crossAxis: value[0] || 0 } : value
+}
+
+/**
+ * The dropdown-shaped anchored panel: bottom-start placement (mirrored in
+ * RTL), a 2px main-axis offset, flip and shift within the clipping ancestors.
+ * Autocomplete, multi-select and the v1 pickers all position exactly this way,
+ * so the wiring — initial position, autoUpdate resubscription and the
+ * disconnect guards on both sides of the await — lives here once.
+ *
+ * `destroy()` also acts as the in-flight guard: a computePosition resolving
+ * after teardown must not touch the content's styles.
+ */
+export const createAnchoredPosition = (anchor: Element, content: HTMLElement): { update: () => Promise<void>, destroy: () => void } => {
+  let disposed = false
+
+  const update = async (): Promise<void> => {
+    if (disposed || !content || !content.isConnected) {
+      return
+    }
+
+    const { x, y } = await computePosition(anchor, content, {
+      middleware: [
+        offset({ mainAxis: 2 }),
+        flip(),
+        shift({ boundary: 'clippingAncestors' })
+      ],
+      placement: isRTL() ? 'bottom-end' : 'bottom-start'
+    })
+
+    if (disposed || !content.isConnected) {
+      return
+    }
+
+    Object.assign(content.style, {
+      position: 'absolute',
+      left: `${x}px`,
+      top: `${y}px`
+    })
+  }
+
+  update()
+  const cleanup = autoUpdate(anchor, content, update)
+
+  return {
+    update,
+    destroy(): void {
+      disposed = true
+      cleanup()
+    }
+  }
 }
 
 export type {


### PR DESCRIPTION
The Floating UI migration left four **byte-identical** positioning blocks (verified by diff) in autocomplete, multi-select, time-picker and date-range-picker: the same placement, offset, flip/shift middleware, autoUpdate wiring and the disconnect guards on both sides of the await. `createAnchoredPosition(anchor, content)` now carries that once, with `destroy()` doubling as the in-flight guard.

Scope discipline, per `workspace/plans/menu-and-dropdown-compat.md`:

- The components keep `_floatingCleanup` and `_updateFloatingPosition` as thin delegates — the specs assert the field and spy on the method; that surface is part of their contract.
- **Menu and Popup stay on their own positioning on purpose.** Both differ genuinely (placement stamping and submenu chains in Menu; custom middleware and the inline-start reset in Popup). Folding them in would trade real duplication for a configuration surface.

Net: **−57 lines**, no behavior change, suite 3453/3453, local gate green.