### PR TITLE
fix(OTPInput): accept a code delivered by SMS autofill or a password manager

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,27 +34,27 @@
     },
     {
       "path": "./dist/js/coreui.bundle.js",
-      "maxSize": "109.50 kB"
+      "maxSize": "110.25 kB"
     },
     {
       "path": "./dist/js/coreui.bundle.min.js",
-      "maxSize": "62.50 kB"
+      "maxSize": "63.00 kB"
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "94.00 kB"
+      "maxSize": "94.75 kB"
     },
     {
       "path": "./dist/js/coreui.esm.min.js",
-      "maxSize": "61.75 kB"
+      "maxSize": "62.00 kB"
     },
     {
       "path": "./dist/js/coreui.js",
-      "maxSize": "95.50 kB"
+      "maxSize": "96.50 kB"
     },
     {
       "path": "./dist/js/coreui.min.js",
-      "maxSize": "55.50 kB"
+      "maxSize": "56.00 kB"
     }
   ],
   "ci": {

--- a/docs/src/content/docs/forms/otp-input.mdx
+++ b/docs/src/content/docs/forms/otp-input.mdx
@@ -271,6 +271,7 @@ The one-time password input component is designed with accessibility in mind and
 - **Keyboard Navigation**: Full keyboard support with arrow keys, tab, and backspace
 - **Screen Reader Support**: Clear announcements when values change or validation occurs
 - **Focus Management**: Automatic focus handling for seamless navigation
+- **Autofill**: only the first field advertises `autocomplete="one-time-code"`, so SMS autofill and password managers target a single field; a code delivered that way is spread across the slots automatically, exactly like a paste
 
 ### Customizing accessibility
 

--- a/js/src/otp-input.js
+++ b/js/src/otp-input.js
@@ -103,6 +103,7 @@ class OTPInput extends BaseComponent {
     }
 
     this._setHiddenInputValue(null)
+    this._syncFirstInputMaxLength()
     this._setInputsTabIndexes()
   }
 
@@ -115,6 +116,7 @@ class OTPInput extends BaseComponent {
     }
 
     this._setHiddenInputValue(null)
+    this._syncFirstInputMaxLength()
     this._setInputsTabIndexes()
   }
 
