### PR TITLE
fix: port the upstream v6-dev bug fixes (EventHandler, Menu, Offcanvas, RangeSlider, Sidebar, Placeholder, CloseButton)

### DIFF
--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -41,7 +41,7 @@ const EVENT_HIDE = `hide${EVENT_KEY}`
 const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_INPUT = `input${EVENT_KEY}`
 const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
-const EVENT_RESIZE = 'resize'
+const EVENT_RESIZE = `resize${EVENT_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_SUBMIT = 'submit'
@@ -329,6 +329,7 @@ class DateRangePicker extends BaseComponent {
   }
 
   override dispose(): void {
+    EventHandler.off(window, EVENT_KEY)
     this._disposeFloating()
 
     if (this._startInputTimeout) {

--- a/js/src/dom/event-handler.ts
+++ b/js/src/dom/event-handler.ts
@@ -24,6 +24,14 @@ interface WrappedHandler {
   uidEvent?: string | number
   callable?: EventCallable
   delegationSelector?: string | null
+  handlerTypeEvent?: string
+}
+
+interface NormalizedParameters {
+  isDelegated: boolean
+  callable: EventCallable
+  typeEvent: string
+  handlerTypeEvent: string
 }
 
 type ElementEvents = Record<string, Record<string, WrappedHandler>>
@@ -113,19 +121,37 @@ function getElementEvents(element: Element & { uidEvent?: string | number }): El
   return eventRegistry[uid]
 }
 
-function bootstrapHandler(element: Element, fn: EventCallable): WrappedHandler {
-  return function handler(event: Event) {
-    hydrateObj(event, { delegateTarget: element })
+// `mouseenter` and `mouseleave` ride on `mouseover` and `mouseout`, which also fire when
+// the pointer moves between descendants of the listening element. Drop those events, so the
+// handler only sees the pointer entering or leaving `delegateTarget` itself.
+// `Node.contains()` is inclusive, so this also covers `relatedTarget === delegateTarget`.
+function isMouseEventWithinTarget(event: CoreUIEvent): boolean {
+  const { delegateTarget, relatedTarget } = event
 
-    if ((handler as WrappedHandler).oneOff) {
-      EventHandler.off(element, event.type, fn)
+  return Boolean(relatedTarget && delegateTarget.contains(relatedTarget))
+}
+
+function bootstrapHandler(element: Element, fn: EventCallable, handlerTypeEvent: string): WrappedHandler {
+  const isCustomMouseEvent = handlerTypeEvent in customEvents
+
+  return function handler(event: Event) {
+    const coreuiEvent = hydrateObj(event, { delegateTarget: element })
+
+    if (isCustomMouseEvent && isMouseEventWithinTarget(coreuiEvent)) {
+      return
     }
 
-    return fn.apply(element, [event as CoreUIEvent])
+    if ((handler as WrappedHandler).oneOff) {
+      EventHandler.off(element, handlerTypeEvent, fn)
+    }
+
+    return fn.apply(element, [coreuiEvent])
   } as WrappedHandler
 }
 
-function bootstrapDelegationHandler(element: Element, selector: string, fn: EventCallable): WrappedHandler {
+function bootstrapDelegationHandler(element: Element, selector: string, fn: EventCallable, handlerTypeEvent: string): WrappedHandler {
+  const isCustomMouseEvent = handlerTypeEvent in customEvents
+
   return function handler(this: Element, event: Event) {
     const domElements = element.querySelectorAll(selector)
 
@@ -135,34 +161,47 @@ function bootstrapDelegationHandler(element: Element, selector: string, fn: Even
           continue
         }
 
-        hydrateObj(event, { delegateTarget: target })
+        const coreuiEvent = hydrateObj(event, { delegateTarget: target })
 
-        if ((handler as WrappedHandler).oneOff) {
-          EventHandler.off(element, event.type, selector, fn)
+        if (isCustomMouseEvent && isMouseEventWithinTarget(coreuiEvent)) {
+          return
         }
 
-        return fn.apply(target, [event as CoreUIEvent])
+        if ((handler as WrappedHandler).oneOff) {
+          EventHandler.off(element, handlerTypeEvent, selector, fn)
+        }
+
+        return fn.apply(target, [coreuiEvent])
       }
     }
-  }
+  } as WrappedHandler
 }
 
-function findHandler(events: Record<string, WrappedHandler>, callable: EventCallable, delegationSelector: string | null = null): WrappedHandler | undefined {
+function findHandler(events: Record<string, WrappedHandler>, callable: EventCallable, handlerTypeEvent: string, delegationSelector: string | null = null): WrappedHandler | undefined {
   return Object.values(events)
-    .find(event => event.callable === callable && event.delegationSelector === delegationSelector)
+    .find(event => event.callable === callable && event.handlerTypeEvent === handlerTypeEvent && event.delegationSelector === delegationSelector)
 }
 
-function normalizeParameters(originalTypeEvent: string, handler?: string | EventCallable, delegationFunction?: EventCallable): [boolean, EventCallable, string] {
+// `typeEvent` is the DOM event type the listener is registered under. `handlerTypeEvent` is
+// the type the caller asked for. The two differ only for `mouseenter` and `mouseleave`, which
+// the registry must keep apart from the `mouseover` and `mouseout` listeners they share.
+function normalizeParameters(originalTypeEvent: string, handler?: string | EventCallable, delegationFunction?: EventCallable): NormalizedParameters {
   const isDelegated = typeof handler === 'string'
   // TODO: tooltip passes `false` instead of selector, so we need to check
   const callable = (isDelegated ? delegationFunction : (handler || delegationFunction)) as EventCallable
-  let typeEvent = getTypeEvent(originalTypeEvent)
+  // Strip the namespace to get the plain event ('click.coreui.button' --> 'click')
+  const baseTypeEvent = originalTypeEvent.replace(stripNameRegex, '')
+  let typeEvent = customEvents[baseTypeEvent] || baseTypeEvent
 
   if (!nativeEvents.has(typeEvent)) {
     typeEvent = originalTypeEvent
   }
 
-  return [isDelegated, callable, typeEvent]
+  const handlerTypeEvent = baseTypeEvent in customEvents ? baseTypeEvent : typeEvent
+
+  return {
+    isDelegated, callable, typeEvent, handlerTypeEvent
+  }
 }
 
 function addHandler(element: Element, originalTypeEvent: string, handler?: string | EventCallable, delegationFunction?: EventCallable, oneOff?: boolean): void {
@@ -170,25 +209,10 @@ function addHandler(element: Element, originalTypeEvent: string, handler?: strin
     return
   }
 
-  let [isDelegated, callable, typeEvent] = normalizeParameters(originalTypeEvent, handler, delegationFunction)
-
-  // in case of mouseenter or mouseleave wrap the handler within a function that checks for its DOM position
-  // this prevents the handler from being dispatched the same way as mouseover or mouseout does
-  if (originalTypeEvent in customEvents) {
-    const wrapFunction = (fn: EventCallable): EventCallable => {
-      return function (event) {
-        if (!event.relatedTarget || (event.relatedTarget !== event.delegateTarget && !event.delegateTarget.contains(event.relatedTarget))) {
-          return fn.call(this, event)
-        }
-      }
-    }
-
-    callable = wrapFunction(callable)
-  }
-
+  const { isDelegated, callable, typeEvent, handlerTypeEvent } = normalizeParameters(originalTypeEvent, handler, delegationFunction)
   const events = getElementEvents(element)
   const handlers = events[typeEvent] || (events[typeEvent] = {})
-  const previousFunction = findHandler(handlers, callable, isDelegated ? (handler as string) : null)
+  const previousFunction = findHandler(handlers, callable, handlerTypeEvent, isDelegated ? (handler as string) : null)
 
   if (previousFunction) {
     previousFunction.oneOff = previousFunction.oneOff && oneOff
@@ -198,11 +222,12 @@ function addHandler(element: Element, originalTypeEvent: string, handler?: strin
 
   const uid = makeEventUid(callable, originalTypeEvent.replace(namespaceRegex, ''))
   const fn = isDelegated ?
-    bootstrapDelegationHandler(element, handler as string, callable) :
-    bootstrapHandler(element, callable)
+    bootstrapDelegationHandler(element, handler as string, callable, handlerTypeEvent) :
+    bootstrapHandler(element, callable, handlerTypeEvent)
 
   fn.delegationSelector = isDelegated ? (handler as string) : null
   fn.callable = callable
+  fn.handlerTypeEvent = handlerTypeEvent
   fn.oneOff = oneOff
   fn.uidEvent = uid
   handlers[uid] = fn
@@ -210,15 +235,9 @@ function addHandler(element: Element, originalTypeEvent: string, handler?: strin
   element.addEventListener(typeEvent, fn, isDelegated)
 }
 
-function removeHandler(element: Element, events: ElementEvents, typeEvent: string, handler: EventCallable, delegationSelector: string | null): void {
-  const fn = findHandler(events[typeEvent], handler, delegationSelector)
-
-  if (!fn) {
-    return
-  }
-
-  element.removeEventListener(typeEvent, fn, Boolean(delegationSelector))
-  delete events[typeEvent][fn.uidEvent!]
+function removeHandler(element: Element, events: ElementEvents, typeEvent: string, handler: WrappedHandler): void {
+  element.removeEventListener(typeEvent, handler, Boolean(handler.delegationSelector))
+  delete events[typeEvent][handler.uidEvent!]
 }
 
 function removeNamespacedHandlers(element: Element, events: ElementEvents, typeEvent: string, namespace: string): void {
@@ -226,7 +245,7 @@ function removeNamespacedHandlers(element: Element, events: ElementEvents, typeE
 
   for (const [handlerKey, event] of Object.entries(storeElementEvent)) {
     if (handlerKey.includes(namespace)) {
-      removeHandler(element, events, typeEvent, event.callable!, event.delegationSelector!)
+      removeHandler(element, events, typeEvent, event)
     }
   }
 }
@@ -251,8 +270,10 @@ const EventHandler = {
       return
     }
 
-    const [isDelegated, callable, typeEvent] = normalizeParameters(originalTypeEvent, handler, delegationFunction)
-    const inNamespace = typeEvent !== originalTypeEvent
+    const { isDelegated, callable, typeEvent, handlerTypeEvent } = normalizeParameters(originalTypeEvent, handler, delegationFunction)
+    // The caller gave a namespace when neither event type matches what they passed in.
+    // `handlerTypeEvent` must take part, or plain `mouseenter` looks namespaced next to `mouseover`.
+    const inNamespace = typeEvent !== originalTypeEvent && handlerTypeEvent !== originalTypeEvent
     const events = getElementEvents(element as Element)
     const storeElementEvent = events[typeEvent] || {}
     const isNamespace = originalTypeEvent.startsWith('.')
@@ -263,7 +284,12 @@ const EventHandler = {
         return
       }
 
-      removeHandler(element as Element, events, typeEvent, callable, isDelegated ? (handler as string) : null)
+      const fn = findHandler(storeElementEvent, callable, handlerTypeEvent, isDelegated ? (handler as string) : null)
+
+      if (fn) {
+        removeHandler(element as Element, events, typeEvent, fn)
+      }
+
       return
     }
 
@@ -276,8 +302,8 @@ const EventHandler = {
     for (const [keyHandlers, event] of Object.entries(storeElementEvent)) {
       const handlerKey = keyHandlers.replace(stripUidRegex, '')
 
-      if (!inNamespace || originalTypeEvent.includes(handlerKey)) {
-        removeHandler(element as Element, events, typeEvent, event.callable!, event.delegationSelector!)
+      if (event.handlerTypeEvent === handlerTypeEvent && (!inNamespace || originalTypeEvent.includes(handlerKey))) {
+        removeHandler(element as Element, events, typeEvent, event)
       }
     }
   },

--- a/js/src/menu.ts
+++ b/js/src/menu.ts
@@ -488,7 +488,10 @@ class Menu extends BaseComponent {
           toFloatingOffset(offsetValue)
       ),
       flip({
-        fallbackPlacements: this._getFallbackPlacements()
+        fallbackPlacements: this._getFallbackPlacements(),
+        // When no placement fits, keep the initial one. Overflow below can be
+        // scrolled to; overflow above the scroll origin can never be reached.
+        fallbackStrategy: 'initialPlacement'
       }),
       shift({
         boundary: (this._config.boundary === 'clippingParents' ? 'clippingAncestors' : this._config.boundary) as Boundary

--- a/js/src/range-slider.ts
+++ b/js/src/range-slider.ts
@@ -162,6 +162,13 @@ class RangeSlider extends BaseComponent {
     this._initializeRangeSlider()
   }
 
+  override dispose(): void {
+    EventHandler.off(window, EVENT_KEY)
+    EventHandler.off(document.documentElement, EVENT_KEY)
+
+    super.dispose()
+  }
+
   // Private
   _addEventListeners(): void {
     if (this._config.disabled) {

--- a/js/src/sidebar.ts
+++ b/js/src/sidebar.ts
@@ -37,7 +37,7 @@ const CLASS_NAME_SIDEBAR_NARROW_UNFOLDABLE = 'sidebar-narrow-unfoldable'
 
 const EVENT_HIDE = `hide${EVENT_KEY}`
 const EVENT_HIDDEN = `hidden${EVENT_KEY}`
-const EVENT_RESIZE = 'resize'
+const EVENT_RESIZE = `resize${EVENT_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
@@ -205,6 +205,12 @@ class Sidebar extends BaseComponent {
     }
 
     this.unfoldable()
+  }
+
+  override dispose(): void {
+    EventHandler.off(window, EVENT_KEY)
+
+    super.dispose()
   }
 
   // Private

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -1569,4 +1569,61 @@ describe('Carousel', () => {
       expect().nothing()
     })
   })
