### PR TITLE
refactor(MultiSelect): checkbox indicators reuse the form-check surface

### DIFF
--- a/js/src/multi-select.ts
+++ b/js/src/multi-select.ts
@@ -76,6 +76,7 @@ const CLASS_NAME_SELECT = 'form-multi-select'
 const CLASS_NAME_SELECT_ALL = 'combobox-all'
 const CLASS_NAME_SELECT_ALL_WITH_CHECKBOX = 'combobox-all-with-checkbox'
 const CLASS_NAME_OPTGROUP_LABEL_WITH_CHECKBOX = 'combobox-optgroup-label-with-checkbox'
+const CLASS_NAME_OPTION_INDICATOR = 'combobox-option-indicator'
 const CLASS_NAME_OPTION_WITH_CHECKBOX = 'combobox-option-with-checkbox'
 const CLASS_NAME_SEARCH = 'form-multi-select-search'
 const CLASS_NAME_SELECTED = 'selected'
@@ -182,6 +183,7 @@ class MultiSelect extends Combobox {
   protected declare _uniqueName: any
   protected declare _indicatorElement: any
   protected declare _selectAllElement: any
+  protected declare _selectAllLabelElement: any
   protected declare _dropdownHeaderElement: any
   protected declare _headerElement: any
   protected declare _selectionElement: any
@@ -852,8 +854,12 @@ class MultiSelect extends Combobox {
 
       if (this._config.selectAllStyle === 'checkbox' && this._config.multiple) {
         selectAllButton.classList.add(CLASS_NAME_SELECT_ALL_WITH_CHECKBOX)
+        selectAllButton.append(this._createCheckboxIndicator())
       }
 
+      const selectAllLabel = document.createElement('span')
+      selectAllButton.append(selectAllLabel)
+      this._selectAllLabelElement = selectAllLabel
       this._selectAllElement = selectAllButton
       header.append(selectAllButton)
     }
@@ -873,6 +879,17 @@ class MultiSelect extends Combobox {
     this._updateMasterCheckbox()
   }
 
+  _createCheckboxIndicator(): HTMLElement {
+    // Decorative reuse of the form-check surface: a span (valid inside the
+    // select-all <button>) styled as .form-check-input; the host's
+    // selected/indeterminate classes drive its state, aria-selected carries
+    // the semantics.
+    const indicator = document.createElement('span')
+    indicator.classList.add('form-check-input', CLASS_NAME_OPTION_INDICATOR)
+    indicator.setAttribute('aria-hidden', 'true')
+    return indicator
+  }
+
   override _decorateOption(optionDiv: HTMLElement, _option: any): void {
     if (this._config.optionsStyle === 'checkbox') {
       optionDiv.classList.add(CLASS_NAME_OPTION_WITH_CHECKBOX)
@@ -889,6 +906,10 @@ class MultiSelect extends Combobox {
     } else {
       optionDiv.textContent = option.text
     }
+
+    if (this._config.optionsStyle === 'checkbox') {
+      optionDiv.prepend(this._createCheckboxIndicator())
+    }
   }
 
   override _decorateOptgroupLabel(label: HTMLElement, _option: any): void {
@@ -896,6 +917,7 @@ class MultiSelect extends Combobox {
       label.classList.add(CLASS_NAME_OPTGROUP_LABEL_WITH_CHECKBOX)
       label.tabIndex = 0
       label.setAttribute('role', 'button')
+      label.prepend(this._createCheckboxIndicator())
     }
   }
 
@@ -1351,7 +1373,7 @@ class MultiSelect extends Combobox {
       return
     }
 
-    this._selectAllElement.textContent = this._getSelectAllLabel()
+    this._selectAllLabelElement.textContent = this._getSelectAllLabel()
   }
 
   _getSelectAllLabel(): string {

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -3581,7 +3581,7 @@ describe('MultiSelect', () => {
         selectAllLabel: 'Choose All'
       })
 
-      expect(multiSelect._selectAllElement.innerHTML).toBe('Choose All')
+      expect(multiSelect._selectAllElement.textContent).toBe('Choose All')
     })
   })
 
