### PR TITLE
docs(DatePicker, DateRangePicker): correct the todayButton API rows

### DIFF
--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -406,8 +406,8 @@ Note that for security reasons the `sanitize`, `sanitizeFn`, and `allowList` opt
 | `showWeekNumber` | boolean | `false` | Set whether to display week numbers in the calendar. |
 | `size` | `'sm'`, `'lg'` | `null` | Size the component small or large. |
 | `timepicker` | boolean | `false` | Provide an additional time selection by adding select boxes to choose times. |
-| `todayButton` | string | `'Today'` | Today button inner HTML |
-| `todayButtonClasses` | array, string | `['btn', 'btn-sm', 'me-2']` | CSS class names that will be added to the today button |
+| `todayButton` | boolean, string | `'Today'` | Toggle visibility or set the content of the today button. Set to `false` to hide it. |
+| `todayButtonClasses` | array, string | `['btn', 'btn-sm', 'btn-primary', 'me-auto']` | CSS class names that will be added to the today button |
 | `valid` | boolean | `false` | Toggle the valid state for the component. |
 | `weekdayFormat` | number, `'long'`, `'narrow'`, `'short'` | `2` | Set length or format of day name. |
 | `weekNumbersLabel` | string | `null` | Label displayed over week numbers in the calendar. |

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -461,8 +461,8 @@ Note that for security reasons the `sanitize`, `sanitizeFn`, and `allowList` opt
 | `startDate` | date, number, string, null | `null` | Initial selected date. |
 | `startName` | string, null | `null` | Set the name attribute for the start date input element. |
 | `timepicker` | boolean | `false` | Provide an additional time selection by adding select boxes to choose times. |
-| `todayButton` | string | `'Today'` | Today button inner HTML |
-| `todayButtonClasses` | array, string | `['btn', 'btn-sm', 'me-2']` | CSS class names that will be added to the today button |
+| `todayButton` | boolean, string | `'Today'` | Toggle visibility or set the content of the today button. Set to `false` to hide it. |
+| `todayButtonClasses` | array, string | `['btn', 'btn-sm', 'btn-primary', 'me-auto']` | CSS class names that will be added to the today button |
 | `valid` | boolean | `false` | Toggle the valid state for the component. |
 | `weekdayFormat` | number, `'long'`, `'narrow'`, `'short'` | `2` | Set length or format of day name. |
 | `weekNumbersLabel` | string | `null` | Label displayed over week numbers in the calendar. |


### PR DESCRIPTION
Same correction as #670 on the v5 line — the v6 tables carry both errors verbatim.

- **`todayButton` type**: documented as `string`, so nothing in the docs suggested it also accepts `false` to hide the button. The code takes both (`DefaultType: todayButton: '(boolean|string)'`), and the neighbouring `cancelButton` / `confirmButton` rows were already right.
- **`todayButtonClasses` default**: listed as `['btn', 'btn-sm', 'me-2']`; the actual default is `['btn', 'btn-sm', 'btn-primary', 'me-auto']`.

Docs only, both picker pages.