### PR TITLE
fix(OTPInput): accept a code delivered by SMS autofill or a password manager

### DIFF
--- a/docs/src/content/docs/forms/otp-input.mdx
+++ b/docs/src/content/docs/forms/otp-input.mdx
@@ -271,6 +271,7 @@ The one-time password input component is designed with accessibility in mind and
 - **Keyboard Navigation**: Full keyboard support with arrow keys, tab, and backspace
 - **Screen Reader Support**: Clear announcements when values change or validation occurs
 - **Focus Management**: Automatic focus handling for seamless navigation
+- **Autofill**: only the first field advertises `autocomplete="one-time-code"`, so SMS autofill and password managers target a single field; a code delivered that way is spread across the slots automatically, exactly like a paste
 
 ### Customizing accessibility
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -304,6 +304,15 @@ the option-by-option migration map. Planned mapping:
   renders at full opacity. The token still works — override it and only the
   background alpha changes.
 
+#### OTP input
+
+- **A code delivered by SMS autofill or a password manager now fills the whole
+  field.** Only the first slot carries `autocomplete="one-time-code"` (the rest
+  are `off`), and a multi-character value arriving in any slot is spread across
+  the field, as a paste already was. Previously such a value stayed in one slot
+  and the submitted value was empty. The slots also gained `enterkeyhint`,
+  `autocorrect="off"` and `spellcheck="false"`.
+
 #### Chip / Chip set / Chip input
 
 - **Chips expose real roles now.** A selectable chip set is a horizontal

