### PR TITLE
refactor(MultiSelect,Autocomplete): move the show/hide lifecycle and shared keyboard wiring into the combobox engine

### DIFF
--- a/js/src/autocomplete.ts
+++ b/js/src/autocomplete.ts
@@ -26,28 +26,21 @@ const DATA_KEY = 'coreui.autocomplete'
 const EVENT_KEY = `.${DATA_KEY}`
 const DATA_API_KEY = '.data-api'
 
-const ARROW_UP_KEY = 'ArrowUp'
 const ARROW_DOWN_KEY = 'ArrowDown'
 const BACKSPACE_KEY = 'Backspace'
 const DELETE_KEY = 'Delete'
-const END_KEY = 'End'
 const ENTER_KEY = 'Enter'
 const ESCAPE_KEY = 'Escape'
-const HOME_KEY = 'Home'
 const TAB_KEY = 'Tab'
 const RIGHT_MOUSE_BUTTON = 2 // MouseEvent.button value for the secondary button, usually the right button
 
 const EVENT_BLUR = `blur${EVENT_KEY}`
 const EVENT_CHANGED = `changed${EVENT_KEY}`
 const EVENT_CLICK = `click${EVENT_KEY}`
-const EVENT_HIDE = `hide${EVENT_KEY}`
-const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_INPUT = `input${EVENT_KEY}`
 const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
 const EVENT_KEYUP = `keyup${EVENT_KEY}`
 const EVENT_MOUSEDOWN = `mousedown${EVENT_KEY}`