+
+  // `mouseenter`/`mouseleave` are emulated with `mouseover`/`mouseout`, which also fire
+  // when the pointer moves between the carousel's own slides.
+  describe('custom mouse events', () => {
+    it('should stay paused while the pointer moves between slides', () => {
+      fixtureEl.innerHTML = [
+        '<div id="myCarousel" class="carousel slide" data-coreui-ride="carousel">',
+        '  <div class="carousel-inner">',
+        '    <div id="item1" class="carousel-item active">item 1</div>',
+        '    <div class="carousel-item">item 2</div>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const carouselEl = fixtureEl.querySelector('#myCarousel')
+      const item = fixtureEl.querySelector('#item1')
+      const carousel = new Carousel(carouselEl)
+      const cycleSpy = spyOn(carousel, 'cycle')
+
+      carouselEl.dispatchEvent(new MouseEvent('mouseout', {
+        bubbles: true,
+        relatedTarget: item
+      }))
+
+      expect(cycleSpy).not.toHaveBeenCalled()
+
+      carouselEl.dispatchEvent(new MouseEvent('mouseout', {
+        bubbles: true,
+        relatedTarget: document.body
+      }))
+
+      expect(cycleSpy).toHaveBeenCalled()
+    })
+
+    it('should not pause again while the pointer moves between slides', () => {
+      fixtureEl.innerHTML = [
+        '<div id="myCarousel" class="carousel slide" data-coreui-ride="carousel">',
+        '  <div class="carousel-inner">',
+        '    <div id="item1" class="carousel-item active">item 1</div>',
+        '    <div class="carousel-item">item 2</div>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const carouselEl = fixtureEl.querySelector('#myCarousel')
+      const item = fixtureEl.querySelector('#item1')
+      const carousel = new Carousel(carouselEl)
+      const pauseSpy = spyOn(carousel, 'pause')
+
+      item.dispatchEvent(new MouseEvent('mouseover', {
+        bubbles: true,
+        relatedTarget: carouselEl
+      }))
+
+      expect(pauseSpy).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/js/tests/unit/dom/event-handler.spec.js
+++ b/js/tests/unit/dom/event-handler.spec.js
@@ -477,4 +477,246 @@ describe('EventHandler', () => {
       })
     })
   })
+
+  // `mouseenter` and `mouseleave` do not bubble, so `EventHandler` emulates them with
+  // `mouseover` and `mouseout` listeners. The registry must still treat them as their own
+  // event types, or removal, deduplication and one-off bookkeeping hit the wrong handler.
+  describe('custom mouse events', () => {
+    const moveMouse = (from, to) => {
+      from.dispatchEvent(new MouseEvent('mouseout', { bubbles: true, relatedTarget: to }))
+      to.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, relatedTarget: from }))
+    }
+
+    it('should ignore transitions between descendants for namespaced listeners', () => {
+      fixtureEl.innerHTML = '<div class="outer"><span></span></div>'
+
+      const outer = fixtureEl.querySelector('.outer')
+      const child = fixtureEl.querySelector('span')
+      const enterSpy = jasmine.createSpy('mouseenter')
+      const leaveSpy = jasmine.createSpy('mouseleave')
+
+      EventHandler.on(outer, 'mouseenter.namespace', enterSpy)
+      EventHandler.on(outer, 'mouseleave.namespace', leaveSpy)
+
+      moveMouse(outer, child)
+      moveMouse(child, outer)
+
+      expect(enterSpy).not.toHaveBeenCalled()
+      expect(leaveSpy).not.toHaveBeenCalled()
+
+      moveMouse(document.body, outer)
+
+      expect(enterSpy.calls.count()).toEqual(1)
+      expect(leaveSpy).not.toHaveBeenCalled()
+    })
+
+    it('should ignore transitions between descendants for delegated listeners', () => {
+      fixtureEl.innerHTML = '<div class="outer"><div class="inner"><span></span></div></div>'
+
+      const outer = fixtureEl.querySelector('.outer')
+      const inner = fixtureEl.querySelector('.inner')
+      const child = fixtureEl.querySelector('span')
+      const enterSpy = jasmine.createSpy('delegated mouseenter')
+
+      EventHandler.on(outer, 'mouseenter.namespace', '.inner', enterSpy)
+
+      moveMouse(inner, child)
+
+      expect(enterSpy).not.toHaveBeenCalled()
+
+      moveMouse(outer, inner)
+
+      expect(enterSpy.calls.count()).toEqual(1)
+    })
+
+    it('should register the same callback only once', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const handler = jasmine.createSpy('mouseenter')
+
+      EventHandler.on(div, 'mouseenter', handler)
+      EventHandler.on(div, 'mouseenter', handler)
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(1)
+    })
+
+    it('should keep mouseenter listeners apart from mouseover listeners', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const handler = jasmine.createSpy('mouse handler')
+
+      EventHandler.on(div, 'mouseenter', handler)
+      EventHandler.on(div, 'mouseover', handler)
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(2)
+
+      EventHandler.off(div, 'mouseover')
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      // only the mouseenter listener is left
+      expect(handler.calls.count()).toEqual(3)
+
+      EventHandler.off(div, 'mouseenter')
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(3)
+    })
+
+    it('should keep a delegated listener apart from a direct one', () => {
+      fixtureEl.innerHTML = '<div class="outer"><div class="inner"></div></div>'
+
+      const outer = fixtureEl.querySelector('.outer')
+      const inner = fixtureEl.querySelector('.inner')
+      const handler = jasmine.createSpy('mouseenter')
+
+      EventHandler.on(outer, 'mouseenter', handler)
+      EventHandler.on(outer, 'mouseenter', '.inner', handler)
+      inner.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+
+      expect(handler.calls.count()).toEqual(2)
+
+      EventHandler.off(outer, 'mouseenter', '.inner', handler)
+      inner.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+
+      // the direct listener survives
+      expect(handler.calls.count()).toEqual(3)
+    })
+
+    it('should remove a listener by reference', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const handler = jasmine.createSpy('mouseenter')
+
+      EventHandler.on(div, 'mouseenter', handler)
+      EventHandler.off(div, 'mouseenter', handler)
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('should remove a delegated listener by reference', () => {
+      fixtureEl.innerHTML = '<div class="outer"><div class="inner"></div></div>'
+
+      const outer = fixtureEl.querySelector('.outer')
+      const inner = fixtureEl.querySelector('.inner')
+      const handler = jasmine.createSpy('delegated mouseenter')
+
+      EventHandler.on(outer, 'mouseenter', '.inner', handler)
+      EventHandler.off(outer, 'mouseenter', '.inner', handler)
+      inner.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('should remove every listener for the event type', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const first = jasmine.createSpy('first')
+      const second = jasmine.createSpy('second')
+
+      EventHandler.on(div, 'mouseenter', first)
+      EventHandler.on(div, 'mouseenter.namespace', second)
+      EventHandler.off(div, 'mouseenter')
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(first).not.toHaveBeenCalled()
+      expect(second).not.toHaveBeenCalled()
+    })
+
+    it('should remove only the namespaced listener when a namespace is given', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const plain = jasmine.createSpy('plain')
+      const namespaced = jasmine.createSpy('namespaced')
+
+      EventHandler.on(div, 'mouseenter', plain)
+      EventHandler.on(div, 'mouseenter.namespace', namespaced)
+      EventHandler.off(div, 'mouseenter.namespace')
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(plain.calls.count()).toEqual(1)
+      expect(namespaced).not.toHaveBeenCalled()
+    })
+
+    it('should remove listeners when only a namespace is given', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const enterSpy = jasmine.createSpy('mouseenter')
+      const leaveSpy = jasmine.createSpy('mouseleave')
+
+      EventHandler.on(div, 'mouseenter.namespace', enterSpy)
+      EventHandler.on(div, 'mouseleave.namespace', leaveSpy)
+      EventHandler.off(div, '.namespace')
+
+      div.dispatchEvent(new MouseEvent('mouseover'))
+      div.dispatchEvent(new MouseEvent('mouseout'))
+
+      expect(enterSpy).not.toHaveBeenCalled()
+      expect(leaveSpy).not.toHaveBeenCalled()
+    })
+
+    // Components such as Menu add a listener each time they open a submenu, then drop it on
+    // close. A failed removal used to leave one live listener behind per cycle.
+    it('should not accumulate listeners across repeated add and remove cycles', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const handler = jasmine.createSpy('mouseenter')
+
+      for (let i = 0; i < 5; i++) {
+        EventHandler.on(div, 'mouseenter', () => handler())
+        EventHandler.off(div, 'mouseenter')
+      }
+
+      EventHandler.on(div, 'mouseenter', () => handler())
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(1)
+    })
+
+    it('should not consume a one-off listener on a transition between descendants', () => {
+      fixtureEl.innerHTML = '<div class="outer"><div class="inner"><span></span></div></div>'
+
+      const outer = fixtureEl.querySelector('.outer')
+      const inner = fixtureEl.querySelector('.inner')
+      const child = fixtureEl.querySelector('span')
+      const enterSpy = jasmine.createSpy('mouseenter')
+      const delegateEnterSpy = jasmine.createSpy('delegated mouseenter')
+
+      EventHandler.one(inner, 'mouseenter', enterSpy)
+      EventHandler.one(outer, 'mouseenter', '.inner', delegateEnterSpy)
+
+      moveMouse(inner, child)
+
+      expect(enterSpy).not.toHaveBeenCalled()
+      expect(delegateEnterSpy).not.toHaveBeenCalled()
+
+      moveMouse(outer, inner)
+      moveMouse(outer, inner)
+
+      expect(enterSpy.calls.count()).toEqual(1)
+      expect(delegateEnterSpy.calls.count()).toEqual(1)
+    })
+
+    it('should call a namespaced one-off listener just once', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const handler = jasmine.createSpy('mouseenter')
+
+      EventHandler.one(div, 'mouseenter.namespace', handler)
+      div.dispatchEvent(new MouseEvent('mouseover'))
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(1)
+    })
+  })
 })

