### PR TITLE
feat(MultiSelect,Autocomplete): rebuild both on an internal shared combobox engine

### DIFF
--- a/build/a11y.config.mjs
+++ b/build/a11y.config.mjs
@@ -120,11 +120,20 @@ export const a11yComponents = [
   },
   {
     component: 'forms/multi-select',
+    // Docs examples are unlabeled fragments, so audit a representative,
+    // correctly labelled instance — that is what exercises the component's own
+    // wiring (label association, hidden native select) rather than the docs.
+    html: `<label for="a11yMultiSelect">Choose technologies</label>
+  <select id="a11yMultiSelect" multiple data-coreui-multi-select>
+    <option value="angular">Angular</option>
+    <option value="react" selected>React.js</option>
+    <option value="vue">Vue.js</option>
+  </select>`,
     criteria: [
       {
         criterion: '4.1.2',
-        status: 'author',
-        note: 'The toggler gets role=combobox with aria-expanded, aria-haspopup and aria-controls; options render as a role=listbox with aria-multiselectable and role=option items; the search input carries aria-label and aria-autocomplete. GAP: _hideNativeSelect() only sets tabindex=-1, so the replaced (unlabelled) <select> stays in the accessibility tree, and the role=combobox toggler <div> has no accessible name — it should be wired to an associated <label> via aria-labelledby.'
+        status: 'built-in',
+        note: 'The toggler gets role=combobox named from the associated <label> via aria-labelledby (or the select\'s aria-label), with aria-expanded, aria-haspopup and aria-controls; options render as a role=listbox with aria-multiselectable and role=option items; the replaced native <select> is removed from the accessibility tree (aria-hidden, tabindex=-1).'
       },
       {
         criterion: '4.1.3',

--- a/docs/src/content/docs/forms/multi-select.mdx
+++ b/docs/src/content/docs/forms/multi-select.mdx
@@ -157,6 +157,22 @@ If you want to display selected options as tags, add the `data-coreui-selection-
     </optgroup>
   </select>`} />
 
+### Chips
+
+Add `data-coreui-selection-type="chips"` to render selected options as [Chip](/components/chip/) components — each selection becomes a real chip with the standard chip styling and a labelled remove button. <AddedIn version="6.0.0" />
+
+<Example pro code={`<select id="multiple-select-chips" data-coreui-multi-select multiple data-coreui-selection-type="chips" data-coreui-search="true">
+    <option value="0">Angular</option>
+    <option value="1">Bootstrap</option>
+    <option value="2">React.js</option>
+    <option value="3">Vue.js</option>
+    <optgroup label="backend">
+      <option value="4">Django</option>
+      <option value="5">Laravel</option>
+      <option value="6">Node.js</option>
+    </optgroup>
+  </select>`} />
+
 ### Counter
 
 If you prefer to show a counter indicating the number of selected options, add the `data-coreui-selection-type="counter"`. This helps users keep track of their selections and includes search functionality for filtering options.
@@ -497,7 +513,7 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 | `selectAllStyle` | string | `'checkbox'` | Sets the select all button style: `'checkbox'` or `'text'`. With `'checkbox'` (and `multiple`), the built-in select all button shows a tri-state checkbox indicator (`none` / `all` / `indeterminate`) reflecting the overall selection, and clicking it toggles between selecting and deselecting all. |
 | `selectionLimit` | number, null | `null` | Sets the maximum number of selectable options. The select all button stays enabled and selects up to the limit (firing the `selectionLimit` event), then toggles to deselect all once the limit is reached. |
 | `selectFilteredLabel` | string | `'Select filtered'` | Label shown instead of `selectAllLabel` when `selectAllMode: 'filtered'` and a search filter narrows the list, so the button reads as acting on the filtered options rather than the whole list. |
-| `selectionType` | string | `'tag'` | Sets the selection style.	 |
+| `selectionType` | string | `'tags'` | Sets the selection style: `'chips'`, `'counter'`, `'tags'` or `'text'`. `'chips'` renders selections as [Chip](/components/chip/) components. |
 | `selectionTypeCounterText` | string | `'item(s) selected'` | Sets the counter selection label.	|
 | `valid` | boolean | `false` | Toggle the valid state for the component. |
 | `value` | boolean | `null` | Sets the initially selected values for the multi-select component. |

--- a/js/src/autocomplete.ts
+++ b/js/src/autocomplete.ts
@@ -5,18 +5,15 @@
  * --------------------------------------------------------------------------
  */
 
-import BaseComponent from './base-component.js'
+import Combobox from './combobox.js'
 import Data from './dom/data.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
-import { createAnchoredPosition } from './util/floating-ui.js'
 import {
-  DefaultAllowlist, escapeHtml, sanitizeHtml, type SanitizerAllowList
+  DefaultAllowlist, escapeHtml, type SanitizerAllowList
 } from './util/sanitizer.js'
-import {
-  defineJQueryPlugin, getNextActiveElement, getElement, getUID, isVisible
-} from './util/index.js'
+import { defineJQueryPlugin, getUID } from './util/index.js'
 
 /**
  * ------------------------------------------------------------------------
@@ -69,7 +66,6 @@ const CLASS_NAME_OPTGROUP = 'autocomplete-optgroup'
 const CLASS_NAME_OPTGROUP_LABEL = 'autocomplete-optgroup-label'
 const CLASS_NAME_OPTION = 'autocomplete-option'
 const CLASS_NAME_OPTIONS = 'autocomplete-options'
-const CLASS_NAME_OPTIONS_EMPTY = 'autocomplete-options-empty'
 const CLASS_NAME_SELECTED = 'selected'
 const CLASS_NAME_SHOW = 'show'
 
@@ -146,20 +142,11 @@ const DefaultType: Record<string, string> = {
  * ------------------------------------------------------------------------
  */
 
-class Autocomplete extends BaseComponent {
-  protected declare _uniqueId: any
+class Autocomplete extends Combobox {
   protected declare _indicatorElement: any
   protected declare _cleanerElement: any
   protected declare _inputElement: any
   protected declare _inputHintElement: any
-  protected declare _togglerElement: any
-  protected declare _optionsElement: any
-  protected declare _menu: any
-  protected declare _selected: any
-  protected declare _options: any
-  protected declare _floatingCleanup: (() => void) | null
-  protected declare _anchoredPosition: ReturnType<typeof createAnchoredPosition> | null
-  protected declare _search: any
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
     super(element, config)
@@ -196,6 +183,16 @@ class Autocomplete extends BaseComponent {
 
   static override get NAME(): string {
     return NAME
+  }
+
+  static override get selectors(): any {
+    return {
+      option: SELECTOR_OPTION,
+      optgroup: SELECTOR_OPTGROUP,
+      options: SELECTOR_OPTIONS,
+      optionsEmpty: SELECTOR_OPTIONS_EMPTY,
+      navigableItems: SELECTOR_VISIBLE_ITEMS
+    }
   }
 
   // Public
@@ -313,19 +310,6 @@ class Autocomplete extends BaseComponent {
     })
   }
 
-  _flattenOptions(options: any[] = this._options, flat: any[] = []): any[] {
-    for (const opt of options) {
-      if (opt && Array.isArray(opt.options)) {
-        this._flattenOptions(opt.options, flat)
-        continue
-      }
-
-      flat.push(opt)
-    }
-
-    return flat
-  }
-
   _getClassNames(): string[] {
     return this._element.classList.value.split(' ')
   }
@@ -349,11 +333,6 @@ class Autocomplete extends BaseComponent {
 
   _isGlobalSearch(): boolean {
     return Array.isArray(this._config.search) && this._config.search.includes('global')
-  }
-
-  _isVisible(element: HTMLElement): boolean {
-    const style = window.getComputedStyle(element)
-    return (style.display !== 'none')
   }
 
   _isShown(): boolean {
@@ -702,23 +681,6 @@ class Autocomplete extends BaseComponent {
     this._updateCleaner()
   }
 
-  _createFloating(): void {
-    this._anchoredPosition = createAnchoredPosition(this._togglerElement, this._menu)
-    this._floatingCleanup = this._anchoredPosition.destroy
-  }
-
-  async _updateFloatingPosition(): Promise<void> {
-    await this._anchoredPosition?.update()
-  }
-
-  _disposeFloating(): void {
-    if (this._floatingCleanup) {
-      this._floatingCleanup()
-      this._floatingCleanup = null
-      this._anchoredPosition = null
-    }
-  }
-
   _createOptionsContainer(): void {
     const dropdownDiv = document.createElement('div')
     dropdownDiv.classList.add(CLASS_NAME_DROPDOWN)
@@ -759,9 +721,7 @@ class Autocomplete extends BaseComponent {
 
         const optgrouplabel = document.createElement('div')
         if (this._config.optionsGroupsTemplate && typeof this._config.optionsGroupsTemplate === 'function') {
-          optgrouplabel.innerHTML = this._config.sanitize ?
-            sanitizeHtml(this._config.optionsGroupsTemplate(option), this._config.allowList, this._config.sanitizeFn) :
-            this._config.optionsGroupsTemplate(option)
+          optgrouplabel.innerHTML = this._maybeSanitize(this._config.optionsGroupsTemplate(option))
         } else {
           optgrouplabel.textContent = option.label
         }
@@ -793,9 +753,7 @@ class Autocomplete extends BaseComponent {
       if (this._isExternalSearch() && this._config.highlightOptionsOnSearch && this._search) {
         optionDiv.innerHTML = this._highlightOption(option.label)
       } else if (this._config.optionsTemplate && typeof this._config.optionsTemplate === 'function') {
-        optionDiv.innerHTML = this._config.sanitize ?
-          sanitizeHtml(this._config.optionsTemplate(option), this._config.allowList, this._config.sanitizeFn) :
-          this._config.optionsTemplate(option)
+        optionDiv.innerHTML = this._maybeSanitize(this._config.optionsTemplate(option))
       } else {
         optionDiv.textContent = option.label
       }
@@ -824,23 +782,6 @@ class Autocomplete extends BaseComponent {
       this._selectOption(foundOption)
       this._inputElement.focus()
     }
-  }
-
-  _findOptionByValue(value: any, options: any[] = this._options): any {
-    for (const option of options) {
-      if (option.value === value) {
-        return option
-      }
-
-      if (option.options && Array.isArray(option.options)) {
-        const found = this._findOptionByValue(value, option.options)
-        if (found) {
-          return found
-        }
-      }
-    }
-
-    return null
   }
 
   _selectOption(option: any): void {
@@ -909,91 +850,23 @@ class Autocomplete extends BaseComponent {
     }
   }
 
-  _filterOptionsList(): void {
-    const options = SelectorEngine.find(SELECTOR_OPTION, this._menu)
-    let visibleOptions = 0
-
-    for (const option of options) {
-      // eslint-disable-next-line unicorn/prefer-includes
-      if (option.textContent.toLowerCase().indexOf(this._search) === -1) {
-        option.style.display = 'none'
-      } else {
-        if (this._config.highlightOptionsOnSearch && !this._config.optionsTemplate) {
-          option.innerHTML = this._highlightOption(option.textContent)
-        }
-
-        option.style.removeProperty('display')
-        visibleOptions++
-      }
-
-      const optgroup = option.closest(SELECTOR_OPTGROUP) as HTMLElement
-      if (optgroup) {
-        // eslint-disable-next-line  unicorn/prefer-array-some
-        if (SelectorEngine.children(optgroup, SELECTOR_OPTION).filter((element: HTMLElement) => this._isVisible(element)).length > 0) {
-          optgroup.style.removeProperty('display')
-        } else {
-          optgroup.style.display = 'none'
-        }
-      }
-    }
-
-    if (visibleOptions > 0) {
-      if (SelectorEngine.findOne(SELECTOR_OPTIONS_EMPTY, this._menu)) {
-        SelectorEngine.findOne(SELECTOR_OPTIONS_EMPTY, this._menu)!.remove()
-      }
-
-      return
-    }
-
-    if (visibleOptions === 0) {
-      if (this._config.searchNoResultsLabel) {
-        const placeholder = document.createElement('div')
-        placeholder.classList.add(CLASS_NAME_OPTIONS_EMPTY)
-        placeholder.setAttribute('role', 'status')
-        placeholder.textContent = this._config.searchNoResultsLabel
-
-        if (!SelectorEngine.findOne(SELECTOR_OPTIONS_EMPTY, this._menu)) {
-          SelectorEngine.findOne(SELECTOR_OPTIONS, this._menu)!.append(placeholder)
-        }
-
-        return
-      }
-
-      this.hide()
+  override _decorateFilteredOption(option: HTMLElement): void {
+    if (this._config.highlightOptionsOnSearch && !this._config.optionsTemplate) {
+      option.innerHTML = this._highlightOption(option.textContent!)
     }
   }
 
-  _selectMenuItem({ key, target }: any): void {
-    const items = SelectorEngine.find(SELECTOR_VISIBLE_ITEMS, this._menu).filter(element => isVisible(element))
-
-    if (!items.length) {
+  override _afterFilter(visibleOptions: number): void {
+    if (visibleOptions > 0 || this._config.searchNoResultsLabel) {
+      this._syncNoResultsPlaceholder(visibleOptions)
       return
     }
 
-    // if target isn't included in items (e.g. when expanding the dropdown)
-    // allow cycling to get the last item in case key equals ARROW_UP_KEY
-    getNextActiveElement(items, target, key === ARROW_DOWN_KEY, !items.includes(target)).focus()
-  }
-
-  _selectFirstOrLastMenuItem(first: boolean): void {
-    const items = SelectorEngine.find(SELECTOR_VISIBLE_ITEMS, this._menu).filter(element => isVisible(element))
-
-    if (!items.length) {
-      return
-    }
-
-    const item = first ? items[0] : items[items.length - 1]
-    item.focus()
+    this.hide()
   }
 
   override _configAfterMerge(config: any): any {
-    if (config.container === true) {
-      config.container = document.body
-    }
-
-    if (typeof config.container === 'object' || typeof config.container === 'string') {
-      config.container = getElement(config.container)
-    }
+    config = this._normalizeContainerConfig(config)
 
     if (typeof config.options === 'string') {
       config.options = config.options.split(/,\s*/).map(String)

--- a/js/src/combobox.ts
+++ b/js/src/combobox.ts
@@ -1,0 +1,231 @@
+/**
+ * --------------------------------------------------------------------------
+ * CoreUI PRO combobox.ts
+ * License (https://coreui.io/pro/license/)
+ * --------------------------------------------------------------------------
+ */
+
+import BaseComponent from './base-component.js'
+import SelectorEngine from './dom/selector-engine.js'
+import { createAnchoredPosition } from './util/floating-ui.js'
+import { sanitizeHtml } from './util/sanitizer.js'
+import { getElement, getNextActiveElement, isVisible } from './util/index.js'
+
+/**
+ * Internal shared engine for the combobox-pattern components (Autocomplete,
+ * MultiSelect). Not exported from the package and not documented — the public
+ * surfaces stay the subclasses, which keep their own markup, class names,
+ * events and options.
+ *
+ * The seam mirrors Menu/Dropdown: subclasses override the static `selectors`
+ * and `optionLabelKey` getters, and the engine reads them through
+ * `this.constructor`, so every shared behavior operates on the subclass's own
+ * class names. Anchored positioning composes `createAnchoredPosition()`
+ * directly (the util extracted from these very components) rather than a Menu
+ * instance, which would impose menu interaction semantics on a listbox.
+ */
+
+const ARROW_DOWN_KEY = 'ArrowDown'
+
+type ComboboxSelectors = {
+  option: string
+  optgroup: string
+  options: string
+  optionsEmpty: string
+  navigableItems: string
+}
+
+class Combobox extends BaseComponent {
+  declare ['constructor']: typeof Combobox
+  protected declare _uniqueId: any
+  protected declare _togglerElement: any
+  protected declare _optionsElement: any
+  protected declare _menu: any
+  protected declare _selected: any
+  protected declare _options: any
+  protected declare _search: any
+  protected declare _floatingCleanup: (() => void) | null
+  protected declare _anchoredPosition: ReturnType<typeof createAnchoredPosition> | null
+
+  // Statics — the subclass seam
+
+  static get selectors(): ComboboxSelectors {
+    throw new Error('Combobox subclasses must define the static "selectors" getter.')
+  }
+
+  // Shorthand resolving the static through the live constructor
+
+  get _selectors(): ComboboxSelectors {
+    return this.constructor.selectors
+  }
+
+  // Option model
+
+  _flattenOptions(options: any[] = this._options, flat: any[] = []): any[] {
+    for (const option of options) {
+      if (option && Array.isArray(option.options)) {
+        this._flattenOptions(option.options, flat)
+        continue
+      }
+
+      flat.push(option)
+    }
+
+    return flat
+  }
+
+  _findOptionByValue(value: any, options: any[] = this._options): any {
+    for (const option of options) {
+      if (String(option.value) === String(value)) {
+        return option
+      }
+
+      if (option.options && Array.isArray(option.options)) {
+        const found = this._findOptionByValue(value, option.options)
+        if (found) {
+          return found
+        }
+      }
+    }
+
+    return null
+  }
+
+  // Anchored positioning (shared wiring around util/floating-ui)
+
+  _createFloating(): void {
+    this._anchoredPosition = createAnchoredPosition(this._togglerElement, this._menu)
+    this._floatingCleanup = this._anchoredPosition.destroy
+  }
+
+  async _updateFloatingPosition(): Promise<void> {
+    await this._anchoredPosition?.update()
+  }
+
+  _disposeFloating(): void {
+    if (this._floatingCleanup) {
+      this._floatingCleanup()
+      this._floatingCleanup = null
+      this._anchoredPosition = null
+    }
+  }
+
+  // Filtering
+
+  _filterOptionsList(): void {
+    const { option: optionSelector, optgroup: optgroupSelector } = this._selectors
+    const options = SelectorEngine.find(optionSelector, this._menu)
+    let visibleOptions = 0
+
+    for (const option of options) {
+      const optionElement = option as HTMLElement
+      // eslint-disable-next-line unicorn/prefer-includes
+      if (optionElement.textContent!.toLowerCase().indexOf(this._search) === -1) {
+        optionElement.style.display = 'none'
+      } else {
+        this._decorateFilteredOption(optionElement)
+        optionElement.style.removeProperty('display')
+        visibleOptions++
+      }
+
+      const optgroup = option.closest(optgroupSelector) as HTMLElement
+      if (optgroup) {
+        // eslint-disable-next-line unicorn/prefer-array-some
+        if (SelectorEngine.children(optgroup, optionSelector).filter((element: Element) => this._isOptionDisplayed(element)).length > 0) {
+          optgroup.style.removeProperty('display')
+        } else {
+          optgroup.style.display = 'none'
+        }
+      }
+    }
+
+    this._afterFilter(visibleOptions)
+  }
+
+  // Hook: decorate an option that stays visible after filtering (e.g. search
+  // highlighting). Default: leave it as rendered.
+  _decorateFilteredOption(option: HTMLElement): void {} // eslint-disable-line @typescript-eslint/no-unused-vars
+
+  // Hook: react to the filter result. Default: sync the no-results placeholder.
+  _afterFilter(visibleOptions: number): void {
+    this._syncNoResultsPlaceholder(visibleOptions)
+  }
+
+  _syncNoResultsPlaceholder(visibleOptions: number): void {
+    const { options: optionsSelector, optionsEmpty: optionsEmptySelector } = this._selectors
+    const emptyMessage = SelectorEngine.findOne(optionsEmptySelector, this._menu)
+
+    if (visibleOptions > 0) {
+      if (emptyMessage) {
+        emptyMessage.remove()
+      }
+
+      return
+    }
+
+    if (!emptyMessage) {
+      const placeholder = document.createElement('div')
+      placeholder.classList.add(optionsEmptySelector.slice(1))
+      placeholder.setAttribute('role', 'status')
+      placeholder.textContent = this._config.searchNoResultsLabel
+
+      SelectorEngine.findOne(optionsSelector, this._menu)!.append(placeholder)
+    }
+  }
+
+  // Checks only `display` (unlike the imported `isVisible`) so it still works
+  // while the menu is closed, e.g. when called from the constructor.
+  _isOptionDisplayed(element: Element): boolean {
+    const style = window.getComputedStyle(element)
+    return (style.display !== 'none')
+  }
+
+  // Listbox keyboard navigation
+
+  _selectMenuItem({ key, target }: any): void {
+    const items = SelectorEngine.find(this._selectors.navigableItems, this._menu).filter(element => isVisible(element))
+
+    if (!items.length) {
+      return
+    }
+
+    // if target isn't included in items (e.g. when expanding the dropdown)
+    // allow cycling to get the last item in case key equals ARROW_UP_KEY
+    getNextActiveElement(items, target, key === ARROW_DOWN_KEY, !items.includes(target)).focus()
+  }
+
+  _selectFirstOrLastMenuItem(first: boolean): void {
+    const items = SelectorEngine.find(this._selectors.navigableItems, this._menu).filter(element => isVisible(element))
+
+    if (!items.length) {
+      return
+    }
+
+    const item = first ? items[0] : items[items.length - 1]
+    item.focus()
+  }
+
+  // Templates
+
+  _maybeSanitize(content: string): string {
+    return this._config.sanitize ?
+      sanitizeHtml(content, this._config.allowList, this._config.sanitizeFn) :
+      content
+  }
+
+  // Config normalization shared by every combobox surface
+
+  _normalizeContainerConfig(config: any): any {
+    if (config.container === true) {
+      config.container = document.body
+    }
+
+    if (typeof config.container === 'object' || typeof config.container === 'string') {
+      config.container = getElement(config.container)
+    }
+
+    return config
+  }
+}
+
+export default Combobox

--- a/js/src/multi-select.ts
+++ b/js/src/multi-select.ts
@@ -7,16 +7,14 @@
  * --------------------------------------------------------------------------
  */
 
-import BaseComponent from './base-component.js'
+import Chip from './chip.js'
+import Combobox from './combobox.js'
 import Data from './dom/data.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
-import { createAnchoredPosition } from './util/floating-ui.js'
-import { DefaultAllowlist, sanitizeHtml, type SanitizerAllowList } from './util/sanitizer.js'
-import {
-  defineJQueryPlugin, getNextActiveElement, getElement, getUID, isVisible
-} from './util/index.js'
+import { DefaultAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
+import { defineJQueryPlugin, getUID } from './util/index.js'
 
 /**
  * ------------------------------------------------------------------------
@@ -41,6 +39,7 @@ const SPACE_KEY = ' '
 const TAB_KEY = 'Tab'
 const RIGHT_MOUSE_BUTTON = 2 // MouseEvent.button value for the secondary button, usually the right button
 
+const SELECTOR_CHIP = '.chip'
 const SELECTOR_CLEANER = '.form-multi-select-cleaner'
 const SELECTOR_OPTGROUP = '.form-multi-select-optgroup'
 const SELECTOR_OPTION = '.form-multi-select-option'
@@ -70,8 +69,10 @@ const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_KEYUP_DATA_API = `keyup${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
+const EVENT_CHIP_REMOVE = 'remove.coreui.chip'
 
 const CLASS_NAME_BUTTONS = 'form-multi-select-buttons'
+const CLASS_NAME_CHIP = 'chip'
 const CLASS_NAME_CLEANER = 'form-multi-select-cleaner'
 const CLASS_NAME_DISABLED = 'disabled'
 const CLASS_NAME_DROPDOWN_HEADER = 'form-multi-select-dropdown-header'
@@ -87,7 +88,6 @@ const CLASS_NAME_OPTGROUP_LABEL_WITH_CHECKBOX = 'form-multi-select-optgroup-labe
 const CLASS_NAME_OPTION = 'form-multi-select-option'
 const CLASS_NAME_OPTION_WITH_CHECKBOX = 'form-multi-select-option-with-checkbox'
 const CLASS_NAME_OPTIONS = 'form-multi-select-options'
-const CLASS_NAME_OPTIONS_EMPTY = 'form-multi-select-options-empty'
 const CLASS_NAME_SEARCH = 'form-multi-select-search'
 const CLASS_NAME_SELECTED = 'form-multi-selected'
 const CLASS_NAME_INDETERMINATE = 'form-multi-select-indeterminate'
@@ -189,8 +189,7 @@ const DefaultType: Record<string, string> = {
  * ------------------------------------------------------------------------
  */
 
-class MultiSelect extends BaseComponent {
-  protected declare _uniqueId: any
+class MultiSelect extends Combobox {
   protected declare _uniqueName: any
   protected declare _indicatorElement: any
   protected declare _selectAllElement: any
@@ -199,15 +198,7 @@ class MultiSelect extends BaseComponent {
   protected declare _selectionElement: any
   protected declare _selectionCleanerElement: any
   protected declare _searchElement: any
-  protected declare _togglerElement: any
-  protected declare _optionsElement: any
   protected declare _wrapperElement: any
-  protected declare _menu: any
-  protected declare _selected: any
-  protected declare _options: any
-  protected declare _floatingCleanup: (() => void) | null
-  protected declare _anchoredPosition: ReturnType<typeof createAnchoredPosition> | null
-  protected declare _search: any
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
     super(element, config)
@@ -254,6 +245,16 @@ class MultiSelect extends BaseComponent {
 
   static override get NAME(): string {
     return NAME
+  }
+
+  static override get selectors(): any {
+    return {
+      option: SELECTOR_OPTION,
+      optgroup: SELECTOR_OPTGROUP,
+      options: SELECTOR_OPTIONS,
+      optionsEmpty: SELECTOR_OPTIONS_EMPTY,
+      navigableItems: SELECTOR_NAVIGABLE_ITEMS
+    }
   }
 
   // Public
@@ -436,6 +437,17 @@ class MultiSelect extends BaseComponent {
       const tag = event.target.closest(SELECTOR_TAG)
       if (tag) {
         this._deselectOption(String(tag.dataset.value))
+      }
+    })
+
+    // Chips-mode selections are real Chip instances: cancel the chip's own
+    // removal and route it through the selection model, which re-renders.
+    EventHandler.on(this._selectionElement, EVENT_CHIP_REMOVE, SELECTOR_CHIP, (event: any) => {
+      event.preventDefault()
+
+      const chip = event.target.closest(SELECTOR_CHIP)
+      if (chip) {
+        this._deselectOption(String(chip.dataset.value))
       }
     })
 
@@ -728,7 +740,32 @@ class MultiSelect extends BaseComponent {
   }
 
   _hideNativeSelect(): void {
+    // The custom control carries the semantics; hide the replaced select from
+    // assistive tech (tabindex -1 keeps it out of the tab order, so the
+    // aria-hidden-focus rule is satisfied even though validation can still
+    // focus it programmatically).
     this._element.tabIndex = '-1' as any
+    this._element.setAttribute('aria-hidden', 'true')
+  }
+
+  // Name the combobox toggler from a <label for> pointing at the native
+  // select, so the replacement control keeps the accessible name.
+  _wireTogglerAccessibleName(): void {
+    const nativeLabel = (this._element as HTMLSelectElement).labels?.[0]
+
+    if (nativeLabel) {
+      if (!nativeLabel.id) {
+        nativeLabel.id = `${this._uniqueId}-label`
+      }
+
+      this._togglerElement.setAttribute('aria-labelledby', nativeLabel.id)
+      return
+    }
+
+    const ariaLabel = this._element.getAttribute('aria-label')
+    if (ariaLabel) {
+      this._togglerElement.setAttribute('aria-label', ariaLabel)
+    }
   }
 
   _createSelect(): void {
@@ -760,6 +797,7 @@ class MultiSelect extends BaseComponent {
 
     this._element.setAttribute('id', this._uniqueId)
     this._element.setAttribute('name', this._uniqueName)
+    this._wireTogglerAccessibleName()
 
     this._createOptionsContainer()
     this._hideNativeSelect()
@@ -787,7 +825,7 @@ class MultiSelect extends BaseComponent {
     selectionEl.classList.add(CLASS_NAME_SELECTION)
     selectionEl.setAttribute('aria-live', 'polite')
 
-    if (this._config.multiple && this._config.selectionType === 'tags') {
+    if (this._config.multiple && ['chips', 'tags'].includes(this._config.selectionType)) {
       selectionEl.classList.add(CLASS_NAME_SELECTION_TAGS)
     }
 
@@ -825,23 +863,6 @@ class MultiSelect extends BaseComponent {
     cleaner.setAttribute('aria-label', this._config.ariaCleanerLabel)
 
     return cleaner
-  }
-
-  _createFloating(): void {
-    this._anchoredPosition = createAnchoredPosition(this._togglerElement, this._menu)
-    this._floatingCleanup = this._anchoredPosition.destroy
-  }
-
-  async _updateFloatingPosition(): Promise<void> {
-    await this._anchoredPosition?.update()
-  }
-
-  _disposeFloating(): void {
-    if (this._floatingCleanup) {
-      this._floatingCleanup()
-      this._floatingCleanup = null
-      this._anchoredPosition = null
-    }
   }
 
   _createSearchInput(): void {
@@ -990,6 +1011,55 @@ class MultiSelect extends BaseComponent {
     }
   }
 
+  _createChip(value: any, text: string, disabled: boolean): HTMLElement {
+    const chip = document.createElement('div')
+    chip.classList.add(CLASS_NAME_CHIP)
+    chip.dataset.value = value
+    chip.textContent = text
+
+    // eslint-disable-next-line no-new
+    new Chip(chip, {
+      ariaRemoveLabel: `${this._config.ariaTagDeleteLabel} ${text}`.trim(),
+      removable: !this._config.disabled && disabled !== true
+    })
+
+    return chip
+  }
+
+  _updateChips(selection: HTMLElement, search: HTMLElement | null): void {
+    const placeholder = SelectorEngine.findOne('.form-multi-select-placeholder', selection)
+    if (placeholder) {
+      placeholder.remove()
+    }
+
+    const existingChips = new Map()
+
+    for (const chip of SelectorEngine.children(selection, SELECTOR_CHIP)) {
+      existingChips.set((chip as HTMLElement).dataset.value, chip)
+    }
+
+    const selectedValues = new Set(this._selected.map((option: any) => String(option.value)))
+
+    for (const [value, chip] of existingChips) {
+      if (!selectedValues.has(value)) {
+        Chip.getInstance(chip)?.dispose()
+        chip.remove()
+        existingChips.delete(value)
+      }
+    }
+
+    for (const option of this._selected) {
+      const value = String(option.value)
+      const chip = existingChips.get(value) || this._createChip(option.value, option.text, option.disabled)
+
+      if (search) {
+        search.before(chip)
+      } else {
+        selection.append(chip)
+      }
+    }
+  }
+
   _createTag(value: any, text: string, disabled: boolean): HTMLElement {
     const tag = document.createElement('div')
     tag.classList.add(CLASS_NAME_TAG)
@@ -1086,23 +1156,6 @@ class MultiSelect extends BaseComponent {
     }
   }
 
-  _findOptionByValue(value: any, options: any[] = this._options): any {
-    for (const option of options) {
-      if (String(option.value) === value) {
-        return option
-      }
-
-      if (this._isOptionGroup(option)) {
-        const found = this._findOptionByValue(value, option.options)
-        if (found) {
-          return found
-        }
-      }
-    }
-
-    return null
-  }
-
   _selectAllOptions(options: any[]): boolean {
     for (const option of options) {
       if (option.disabled) {
@@ -1153,12 +1206,6 @@ class MultiSelect extends BaseComponent {
   _getDisplayedItems(): any[] {
     return SelectorEngine.find(SELECTOR_VISIBLE_ITEMS, this._menu)
       .filter(element => this._isOptionDisplayed(element))
-  }
-
-  _maybeSanitize(content: string): string {
-    return this._config.sanitize ?
-      sanitizeHtml(content, this._config.allowList, this._config.sanitizeFn) :
-      content
   }
 
   _isOptionGroup(option: any): boolean {
@@ -1300,11 +1347,7 @@ class MultiSelect extends BaseComponent {
     const search = SelectorEngine.findOne(SELECTOR_SEARCH, this._wrapperElement)
 
     if (this._selected.length === 0 && !this._config.search) {
-      const placeholder = document.createElement('span')
-      placeholder.classList.add('form-multi-select-placeholder')
-      placeholder.textContent = this._config.placeholder
-      selection.innerHTML = ''
-      selection.append(placeholder)
+      this._renderEmptySelection(selection)
       return
     }
 
@@ -1314,6 +1357,10 @@ class MultiSelect extends BaseComponent {
 
     if (this._config.multiple && this._config.selectionType === 'tags') {
       this._updateTags(selection, search)
+    }
+
+    if (this._config.multiple && this._config.selectionType === 'chips') {
+      this._updateChips(selection, search)
     }
 
     if (this._config.multiple && this._config.selectionType === 'text') {
@@ -1337,6 +1384,19 @@ class MultiSelect extends BaseComponent {
     if (this._floatingCleanup) {
       this._updateFloatingPosition()
     }
+  }
+
+  _renderEmptySelection(selection: HTMLElement): void {
+    const placeholder = document.createElement('span')
+    placeholder.classList.add('form-multi-select-placeholder')
+    placeholder.textContent = this._config.placeholder
+
+    for (const chip of SelectorEngine.find(SELECTOR_CHIP, selection)) {
+      Chip.getInstance(chip)?.dispose()
+    }
+
+    selection.innerHTML = ''
+    selection.append(placeholder)
   }
 
   _updateSelectionCleaner(): void {
@@ -1398,12 +1458,12 @@ class MultiSelect extends BaseComponent {
       return
     }
 
-    if (this._selected.length > 0 && (this._config.selectionType === 'tags' || this._config.selectionType === 'text')) {
+    if (this._selected.length > 0 && ['chips', 'tags', 'text'].includes(this._config.selectionType)) {
       this._searchElement.size = size
       return
     }
 
-    if (this._selected.length === 0 && (this._config.selectionType === 'tags' || this._config.selectionType === 'text')) {
+    if (this._selected.length === 0 && ['chips', 'tags', 'text'].includes(this._config.selectionType)) {
       this._searchElement.removeAttribute('size')
     }
   }
@@ -1560,13 +1620,6 @@ class MultiSelect extends BaseComponent {
     }
   }
 
-  // Checks only `display` (unlike the imported `isVisible`) so it still works while
-  // the menu is closed, e.g. when called from the constructor.
-  _isOptionDisplayed(element: any): boolean {
-    const style = window.getComputedStyle(element)
-    return (style.display !== 'none')
-  }
-
   _isShown(): boolean {
     return this._wrapperElement.classList.contains(CLASS_NAME_SHOW)
   }
@@ -1585,52 +1638,11 @@ class MultiSelect extends BaseComponent {
     })
   }
 
-  _filterOptionsList(): void {
-    const options = SelectorEngine.find(SELECTOR_OPTION, this._menu)
-    let visibleOptions = 0
-
-    for (const option of options) {
-      // eslint-disable-next-line unicorn/prefer-includes
-      if (option.textContent.toLowerCase().indexOf(this._search) === -1) {
-        option.style.display = 'none'
-      } else {
-        option.style.removeProperty('display')
-        visibleOptions++
-      }
-
-      const optgroup = option.closest(SELECTOR_OPTGROUP) as HTMLElement
-      if (optgroup) {
-        // eslint-disable-next-line  unicorn/prefer-array-some
-        if (SelectorEngine.children(optgroup, SELECTOR_OPTION).filter((element: HTMLElement) => this._isOptionDisplayed(element)).length > 0) {
-          optgroup.style.removeProperty('display')
-        } else {
-          optgroup.style.display = 'none'
-        }
-      }
-    }
-
+  override _afterFilter(visibleOptions: number): void {
     this._updateHeader()
     this._updateMasterCheckbox()
     this._updateSelectAllVisibility(visibleOptions)
-
-    const emptyMessage = SelectorEngine.findOne(SELECTOR_OPTIONS_EMPTY, this._menu)
-
-    if (visibleOptions > 0) {
-      if (emptyMessage) {
-        emptyMessage.remove()
-      }
-
-      return
-    }
-
-    if (visibleOptions === 0 && !emptyMessage) {
-      const placeholder = document.createElement('div')
-      placeholder.classList.add(CLASS_NAME_OPTIONS_EMPTY)
-      placeholder.setAttribute('role', 'status')
-      placeholder.textContent = this._config.searchNoResultsLabel
-
-      SelectorEngine.findOne(SELECTOR_OPTIONS, this._menu)!.append(placeholder)
-    }
+    this._syncNoResultsPlaceholder(visibleOptions)
   }
 
   _updateSelectAllVisibility(visibleOptions: number): void {
@@ -1645,37 +1657,8 @@ class MultiSelect extends BaseComponent {
     }
   }
 
-  _selectMenuItem({ key, target }: any): void {
-    const items = SelectorEngine.find(SELECTOR_NAVIGABLE_ITEMS, this._menu).filter(element => isVisible(element))
-
-    if (!items.length) {
-      return
-    }
-
-    // if target isn't included in items (e.g. when expanding the dropdown)
-    // allow cycling to get the last item in case key equals ARROW_UP_KEY
-    getNextActiveElement(items, target, key === ARROW_DOWN_KEY, !items.includes(target)).focus()
-  }
-
-  _selectFirstOrLastMenuItem(first: boolean): void {
-    const items = SelectorEngine.find(SELECTOR_NAVIGABLE_ITEMS, this._menu).filter(element => isVisible(element))
-
-    if (!items.length) {
-      return
-    }
-
-    const item = first ? items[0] : items[items.length - 1]
-    item.focus()
-  }
-
   override _configAfterMerge(config: any): any {
-    if (config.container === true) {
-      config.container = document.body
-    }
-
-    if (typeof config.container === 'object' || typeof config.container === 'string') {
-      config.container = getElement(config.container)
-    }
+    config = this._normalizeContainerConfig(config)
 
     if (typeof config.value === 'number') {
       config.value = [String(config.value)]

--- a/js/tests/unit/autocomplete.spec.js
+++ b/js/tests/unit/autocomplete.spec.js
@@ -3429,7 +3429,7 @@ describe('Autocomplete', () => {
     })
   })
 
-  describe('_isVisible', () => {
+  describe('_isOptionDisplayed', () => {
     it('should return true for visible elements', () => {
       fixtureEl.innerHTML = '<div class="autocomplete"></div>'
       const autocompleteEl = fixtureEl.querySelector('.autocomplete')
@@ -3437,7 +3437,7 @@ describe('Autocomplete', () => {
 
       const el = document.createElement('div')
       document.body.append(el)
-      expect(autocomplete._isVisible(el)).toBe(true)
+      expect(autocomplete._isOptionDisplayed(el)).toBe(true)
       el.remove()
     })
 
@@ -3449,7 +3449,7 @@ describe('Autocomplete', () => {
       const el = document.createElement('div')
       el.style.display = 'none'
       document.body.append(el)
-      expect(autocomplete._isVisible(el)).toBe(false)
+      expect(autocomplete._isOptionDisplayed(el)).toBe(false)
       el.remove()
     })
   })

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -4691,4 +4691,106 @@ describe('MultiSelect', () => {
       el.remove()
     })
   })
+
+  describe('accessibility of the replaced select', () => {
+    it('should hide the native select from assistive technologies', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      // eslint-disable-next-line no-new
+      new MultiSelect(selectEl, {
+        options: [{ value: '1', text: 'Opt 1' }]
+      })
+
+      expect(selectEl.getAttribute('aria-hidden')).toBe('true')
+      expect(selectEl.tabIndex).toBe(-1)
+    })
+
+    it('should name the toggler from an associated label', () => {
+      fixtureEl.innerHTML = [
+        '<label for="myMultiSelect">Choose fruits</label>',
+        '<select id="myMultiSelect"></select>'
+      ].join('')
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [{ value: '1', text: 'Opt 1' }]
+      })
+
+      const label = fixtureEl.querySelector('label')
+      expect(label.id).not.toBe('')
+      expect(multiSelect._togglerElement.getAttribute('aria-labelledby')).toBe(label.id)
+    })
+
+    it('should copy an aria-label from the native select to the toggler', () => {
+      fixtureEl.innerHTML = '<select aria-label="Fruits"></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [{ value: '1', text: 'Opt 1' }]
+      })
+
+      expect(multiSelect._togglerElement.getAttribute('aria-label')).toBe('Fruits')
+    })
+  })
+
+  describe('selectionType chips', () => {
+    it('should render selected options as chips with a labelled remove button', () => {
+      fixtureEl.innerHTML = '<select multiple></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [
+          { value: '1', text: 'Apple' },
+          { value: '2', text: 'Banana' }
+        ],
+        selectionType: 'chips',
+        value: '1'
+      })
+
+      const chip = multiSelect._selectionElement.querySelector('.chip')
+
+      expect(chip).not.toBeNull()
+      expect(chip.dataset.value).toBe('1')
+      expect(chip.textContent).toContain('Apple')
+
+      const removeButton = chip.querySelector('.chip-remove')
+      expect(removeButton).not.toBeNull()
+      expect(removeButton.getAttribute('aria-label')).toBe('Remove Apple')
+    })
+
+    it('should deselect the option when its chip is removed', () => {
+      fixtureEl.innerHTML = '<select multiple></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [
+          { value: '1', text: 'Apple' },
+          { value: '2', text: 'Banana' }
+        ],
+        selectionType: 'chips',
+        value: '1'
+      })
+
+      const chip = multiSelect._selectionElement.querySelector('.chip')
+      chip.querySelector('.chip-remove').click()
+
+      expect(multiSelect.getValue()).toHaveLength(0)
+      expect(multiSelect._selectionElement.querySelector('.chip')).toBeNull()
+      expect(selectEl.querySelector('option[value="1"]').selected).toBe(false)
+    })
+
+    it('should not render a remove button on chips for disabled options', () => {
+      fixtureEl.innerHTML = [
+        '<select multiple>',
+        '  <option value="1" selected disabled>Apple</option>',
+        '  <option value="2">Banana</option>',
+        '</select>'
+      ].join('')
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        selectionType: 'chips'
+      })
+
+      const chip = multiSelect._selectionElement.querySelector('.chip')
+
+      expect(chip).not.toBeNull()
+      expect(chip.querySelector('.chip-remove')).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

MultiSelect and Autocomplete are variants of the same combobox pattern. This PR introduces the **internal combobox core** (`js/src/combobox.ts` — not exported, not documented) and rebuilds both components on it, with their public APIs, markup, class names and events **unchanged**: both existing suites (209 + 301 tests) pass as-is.

## How it works

```
            ┌───────────────────────────────┐
            │  Combobox (internal core)     │
            │  • option tree (flatten/find) │
            │  • filter engine + hooks      │
            │  • no-results (role=status)   │
            │  • listbox keyboard nav       │
            │  • anchored positioning       │
            │  • sanitize + config helpers  │
            └──────────┬───────────┬────────┘
        static selectors│           │static selectors
            ┌──────────┴───┐   ┌───┴──────────────┐
            │ Autocomplete │   │ MultiSelect      │
            │ editable     │   │ select-only,     │
            │ typeahead    │   │ multiple, tags / │
            │ hints,       │   │ chips / counter, │
            │ highlight    │   │ select-all,      │
            │              │   │ native <select>  │
            └──────────────┘   └──────────────────┘
```

- **The seam is the Menu/Dropdown pattern**: each subclass overrides the static `selectors` getter (option/optgroup/options/no-results/navigable items) and the engine reads them through `this.constructor`, so every shared behavior operates on the subclass's own class names.
- **Surface-specific behavior stays in hooks**: `_decorateFilteredOption` (Autocomplete's search highlighting), `_afterFilter` (MultiSelect's header/select-all refresh), both falling through to the shared `role=status` no-results placeholder.
- **Positioning composes `createAnchoredPosition()`** (the util extracted from these very components in #650) rather than a Menu instance — a full Menu would impose menu interaction semantics on a listbox. This deviates from the original plan note and is recorded there.

## On top of the engine

- **fix(MultiSelect) — closes the WCAG suite's recorded GAP**: the replaced `<select>` is removed from the accessibility tree (`aria-hidden` + `tabindex=-1`), and the `role=combobox` toggler now gets an accessible name from an associated `<label>` via `aria-labelledby` (or the select's `aria-label`). The `forms/multi-select` 4.1.2 criterion is **promoted to `built-in`** and audited in CI against a representative labelled instance (26 automated passes, 0 failures).
- **feat(MultiSelect): `selectionType: 'chips'`** — selections render as real **Chip** components (standard chip styling, labelled remove button, chip keyboard handling); removal is intercepted (`remove.coreui.chip`) and routed through the selection model. Documented with an example on the Multi Select page.

## Numbers

- `autocomplete.ts` 1084 → 897 lines, `multi-select.ts` 1773 → 1739 lines (while gaining the chips surface and the a11y fixes); the shared engine is 233 lines, exercised by both suites (coverage: 95.5% lines / 88.8% branches, above thresholds).
- Full gate green locally: unit (3459), jQuery project, typecheck, lint, docs build, WCAG conformance suite.

## Next steps (tracked in the workspace plan)

- Extract the remaining shared candidates where behavior genuinely converges (options-model normalization, show/hide skeleton) — deferred here because their current shapes differ in spec-observable ways.
- The public `Combobox` component stays future work; the core is internal for now by design.