### PR TITLE
fix(browserslist)!: declare the Firefox floor :has() already requires; make .alert-dismissible optional

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,12 +1,20 @@
 # https://github.com/browserslist/browserslist#readme
 #
-# The floor is native `light-dark()`: Chrome 123, Edge 123, Firefox 120,
-# Safari 17.5. The v6 color system resolves every theme decision in the
-# browser through `light-dark()` and `color-mix()`, ships no fallback, and
-# below these versions dark mode simply does not work — so declaring anything
-# lower would be fiction, and raising it further is a product choice we have
-# not made. The JS floor rides along (everything the sources use is older
-# than this line).
+# Each floor is set by the newest platform feature v6 already requires, since
+# the floor has to hold for the whole 6.x line:
+#
+#   light-dark()  Chrome 123, Edge 123, Safari 17.5 — the color system resolves
+#                 every theme decision through it, and color-mix(), with no
+#                 fallback, so below it dark mode simply does not work.
+#   :has()        Firefox 121 — validation and focus states on Multi Select and
+#                 Autocomplete, the sidebar navigation indicators, calendar
+#                 ranges and the rating icons are selected with it. An
+#                 unsupported :has() invalidates the entire rule it appears in,
+#                 so this is not a graceful degradation.
+#
+# Declaring anything lower would be fiction; raising it further is a product
+# choice we have not made. The JS floor rides along (everything the sources use
+# is older than this line).
 #
 # Run `npx browserslist --coverage` after any change and update the figure on
 # the browsers & devices docs page.
@@ -17,7 +25,7 @@ unreleased versions
 
 Chrome >= 123
 Edge >= 123
-Firefox >= 120
+Firefox >= 121
 iOS >= 17.5
 Safari >= 17.5
 