--- a/js/tests/unit/menu.spec.js
+++ b/js/tests/unit/menu.spec.js
@@ -4610,4 +4610,49 @@ describe('Menu', () => {
       })
     })
   })
+
+  // `_openSubmenu()` adds a `mouseenter` listener and `_closeSubmenu()` drops it again.
+  // A failed removal used to leave one live listener behind per open and close cycle.
+  describe('custom mouse events', () => {
+    it('should not accumulate mouseenter listeners across open and close cycles', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-coreui-toggle="menu">Menu</button>',
+          '  <ul class="menu">',
+          '    <li class="submenu">',
+          '      <button class="menu-item" type="button">More options</button>',
+          '      <ul class="menu">',
+          '        <li><a class="menu-item" href="#">Sub-action</a></li>',
+          '      </ul>',
+          '    </li>',
+          '  </ul>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-coreui-toggle="menu"]')
+        const submenuTrigger = fixtureEl.querySelector('.submenu > .menu-item')
+        const submenu = fixtureEl.querySelector('.submenu > .menu')
+
+        btnMenu.addEventListener('shown.coreui.menu', () => {
+          for (let i = 0; i < 3; i++) {
+            submenuTrigger.click()
+            submenuTrigger.click()
+          }
+
+          submenuTrigger.click()
+          expect(submenu.classList.contains('show')).toBeTrue()
+
+          const spy = spyOn(menu, '_cancelSubmenuCloseTimeout')
+          submenu.dispatchEvent(new MouseEvent('mouseover'))
+
+          expect(spy.calls.count()).toEqual(1)
+          resolve()
+        })
+
+        const menu = new Menu(btnMenu)
+        btnMenu.click()
+      })
+    })
+  })
 })