--- a/js/src/otp-input.ts
+++ b/js/src/otp-input.ts
@@ -178,6 +178,20 @@ class OTPInput extends BaseComponent {
     EventHandler.on(this._element, EVENT_INPUT, SELECTOR_FORM_OTP_CONTROL, event => {
       const { target } = event as unknown as { target: HTMLInputElement }
 
+      // SMS autofill, password managers, dictation and IME commits insert the
+      // whole code at once and fire `input`, not `paste`. Spread it across the
+      // slots instead of leaving it in one of them.
+      if (target!.value.length > 1) {
+        const chars = this._extractValidChars(target!.value)
+        target!.value = ''
+
+        if (chars) {
+          this._distributeChars(target as HTMLInputElement, chars)
+        }
+
+        return
+      }
+
       if (target!.value.length === 1 && !this._isValidInput(target!.value)) {
         target!.value = ''
         return
@@ -263,25 +277,48 @@ class OTPInput extends BaseComponent {
         return
       }
 
-      const inputs = this._getInputs()
-      const currentIndex = inputs.indexOf(event.target as HTMLInputElement)
-
-      for (let i = 0; i < validChars.length && (currentIndex + i) < inputs.length; i++) {
-        inputs[currentIndex + i].value = validChars[i]
-      }
-
-      // Focus the next empty input or the last filled input
-      const nextEmptyIndex = currentIndex + validChars.length
-      if (nextEmptyIndex < inputs.length) {
-        inputs[nextEmptyIndex].focus()
-      } else {
-        inputs[inputs.length - 1].focus()
-      }
-
-      this._setHiddenInputValue(validChars)
-      this._setInputsTabIndexes()
-      this._checkAutoSubmit(inputs)
+      this._distributeChars(event.target as HTMLInputElement, validChars)
     })
+  }
+
+  // Write `chars` across the slots starting at `startInput`, then sync focus,
+  // the hidden form value and auto-submit. Shared by paste and by multi-character
+  // `input` events.
+  _distributeChars(startInput: HTMLInputElement, chars: string): void {
+    const inputs = this._getInputs()
+
+    if (!inputs.length) {
+      return
+    }
+
+    // A value at least as long as the field is a complete code: fill from the
+    // first slot, whichever slot happens to be focused.
+    const startIndex = chars.length >= inputs.length ? 0 : Math.max(inputs.indexOf(startInput), 0)
+
+    for (let i = 0; i < chars.length && (startIndex + i) < inputs.length; i++) {
+      inputs[startIndex + i].value = chars[i]
+    }
+
+    // Focus the next empty input or the last filled one
+    const nextEmptyIndex = startIndex + chars.length
+    inputs[nextEmptyIndex < inputs.length ? nextEmptyIndex : inputs.length - 1].focus()
+
+    // Read the value back from the slots so already-filled ones are preserved.
+    this._setHiddenInputValue(inputs.map((input: HTMLInputElement) => input.value).join(''))
+    this._syncFirstInputMaxLength()
+    this._setInputsTabIndexes()
+    this._checkAutoSubmit(inputs)
+  }
+
+  // An empty first slot is where autofill lands, so it has to accept the whole
+  // code; once it holds a character it behaves like every other slot.
+  _syncFirstInputMaxLength(): void {
+    const inputs = this._getInputs()
+    const [first] = inputs
+
+    if (first) {
+      first.maxLength = first.value ? 1 : inputs.length
+    }
   }
 
   _checkAutoSubmit(inputs: HTMLInputElement[]): void {
@@ -373,7 +410,13 @@ class OTPInput extends BaseComponent {
       input.type = this._config.masked ? 'password' : 'text'
 
       input.maxLength = 1
-      input.autocomplete = 'one-time-code'
+      // Only the first slot advertises the one-time code, so SMS autofill and
+      // password managers target a single field instead of every slot.
+      input.autocomplete = index === 0 ? 'one-time-code' : 'off'
+      input.autocapitalize = 'off'
+      input.setAttribute('autocorrect', 'off')
+      input.spellcheck = false
+      input.enterKeyHint = index === inputs.length - 1 ? 'done' : 'next'
 
       if (this._config.placeholder !== null) {
         const placeholder = String(this._config.placeholder)
@@ -424,6 +467,8 @@ class OTPInput extends BaseComponent {
         input.setAttribute('aria-label', ariaLabel as unknown as string)
       }
     }
+
+    this._syncFirstInputMaxLength()
   }
 
   _setInputsTabIndexes(): void {

--- a/js/tests/unit/otp-input.spec.js
+++ b/js/tests/unit/otp-input.spec.js
@@ -103,13 +103,37 @@ describe('OTPInput', () => {
       new OTPInput(otpContainer, { type: 'number' }) // eslint-disable-line no-new
 
       const inputs = otpContainer.querySelectorAll('.form-otp-control')
-      for (const input of inputs) {
-        expect(input.maxLength).toBe(1)
-        expect(input.autocomplete).toBe('one-time-code')
+      for (const [index, input] of [...inputs].entries()) {
         expect(input.hasAttribute('required')).toBe(true)
         expect(input.inputMode).toBe('numeric')
         expect(input.pattern).toBe('[0-9]*')
+        expect(input.getAttribute('autocorrect')).toBe('off')
+        expect(input.spellcheck).toBe(false)
+        // Only the first slot advertises the code, so autofill targets one field
+        expect(input.autocomplete).toBe(index === 0 ? 'one-time-code' : 'off')
+        // The empty first slot has to fit a whole autofilled code
+        expect(input.maxLength).toBe(index === 0 ? inputs.length : 1)
       }
+    })
+
+    it('should shrink the first slot back to a single character once it is filled', () => {
+      fixtureEl.innerHTML = `
+        <div class="form-otp">
+          <input type="text" class="form-otp-control">
+          <input type="text" class="form-otp-control">
+        </div>
+      `
+
+      const otpContainer = fixtureEl.querySelector('.form-otp')
+      new OTPInput(otpContainer, { type: 'number' }) // eslint-disable-line no-new
+
+      const inputs = otpContainer.querySelectorAll('.form-otp-control')
+      expect(inputs[0].maxLength).toBe(2)
+
+      inputs[0].value = '12'
+      inputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+
+      expect(inputs[0].maxLength).toBe(1)
     })
 
     it('should set aria-labels for inputs', () => {
@@ -1034,6 +1058,85 @@ describe('OTPInput', () => {
 
       expect(inputs[0].value).toBe('1')
       expect(inputs[1].value).toBe('2')
+    })
+  })
+
+  // SMS autofill, password managers, dictation and IME commits insert the whole
+  // code at once and fire `input`, never `paste`.
+  describe('autofill (multi-character input)', () => {
+    const markup = (count = 6) => {
+      fixtureEl.innerHTML = `<form><div class="form-otp">${'<input type="text" class="form-otp-control">'.repeat(count)}</div></form>`
+      return fixtureEl.querySelector('.form-otp')
+    }
+
+    it('should spread a code inserted into the first slot across every slot', () => {
+      const otpContainer = markup()
+      new OTPInput(otpContainer, { type: 'number', name: 'code' }) // eslint-disable-line no-new
+
+      const inputs = [...otpContainer.querySelectorAll('.form-otp-control')]
+      inputs[0].value = '424242'
+      inputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+
+      expect(inputs.map(input => input.value)).toEqual(['4', '2', '4', '2', '4', '2'])
+      expect(otpContainer.querySelector('input[type="hidden"]').value).toEqual('424242')
+    })
+
+    it('should spread a full code even when another slot received it', () => {
+      const otpContainer = markup()
+      new OTPInput(otpContainer, { type: 'number', name: 'code' }) // eslint-disable-line no-new
+
+      const inputs = [...otpContainer.querySelectorAll('.form-otp-control')]
+      inputs[2].value = '424242'
+      inputs[2].dispatchEvent(new Event('input', { bubbles: true }))
+
+      expect(inputs.map(input => input.value)).toEqual(['4', '2', '4', '2', '4', '2'])
+    })
+
+    it('should trigger change and complete events', () => {
+      return new Promise(resolve => {
+        const otpContainer = markup()
+        new OTPInput(otpContainer, { type: 'number', name: 'code' }) // eslint-disable-line no-new
+
+        otpContainer.addEventListener('complete.coreui.otp-input', event => {
+          expect(event.value).toEqual('424242')
+          resolve()
+        })
+
+        const first = otpContainer.querySelector('.form-otp-control')
+        first.value = '424242'
+        first.dispatchEvent(new Event('input', { bubbles: true }))
+      })
+    })
+
+    it('should filter invalid characters out of an inserted code', () => {
+      const otpContainer = markup(4)
+      new OTPInput(otpContainer, { type: 'number', name: 'code' }) // eslint-disable-line no-new
+
+      const inputs = [...otpContainer.querySelectorAll('.form-otp-control')]
+      inputs[0].value = 'a1b2c3d4'
+      inputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+
+      expect(inputs.map(input => input.value)).toEqual(['1', '2', '3', '4'])
+    })
+
+    it('should keep already filled slots when a partial code is pasted', () => {
+      const otpContainer = markup(4)
+      new OTPInput(otpContainer, { type: 'number', name: 'code' }) // eslint-disable-line no-new
+
+      const inputs = [...otpContainer.querySelectorAll('.form-otp-control')]
+      inputs[0].value = '9'
+      inputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+
+      const pasteEvent = new ClipboardEvent('paste', {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: new DataTransfer()
+      })
+      pasteEvent.clipboardData.setData('text', '87')
+      inputs[1].dispatchEvent(pasteEvent)
+
+      expect(inputs.map(input => input.value)).toEqual(['9', '8', '7', ''])
+      expect(otpContainer.querySelector('input[type="hidden"]').value).toEqual('987')
     })
   })
 })


### PR DESCRIPTION
Found while comparing our OTP against Bootstrap v6, [input-otp](https://input-otp.rodz.dev) and [Base UI](https://base-ui.com/react/components/otp-field).

## The bug

Autofill and password managers insert the **whole code at once and fire `input`, never `paste`**. Our `input` handler only accepted `value.length === 1`, every slot carried `maxlength=1`, and every slot advertised `autocomplete="one-time-code"`.

Measured on the built bundle in headless Chromium (6 slots, code `424242`):

| scenario | slots | value submitted |
| --- | --- | --- |
| SMS autofill into the first slot | `424242` in slot 1, rest empty | **empty** |
| autofill truncated by `maxlength=1` | `4` | `4` |
| autofill into the third slot | `424242` in slot 3 | **empty** |
| *control:* paste | `4 2 4 2 4 2` | `424242` |

Neither `change` nor `complete` fired either, so **auto-submit flows never ran**: the user gets the SMS, autofill "fills" the field, nothing happens, and submitting by hand sends an empty code.

## The fix

- A multi-character value arriving in **any** slot is spread across the field through the same path as a paste. A value at least as long as the field is treated as a complete code and fills from the first slot, whichever slot received it.
- The hidden value is read back from the slots, so a partial paste no longer discards characters already entered (`9` + paste `87` → `987`, was `87`).
- Only the first slot advertises `autocomplete="one-time-code"`; the rest are `off`. The first slot accepts the whole code **while empty** and shrinks back to one character once filled, so manual typing behaves exactly as before.
- Slots gained `enterkeyhint` (`next`/`done`), `autocorrect="off"`, `spellcheck="false"`.

The attribute recipe follows Base UI's OTP field, which uses the same one-input-per-slot architecture we do — so this is a fix, not an architecture change (Bootstrap v6 and input-otp both use a single input with rendered slots; that sidesteps this bug class by construction, but is a rewrite).

## Verification

- **7 regression tests, all red before the fix** (autofill into first/other slot, event firing, character filtering, partial-paste preservation, attribute recipe, dynamic maxlength).
- All five scenarios re-run against the rebuilt bundle: every one now yields `424242`.
- Full unit 3501, lint, typecheck, docs build green. Documented in the OTP accessibility notes and the v6 migration guide.

Applies to v5 as well — recorded in the workspace backport registry.