@@ -4791,6 +4791,38 @@ describe('MultiSelect', () => {
 
       expect(chip).not.toBeNull()
       expect(chip.querySelector('.chip-remove')).toBeNull()
+    })
+  })
+
+  describe('checkbox indicators reuse the form-check surface', () => {
+    it('should render a decorative form-check-input indicator in checkbox options', () => {
+      fixtureEl.innerHTML = '<select multiple></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [{ value: '1', text: 'Apple' }]
+      })
+
+      const indicator = multiSelect._optionsElement.querySelector('.combobox-option .combobox-option-indicator')
+
+      expect(indicator).not.toBeNull()
+      expect(indicator.tagName).toBe('SPAN')
+      expect(indicator).toHaveClass('form-check-input')
+      expect(indicator.getAttribute('aria-hidden')).toBe('true')
+    })
+
+    it('should render the indicator inside the select all button before its label', () => {
+      fixtureEl.innerHTML = '<select multiple></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [{ value: '1', text: 'Apple' }],
+        selectAll: true,
+        selectAllLabel: 'Select all'
+      })
+
+      const button = multiSelect._selectAllElement
+
+      expect(button.firstElementChild).toHaveClass('combobox-option-indicator')
+      expect(button.textContent).toBe('Select all')
     })
   })
 })

--- a/scss/_combobox.scss
+++ b/scss/_combobox.scss
@@ -1,4 +1,5 @@
 @use "functions/defaults" as *;
+@use "functions/escape-svg" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/box-shadow" as *;
 @use "mixins/tokens" as *;
