### PR TITLE
fix(a11y): keep list semantics when hiding markers

### DIFF
--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -48,7 +48,7 @@ $breadcrumb-tokens: defaults(
     padding: var(--#{$prefix}breadcrumb-padding-y) var(--#{$prefix}breadcrumb-padding-x);
     margin-bottom: var(--#{$prefix}breadcrumb-margin-bottom);
     font-size: var(--#{$prefix}breadcrumb-font-size);
-    list-style: none;
+    list-style-type: "";
     background-color: var(--#{$prefix}breadcrumb-bg);
     @include border-radius(var(--#{$prefix}breadcrumb-border-radius));
   }

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -148,7 +148,7 @@ $dropdown-dark-tokens: defaults(
     font-size: var(--#{$prefix}dropdown-font-size);
     color: var(--#{$prefix}dropdown-color);
     text-align: start; // Ensures proper alignment if parent has it changed (e.g., modal footer)
-    list-style: none;
+    list-style-type: "";
     background-color: var(--#{$prefix}dropdown-bg);
     background-clip: padding-box;
     border: var(--#{$prefix}dropdown-border-width) solid var(--#{$prefix}dropdown-border-color);

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -164,7 +164,7 @@ $header-tokens: defaults(
     flex-direction: row; // cannot use `inherit` to get the `.header`s value
     padding-inline-start: 0;
     margin-bottom: 0;
-    list-style: none;
+    list-style-type: "";
 
     .nav-link {
       padding: var(--#{$prefix}header-nav-link-padding-y) var(--#{$prefix}header-nav-link-padding-x);

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -73,7 +73,7 @@ $list-group-tokens: defaults(
     display: flex;
     flex-direction: column;
 
-    // No need to set list-style: none; since .list-group-item is block level
+    // No need to set list-style-type: ""; since .list-group-item is block level
     padding-inline-start: 0; // reset padding because ul and ol
     margin-bottom: 0;
     @include border-radius(var(--#{$prefix}list-group-border-radius));

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -152,7 +152,7 @@ $nav-underline-border-tokens: defaults(
     flex-wrap: wrap;
     padding-inline-start: 0;
     margin-bottom: 0;
-    list-style: none;
+    list-style-type: "";
   }
 
   .nav-link {

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -201,7 +201,7 @@ $navbar-dark-tokens: defaults(
     flex-direction: column; // cannot use `inherit` to get the `.navbar`s value
     padding-inline-start: 0;
     margin-bottom: 0;
-    list-style: none;
+    list-style-type: "";
 
     .nav-link {
       &.active,

--- a/scss/mixins/_lists.scss
+++ b/scss/mixins/_lists.scss
@@ -3,5 +3,5 @@
 // Unstyled keeps list items block level, just removes default browser padding and list-style
 @mixin list-unstyled {
   padding-inline-start: 0;
-  list-style: none;
+  list-style-type: "";
 }

--- a/scss/sidebar/_sidebar-nav.scss
+++ b/scss/sidebar/_sidebar-nav.scss
@@ -151,7 +151,7 @@ $sidebar-nav-tree-link-active-icon-bullet-bg:  var(--#{$prefix}border-color) !de
     margin-bottom: 0;
     overflow-x: hidden;
     overflow-y: auto;
-    list-style: none;
+    list-style-type: "";
 
     .nav-item + .nav-item,
     .nav-item + .nav-group,
@@ -321,7 +321,7 @@ $sidebar-nav-tree-link-active-icon-bullet-bg:  var(--#{$prefix}border-color) !de
     .nav-group-items {
       padding: var(--#{$prefix}sidebar-nav-group-items-padding-y) var(--#{$prefix}sidebar-nav-group-items-padding-x);
       overflow: hidden;
-      list-style: none;
+      list-style-type: "";
       @include transition($sidebar-nav-group-items-transition);
 
       .nav-link {


### PR DESCRIPTION
Ported from Bootstrap v6-dev (twbs#42526).

Safari drops the `list` role — and VoiceOver stops announcing the item count — when a list is styled with `list-style: none`. `list-style-type: ""` hides the markers with the **same visual result** while keeping the list exposed to assistive technologies.

Swept every remaining occurrence: `nav`, `navbar`, `header`, `sidebar-nav`, `dropdown`, `breadcrumb` and the `list-unstyled` mixin (Menu already shipped this way, ported with the component). Compiled CSS: 11 × `list-style-type: ""`, 0 × `list-style: none`.

No class or markup change; `css-test`, stylelint and the class-API gate are green.