--- a/docs/src/content/docs/components/alerts.mdx
+++ b/docs/src/content/docs/components/alerts.mdx
@@ -156,13 +156,14 @@ To create a solid alert, remove the `alert-*` contextual class (like alert-prima
 Using the JavaScript plugin, you can remove any alert.
 
 - Ensure that you've loaded the Bootstrap alert plugin or the compiled CoreUI JavaScript.
-- Add a [close button](/components/close-button//) along with the `.alert-dismissible` class, which provides extra padding to the right of the alert component and positions the `.close` button.
+- Add a [close button](/components/close-button//) as a child of the alert. The alert makes room for it and positions it on its own — the `.alert-dismissible` class is no longer required. <AddedIn version="6.0.0" />
+- Keep `.alert-dismissible` if the close button is added later by your own code, or if it sits inside a wrapper element rather than directly in the alert. The class keeps working and does exactly what it always did.
 - On the close button, include the `data-coreui-dismiss="alert"` attribute, which triggers the JavaScript functionality. You must use the `<button>` element with it for proper behavior across all devices.
 - To animate alerts during dismissal, you need to add the `.fade` and `.show` classes.
 
 You can observe this in action with a live demonstration:
 
-<Example code={`<div class="alert alert-warning alert-dismissible fade show" role="alert">
+<Example code={`<div class="alert alert-warning fade show" role="alert">
     Wow, you might want to take a look at some of the fields listed below.
     <button type="button" class="btn-close" data-coreui-dismiss="alert" aria-label="Close"></button>
   </div>`} />

--- a/docs/src/content/docs/getting-started/browsers-devices.mdx
+++ b/docs/src/content/docs/getting-started/browsers-devices.mdx
@@ -9,12 +9,22 @@ CoreUI for Bootstrap supports the **latest, stable releases** of all major brows
 
 Alternative browsers which use the latest version of WebKit, Blink, or Gecko, whether directly or via the platform's web view API, are not explicitly supported. However, CoreUI for Bootstrap should (in most cases) display and function correctly in these browsers as well. More specific support information is provided below.
 
-The floor is set by the v6 color system: every theme decision resolves in the
-browser through `light-dark()` and `color-mix()`, with no fallback shipped —
-so the oldest supported versions are the first ones with native `light-dark()`
-support: **Chrome 123, Edge 123, Firefox 120, Safari 17.5 and iOS 17.5**.
-Together with the evergreen lines below, this covers about 87% of global
-usage as measured with `npx browserslist --coverage`.
+The floor is set by the platform features v6 depends on, with no fallbacks
+shipped: **Chrome 123, Edge 123, Firefox 121, Safari 17.5 and iOS 17.5**.
+Together with the evergreen lines below, this covers about 87% of global usage
+as measured with `npx browserslist --coverage`.
+
+Each floor is set by the newest feature v6 already requires, because the floor
+has to hold for the whole 6.x line:
+
+| Feature | Sets the floor for |
+| --- | --- |
+| `light-dark()` | Chrome and Edge 123, Safari and iOS 17.5 — every theme decision resolves through it, and `color-mix()`, with no fallback |
+| `:has()` | Firefox 121 — validation and focus states on Multi Select and Autocomplete, the sidebar navigation indicators, calendar ranges and the rating icons are all selected with it |
+
+A browser below the floor does not merely lose polish: an unsupported
+`:has()` invalidates the whole rule it appears in, and unresolved
+`light-dark()` leaves colors unset.
 
 You can find our supported range of browsers and their versions [in our `.browserslistrc` file](https://github.com/coreui/coreui/blob/main/.browserslistrc):
 
@@ -25,7 +35,7 @@ unreleased versions
 
 Chrome >= 123
 Edge >= 123
-Firefox >= 120
+Firefox >= 121
 iOS >= 17.5
 Safari >= 17.5
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -42,9 +42,12 @@ description: "Track and review changes to the CoreUI for Bootstrap source files,
 
 <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
 
-**The minimum supported browsers are now Chrome 123, Edge 123, Firefox 120,
-Safari 17.5 and iOS 17.5** — the first versions with native `light-dark()`
-support. This is the floor the v6 color system already required in practice:
+**The minimum supported browsers are now Chrome 123, Edge 123, Firefox 121,
+Safari 17.5 and iOS 17.5.** `light-dark()` sets the Chrome/Edge/Safari floor;
+`:has()` sets Firefox 121, since validation and focus states on Multi Select
+and Autocomplete, the sidebar navigation indicators, calendar ranges and the
+rating icons are all selected with it — and an unsupported `:has()` invalidates
+the entire rule it appears in. This is the floor the v6 color system already required in practice:
 theme decisions resolve in the browser via `light-dark()` and `color-mix()`
 with no fallback, so on older browsers dark mode did not work regardless of
 what the previous `.browserslistrc` claimed (Chrome 60 / Safari 12). v6 makes
@@ -312,6 +315,14 @@ the option-by-option migration map. Planned mapping:
   the field, as a paste already was. Previously such a value stayed in one slot
   and the submitted value was empty. The slots also gained `enterkeyhint`,
   `autocorrect="off"` and `spellcheck="false"`.
+
+#### Alert
+
+- **`.alert-dismissible` is optional now.** An alert that contains a close
+  button as a direct child makes room for it and positions it on its own
+  (`.alert:has(> .btn-close)`). The class keeps working — and is still the way
+  to go when the button is injected later or sits inside a wrapper — so no
+  existing markup changes.
 
 #### Chip / Chip set / Chip input
 

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -67,12 +67,17 @@ $alert-tokens: defaults(
 
   // Dismissible alerts
   //
-  // Expand the right padding and account for the close button's positioning.
+  // Expand the inline-end padding and account for the close button's
+  // positioning. An alert that contains a close button gets this on its own —
+  // `.alert-dismissible` stays supported for markup that already carries it,
+  // and for the case where the button is rendered later.
 
+  .alert:has(> .btn-close),
   .alert-dismissible {
     padding-inline-end: $alert-dismissible-padding-r;
 
-    // Adjust close link position
+    // Adjust close link position (descendant, as before: the button may sit
+    // inside a wrapper in existing `.alert-dismissible` markup)
     .btn-close {
       position: absolute;
       inset-inline-end: 0;


### PR DESCRIPTION
Came out of looking at how Bootstrap v6 dropped `.alert-dismissible`. Their answer is to make `.alert` a flex container and let the close button be a flex child — for us that reflows every existing multi-block alert into a row, so it is not portable. `:has()` reaches the same result without touching the layout contract — **and checking whether we may use `:has()` turned up a bug in our browser support declaration.**

## 1. Our declared Firefox floor was fiction

We select with `:has()` in **eleven places across five partials**, none behind `@supports`:

| Where | What it does |
| --- | --- |
| `forms/_form-multi-select.scss` (4×) | validation states (`:has(> select:invalid/:valid)`), focus (`:has(*:focus)`) |
| `_autocomplete.scss` | focus state |
| `sidebar/_sidebar-nav.scss` (3×) | nav-group toggle indicators |
| `_calendar.scss` (2×) | range rendering |
| `_rating.scss` | icon pairing |

Firefox shipped `:has()` in **121**; `.browserslistrc` claimed **120**. This is not a graceful degradation — an unsupported `:has()` **invalidates the entire rule**, taking any sibling selector in the same comma list with it (e.g. `form-multi-select.scss:235-236`, where the non-`:has()` focus selector would die alongside it).

We argued in #652 that the declaration should be honest; this makes it honest. Floor is now Firefox 121, and both `.browserslistrc` and the browsers & devices page now state **which feature sets which floor** — the same treatment `light-dark()` already had, and the same thing upstream does.

**Coverage cost: 87.19% → 87.06%** (0.13pp), measured with `npx browserslist --coverage`.

## 2. `.alert-dismissible` is now optional

`.alert:has(> .btn-close)` gets the inline-end padding and positions the button. The class stays fully supported — and is still the right call when the button is injected later or sits inside a wrapper, since the `:has()` check is deliberately a **direct-child** test to avoid false positives from nested components. The close-button positioning keeps its **descendant** selector, so markup with a wrapped button renders exactly as before.

Verified in headless Chromium against the built CSS — four variants, all correct:

| variant | padding-inline-end | button position |
| --- | --- | --- |
| close button, no class | 48px | absolute |
| close button + `.alert-dismissible` | 48px | absolute |
| `.alert-dismissible` + button in a wrapper | 48px | absolute |
| no close button | 16px | — |

## Verification

Unit 3501, css-test 44, stylelint, find-unused-sass-variables, class-API, bundlewatch, docs build. Documented in the alert docs (with `<AddedIn version="6.0.0" />`) and the migration guide.

Note: branches off `v6-dev` before #666, so it may want a rebase on the tightened bundlewatch budgets once that lands.