--- a/js/tests/unit/range-slider.spec.js
+++ b/js/tests/unit/range-slider.spec.js
@@ -1900,4 +1900,37 @@ describe('RangeSlider', () => {
       expect(input.value).toBe('60')
     })
   })
+
+  describe('dispose', () => {
+    it('should drop its window and documentElement listeners', () => {
+      fixtureEl.innerHTML = '<div id="mySlider"></div>'
+
+      const el = fixtureEl.querySelector('#mySlider')
+      const rangeSlider = new RangeSlider(el, { value: [10, 40] })
+
+      // Watch the prototype and match on the receiver: `dispose()` nulls the
+      // instance's own properties (an instance spy would be wiped), and other
+      // sliders in this file may still hold their own global listeners.
+      const original = RangeSlider.prototype._updateLabelsContainerSize
+      let calledOnDisposedInstance = false
+      RangeSlider.prototype._updateLabelsContainerSize = function (...args) {
+        if (this === rangeSlider) {
+          calledOnDisposedInstance = true
+        }
+
+        return original.apply(this, args)
+      }
+
+      try {
+        rangeSlider.dispose()
+        window.dispatchEvent(new Event('resize'))
+        document.documentElement.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }))
+        document.documentElement.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+      } finally {
+        RangeSlider.prototype._updateLabelsContainerSize = original
+      }
+
+      expect(calledOnDisposedInstance).toBeFalse()
+    })
+  })
 })

