### PR TITLE
fix(Modal,Offcanvas): don't scroll on focus restore, release the scroll lock when disposed while open

### DIFF
--- a/js/src/modal.ts
+++ b/js/src/modal.ts
@@ -152,6 +152,20 @@ class Modal extends BaseComponent {
   }
 
   dispose(): any {
+    // Disposed while still open (e.g. an SPA tearing the component down
+    // mid-navigation): restore the page state synchronously, or `modal-open`
+    // (overflow: hidden) and the scrollbar padding stay stuck on the body.
+    if (this._isShown) {
+      this._element.style.display = 'none'
+      this._element.classList.remove(CLASS_NAME_SHOW)
+      this._element.setAttribute('aria-hidden', true as unknown as string)
+      this._element.removeAttribute('aria-modal')
+      this._element.removeAttribute('role')
+      document.body.classList.remove(CLASS_NAME_OPEN)
+      this._resetAdjustments()
+      this._scrollBar.reset()
+    }
+
     EventHandler.off(window, EVENT_KEY)
     EventHandler.off(this._dialog!, EVENT_KEY)
 
@@ -362,7 +376,8 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
 
     EventHandler.one(target, EVENT_HIDDEN, () => {
       if (isVisible(this)) {
-        this.focus()
+        // Returning focus must not scroll the page back to the trigger.
+        this.focus({ preventScroll: true })
       }
     })
   })

--- a/js/src/offcanvas.ts
+++ b/js/src/offcanvas.ts
@@ -166,6 +166,18 @@ class Offcanvas extends BaseComponent {
   }
 
   dispose(): any {
+    // Disposed while still open: release the scroll lock synchronously, or the
+    // body keeps `overflow: hidden` and the scrollbar padding forever.
+    if (this._isShown) {
+      this._element.classList.remove(CLASS_NAME_SHOW, CLASS_NAME_SHOWING, CLASS_NAME_HIDING)
+      this._element.removeAttribute('aria-modal')
+      this._element.removeAttribute('role')
+
+      if (!this._config.scroll) {
+        new ScrollBarHelper().reset()
+      }
+    }
+
     this._backdrop.dispose()
     this._focustrap.deactivate()
     super.dispose()
@@ -249,9 +261,10 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
   }
 
   EventHandler.one(target, EVENT_HIDDEN, () => {
-    // focus on trigger when it is closed
+    // focus on trigger when it is closed; returning focus must not scroll the
+    // page back to the trigger
     if (isVisible(this)) {
-      this.focus()
+      this.focus({ preventScroll: true })
     }
   })
 

--- a/js/tests/unit/modal.spec.js
+++ b/js/tests/unit/modal.spec.js
@@ -1326,4 +1326,27 @@ describe('Modal', () => {
       expect(modal2._config.backdrop).toBeTrue()
     })
   })
+
+  describe('dispose while open', () => {
+    it('should release the page scroll lock when disposed while shown', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div class="modal"><div class="modal-dialog"></div></div>'
+
+        const modalEl = fixtureEl.querySelector('.modal')
+        const modal = new Modal(modalEl)
+
+        modalEl.addEventListener('shown.coreui.modal', () => {
+          expect(document.body).toHaveClass('modal-open')
+
+          modal.dispose()
+
+          expect(document.body).not.toHaveClass('modal-open')
+          expect(document.body.style.overflow).not.toEqual('hidden')
+          resolve()
+        })
+
+        modal.show()
+      })
+    })
+  })
 })

--- a/js/tests/unit/offcanvas.spec.js
+++ b/js/tests/unit/offcanvas.spec.js
@@ -922,4 +922,26 @@ describe('Offcanvas', () => {
       expect(offcanvas2._config.scroll).toBeTrue()
     })
   })
+
+  describe('dispose while open', () => {
+    it('should release the page scroll lock when disposed while shown', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div class="offcanvas"></div>'
+
+        const offCanvasEl = fixtureEl.querySelector('.offcanvas')
+        const offCanvas = new Offcanvas(offCanvasEl)
+
+        offCanvasEl.addEventListener('shown.coreui.offcanvas', () => {
+          expect(document.body.style.overflow).toEqual('hidden')
+
+          offCanvas.dispose()
+
+          expect(document.body.style.overflow).not.toEqual('hidden')
+          resolve()
+        })
+
+        offCanvas.show()
+      })
+    })
+  })
 })


### PR DESCRIPTION
Continuation of the Bootstrap v6-dev sweep (twbs#42544 — upstream issues #38070/#41615/#35391 and #35934/#39910). Both defects confirmed in our sources; no API or markup change.

- **Focus restore scrolled the page.** Returning focus to the trigger after close jumped the page to it (or to the top when `scroll-padding-top` is set). The restore now passes `{ preventScroll: true }`, matching what Tab and Stepper already do here.
- **Disposing while open left the page scroll-locked forever.** `dispose()` only tore down the backdrop and the focus trap, so `modal-open` (`overflow: hidden`) and the scrollbar padding stayed on `<body>` — the classic SPA case where a route change tears the component down mid-navigation. Both components now restore the page state **synchronously** when disposed while shown: no events are fired and no transition is queued, so a disposed instance never calls back into nulled state.

Regression tests for both — they time out and fail on the old code, since the lock is never released. Full unit 3495 green.