### PR TITLE
feat!: raise the browser floors to native light-dark()

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,12 +1,27 @@
 # https://github.com/browserslist/browserslist#readme
+#
+# The floor is native `light-dark()`: Chrome 123, Edge 123, Firefox 120,
+# Safari 17.5. The v6 color system resolves every theme decision in the
+# browser through `light-dark()` and `color-mix()`, ships no fallback, and
+# below these versions dark mode simply does not work — so declaring anything
+# lower would be fiction, and raising it further is a product choice we have
+# not made. The JS floor rides along (everything the sources use is older
+# than this line).
+#
+# Run `npx browserslist --coverage` after any change and update the figure on
+# the browsers & devices docs page.
 
->= 0.5%
 last 2 major versions
 not dead
-Chrome >= 60
-Firefox >= 60
-Firefox ESR
-iOS >= 12
-Safari >= 12
-not Explorer <= 11
-not kaios <= 2.5 # fix floating label issues in Firefox (see https://github.com/postcss/autoprefixer/issues/1533)
+unreleased versions
+
+Chrome >= 123
+Edge >= 123
+Firefox >= 120
+iOS >= 17.5
+Safari >= 17.5
+
+not and_uc > 0
+not and_qq > 0
+not kaios > 0
+not op_mini all

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -2,11 +2,11 @@
   "files": [
     {
       "path": "./dist/css/coreui-grid.css",
-      "maxSize": "7.25 kB"
+      "maxSize": "7.00 kB"
     },
     {
       "path": "./dist/css/coreui-grid.min.css",
-      "maxSize": "6.50 kB"
+      "maxSize": "6.25 kB"
     },
     {
       "path": "./dist/css/coreui-reboot.css",
@@ -18,43 +18,43 @@
     },
     {
       "path": "./dist/css/coreui-utilities.css",
-      "maxSize": "14.95 kB"
+      "maxSize": "14.25 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",
-      "maxSize": "13.85 kB"
+      "maxSize": "13.10 kB"
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "61.40 kB"
+      "maxSize": "59.00 kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "57.95 kB"
+      "maxSize": "48.00 kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",
-      "maxSize": "122.00 kB"
+      "maxSize": "120.50 kB"
     },
     {
       "path": "./dist/js/coreui.bundle.min.js",
-      "maxSize": "78.50 kB"
+      "maxSize": "78.00 kB"
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "110.50 kB"
+      "maxSize": "109.00 kB"
     },
     {
       "path": "./dist/js/coreui.esm.min.js",
-      "maxSize": "80.00 kB"
+      "maxSize": "79.50 kB"
     },
     {
       "path": "./dist/js/coreui.js",
-      "maxSize": "112.00 kB"
+      "maxSize": "110.50 kB"
     },
     {
       "path": "./dist/js/coreui.min.js",
-      "maxSize": "72.50 kB"
+      "maxSize": "72.00 kB"
     }
   ],
   "ci": {

--- a/docs/src/content/docs/getting-started/browsers-devices.mdx
+++ b/docs/src/content/docs/getting-started/browsers-devices.mdx
@@ -9,21 +9,30 @@ CoreUI for Bootstrap supports the **latest, stable releases** of all major brows
 
 Alternative browsers which use the latest version of WebKit, Blink, or Gecko, whether directly or via the platform's web view API, are not explicitly supported. However, CoreUI for Bootstrap should (in most cases) display and function correctly in these browsers as well. More specific support information is provided below.
 
-You can find our supported range of browsers and their versions [in our `.browserslistrc file`](https://github.com/coreui/coreui/blob/v5.8.0/.browserslistrc):
+The floor is set by the v6 color system: every theme decision resolves in the
+browser through `light-dark()` and `color-mix()`, with no fallback shipped —
+so the oldest supported versions are the first ones with native `light-dark()`
+support: **Chrome 123, Edge 123, Firefox 120, Safari 17.5 and iOS 17.5**.
+Together with the evergreen lines below, this covers about 87% of global
+usage as measured with `npx browserslist --coverage`.
+
+You can find our supported range of browsers and their versions [in our `.browserslistrc` file](https://github.com/coreui/coreui/blob/main/.browserslistrc):
 
 ```text
-# https://github.com/browserslist/browserslist#readme
-
->= 0.5%
 last 2 major versions
 not dead
-Chrome >= 60
-Firefox >= 60
-Firefox ESR
-iOS >= 12
-Safari >= 12
-not Explorer <= 11
-not kaios <= 2.5 # fix floating label issues in Firefox (see https://github.com/postcss/autoprefixer/issues/1533)
+unreleased versions
+
+Chrome >= 123
+Edge >= 123
+Firefox >= 120
+iOS >= 17.5
+Safari >= 17.5
+
+not and_uc > 0
+not and_qq > 0
+not kaios > 0
+not op_mini all
 ```
 
 We use [Autoprefixer](https://github.com/postcss/autoprefixer) to handle intended browser support via CSS prefixes, which uses [Browserslist](https://github.com/browserslist/browserslist) to manage these browser versions. Consult their documentation for how to integrate these tools into your projects.
@@ -52,7 +61,7 @@ Unofficially, CoreUI for Bootstrap should look and behave well enough in Chromiu
 
 ## Internet Explorer
 
-Internet Explorer is not supported. **If you require Internet Explorer support, please use CoreUI v3.**
+Internet Explorer is not supported. **If you require Internet Explorer support, please use CoreUI v3.** If you need the previous browser floors (Chrome 60+, Safari 12+), stay on CoreUI v5.
 
 ## Modals and dropdowns on mobile
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -38,6 +38,21 @@ description: "Track and review changes to the CoreUI for Bootstrap source files,
     Code that read the tip's coordinates synchronously right after `show()`
     should wait for the `shown` event.
 
+### Browser support
+
+<span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+
+**The minimum supported browsers are now Chrome 123, Edge 123, Firefox 120,
+Safari 17.5 and iOS 17.5** — the first versions with native `light-dark()`
+support. This is the floor the v6 color system already required in practice:
+theme decisions resolve in the browser via `light-dark()` and `color-mix()`
+with no fallback, so on older browsers dark mode did not work regardless of
+what the previous `.browserslistrc` claimed (Chrome 60 / Safari 12). v6 makes
+the declaration honest and takes the wins: the compiled CSS drops legacy
+vendor prefixes (about 8&nbsp;kB gzip off `coreui.min.css`) and the JavaScript
+ships modern syntax un-transpiled. If you must support older browsers, stay
+on v5.
+
 ### JavaScript
 
 v6's JavaScript is written in TypeScript. The published behaviour is unchanged —

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -102,13 +102,6 @@ export default [
       ],
       'no-console': 'error',
       'no-negated-condition': 'off',
-      'no-restricted-properties': [
-        'error',
-        {
-          property: 'at',
-          message: 'Avoid Array/String.prototype.at(): it is unsupported in the browsers declared in .browserslistrc (Chrome < 92, Safari < 15.4) and the build does not polyfill. Use index access, e.g. arr[arr.length - 1].'
-        }
-      ],
       'object-curly-spacing': ['error', 'always'],
       'operator-linebreak': ['error', 'after'],
       'prefer-object-has-own': 'off',


### PR DESCRIPTION
Resolves the browserslist-fiction finding from the rolldown work (mrholek decided: option A — raise to the truth).

## The floor and why exactly there

**Chrome 123, Edge 123, Firefox 120, Safari 17.5, iOS 17.5** — the first versions with native `light-dark()`. The v6 color system resolves every theme decision in the browser via `light-dark()` + `color-mix()` and ships no fallback, so below this line dark mode has not worked since the token architecture landed, regardless of what `.browserslistrc` claimed (Chrome 60 / Safari 12). The JS floor rides along: `toSorted`, `findLast` and `replaceAll` all exist above the line.

Coverage: **87.19%** of global usage measured against today's caniuse data (upstream's higher floors measure 85.01%).

## Structural fixes, from upstream's lessons

- the old `>=` lines never acted as floors — the percentage query OR-ed them away; the floors are real now
- `unreleased versions` recovers the Safari share caniuse hides behind a null release date
- proxy/fringe engines (and_uc, and_qq, kaios, op_mini) explicitly excluded

## Wins taken, not banked

- Autoprefixer output: **613 → 84** prefixed declarations; `coreui.min.css` **54.5 → 46.6 kB gzip (−8 kB)**
- the oxc targets derived from this file stop lowering modern syntax in dist
- bundlewatch budgets re-tightened to the new sizes across CSS and JS
- the eslint ban on `Array.prototype.at()` is lifted (added when the floors were lower; `no-restricted-properties` remains the mechanism if a future API needs guarding)

## Docs

The browsers-and-devices page states the floor, the reason and the measured coverage; the migration guide carries a Breaking entry with "stay on v5 for older floors". Suite 3453/3453, docs build clean, local gate green.