### PR TITLE
docs(DatePicker, DateRangePicker): correct the todayButton API rows

### DIFF
--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -406,8 +406,8 @@ Note that for security reasons the `sanitize`, `sanitizeFn`, and `allowList` opt
 | `showWeekNumber` | boolean | `false` | Set whether to display week numbers in the calendar. |
 | `size` | `'sm'`, `'lg'` | `null` | Size the component small or large. |
 | `timepicker` | boolean | `false` | Provide an additional time selection by adding select boxes to choose times. |
-| `todayButton` | string | `'Today'` | Today button inner HTML |
-| `todayButtonClasses` | array, string | `['btn', 'btn-sm', 'me-2']` | CSS class names that will be added to the today button |
+| `todayButton` | boolean, string | `'Today'` | Toggle visibility or set the content of the today button. Set to `false` to hide it. |
+| `todayButtonClasses` | array, string | `['btn', 'btn-sm', 'btn-primary', 'me-auto']` | CSS class names that will be added to the today button |
 | `valid` | boolean | `false` | Toggle the valid state for the component. |
 | `weekdayFormat` | number, `'long'`, `'narrow'`, `'short'` | `2` | Set length or format of day name. |
 | `weekNumbersLabel` | string | `null` | Label displayed over week numbers in the calendar. |

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -461,8 +461,8 @@ Note that for security reasons the `sanitize`, `sanitizeFn`, and `allowList` opt
 | `startDate` | date, number, string, null | `null` | Initial selected date. |
 | `startName` | string, null | `null` | Set the name attribute for the start date input element. |
 | `timepicker` | boolean | `false` | Provide an additional time selection by adding select boxes to choose times. |
-| `todayButton` | string | `'Today'` | Today button inner HTML |
-| `todayButtonClasses` | array, string | `['btn', 'btn-sm', 'me-2']` | CSS class names that will be added to the today button |
+| `todayButton` | boolean, string | `'Today'` | Toggle visibility or set the content of the today button. Set to `false` to hide it. |
+| `todayButtonClasses` | array, string | `['btn', 'btn-sm', 'btn-primary', 'me-auto']` | CSS class names that will be added to the today button |
 | `valid` | boolean | `false` | Toggle the valid state for the component. |
 | `weekdayFormat` | number, `'long'`, `'narrow'`, `'short'` | `2` | Set length or format of day name. |
 | `weekNumbersLabel` | string | `null` | Label displayed over week numbers in the calendar. |


### PR DESCRIPTION
Two errors in the hand-maintained API tables on both picker pages, found while answering a customer report.

## `todayButton` type

Documented as `string`, so nothing in the docs suggested it also accepts `false` to hide the button. The code has always taken both — `DefaultType: todayButton: '(boolean|string)'` ([date-range-picker.js:199](https://github.com/coreui/coreui-pro/blob/main/js/src/date-range-picker.js#L199)) — and the neighbouring `cancelButton` / `confirmButton` rows already said `boolean, string`; only this one was wrong.

The behaviour is covered by an existing test (`should not create today button when todayButton is false`, with `footer: true`), so the footer keeps Cancel/OK and stays right-aligned — nothing else changes.

A customer read the table, concluded the Today button could not be hidden, and reported it as a bug.

## `todayButtonClasses` default

Listed as `['btn', 'btn-sm', 'me-2']`; the actual default is `['btn', 'btn-sm', 'btn-primary', 'me-auto']`.

## Scope

Docs only, both `date-picker.mdx` and `date-range-picker.mdx`. The React and Vue tables are generated from the prop types and already describe the prop correctly ("Toggle visibility or set the content of today button"). The same correction goes to `v6-dev` separately.