--- a/js/tests/unit/sidebar.spec.js
+++ b/js/tests/unit/sidebar.spec.js
@@ -661,4 +661,35 @@ describe('Sidebar', () => {
       expect(spySidebarInterface).toHaveBeenCalledWith(sidebarEl)
     })
   })
+
+  describe('dispose', () => {
+    it('should drop its window resize listener', () => {
+      fixtureEl.innerHTML = '<div class="sidebar"></div>'
+
+      const el = fixtureEl.querySelector('.sidebar')
+      const sidebar = new Sidebar(el)
+
+      // Watch the prototype and match on the receiver: `dispose()` nulls the
+      // instance's own properties (an instance spy would be wiped), and other
+      // sidebars in this file may still hold their own resize listeners.
+      const original = Sidebar.prototype._isMobile
+      let calledOnDisposedInstance = false
+      Sidebar.prototype._isMobile = function (...args) {
+        if (this === sidebar) {
+          calledOnDisposedInstance = true
+        }
+
+        return original.apply(this, args)
+      }
+
+      try {
+        sidebar.dispose()
+        window.dispatchEvent(new Event('resize'))
+      } finally {
+        Sidebar.prototype._isMobile = original
+      }
+
+      expect(calledOnDisposedInstance).toBeFalse()
+    })
+  })
 })

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -1763,4 +1763,31 @@ describe('Tooltip', () => {
       }).toThrowError(TypeError, `No method named "${action}"`)
     })
   })
