### PR TITLE
fix(OTPInput): restore the first slot's autofill capacity on clear() and reset()

### DIFF
--- a/js/src/otp-input.ts
+++ b/js/src/otp-input.ts
@@ -124,6 +124,7 @@ class OTPInput extends BaseComponent {
     }
 
     this._setHiddenInputValue(null)
+    this._syncFirstInputMaxLength()
     this._setInputsTabIndexes()
   }
 
@@ -136,6 +137,7 @@ class OTPInput extends BaseComponent {
     }
 
     this._setHiddenInputValue(null)
+    this._syncFirstInputMaxLength()
     this._setInputsTabIndexes()
   }
 

--- a/js/tests/unit/otp-input.spec.js
+++ b/js/tests/unit/otp-input.spec.js
@@ -1138,5 +1138,33 @@ describe('OTPInput', () => {
       expect(inputs.map(input => input.value)).toEqual(['9', '8', '7', ''])
       expect(otpContainer.querySelector('input[type="hidden"]').value).toEqual('987')
     })
+
+    it('should let the first slot accept a code again after clear()', () => {
+      const otpContainer = markup(4)
+      const otpInput = new OTPInput(otpContainer, { type: 'number', name: 'code' })
+
+      const inputs = [...otpContainer.querySelectorAll('.form-otp-control')]
+      inputs[0].value = '1234'
+      inputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+
+      expect(inputs[0].maxLength).toBe(1)
+
+      otpInput.clear()
+
+      expect(inputs[0].maxLength).toBe(4)
+    })
+
+    it('should size the first slot to the value restored by reset()', () => {
+      const otpContainer = markup(4)
+      const otpInput = new OTPInput(otpContainer, { type: 'number', name: 'code', value: '1234' })
+
+      otpInput.clear()
+
+      expect(otpContainer.querySelector('.form-otp-control').maxLength).toBe(4)
+
+      otpInput.reset()
+
+      expect(otpContainer.querySelector('.form-otp-control').maxLength).toBe(1)
+    })
   })
 })


### PR DESCRIPTION
Follow-up to #665, found while backporting it to the v5 line.

## The gap

`_syncFirstInputMaxLength()` runs on init and after a distributed code, but never from the public `clear()` / `reset()`. So once the field had been filled, the first slot kept `maxlength=1`, and the next code delivered by SMS autofill or a password manager was truncated to a single character again — exactly the situation those methods exist for: a rejected code, then a fresh one arriving by SMS.

## The fix

`clear()` and `reset()` call `_syncFirstInputMaxLength()`, which sizes the first slot in both directions — back up to the slot count when it ends up empty, down to one character when `reset()` restores a configured value.

## Tests

Two regression tests, both red before the fix. Full unit suite green (64 in `otp-input.spec.js`), eslint clean.

## v5

The same gap was fixed on the v5 line in coreui/coreui-pro#668 (merged), together with the #665 backport, so the two lines stay in sync.