### PR TITLE
fix(MultiSelect): match the combobox checkbox indicators to the standard form checks

### DIFF
--- a/scss/_combobox.scss
+++ b/scss/_combobox.scss
@@ -63,7 +63,7 @@ $combobox-option-hover-bg:            var(--#{$prefix}tertiary-bg) !default;
 $combobox-option-disabled-color:      var(--#{$prefix}secondary-color) !default;
 $combobox-option-selected-bg:         var(--#{$prefix}secondary-bg) !default;
 
-$combobox-option-indicator-width:         1em !default;
+$combobox-option-indicator-width:         var(--#{$prefix}form-check-input-width, 1em) !default;
 
 
 // scss-docs-end combobox-variables
@@ -269,6 +269,9 @@ $combobox-tokens: defaults(
     margin: 0;
     pointer-events: none;
     transform: translateY(-50%);
+    // A span never matches the [type="checkbox"] radius selector of the
+    // form-check surface, so apply the same token here.
+    @include border-radius(var(--#{$prefix}form-check-input-border-radius));
   }
 
   .selected > .combobox-option-indicator {


### PR DESCRIPTION
Follow-up to #660, from review: the indicators looked different from standard checkboxes. Two deltas:

1. **Sharp corners** — the form-check surface applies its border radius only through `&[type="checkbox"]`, which a decorative `<span>` never matches. The indicator now applies the same `--cui-form-check-input-border-radius` token itself.
2. **Size drift** — the indicator width overrode the form-check width with its own `1em`. It now defaults to `var(--cui-form-check-input-width, 1em)`, so resizing form checks resizes the combobox indicators too.

Verified with a headless-Chromium computed-style probe: the indicator is now **identical** to a native `.form-check-input` in both states — width/height 16px, radius 4px, border, background colors and the checkmark SVG all match.