### PR TITLE
docs(Menu): add the Menu page to the docs sidebar

### DIFF
--- a/docs/src/data/sidebar.yml
+++ b/docs/src/data/sidebar.yml
@@ -263,6 +263,8 @@
       badge:
         color: danger
         text: PRO
+    - title: Menu
+      to: /components/menu/
     - title: Modal
       to: /components/modal/
     - title: Navbar


### PR DESCRIPTION
The Menu docs page landed in #649 without a sidebar entry, so it was only reachable by URL. Adds it between Loading buttons and Modal (alphabetical).