-const EVENT_SHOW = `show${EVENT_KEY}`
-const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_KEYUP_DATA_API = `keyup${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
@@ -197,52 +190,19 @@ class Autocomplete extends Combobox {
 
   // Public
 
-  toggle(): void {
-    return this._isShown() ? this.hide() : this.show()
+  override _canShow(): boolean {
+    return Boolean(this._config.searchNoResultsLabel) ||
+      this._flattenOptions().some(option => option.label.toLowerCase().includes(this._search.toLowerCase()))
   }
 
-  show(): void {
-    if (this._config.disabled || this._isShown()) {
-      return
-    }
-
-    if (
-      !this._config.searchNoResultsLabel &&
-      this._flattenOptions().filter(option => option.label.toLowerCase().includes(this._search.toLowerCase())).length === 0) {
-      return
-    }
-
-    EventHandler.trigger(this._element, EVENT_SHOW)
-    this._element.classList.add(CLASS_NAME_SHOW)
-    this._inputElement.setAttribute('aria-expanded', 'true')
-
-    if (this._config.container) {
-      this._menu.style.minWidth = `${this._element.offsetWidth}px`
-      this._menu.classList.add(CLASS_NAME_SHOW)
-    }
-
-    EventHandler.trigger(this._element, EVENT_SHOWN)
-
-    this._createFloating()
+  override _getAriaExpandedTarget(): HTMLElement {
+    return this._inputElement
   }
 
-  hide(): void {
-    EventHandler.trigger(this._element, EVENT_HIDE)
-
-    this._disposeFloating()
-
-    this._element.classList.remove(CLASS_NAME_SHOW)
-    this._inputElement.setAttribute('aria-expanded', 'false')
-
-    if (this._config.container) {
-      this._menu.classList.remove(CLASS_NAME_SHOW)
-    }
-
+  override _onHideEnd(): void {
     if (this._inputHintElement) {
       this._inputHintElement.value = ''
     }
-
-    EventHandler.trigger(this._element, EVENT_HIDDEN)
   }
 
   override dispose(): void {
@@ -335,10 +295,6 @@ class Autocomplete extends Combobox {
     return Array.isArray(this._config.search) && this._config.search.includes('global')
   }
 
-  _isShown(): boolean {
-    return this._element.classList.contains(CLASS_NAME_SHOW)
-  }
-
   // Private
 
   _addEventListeners(): void {
@@ -370,18 +326,7 @@ class Autocomplete extends Combobox {
       }
     })
 
-    EventHandler.on(this._togglerElement, EVENT_KEYDOWN, (event: any) => {
-      if (!this._isShown() && (event.key === ENTER_KEY || event.key === ARROW_DOWN_KEY)) {
-        event.preventDefault()
-        this.show()
-        return
-      }
-
-      if (this._isShown() && event.key === ARROW_DOWN_KEY) {
-        event.preventDefault()
-        this._selectMenuItem(event)
-      }
-    })
+    this._addTogglerKeydownListeners()
 
     EventHandler.on(this._indicatorElement, EVENT_CLICK, (event: any) => {
       event.preventDefault()
@@ -506,21 +451,7 @@ class Autocomplete extends Combobox {
       }
     })
 
-    EventHandler.on(this._optionsElement, EVENT_KEYDOWN, (event: any) => {
-      if (event.key === ENTER_KEY) {
-        this._onOptionsClick(event.target)
-      }
-
-      if ([ARROW_UP_KEY, ARROW_DOWN_KEY].includes(event.key)) {
-        event.preventDefault()
-        this._selectMenuItem(event)
-      }
-
-      if ([HOME_KEY, END_KEY].includes(event.key)) {
-        event.preventDefault()
-        this._selectFirstOrLastMenuItem(event.key === HOME_KEY)
-      }
-    })
+    this._addOptionsKeydownListeners()
   }
 
   _getOptionsFromConfig(options: any = this._config.options): any[] {

--- a/js/src/combobox.ts
+++ b/js/src/combobox.ts
@@ -6,6 +6,7 @@
  */
 
 import BaseComponent from './base-component.js'
+import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { createAnchoredPosition } from './util/floating-ui.js'
 import { sanitizeHtml } from './util/sanitizer.js'
@@ -17,15 +18,21 @@ import { getElement, getNextActiveElement, isVisible } from './util/index.js'
  * surfaces stay the subclasses, which keep their own markup, class names,
  * events and options.
  *
- * The seam mirrors Menu/Dropdown: subclasses override the static `selectors`
- * and `optionLabelKey` getters, and the engine reads them through
+ * The seam mirrors Menu/Dropdown: subclasses override the static getters
+ * (`selectors`, `activationKeys`) and the engine reads them through
  * `this.constructor`, so every shared behavior operates on the subclass's own
  * class names. Anchored positioning composes `createAnchoredPosition()`
  * directly (the util extracted from these very components) rather than a Menu
  * instance, which would impose menu interaction semantics on a listbox.
  */
 
+const ARROW_UP_KEY = 'ArrowUp'
 const ARROW_DOWN_KEY = 'ArrowDown'
+const END_KEY = 'End'
+const ENTER_KEY = 'Enter'
+const HOME_KEY = 'Home'
+
+const CLASS_NAME_SHOW = 'show'
 
 type ComboboxSelectors = {
   option: string
@@ -53,11 +60,129 @@ class Combobox extends BaseComponent {
     throw new Error('Combobox subclasses must define the static "selectors" getter.')
   }
 
+  // Keys that activate the focused option in the options list.
+  static get activationKeys(): string[] {
+    return [ENTER_KEY]
+  }
+
   // Shorthand resolving the static through the live constructor
 
   get _selectors(): ComboboxSelectors {
     return this.constructor.selectors
   }
+
+  // Show / hide lifecycle — one event contract for every combobox surface.
+  // Subclasses adjust behavior through the hooks below, never by overriding
+  // the template methods, so the event order stays identical across surfaces.
+
+  toggle(): void {
+    return this._isShown() ? this.hide() : this.show()
+  }
+
+  show(): void {
+    if (this._config.disabled || this._isShown() || !this._canShow()) {
+      return
+    }
+
+    EventHandler.trigger(this._element, this.constructor.eventName('show'))
+    const showTarget = this._getShowTarget()
+    showTarget.classList.add(CLASS_NAME_SHOW)
+    this._getAriaExpandedTarget().setAttribute('aria-expanded', 'true')
+
+    if (this._config.container) {
+      this._menu.style.minWidth = `${showTarget.offsetWidth}px`
+      this._menu.classList.add(CLASS_NAME_SHOW)
+    }
+
+    EventHandler.trigger(this._element, this.constructor.eventName('shown'))
+
+    this._createFloating()
+    this._afterShow()
+  }
+
+  hide(): void {
+    EventHandler.trigger(this._element, this.constructor.eventName('hide'))
+    this._onHideStart()
+
+    this._disposeFloating()
+    this._afterHideDispose()
+
+    this._getShowTarget().classList.remove(CLASS_NAME_SHOW)
+    this._getAriaExpandedTarget().setAttribute('aria-expanded', 'false')
+
+    if (this._config.container) {
+      this._menu.classList.remove(CLASS_NAME_SHOW)
+    }
+
+    this._onHideEnd()
+    EventHandler.trigger(this._element, this.constructor.eventName('hidden'))
+  }
+
+  _isShown(): boolean {
+    return this._getShowTarget().classList.contains(CLASS_NAME_SHOW)
+  }
+
+  // Lifecycle hooks
+
+  _canShow(): boolean {
+    return true
+  }
+
+  _afterShow(): void {}
+
+  _onHideStart(): void {}
+
+  _afterHideDispose(): void {}
+
+  _onHideEnd(): void {}
+
+  _getShowTarget(): HTMLElement {
+    return this._element
+  }
+
+  _getAriaExpandedTarget(): HTMLElement {
+    return this._togglerElement
+  }
+
+  // Shared keyboard wiring
+
+  _addTogglerKeydownListeners(): void {
+    EventHandler.on(this._togglerElement, this.constructor.eventName('keydown'), (event: any) => {
+      if (!this._isShown() && (event.key === ENTER_KEY || event.key === ARROW_DOWN_KEY)) {
+        event.preventDefault()
+        this.show()
+        return
+      }
+
+      if (this._isShown() && event.key === ARROW_DOWN_KEY) {
+        event.preventDefault()
+        this._selectMenuItem(event)
+      }
+    })
+  }
+
+  _addOptionsKeydownListeners(): void {
+    EventHandler.on(this._optionsElement, this.constructor.eventName('keydown'), (event: any) => {
+      if (this.constructor.activationKeys.includes(event.key)) {
+        // Space would otherwise scroll the options list.
+        event.preventDefault()
+        this._onOptionsClick(event.target)
+      }
+
+      if ([ARROW_UP_KEY, ARROW_DOWN_KEY].includes(event.key)) {
+        event.preventDefault()
+        this._selectMenuItem(event)
+      }
+
+      if ([HOME_KEY, END_KEY].includes(event.key)) {
+        event.preventDefault()
+        this._selectFirstOrLastMenuItem(event.key === HOME_KEY)
+      }
+    })
+  }
+
+  // Subclasses implement option activation.
+  _onOptionsClick(element: any): void {} // eslint-disable-line @typescript-eslint/no-unused-vars
 
   // Option model
 

--- a/js/src/multi-select.ts
+++ b/js/src/multi-select.ts
@@ -58,14 +58,11 @@ const SELECTOR_NAVIGABLE_ITEMS = `.form-multi-select-all:not(.disabled):not(:dis
 
 const EVENT_CHANGED = `changed${EVENT_KEY}`
 const EVENT_CLICK = `click${EVENT_KEY}`
-const EVENT_HIDE = `hide${EVENT_KEY}`
 const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
 const EVENT_KEYUP = `keyup${EVENT_KEY}`
 const EVENT_SEARCH = `search${EVENT_KEY}`
 const EVENT_SELECTION_LIMIT = `selectionLimit${EVENT_KEY}`
-const EVENT_SHOW = `show${EVENT_KEY}`
-const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_KEYUP_DATA_API = `keyup${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
@@ -199,6 +196,7 @@ class MultiSelect extends Combobox {
   protected declare _selectionCleanerElement: any
   protected declare _searchElement: any
   protected declare _wrapperElement: any
+  protected declare _refocusOnHide: boolean
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
     super(element, config)
@@ -257,62 +255,42 @@ class MultiSelect extends Combobox {
     }
   }
 
-  // Public
-  toggle(): void {
-    return this._isShown() ? this.hide() : this.show()
+  static override get activationKeys(): string[] {
+    return [ENTER_KEY, SPACE_KEY]
   }
 
-  show(): void {
-    if (this._config.disabled || this._isShown()) {
-      return
-    }
+  // Public
 
-    EventHandler.trigger(this._element, EVENT_SHOW)
-    this._wrapperElement.classList.add(CLASS_NAME_SHOW)
-    this._togglerElement.setAttribute('aria-expanded', 'true')
+  override _getShowTarget(): HTMLElement {
+    return this._wrapperElement
+  }
 
-    if (this._config.container) {
-      this._menu.style.minWidth = `${this._wrapperElement.offsetWidth}px`
-      this._menu.classList.add(CLASS_NAME_SHOW)
-    }
-
-    EventHandler.trigger(this._element, EVENT_SHOWN)
-
-    this._createFloating()
-
+  override _afterShow(): void {
     if (this._config.search) {
       SelectorEngine.findOne(SELECTOR_SEARCH, this._wrapperElement)!.focus()
     }
   }
 
-  hide(): void {
-    EventHandler.trigger(this._element, EVENT_HIDE)
-
-    const refocusFromInside = this._wrapperElement.contains(document.activeElement) ||
+  override _onHideStart(): void {
+    this._refocusOnHide = this._wrapperElement.contains(document.activeElement) ||
       this._menu.contains(document.activeElement)
+  }
 
-    this._disposeFloating()
-
+  override _afterHideDispose(): void {
     if (this._config.search) {
       this._searchElement.value = ''
     }
 
     this._onSearchChange(this._searchElement)
-    this._wrapperElement.classList.remove(CLASS_NAME_SHOW)
-    this._togglerElement.setAttribute('aria-expanded', 'false')
+  }
 
-    if (this._config.container) {
-      this._menu.classList.remove(CLASS_NAME_SHOW)
-    }
-
-    if (refocusFromInside && !this._config.disabled) {
+  override _onHideEnd(): void {
+    if (this._refocusOnHide && !this._config.disabled) {
       const refocusTarget = this._config.search ? this._searchElement : this._togglerElement
       if (refocusTarget) {
         refocusTarget.focus()
       }
     }
-
-    EventHandler.trigger(this._element, EVENT_HIDDEN)
   }
 
   override dispose(): void {
@@ -482,18 +460,7 @@ class MultiSelect extends Combobox {
       }
     })
 
-    EventHandler.on(this._togglerElement, EVENT_KEYDOWN, (event: any) => {
-      if (!this._isShown() && (event.key === ENTER_KEY || event.key === ARROW_DOWN_KEY)) {
-        event.preventDefault()
-        this.show()
-        return
-      }
-
-      if (this._isShown() && event.key === ARROW_DOWN_KEY) {
-        event.preventDefault()
-        this._selectMenuItem(event)
-      }
-    })
+    this._addTogglerKeydownListeners()
 
     // Validation focuses the overlay select; hand its keystrokes to the custom control.
     EventHandler.on(this._element, EVENT_KEYDOWN, (event: any) => {
@@ -585,23 +552,7 @@ class MultiSelect extends Combobox {
       this._onOptionsClick(event.target)
     })
 
-    EventHandler.on(this._optionsElement, EVENT_KEYDOWN, (event: any) => {
-      if (event.key === ENTER_KEY || event.key === SPACE_KEY) {
-        // Space would otherwise scroll the options list.
-        event.preventDefault()
-        this._onOptionsClick(event.target)
-      }
-
-      if ([ARROW_UP_KEY, ARROW_DOWN_KEY].includes(event.key)) {
-        event.preventDefault()
-        this._selectMenuItem(event)
-      }
-
-      if ([HOME_KEY, END_KEY].includes(event.key)) {
-        event.preventDefault()
-        this._selectFirstOrLastMenuItem(event.key === HOME_KEY)
-      }
-    })
+    this._addOptionsKeydownListeners()
   }
 
   _getOptions(): any[] {
@@ -1618,10 +1569,6 @@ class MultiSelect extends Combobox {
 
       this._updateSearchSize(element.value.length + 1)
     }
-  }
-
-  _isShown(): boolean {
-    return this._wrapperElement.classList.contains(CLASS_NAME_SHOW)
   }
 
   _hasSelectionLimit(): boolean {


### PR DESCRIPTION
## Summary

Stage 2 of the combobox consolidation (follows #656). The internal engine now owns the **template methods** — `toggle()`, `show()`, `hide()`, `_isShown()` — so the lifecycle event contract (`show` → class/aria/container → `shown` → positioning; `hide` → dispose → class/aria/container → `hidden`) is one code path for every combobox surface. Subclasses adjust behavior **only through hooks**, never by overriding the templates:

| Hook | Autocomplete | MultiSelect |
|---|---|---|
| `_canShow()` | no-results guard | — |
| `_afterShow()` | — | focus the search input |
| `_onHideStart()` | — | capture whether focus was inside |
| `_afterHideDispose()` | — | clear + re-run the search |
| `_onHideEnd()` | clear the typeahead hint | refocus search/toggler |
| `_getShowTarget()` | the component element | the wrapper |
| `_getAriaExpandedTarget()` | the combobox input | the combobox toggler |

The **toggler keydown** handler (Enter/ArrowDown opens, ArrowDown navigates — previously duplicated verbatim) and the **options-list keydown** handler (activation keys via the static `activationKeys` getter — Enter, plus Space for MultiSelect — arrows, Home/End) also move into the engine.

## Behavior notes

- Events keep their per-component names via `BaseComponent.eventName()` (`show.coreui.autocomplete` / `show.coreui.multi-select`, …) — payloads and ordering unchanged.
- The only observable delta: Autocomplete's Enter on a focused option now calls `preventDefault()` like MultiSelect's — inert on the option `<div>`s, which have no default activation.

## Verification

- Both suites pass **unchanged**: Autocomplete 209, MultiSelect 301; full unit 3459, jQuery project, typecheck, lint, WCAG conformance suite (26 automated passes), pre-push gate with bundlewatch.
- Net: `combobox.ts` +117 lines of engine, the two components −146 lines of duplication.

Stage 2 continuation (options-model normalization) and stage 3 (the public `Combobox`) stay tracked in the workspace plan.