### PR TITLE
fix(Tooltip,ChipInput): resolve the axe-core violations

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -278,6 +278,22 @@ the option-by-option migration map. Planned mapping:
 - The `data-coreui-toggle="pill"` and `"list"` toggles **stay** — they are
   documented markup, and v6 keeps documented markup working.
 
+#### Tooltip
+
+- **`--cui-tooltip-opacity` now blends into the background colour instead of
+  fading the whole element.** The old element-level `opacity: .9` also faded the
+  label text, compositing it below the WCAG 1.4.3 contrast minimum (about
+  3.5&#8758;1). The surface and arrow keep the same translucent look; the text
+  renders at full opacity. The token still works — override it and only the
+  background alpha changes.
+
+#### Chip input
+
+- **`aria-disabled`/`aria-readonly` are no longer stamped on the container.**
+  The container is a generic element, so those attributes were invalid on it
+  (axe `aria-allowed-attr`); the native `disabled`/`readonly` states on the
+  inner `<input>` carry the semantics.
+
 ### Sass architecture & design tokens
 
 v6 adopts the Bootstrap v6 SCSS architecture: CSS cascade layers, per-component

--- a/js/src/chip-input.ts
+++ b/js/src/chip-input.ts
@@ -262,10 +262,10 @@ class ChipInput extends ChipSet {
   _applyInteractionState(): void {
     const { readonly } = this._config
     this._element.classList.toggle(CLASS_NAME_DISABLED, this._disabled)
+    // The container is a generic element, so `aria-disabled`/`aria-readonly`
+    // are not allowed on it — the native input states carry the semantics.
     this._input.disabled = this._disabled
     this._input.readOnly = !this._disabled && readonly
-    this._element.setAttribute('aria-disabled', this._disabled ? 'true' : 'false')
-    this._element.setAttribute('aria-readonly', readonly ? 'true' : 'false')
   }
 
   _handleInputKeydown(event: any): void {

--- a/js/tests/unit/chip-input.spec.js
+++ b/js/tests/unit/chip-input.spec.js
@@ -170,15 +170,15 @@ describe('ChipInput', () => {
       expect(chipInput.getValues()).toEqual(['First', 'Second'])
     })
 
-    it('should set aria attributes on element', () => {
+    it('should not set aria attributes on the container element', () => {
       fixtureEl.innerHTML = '<div class="chip-input"></div>'
 
       const el = fixtureEl.querySelector('.chip-input')
       // eslint-disable-next-line no-new
       new ChipInput(el)
 
-      expect(el.getAttribute('aria-disabled')).toEqual('false')
-      expect(el.getAttribute('aria-readonly')).toEqual('false')
+      expect(el.getAttribute('aria-disabled')).toBeNull()
+      expect(el.getAttribute('aria-readonly')).toBeNull()
     })
 
     it('should set label for attribute when label has no for', () => {

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -49,6 +49,11 @@ $tooltip-tokens: defaults(
   .tooltip {
     @include tokens($tooltip-tokens);
 
+    // Fold `--#{$prefix}tooltip-opacity` into the surface colour instead of the
+    // element: element-level opacity also faded the label text, compositing it
+    // below the WCAG 1.4.3 contrast minimum.
+    --#{$prefix}tooltip-surface-bg: color-mix(in srgb, var(--#{$prefix}tooltip-bg) calc(var(--#{$prefix}tooltip-opacity) * 100%), transparent); // stylelint-disable-line function-disallowed-list
+
     z-index: var(--#{$prefix}tooltip-zindex);
     display: block;
     margin: var(--#{$prefix}tooltip-margin);
@@ -61,7 +66,7 @@ $tooltip-tokens: defaults(
     word-wrap: break-word;
     opacity: 0;
 
-    &.show { opacity: var(--#{$prefix}tooltip-opacity); }
+    &.show { opacity: 1; }
 
     .tooltip-arrow {
       display: block;
@@ -83,7 +88,7 @@ $tooltip-tokens: defaults(
     &::before {
       top: -1px;
       border-width: var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
-      border-top-color: var(--#{$prefix}tooltip-bg);
+      border-top-color: var(--#{$prefix}tooltip-surface-bg);
     }
   }
 
@@ -96,7 +101,7 @@ $tooltip-tokens: defaults(
     &::before {
       right: -1px;
       border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
-      border-right-color: var(--#{$prefix}tooltip-bg);
+      border-right-color: var(--#{$prefix}tooltip-surface-bg);
     }
   }
 
@@ -108,7 +113,7 @@ $tooltip-tokens: defaults(
     &::before {
       bottom: -1px;
       border-width: 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
-      border-bottom-color: var(--#{$prefix}tooltip-bg);
+      border-bottom-color: var(--#{$prefix}tooltip-surface-bg);
     }
   }
 
@@ -121,7 +126,7 @@ $tooltip-tokens: defaults(
     &::before {
       left: -1px;
       border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
-      border-left-color: var(--#{$prefix}tooltip-bg);
+      border-left-color: var(--#{$prefix}tooltip-surface-bg);
     }
   }
 
@@ -148,7 +153,7 @@ $tooltip-tokens: defaults(
     padding: var(--#{$prefix}tooltip-padding-y) var(--#{$prefix}tooltip-padding-x);
     color: var(--#{$prefix}tooltip-color);
     text-align: center;
-    background-color: var(--#{$prefix}tooltip-bg);
+    background-color: var(--#{$prefix}tooltip-surface-bg);
     @include border-radius(var(--#{$prefix}tooltip-border-radius));
   }
 }


### PR DESCRIPTION
## Summary

Two accessibility fixes surfaced by axe-core, landed ahead of the WCAG conformance test suite:

- **Tooltip** — `--cui-tooltip-opacity` now blends into the surface colour (`color-mix`) instead of fading the whole element. Element-level opacity composited the label text together with the background, which axe flattens to a sub-AA contrast ratio. Same translucent look, text at full opacity; the token keeps working and now drives the background alpha only. Verified in headless Chromium: effective text contrast 15.86:1 (light) / 12.51:1 (dark).
- **Chip input** — `aria-disabled`/`aria-readonly` are no longer stamped on the container, which is a generic element where those attributes are invalid (axe `aria-allowed-attr`, critical). The native `disabled`/`readOnly` states on the inner `<input>` carry the semantics.

Both changes are documented in the v6 migration guide.