### PR TITLE
fix(Chip,ChipSet,ChipInput): expose real roles for chip selection and announce add/remove

### DIFF
--- a/build/a11y.config.mjs
+++ b/build/a11y.config.mjs
@@ -172,13 +172,43 @@ export const a11yComponents = [
       },
       {
         criterion: '4.1.3',
-        status: 'author',
-        note: 'GAP: adding/removing chips is not announced — there is no aria-live region around the chip list.'
+        status: 'built-in',
+        note: 'Adding and removing chips is announced through the inherited visually hidden role=status region next to the container. Verified here: typing a value and pressing Enter updates the region.'
+      }
+    ],
+    html: `<div class="chip-input" id="a11yChipInput" data-coreui-chip-input>
+    <label class="chip-input-label">Tags</label>
+  </div>`,
+    assertions: [
+      {
+        criterion: '4.1.3',
+        label: 'adding a chip is announced in the status region',
+        steps: [
+          { click: '#a11yChipInput input' },
+          { type: 'News' },
+          { press: 'Enter' },
+          { wait: 100 }
+        ],
+        run: 'const region = document.querySelector(\'.chip-input + [role="status"]\'); return Boolean(region && region.textContent.includes(\'added\'))'
       }
     ]
   },
   {
     component: 'components/chip-set',
+    // Audit a representative labelled, selectable, removable set — that is
+    // what exercises the component's own role/announcement wiring.
+    html: `<div class="chip-set" aria-label="Applied filters" data-coreui-chip-set data-coreui-selectable="true" data-coreui-removable="true">
+    <span class="chip">Alpha</span>
+    <span class="chip">Beta</span>
+  </div>`,
+    assertions: [
+      {
+        criterion: '4.1.3',
+        label: 'removing a chip is announced in the status region',
+        steps: [{ click: '.chip .chip-remove' }, { wait: 100 }],
+        run: 'const region = document.querySelector(\'.chip-set + [role="status"]\'); return Boolean(region && region.textContent.includes(\'removed\'))'
+      }
+    ],
     criteria: [
       {
         criterion: '2.1.1',
@@ -187,13 +217,18 @@ export const a11yComponents = [
       },
       {
         criterion: '4.1.2',
-        status: 'author',
-        note: 'GAP: chips are focusable <span>s with no role, yet selectable chips get aria-selected and disabled chips aria-disabled — both invalid on a generic element. The set should expose listbox/option (or toggle-button) semantics.'
+        status: 'built-in',
+        note: 'A selectable set is exposed as a horizontal listbox of role=option chips (aria-selected/aria-disabled valid there); a standalone selectable chip is a toggle button with aria-pressed; a non-selectable set is a role=group, which also legitimizes the documented aria-label.'
+      },
+      {
+        criterion: '1.3.1',
+        status: 'built-in',
+        note: 'The listbox contains only option children — the add/remove live region lives next to the set, not inside it.'
       },
       {
         criterion: '4.1.3',
-        status: 'author',
-        note: 'GAP: selection and removal are not announced; no live region is rendered.'
+        status: 'built-in',
+        note: 'Adding and removing chips is announced through a visually hidden role=status region (labels configurable via ariaAddedAnnouncement/ariaRemovedAnnouncement). Verified here: removing a chip updates the region.'
       }
     ]
   },

--- a/docs/src/content/docs/components/chip-set.mdx
+++ b/docs/src/content/docs/components/chip-set.mdx
@@ -102,7 +102,9 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
+| `ariaAddedAnnouncement` | string | `'added'` | Wording appended to a chip's value when its addition is announced in the status live region. |
 | `ariaRemoveLabel` | string | `'Remove'` | Accessible label applied to each chip's remove button. |
+| `ariaRemovedAnnouncement` | string | `'removed'` | Wording appended to a chip's value when its removal is announced in the status live region. |
 | `chipClassName` | string, function, null | `null` | CSS class(es) added to chips created through `add`. A function receives the chip value and returns the class string. |
 | `disabled` | boolean | `false` | Disables interactions and focus for the chips in the set. |
 | `filter` | boolean | `false` | Turns the chips into filter chips — a check icon is shown on the selected ones. Implies `selectable`. |
@@ -170,7 +172,8 @@ Disabled chips (`.chip.disabled`) are skipped while navigating.
 
 - The chip set manages roving focus, so the arrow keys move focus between chips rather than relying on the browser's default tab order.
 - Add a descriptive `aria-label` to the chip set element when the group has a meaningful role (e.g., "Applied filters").
-- Selection state is reflected on each chip via `aria-selected`; see the [Chip](/components/chip/) accessibility notes.
+- A selectable set is exposed as a horizontal `role="listbox"` (with `aria-multiselectable` in multiple mode) and each chip becomes a `role="option"` with `aria-selected`; a non-selectable set is a `role="group"`.
+- Adding and removing chips is announced through a visually hidden `role="status"` region rendered next to the set; customize the wording with the `ariaAddedAnnouncement` and `ariaRemovedAnnouncement` options.
 
 ## Customizing
 

--- a/docs/src/content/docs/components/chip.mdx
+++ b/docs/src/content/docs/components/chip.mdx
@@ -348,8 +348,8 @@ When chips are grouped in a [Chip set](/components/chip-set/), the arrow keys, <
 The Bootstrap Chip component follows WAI-ARIA patterns for interactive widgets, ensuring the chip component is fully usable with keyboards and assistive technologies.
 
 - Chips become focusable when `selectable` or `removable` is enabled.
-- `aria-selected` is kept in sync with `.active` on selectable chips.
-- `aria-disabled="true"` is applied to disabled chips.
+- A standalone selectable chip is exposed as a toggle button (`role="button"`) with `aria-pressed` kept in sync with `.active`. Inside a selectable [Chip set](/components/chip-set/) the set exposes a listbox and each chip becomes a `role="option"` with `aria-selected` instead.
+- `aria-disabled="true"` is applied to disabled chips that carry a role; a role-less chip conveys the state through the `disabled` class and its removed interactivity.
 - Each `.chip-remove` button includes an accessible label via `ariaRemoveLabel`.
 - Use descriptive `aria-label` attributes on chip containers when the chip component group has a meaningful role (e.g., "Applied filters").
 

--- a/docs/src/content/docs/forms/chip-input.mdx
+++ b/docs/src/content/docs/forms/chip-input.mdx
@@ -281,7 +281,7 @@ The Bootstrap Chip Input component follows WAI-ARIA patterns to ensure the chip 
 - Associate a `<label>` with the ghost input for screen readers.
 - Chips are focusable and keyboard navigable when initialized by the plugin.
 - Remove buttons include `aria-label="Remove"` by default.
-- Selected chips are reflected via `.active` and `aria-selected`.
+- Adding and removing chips is announced through a visually hidden `role="status"` region rendered next to the container.
 - Use a descriptive `aria-label` or `<label>` on the chip input container to communicate its purpose (e.g., "Add skills" or "Recipients").
 
 ## Customizing

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -287,12 +287,22 @@ the option-by-option migration map. Planned mapping:
   renders at full opacity. The token still works — override it and only the
   background alpha changes.
 
-#### Chip input
+#### Chip / Chip set / Chip input
 
-- **`aria-disabled`/`aria-readonly` are no longer stamped on the container.**
-  The container is a generic element, so those attributes were invalid on it
-  (axe `aria-allowed-attr`); the native `disabled`/`readonly` states on the
-  inner `<input>` carry the semantics.
+- **Chips expose real roles now.** A selectable chip set is a horizontal
+  `role="listbox"` (with `aria-multiselectable` in multiple mode) whose chips
+  are `role="option"` elements carrying `aria-selected`; a standalone
+  selectable chip is a toggle button (`role="button"`) reflecting its state
+  via **`aria-pressed` instead of `aria-selected`**; a non-selectable set is a
+  `role="group"`. `aria-disabled` is only stamped on chips that carry a role —
+  on a role-less chip the attribute was invalid and is now removed.
+- **Adding and removing chips is announced.** Chip set and Chip input render a
+  visually hidden `role="status"` region next to the container; the wording is
+  configurable via `ariaAddedAnnouncement`/`ariaRemovedAnnouncement`.
+- **Chip input: `aria-disabled`/`aria-readonly` are no longer stamped on the
+  container.** The container is a generic element, so those attributes were
+  invalid on it (axe `aria-allowed-attr`); the native `disabled`/`readonly`
+  states on the inner `<input>` carry the semantics.
 
 ### Sass architecture & design tokens
 

--- a/js/src/chip-input.ts
+++ b/js/src/chip-input.ts
@@ -125,6 +125,12 @@ class ChipInput extends ChipSet {
   }
 
   // Private
+
+  // The container mixes a label, the text input and chips — it is neither a
+  // listbox nor a plain group, so no container role is stamped and the chips
+  // stay generic (their remove buttons carry the actions).
+  override _applyAccessibilityRoles(): void {}
+
   override _canModify(): boolean {
     return !this._disabled && !this._config.readonly
   }

--- a/js/src/chip-set.ts
+++ b/js/src/chip-set.ts
@@ -48,7 +48,9 @@ const DEFAULT_REMOVE_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" wid
 const DEFAULT_SELECTED_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="currentColor"><path d="M425.373 89.373 196 318.745 86.627 209.373l-45.254 45.254L196 409.255l274.627-274.628z"/></svg>'
 
 export type ChipSetConfig = {
+  ariaAddedAnnouncement: string
   ariaRemoveLabel: string
+  ariaRemovedAnnouncement: string
   chipClassName: string | ((value: string) => string) | null
   disabled: boolean
   filter: boolean
@@ -62,7 +64,9 @@ export type ChipSetConfig = {
 }
 
 const Default: ChipSetConfig = {
+  ariaAddedAnnouncement: 'added',
   ariaRemoveLabel: 'Remove',
+  ariaRemovedAnnouncement: 'removed',
   chipClassName: null,
   disabled: false,
   filter: false,
@@ -76,7 +80,9 @@ const Default: ChipSetConfig = {
 }
 
 const DefaultType: Record<string, string> = {
+  ariaAddedAnnouncement: 'string',
   ariaRemoveLabel: 'string',
+  ariaRemovedAnnouncement: 'string',
   chipClassName: '(string|function|null)',
   disabled: 'boolean',
   filter: 'boolean',
@@ -98,6 +104,7 @@ class ChipSet extends BaseComponent {
   protected declare _pendingFocus: HTMLElement | null
   protected declare _chips: string[]
   protected declare _input: HTMLElement | null
+  protected declare _liveRegion: HTMLElement | null
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
     super(element, config)
@@ -105,8 +112,11 @@ class ChipSet extends BaseComponent {
     this._disabled = this._config.disabled || this._element.classList.contains(CLASS_NAME_DISABLED)
     this._pendingFocus = null
     this._chips = []
+    this._liveRegion = null
 
+    this._applyAccessibilityRoles()
     this._initChips()
+    this._createLiveRegion()
     this._addEventListeners()
   }
 
@@ -157,6 +167,7 @@ class ChipSet extends BaseComponent {
     this._appendChip(element)
     this._setupChip(element)
     this._chips.push(value)
+    this._announce(`${value} ${this._config.ariaAddedAnnouncement}`)
 
     EventHandler.trigger(this._element, this.constructor.eventName(EVENT_CHANGE), {
       values: this.getValues()
@@ -263,6 +274,12 @@ class ChipSet extends BaseComponent {
 
   override dispose(): void {
     EventHandler.off(this._element, Chip.EVENT_KEY)
+
+    if (this._liveRegion) {
+      this._liveRegion.remove()
+      this._liveRegion = null
+    }
+
     super.dispose()
   }
 
@@ -322,7 +339,46 @@ class ChipSet extends BaseComponent {
     }
   }
 
+  // A selectable set is a horizontal listbox: the set element gets the
+  // listbox role and each chip becomes an option, so the chips' selection and
+  // disabled states are expressed on roles that allow them. A non-selectable
+  // set is a plain group (which also legitimizes the documented aria-label).
+  _applyAccessibilityRoles(): void {
+    if (!this._element.hasAttribute('role')) {
+      this._element.setAttribute('role', this._config.selectable ? 'listbox' : 'group')
+    }
+
+    if (this._config.selectable && this._element.getAttribute('role') === 'listbox') {
+      this._element.setAttribute('aria-orientation', 'horizontal')
+
+      if (this._config.selectionMode === 'multiple') {
+        this._element.setAttribute('aria-multiselectable', 'true')
+      }
+    }
+  }
+
+  // Announce add/remove without moving focus. The region lives NEXT TO the
+  // set element: a role=status child inside a listbox would violate the
+  // listbox's required children.
+  _createLiveRegion(): void {
+    const region = document.createElement('span')
+    region.classList.add('visually-hidden')
+    region.setAttribute('role', 'status')
+    this._element.after(region)
+    this._liveRegion = region
+  }
+
+  _announce(message: string): void {
+    if (this._liveRegion) {
+      this._liveRegion.textContent = message
+    }
+  }
+
   _setupChip(chip: HTMLElement): void {
+    if (this._element.getAttribute('role') === 'listbox' && !chip.hasAttribute('role')) {
+      chip.setAttribute('role', 'option')
+    }
+
     Chip.getOrCreateInstance(chip, this._getChipConfig(chip))
   }
 
@@ -489,6 +545,8 @@ class ChipSet extends BaseComponent {
     if (index !== -1) {
       this._chips.splice(index, 1)
     }
+
+    this._announce(`${value} ${this._config.ariaRemovedAnnouncement}`)
 
     EventHandler.trigger(this._element, this.constructor.eventName(EVENT_CHANGE), {
       values: this.getValues()

--- a/js/src/chip.ts
+++ b/js/src/chip.ts
@@ -100,6 +100,7 @@ class Chip extends BaseComponent {
     this._disabled = this._config.disabled || this._element.classList.contains(CLASS_NAME_DISABLED)
     this._selected = this._config.selected || this._element.classList.contains(CLASS_NAME_ACTIVE)
 
+    this._applyRole()
     this._ensureRemoveButton()
     this._applyState()
 
@@ -218,24 +219,52 @@ class Chip extends BaseComponent {
     })
   }
 
+  // A selectable chip needs a role its selection state is valid on: inside a
+  // selectable chip set the set stamps role="option" (listbox pattern) before
+  // initializing the chip; a standalone selectable chip is a toggle button.
+  _applyRole(): void {
+    if (this._config.selectable && !this._element.hasAttribute('role')) {
+      this._element.setAttribute('role', 'button')
+    }
+  }
+
+  // aria-selected is only valid on role="option"; a toggle button reflects its
+  // state via aria-pressed instead.
+  _selectionStateAttribute(): string {
+    return this._element.getAttribute('role') === 'option' ? 'aria-selected' : 'aria-pressed'
+  }
+
   _applyState(): void {
     if (!this._disabled && (this._config.clickable || this._config.selectable)) {
       this._element.classList.add(CLASS_NAME_CHIP_CLICKABLE)
     }
 
+    // aria-disabled is not allowed on a generic element — only stamp it when
+    // the chip carries a role; a role-less chip conveys the state through the
+    // disabled class and the removed interactivity.
+    const hasRole = this._element.hasAttribute('role')
+
     if (this._disabled) {
       this._element.classList.add(CLASS_NAME_DISABLED)
-      this._element.setAttribute('aria-disabled', 'true')
+      if (hasRole) {
+        this._element.setAttribute('aria-disabled', 'true')
+      } else {
+        this._element.removeAttribute('aria-disabled')
+      }
     } else {
       this._element.classList.remove(CLASS_NAME_DISABLED)
-      if (this._element.getAttribute('aria-disabled') === 'true') {
-        this._element.setAttribute('aria-disabled', 'false')
+      if (this._element.hasAttribute('aria-disabled')) {
+        if (hasRole) {
+          this._element.setAttribute('aria-disabled', 'false')
+        } else {
+          this._element.removeAttribute('aria-disabled')
+        }
       }
     }
 
     if (this._config.selectable) {
       this._element.classList.toggle(CLASS_NAME_ACTIVE, this._selected)
-      this._element.setAttribute('aria-selected', this._selected ? 'true' : 'false')
+      this._element.setAttribute(this._selectionStateAttribute(), this._selected ? 'true' : 'false')
 
       if (this._config.filter) {
         if (this._selected) {
@@ -246,8 +275,10 @@ class Chip extends BaseComponent {
       }
     } else {
       this._element.classList.remove(CLASS_NAME_ACTIVE)
-      if (this._element.getAttribute('aria-selected') === 'true') {
+      if (this._element.getAttribute('role') === 'option') {
         this._element.setAttribute('aria-selected', 'false')
+      } else {
+        this._element.removeAttribute('aria-selected')
       }
     }
   }

--- a/js/tests/unit/chip-input.spec.js
+++ b/js/tests/unit/chip-input.spec.js
@@ -181,6 +181,19 @@ describe('ChipInput', () => {
       expect(el.getAttribute('aria-readonly')).toBeNull()
     })
 
+    it('should not stamp a role on the container and announce added chips', () => {
+      fixtureEl.innerHTML = '<div class="chip-input"></div>'
+
+      const el = fixtureEl.querySelector('.chip-input')
+      const chipInput = new ChipInput(el)
+
+      chipInput.add('News')
+
+      expect(el.hasAttribute('role')).toBe(false)
+      expect(el.nextElementSibling.getAttribute('role')).toEqual('status')
+      expect(el.nextElementSibling.textContent).toEqual('News added')
+    })
+
     it('should set label for attribute when label has no for', () => {
       fixtureEl.innerHTML = [
         '<div class="chip-input">',

--- a/js/tests/unit/chip-set.spec.js
+++ b/js/tests/unit/chip-set.spec.js
@@ -592,4 +592,96 @@ describe('ChipSet', () => {
       expect(el.querySelector('.chip').textContent).toContain('First')
     })
   })
+
+  describe('accessibility roles', () => {
+    it('should expose a selectable set as a horizontal multiselectable listbox of options', () => {
+      const el = setMarkup(['First', 'Second'])
+      // eslint-disable-next-line no-new
+      new ChipSet(el, { selectable: true })
+
+      expect(el.getAttribute('role')).toEqual('listbox')
+      expect(el.getAttribute('aria-orientation')).toEqual('horizontal')
+      expect(el.getAttribute('aria-multiselectable')).toEqual('true')
+
+      for (const chip of el.querySelectorAll('.chip')) {
+        expect(chip.getAttribute('role')).toEqual('option')
+        expect(chip.getAttribute('aria-selected')).toEqual('false')
+      }
+    })
+
+    it('should not set aria-multiselectable in single selection mode', () => {
+      const el = setMarkup(['First'])
+      // eslint-disable-next-line no-new
+      new ChipSet(el, { selectable: true, selectionMode: 'single' })
+
+      expect(el.getAttribute('role')).toEqual('listbox')
+      expect(el.hasAttribute('aria-multiselectable')).toBeFalse()
+    })
+
+    it('should expose a non-selectable set as a group', () => {
+      const el = setMarkup(['First'])
+      // eslint-disable-next-line no-new
+      new ChipSet(el)
+
+      expect(el.getAttribute('role')).toEqual('group')
+      expect(el.querySelector('.chip').hasAttribute('role')).toBeFalse()
+    })
+
+    it('should keep an author-provided role on the set element', () => {
+      const el = setMarkup(['First'], ' role="list"')
+      // eslint-disable-next-line no-new
+      new ChipSet(el)
+
+      expect(el.getAttribute('role')).toEqual('list')
+    })
+
+    it('should stamp role option on chips added to a selectable set', () => {
+      const el = setMarkup([])
+      const chipSet = new ChipSet(el, { selectable: true })
+
+      const chip = chipSet.add('Fresh')
+
+      expect(chip.getAttribute('role')).toEqual('option')
+    })
+  })
+
+  describe('live region', () => {
+    it('should announce added and removed chips in a status region next to the set', () => {
+      const el = setMarkup([])
+      const chipSet = new ChipSet(el, { removable: true })
+
+      const region = el.nextElementSibling
+      expect(region.getAttribute('role')).toEqual('status')
+      expect(region).toHaveClass('visually-hidden')
+
+      chipSet.add('Alpha')
+      expect(region.textContent).toEqual('Alpha added')
+
+      chipSet.remove('Alpha')
+      expect(region.textContent).toEqual('Alpha removed')
+    })
+
+    it('should use the configured announcement labels', () => {
+      const el = setMarkup([])
+      const chipSet = new ChipSet(el, {
+        ariaAddedAnnouncement: 'dodano',
+        ariaRemovedAnnouncement: 'usuni\u0119to'
+      })
+
+      chipSet.add('Alfa')
+
+      expect(el.nextElementSibling.textContent).toEqual('Alfa dodano')
+    })
+
+    it('should remove the live region on dispose', () => {
+      const el = setMarkup([])
+      const chipSet = new ChipSet(el)
+
+      expect(el.nextElementSibling.getAttribute('role')).toEqual('status')
+
+      chipSet.dispose()
+
+      expect(el.nextElementSibling).toBeNull()
+    })
+  })
 })

--- a/js/tests/unit/chip.spec.js
+++ b/js/tests/unit/chip.spec.js
@@ -398,7 +398,7 @@ describe('Chip', () => {
   })
 
   describe('select', () => {
-    it('should add active class and set aria-selected when selected', () => {
+    it('should add active class and set aria-pressed when selected', () => {
       fixtureEl.innerHTML = '<span class="chip">Tag</span>'
 
       const chipEl = fixtureEl.querySelector('.chip')
@@ -407,7 +407,19 @@ describe('Chip', () => {
       chip.select()
 
       expect(chipEl).toHaveClass('active')
+      expect(chipEl.getAttribute('aria-pressed')).toEqual('true')
+    })
+
+    it('should set aria-selected when selected inside a listbox (role option)', () => {
+      fixtureEl.innerHTML = '<span class="chip" role="option">Tag</span>'
+
+      const chipEl = fixtureEl.querySelector('.chip')
+      const chip = new Chip(chipEl, { selectable: true })
+
+      chip.select()
+
       expect(chipEl.getAttribute('aria-selected')).toEqual('true')
+      expect(chipEl.hasAttribute('aria-pressed')).toBe(false)
     })
 
     it('should trigger select and selected events', () => {
@@ -481,7 +493,7 @@ describe('Chip', () => {
   })
 
   describe('deselect', () => {
-    it('should remove active class and set aria-selected to false when deselected', () => {
+    it('should remove active class and set aria-pressed to false when deselected', () => {
       fixtureEl.innerHTML = '<span class="chip active">Tag</span>'
 
       const chipEl = fixtureEl.querySelector('.chip')
@@ -490,7 +502,7 @@ describe('Chip', () => {
       chip.deselect()
 
       expect(chipEl).not.toHaveClass('active')
-      expect(chipEl.getAttribute('aria-selected')).toEqual('false')
+      expect(chipEl.getAttribute('aria-pressed')).toEqual('false')
     })
 
     it('should trigger deselect and deselected events', () => {
@@ -723,7 +735,7 @@ describe('Chip', () => {
       expect(chipEl).toHaveClass('chip-clickable')
     })
 
-    it('should add disabled class and aria-disabled when disabled', () => {
+    it('should add disabled class but no aria-disabled on a role-less chip', () => {
       fixtureEl.innerHTML = '<span class="chip">Tag</span>'
 
       const chipEl = fixtureEl.querySelector('.chip')
@@ -731,31 +743,65 @@ describe('Chip', () => {
       new Chip(chipEl, { disabled: true })
 
       expect(chipEl).toHaveClass('disabled')
+      expect(chipEl.getAttribute('aria-disabled')).toBeNull()
+    })
+
+    it('should set aria-disabled on a disabled selectable chip (role button)', () => {
+      fixtureEl.innerHTML = '<span class="chip">Tag</span>'
+
+      const chipEl = fixtureEl.querySelector('.chip')
+      // eslint-disable-next-line no-new
+      new Chip(chipEl, { disabled: true, selectable: true })
+
+      expect(chipEl.getAttribute('role')).toEqual('button')
       expect(chipEl.getAttribute('aria-disabled')).toEqual('true')
     })
 
-    it('should set aria-selected when selectable', () => {
+    it('should expose a standalone selectable chip as a toggle button', () => {
       fixtureEl.innerHTML = '<span class="chip">Tag</span>'
 
       const chipEl = fixtureEl.querySelector('.chip')
       // eslint-disable-next-line no-new
       new Chip(chipEl, { selectable: true })
 
+      expect(chipEl.getAttribute('role')).toEqual('button')
+      expect(chipEl.getAttribute('aria-pressed')).toEqual('false')
+      expect(chipEl.hasAttribute('aria-selected')).toBe(false)
+    })
+
+    it('should keep an author-provided role and use aria-selected on role option', () => {
+      fixtureEl.innerHTML = '<span class="chip" role="option">Tag</span>'
+
+      const chipEl = fixtureEl.querySelector('.chip')
+      // eslint-disable-next-line no-new
+      new Chip(chipEl, { selectable: true })
+
+      expect(chipEl.getAttribute('role')).toEqual('option')
       expect(chipEl.getAttribute('aria-selected')).toEqual('false')
     })
 
-    it('should reset a stale aria-disabled attribute when not disabled', () => {
+    it('should drop a stale aria-disabled attribute from a role-less chip', () => {
       fixtureEl.innerHTML = '<span class="chip" aria-disabled="true">Tag</span>'
 
       const chipEl = fixtureEl.querySelector('.chip')
       // eslint-disable-next-line no-new
       new Chip(chipEl)
 
-      expect(chipEl.getAttribute('aria-disabled')).toEqual('false')
+      expect(chipEl.getAttribute('aria-disabled')).toBeNull()
     })
 
-    it('should reset a stale aria-selected attribute when not selectable', () => {
+    it('should drop a stale aria-selected attribute from a role-less chip', () => {
       fixtureEl.innerHTML = '<span class="chip" aria-selected="true">Tag</span>'
+
+      const chipEl = fixtureEl.querySelector('.chip')
+      // eslint-disable-next-line no-new
+      new Chip(chipEl)
+
+      expect(chipEl.getAttribute('aria-selected')).toBeNull()
+    })
+
+    it('should reset a stale aria-selected attribute on a non-selectable option chip', () => {
+      fixtureEl.innerHTML = '<span class="chip" role="option" aria-selected="true">Tag</span>'
 
       const chipEl = fixtureEl.querySelector('.chip')
       // eslint-disable-next-line no-new


### PR DESCRIPTION
## Summary

Closes the chip-family GAPs recorded by the WCAG conformance suite (#654): selection state stamped on role-less `<span>`s (invalid `aria-selected`/`aria-disabled`, axe `aria-allowed-attr`) and silent add/remove.

## Semantics

- **Selectable chip set** → horizontal `role="listbox"` (`aria-multiselectable` in multiple mode); the set stamps `role="option"` on its chips, so `aria-selected`/`aria-disabled` land on roles that allow them.
- **Standalone selectable chip** → toggle button (`role="button"`) reflecting its state via **`aria-pressed`** (an `option` requires a `listbox` parent, so it can't be used standalone).
- **Non-selectable set** → `role="group"`, which also legitimizes the documented `aria-label` guidance.
- **Role-less chips** no longer get `aria-disabled` (invalid there); stale attributes are removed. Author-provided roles always win.

## Announcements

`ChipSet` renders a visually hidden `role="status"` region **next to** the set — a status child inside a listbox would violate its required children (`aria-required-children`) — and announces added/removed chips (`ariaAddedAnnouncement`/`ariaRemovedAnnouncement` options, documented). `ChipInput` inherits the announcements; its mixed container (label + input + chips) opts out of container roles.

## Verification

- Chip-set **4.1.2 / 1.3.1 / 4.1.3** and chip-input **4.1.3** promoted to `built-in` in the WCAG suite and audited in CI — including scripted assertions that removing a chip and committing a typed value update the status region. Suite: **30 automated passes, 0 failures**.
- Unit suites updated to the new semantics plus new coverage (roles per context, live region, dispose cleanup): 3472 tests green, coverage above thresholds; docs build clean.
- MultiSelect's `selectionType: 'chips'` chips are standalone non-selectable, so they stay role-less and are unaffected.
- Migration guide notes the `aria-selected` → `aria-pressed` change for standalone selectable chips and the removed invalid attributes.