+
+  describe('custom mouse events', () => {
+    it('should not start hiding while the pointer moves between children of the trigger', () => {
+      fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip"><span>child</span></a>'
+
+      const tooltipEl = fixtureEl.querySelector('a')
+      const childEl = fixtureEl.querySelector('span')
+      const tooltip = new Tooltip(tooltipEl, { trigger: 'hover' })
+      const spy = spyOn(tooltip, '_leave')
+
+      // The pointer leaves the child but stays inside the trigger, so `mouseout` carries a
+      // `relatedTarget` within the trigger. This must not count as a leave.
+      childEl.dispatchEvent(new MouseEvent('mouseout', {
+        bubbles: true,
+        relatedTarget: tooltipEl
+      }))
+
+      expect(spy).not.toHaveBeenCalled()
+
+      tooltipEl.dispatchEvent(new MouseEvent('mouseout', {
+        bubbles: true,
+        relatedTarget: document.body
+      }))
+
+      expect(spy).toHaveBeenCalled()
+    })
+  })
 })

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -178,6 +178,9 @@ $offcanvas-tokens: defaults(
   }
 
   .offcanvas-body {
+    // Contain absolutely positioned children (e.g. menus) so they scroll with
+    // the body instead of being clipped by the offcanvas' overflow.
+    position: relative;
     flex-grow: 1;
     padding: var(--#{$prefix}offcanvas-padding-y) var(--#{$prefix}offcanvas-padding-x);
     overflow-y: auto;

--- a/scss/_placeholder.scss
+++ b/scss/_placeholder.scss
@@ -32,6 +32,12 @@
   .placeholder-glow {
     .placeholder {
       animation: placeholder-glow 2s ease-in-out infinite;
+
+      @if $enable-reduced-motion {
+        @media (prefers-reduced-motion: reduce) {
+          animation: none;
+        }
+      }
     }
   }
 
@@ -45,6 +51,12 @@
     mask-image: linear-gradient(130deg, $black 55%, rgba(0, 0, 0, (1 - $placeholder-opacity-min)) 75%, $black 95%);
     mask-size: 200% 100%;
     animation: placeholder-wave 2s linear infinite;
+
+    @if $enable-reduced-motion {
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
   }
 
   @keyframes placeholder-wave {

--- a/scss/buttons/_close.scss
+++ b/scss/buttons/_close.scss
@@ -49,8 +49,12 @@ $close-tokens: defaults(
     @include tokens($close-tokens);
 
     box-sizing: content-box;
+    // Flex containers may shrink the button below its icon; a minimum keeps it
+    // square and clickable.
     width: $btn-close-width;
+    min-width: $btn-close-width;
     height: $btn-close-height;
+    min-height: $btn-close-height;
     padding: $btn-close-padding-y $btn-close-padding-x;
     color: var(--#{$prefix}btn-close-color);
     background: transparent var(--#{$prefix}btn-close-bg) center / $btn-close-width auto no-repeat; // include transparent for button elements

--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -594,9 +594,14 @@ $th-font-weight:       null !default;
     display: inline-block;
   }
 
-  // Remove border from iframe
+  // Reset iframe color-scheme
+  //
+  // If the color scheme of an iframe differs from the parent document, the
+  // iframe gets an opaque canvas background of its own (a white background on
+  // a page in dark mode). Remove its border while we are here.
 
   iframe {
+    color-scheme: light dark;
     border: 0;
   }
 


### PR DESCRIPTION
First results of the Bootstrap v6-dev sweep — everything here is a **bug fix with no API or markup change**. Every ported fix was verified against our own sources first (several upstream fixes turned out to be already ported, or to be architectural changes we deliberately don't take — those are listed in the workspace audit, not here).

## EventHandler custom mouse events (twbs#42778)

`mouseenter`/`mouseleave` are emulated with `mouseover`/`mouseout`. The containment guard read `originalTypeEvent in customEvents`, which only matches the bare strings — **every component namespaces its events, so no component ever got the check**. The guard also wrapped the caller's callback and stored the wrapper, so removal by reference, deduplication and one-off bookkeeping all compared against a function the caller never held.

Confirmed user-visible effects, each covered by a regression test that fails without the source change:
- **Carousel** resumed autoplay (and re-paused) while the pointer moved between slides
- **Tooltip** started hiding while the pointer moved between children of its trigger
- **Menu** leaked a submenu `mouseenter` listener on every open/close cycle

13 EventHandler specs + 4 component specs ported; **10 of the 13 fail on the old code**.

## Leaked global listeners (pattern from twbs#42746, nav-overflow)

`RangeSlider`, `Sidebar` and `DateRangePicker` register `window`/`documentElement` listeners per instance that outlived `dispose()` — the base implementation only drops listeners bound to the component's own element. Sidebar and DateRangePicker additionally used a bare `'resize'` type that no namespaced `off()` could ever remove. Now namespaced and dropped on dispose.

The regression tests assert on the *receiver* rather than an instance spy: `dispose()` nulls the instance's own properties, so an instance spy is wiped before a leaked listener could reach it. (This also surfaced that other tests in the same files were leaking listeners onto `window`.)

## Smaller ports

- **Menu**: `flip` keeps the initial placement when nothing fits (`fallbackStrategy: 'initialPlacement'`) — overflow below can be scrolled to, overflow above the scroll origin cannot (twbs#42777)
- **Offcanvas**: `.offcanvas-body` is a containing block, so menus/combobox popups scroll with the body instead of being clipped (twbs#42777)
- **Placeholder**: glow/wave animations guarded behind `prefers-reduced-motion` (twbs#42768)
- **.btn-close**: minimum size so flex containers can't collapse it below its icon (twbs#42518)
- **Reboot**: `iframe { color-scheme: light dark }` so an iframe doesn't render an opaque light canvas inside a dark-scheme page (twbs#42605) — matters more since the `light-dark()` floors landed

## Verification

Full unit 3493, typecheck, lint, stylelint, class-API gate, CSS compile — green locally.