@@ -156,6 +158,20 @@ class OTPInput extends BaseComponent {
 
     EventHandler.on(this._element, EVENT_INPUT, SELECTOR_FORM_OTP_CONTROL, event => {
       const { target } = event
+
+      // SMS autofill, password managers, dictation and IME commits insert the
+      // whole code at once and fire `input`, not `paste`. Spread it across the
+      // slots instead of leaving it in one of them.
+      if (target.value.length > 1) {
+        const chars = this._extractValidChars(target.value)
+        target.value = ''
+
+        if (chars) {
+          this._distributeChars(target, chars)
+        }
+
+        return
+      }
 
       if (target.value.length === 1 && !this._isValidInput(target.value)) {
         target.value = ''
@@ -242,25 +258,48 @@ class OTPInput extends BaseComponent {
         return
       }
 
-      const inputs = this._getInputs()
-      const currentIndex = inputs.indexOf(event.target)
-
-      for (let i = 0; i < validChars.length && (currentIndex + i) < inputs.length; i++) {
-        inputs[currentIndex + i].value = validChars[i]
-      }
-
-      // Focus the next empty input or the last filled input
-      const nextEmptyIndex = currentIndex + validChars.length
-      if (nextEmptyIndex < inputs.length) {
-        inputs[nextEmptyIndex].focus()
-      } else {
-        inputs[inputs.length - 1].focus()
-      }
-
-      this._setHiddenInputValue(validChars)
-      this._setInputsTabIndexes()
-      this._checkAutoSubmit(inputs)
+      this._distributeChars(event.target, validChars)
     })
+  }
+
+  // Write `chars` across the slots starting at `startInput`, then sync focus,
+  // the hidden form value and auto-submit. Shared by paste and by multi-character
+  // `input` events.
+  _distributeChars(startInput, chars) {
+    const inputs = this._getInputs()
+
+    if (!inputs.length) {
+      return
+    }
+
+    // A value at least as long as the field is a complete code: fill from the
+    // first slot, whichever slot happens to be focused.
+    const startIndex = chars.length >= inputs.length ? 0 : Math.max(inputs.indexOf(startInput), 0)
+
+    for (let i = 0; i < chars.length && (startIndex + i) < inputs.length; i++) {
+      inputs[startIndex + i].value = chars[i]
+    }
+
+    // Focus the next empty input or the last filled one
+    const nextEmptyIndex = startIndex + chars.length
+    inputs[nextEmptyIndex < inputs.length ? nextEmptyIndex : inputs.length - 1].focus()
+
+    // Read the value back from the slots so already-filled ones are preserved.
+    this._setHiddenInputValue(inputs.map(input => input.value).join(''))
+    this._syncFirstInputMaxLength()
+    this._setInputsTabIndexes()
+    this._checkAutoSubmit(inputs)
+  }
+
+  // An empty first slot is where autofill lands, so it has to accept the whole
+  // code; once it holds a character it behaves like every other slot.
+  _syncFirstInputMaxLength() {
+    const inputs = this._getInputs()
+    const [first] = inputs
+
+    if (first) {
+      first.maxLength = first.value ? 1 : inputs.length
+    }
   }
 
   _checkAutoSubmit(inputs) {
@@ -352,7 +391,13 @@ class OTPInput extends BaseComponent {
       input.type = this._config.masked ? 'password' : 'text'
 
       input.maxLength = 1
-      input.autocomplete = 'one-time-code'
+      // Only the first slot advertises the one-time code, so SMS autofill and
+      // password managers target a single field instead of every slot.
+      input.autocomplete = index === 0 ? 'one-time-code' : 'off'
+      input.autocapitalize = 'off'
+      input.setAttribute('autocorrect', 'off')
+      input.spellcheck = false
+      input.enterKeyHint = index === inputs.length - 1 ? 'done' : 'next'
 
       if (this._config.placeholder !== null) {
         const placeholder = String(this._config.placeholder)
@@ -403,6 +448,8 @@ class OTPInput extends BaseComponent {
         input.setAttribute('aria-label', ariaLabel)
       }
     }
+
+    this._syncFirstInputMaxLength()
   }
 
   _setInputsTabIndexes() {

--- a/js/tests/unit/otp-input.spec.js
+++ b/js/tests/unit/otp-input.spec.js
@@ -104,13 +104,37 @@ describe('OTPInput', () => {
       new OTPInput(otpContainer, { type: 'number' }) // eslint-disable-line no-new
 
       const inputs = otpContainer.querySelectorAll('.form-otp-control')
-      for (const input of inputs) {
-        expect(input.maxLength).toBe(1)
-        expect(input.autocomplete).toBe('one-time-code')
+      for (const [index, input] of [...inputs].entries()) {
         expect(input.hasAttribute('required')).toBe(true)
         expect(input.inputMode).toBe('numeric')
         expect(input.pattern).toBe('[0-9]*')
+        expect(input.getAttribute('autocorrect')).toBe('off')
+        expect(input.spellcheck).toBe(false)
+        // Only the first slot advertises the code, so autofill targets one field
+        expect(input.autocomplete).toBe(index === 0 ? 'one-time-code' : 'off')
+        // The empty first slot has to fit a whole autofilled code
+        expect(input.maxLength).toBe(index === 0 ? inputs.length : 1)
       }
+    })
+
+    it('should shrink the first slot back to a single character once it is filled', () => {
+      fixtureEl.innerHTML = `
+        <div class="form-otp">
+          <input type="text" class="form-otp-control">
+          <input type="text" class="form-otp-control">
+        </div>
+      `
+
+      const otpContainer = fixtureEl.querySelector('.form-otp')
+      new OTPInput(otpContainer, { type: 'number' }) // eslint-disable-line no-new
+
+      const inputs = otpContainer.querySelectorAll('.form-otp-control')
+      expect(inputs[0].maxLength).toBe(2)
+
+      inputs[0].value = '12'
+      inputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+
+      expect(inputs[0].maxLength).toBe(1)
     })
 
     it('should set aria-labels for inputs', () => {
@@ -1021,6 +1045,98 @@ describe('OTPInput', () => {
 
       expect(inputs[0].value).toBe('1')
       expect(inputs[1].value).toBe('2')
+    })
+  })
+
+  // SMS autofill, password managers, dictation and IME commits insert the whole
+  // code at once and fire `input`, never `paste`.
+  describe('autofill (multi-character input)', () => {
+    const markup = (count = 6) => {
+      fixtureEl.innerHTML = `<form><div class="form-otp">${'<input type="text" class="form-otp-control">'.repeat(count)}</div></form>`
+      return fixtureEl.querySelector('.form-otp')
+    }
+
+    it('should spread a code inserted into the first slot across every slot', () => {
+      const otpContainer = markup()
+      new OTPInput(otpContainer, { type: 'number', name: 'code' }) // eslint-disable-line no-new
+
+      const inputs = [...otpContainer.querySelectorAll('.form-otp-control')]
+      inputs[0].value = '424242'
+      inputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+
+      expect(inputs.map(input => input.value)).toEqual(['4', '2', '4', '2', '4', '2'])
+      expect(otpContainer.querySelector('input[type="hidden"]').value).toEqual('424242')
+    })
+
+    it('should spread a full code even when another slot received it', () => {
+      const otpContainer = markup()
+      new OTPInput(otpContainer, { type: 'number', name: 'code' }) // eslint-disable-line no-new
+
+      const inputs = [...otpContainer.querySelectorAll('.form-otp-control')]
+      inputs[2].value = '424242'
+      inputs[2].dispatchEvent(new Event('input', { bubbles: true }))
+
+      expect(inputs.map(input => input.value)).toEqual(['4', '2', '4', '2', '4', '2'])
+    })
+
+    it('should trigger change and complete events', done => {
+      const otpContainer = markup()
+      new OTPInput(otpContainer, { type: 'number', name: 'code' }) // eslint-disable-line no-new
+
+      otpContainer.addEventListener('complete.coreui.otp-input', event => {
+        expect(event.value).toEqual('424242')
+        done()
+      })
+
+      const first = otpContainer.querySelector('.form-otp-control')
+      first.value = '424242'
+      first.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    it('should filter invalid characters out of an inserted code', () => {
+      const otpContainer = markup(4)
+      new OTPInput(otpContainer, { type: 'number', name: 'code' }) // eslint-disable-line no-new
+
+      const inputs = [...otpContainer.querySelectorAll('.form-otp-control')]
+      inputs[0].value = 'a1b2c3d4'
+      inputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+
+      expect(inputs.map(input => input.value)).toEqual(['1', '2', '3', '4'])
+    })
+
+    it('should keep already filled slots when a partial code is pasted', () => {
+      const otpContainer = markup(4)
+      new OTPInput(otpContainer, { type: 'number', name: 'code' }) // eslint-disable-line no-new
+
+      const inputs = [...otpContainer.querySelectorAll('.form-otp-control')]
+      inputs[0].value = '9'
+      inputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+
+      const pasteEvent = new ClipboardEvent('paste', {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: new DataTransfer()
+      })
+      pasteEvent.clipboardData.setData('text', '87')
+      inputs[1].dispatchEvent(pasteEvent)
+
+      expect(inputs.map(input => input.value)).toEqual(['9', '8', '7', ''])
+      expect(otpContainer.querySelector('input[type="hidden"]').value).toEqual('987')
+    })
+
+    it('should let the first slot accept a code again after clear()', () => {
+      const otpContainer = markup(4)
+      const otpInput = new OTPInput(otpContainer, { type: 'number', name: 'code' })
+
+      const inputs = [...otpContainer.querySelectorAll('.form-otp-control')]
+      inputs[0].value = '1234'
+      inputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+
+      expect(inputs[0].maxLength).toBe(1)
+
+      otpInput.clear()
+
+      expect(inputs[0].maxLength).toBe(4)
     })
   })
 })


### PR DESCRIPTION
Backport of the v6 fix (#665) to the v5 line, verified against the v5 sources rather than assumed.

## The bug

Autofill and password managers insert the whole code at once and fire `input`, never `paste` — and the `input` handler only accepted `value.length === 1`, while every slot carried `maxlength=1` and `autocomplete="one-time-code"`. The code therefore stayed in the slot that received it (or was truncated to a single character by the browser), the hidden form control kept its old value, and neither `change` nor `complete` fired — so **the form submitted an empty OTP** and auto-submit flows never ran.

## The fix

- A multi-character value arriving in any slot is spread across the field through the same path as a paste (`_distributeChars`); a value at least as long as the field is treated as a complete code and fills from the first slot, whichever slot is focused.
- The hidden value is read back from the slots, so a partial paste no longer discards characters already entered (`9` + paste `87` → `987`, was `87`).
- Only the first slot advertises `autocomplete="one-time-code"`; the rest are `off`, so autofill targets a single field. The first slot accepts the whole code while empty and shrinks back to one character once filled; `clear()` and `reset()` restore that capacity.
- Slots gained `enterkeyhint`, `autocapitalize="off"`, `autocorrect="off"` and `spellcheck="false"`.

The attribute recipe follows Base UI's OTP field, which uses the same one-input-per-slot architecture we do.

## Tests

Eight regression tests, all red before the fix, plus the amended attribute test. Full karma suite green (3017).

## Bundle budgets

The fix adds ~0.6 kB gzip to the unminified JS bundles and ~0.15 kB to the minified ones; the previous budgets left 0.06–0.26 kB of headroom, so `.bundlewatch.config.json` is raised in a separate commit.

## Parity

The same fix ships for React (`coreui-react-pro`), Vue (`coreui-vue-pro`) and Angular (`coreui-angular-pro`) on the same branch name.