@@ -63,17 +64,8 @@ $combobox-option-disabled-color:      var(--#{$prefix}secondary-color) !default;
 $combobox-option-selected-bg:         var(--#{$prefix}secondary-bg) !default;
 
 $combobox-option-indicator-width:         1em !default;
-$combobox-option-indicator-bg:            var(--#{$prefix}btn-input-bg) !default;
-$combobox-option-indicator-border:        $form-check-input-border !default;
-$combobox-option-indicator-border-radius: .25em !default;
 
-$combobox-option-selected-indicator-bg:           var(--#{$prefix}control-checked-bg) !default;
-$combobox-option-selected-indicator-bg-image:     $form-check-input-checked-bg-image !default;
-$combobox-option-selected-indicator-border-color: var(--#{$prefix}control-checked-border-color) !default;
 
-$combobox-option-indeterminate-indicator-bg:           var(--#{$prefix}control-indeterminate-bg) !default;
-$combobox-option-indeterminate-indicator-bg-image:     $form-check-input-indeterminate-bg-image !default;
-$combobox-option-indeterminate-indicator-border-color: var(--#{$prefix}control-indeterminate-border-color) !default;
 // scss-docs-end combobox-variables
 
 $combobox-tokens: () !default;
@@ -128,15 +120,6 @@ $combobox-tokens: defaults(
     --#{$prefix}combobox-option-disabled-color: #{$combobox-option-disabled-color},
     --#{$prefix}combobox-option-selected-bg: #{$combobox-option-selected-bg},
     --#{$prefix}combobox-option-indicator-width: #{$combobox-option-indicator-width},
-    --#{$prefix}combobox-option-indicator-bg: #{$combobox-option-indicator-bg},
-    --#{$prefix}combobox-option-indicator-border: #{$combobox-option-indicator-border},
-    --#{$prefix}combobox-option-indicator-border-radius: #{$combobox-option-indicator-border-radius},
-    --#{$prefix}combobox-option-selected-indicator-bg: #{$combobox-option-selected-indicator-bg},
-    --#{$prefix}combobox-option-selected-indicator-bg-image: #{$combobox-option-selected-indicator-bg-image},
-    --#{$prefix}combobox-option-selected-indicator-border-color: #{$combobox-option-selected-indicator-border-color},
-    --#{$prefix}combobox-option-indeterminate-indicator-bg: #{$combobox-option-indeterminate-indicator-bg},
-    --#{$prefix}combobox-option-indeterminate-indicator-bg-image: #{$combobox-option-indeterminate-indicator-bg-image},
-    --#{$prefix}combobox-option-indeterminate-indicator-border-color: #{$combobox-option-indeterminate-indicator-border-color},
   ),
   $combobox-tokens
 );
@@ -272,36 +255,34 @@ $combobox-tokens: defaults(
   .combobox-optgroup-label-with-checkbox {
     position: relative;
     padding-inline-start: calc(var(--#{$prefix}combobox-option-padding-x) + var(--#{$prefix}combobox-option-indicator-width)); // stylelint-disable-line function-disallowed-list
+  }
 
-    &::before {
-      position: absolute;
-      inset-inline-start: calc(var(--#{$prefix}combobox-option-padding-x) * .5); // stylelint-disable-line function-disallowed-list
-      top: 50%;
-      display: block;
-      width: var(--#{$prefix}combobox-option-indicator-width);
-      height: var(--#{$prefix}combobox-option-indicator-width);
-      pointer-events: none;
-      content: "";
-      background-color: var(--#{$prefix}combobox-option-indicator-bg);
-      background-repeat: no-repeat;
-      background-position: center;
-      background-size: contain;
-      border: var(--#{$prefix}combobox-option-indicator-border);
-      transform: translateY(-50%);
-      @include border-radius(var(--#{$prefix}combobox-option-indicator-border-radius));
-    }
+  // The indicator is a decorative .form-check-input (span), so the checkbox
+  // visuals come from the form-check surface itself; only the placement and
+  // the class-driven states (a span never matches :checked) live here.
+  .combobox-option-indicator {
+    position: absolute;
+    inset-inline-start: calc(var(--#{$prefix}combobox-option-padding-x) * .5); // stylelint-disable-line function-disallowed-list
+    top: 50%;
+    width: var(--#{$prefix}combobox-option-indicator-width);
+    height: var(--#{$prefix}combobox-option-indicator-width);
+    margin: 0;
+    pointer-events: none;
+    transform: translateY(-50%);
+  }
 
-    &.selected::before {
-      background-color: var(--#{$prefix}combobox-option-selected-indicator-bg);
-      background-image: var(--#{$prefix}combobox-option-selected-indicator-bg-image);
-      border-color: var(--#{$prefix}combobox-option-selected-indicator-border-color);
-    }
+  .selected > .combobox-option-indicator {
+    --#{$prefix}form-check-bg-image: #{escape-svg($form-check-input-checked-bg-image)};
 
-    &.indeterminate::before {
-      background-color: var(--#{$prefix}combobox-option-indeterminate-indicator-bg);
-      background-image: var(--#{$prefix}combobox-option-indeterminate-indicator-bg-image);
-      border-color: var(--#{$prefix}combobox-option-indeterminate-indicator-border-color);
-    }
+    background-color: var(--#{$prefix}form-check-input-checked-bg-color);
+    border-color: var(--#{$prefix}form-check-input-checked-border-color);
+  }
+
+  .indeterminate > .combobox-option-indicator {
+    --#{$prefix}form-check-bg-image: #{escape-svg($form-check-input-indeterminate-bg-image)};
+
+    background-color: var(--#{$prefix}form-check-input-indeterminate-bg-color);
+    border-color: var(--#{$prefix}form-check-input-indeterminate-border-color);
   }
 
   .combobox-options-empty {


### PR DESCRIPTION
## Summary

Follow-up to #659, from review: the combobox checkbox indicators re-implemented the form-check visuals as `::before` pseudo-elements with their own nine-variable token set — while already borrowing the underlying `control-*`/form-check values. Now they **reuse the form-check surface literally**.

## How

- The indicator is a **decorative `.form-check-input` `<span>`** rendered by MultiSelect in checkbox options, selectable group labels and the select-all button. A span (not a real `<input>`) because interactive content is invalid inside the select-all `<button>`, and the semantics already live on `aria-selected` — the span is `aria-hidden`.
- Size, border, radius, background and theming come straight from the form-check tokens (mounted by the `.form-check-input` class itself); the host's `selected`/`indeterminate` classes drive the checked/indeterminate visuals through the same `--cui-form-check-*` custom properties a native checkbox uses.
- `scss/_combobox.scss` keeps only the indicator placement + two class-driven state rules; **nine `$combobox-option-indicator-*` variables and their tokens are removed**. Theming checkboxes now themes the combobox indicators for free.
- The select-all button wraps its label in a `<span>` so header refreshes don't wipe the indicator (`textContent` behavior unchanged; one spec assertion moved from `innerHTML` to `textContent`).

## Verification

Full unit 3474 (both suites + 2 new indicator specs), WCAG conformance 30/0, class-API gate, stylelint, find-unused-sass-variables, typecheck, docs build — all green locally.