### PR TITLE
feat(DatePicker,DateRangePicker,DateInput): add week and quarter section masks

### DIFF
--- a/docs/src/content/docs/forms/date-input.mdx
+++ b/docs/src/content/docs/forms/date-input.mdx
@@ -30,7 +30,7 @@ By default, the section order and separators are derived from the user's locale,
 
 ## Formats
 
-Set an explicit format with the `data-coreui-format` attribute. The parser accepts both dayjs/moment-style tokens (`DD`, `MM`, `YYYY`, `YY`) and date-fns/Unicode-style tokens (`dd`, `MM`, `yyyy`, `yy`), so you can reuse the format strings from the date library you already use. Any other character becomes a literal separator.
+Set an explicit format with the `data-coreui-format` attribute. The parser accepts both dayjs/moment-style tokens (`DD`, `MM`, `YYYY`, `YY`) and date-fns/Unicode-style tokens (`dd`, `MM`, `yyyy`, `yy`), plus `ww` for ISO week numbers and `q` (numeric) or `QQQ` (`Q1`–`Q4`) for quarters, so you can reuse the format strings from the date library you already use. Any other character becomes a literal separator.
 
 <Example pro code={`<div class="mb-3">
     <label class="form-label">dd.MM.yyyy</label>
@@ -58,7 +58,16 @@ The format doesn't have to include every section — a month-and-year mask works
     <div class="form-control form-date-time" data-coreui-date-input data-coreui-format="MMMM yyyy" data-coreui-locale="en-US"></div>
   </div>`} />
 
-For picking whole weeks, use the [date picker](/forms/date-picker/) with `selectionType="week"` — a masked week-number field has no native or MUI equivalent and isn't supported.
+Week and quarter masks work the same way. A week mask (`yyyy-Www` — the uppercase `W` is a literal, `ww` the section) edits the ISO week directly and reports the Monday of that week; its year section holds the ISO week-numbering year, which can differ from the calendar year around January 1st. A quarter mask reports the first day of the quarter:
+
+<Example pro code={`<div class="mb-3">
+    <label class="form-label">yyyy-Www</label>
+    <div class="form-control form-date-time" data-coreui-date-input data-coreui-format="yyyy-Www"></div>
+  </div>
+  <div>
+    <label class="form-label">QQQ yyyy</label>
+    <div class="form-control form-date-time" data-coreui-date-input data-coreui-format="QQQ yyyy"></div>
+  </div>`} />
 
 ## Month names
 

--- a/docs/src/content/docs/forms/date-input.mdx
+++ b/docs/src/content/docs/forms/date-input.mdx
@@ -30,7 +30,7 @@ By default, the section order and separators are derived from the user's locale,
 
 ## Formats
 
-Set an explicit format with the `data-coreui-format` attribute. The parser accepts both dayjs/moment-style tokens (`DD`, `MM`, `YYYY`, `YY`) and date-fns/Unicode-style tokens (`dd`, `MM`, `yyyy`, `yy`), plus `ww` for ISO week numbers and `q` (numeric) or `QQQ` (`Q1`–`Q4`) for quarters, so you can reuse the format strings from the date library you already use. Any other character becomes a literal separator.
+Set an explicit format with the `data-coreui-format` attribute. The parser accepts both dayjs/moment-style tokens (`DD`, `MM`, `YYYY`, `YY`) and date-fns/Unicode-style tokens (`dd`, `MM`, `yyyy`, `yy`), plus `ww` for ISO week numbers and `q` (numeric) or `QQQ` (`Q1`–`Q4`) for quarters, so you can reuse the format strings from the date library you already use. Any other character becomes a literal separator — a fixed, non-editable part of the mask — and text wrapped in single quotes is always a literal, even when it contains token letters (`'Week' ww` renders `Week 29`; escape a quote by doubling it, `''`).
 
 <Example pro code={`<div class="mb-3">
     <label class="form-label">dd.MM.yyyy</label>
@@ -58,9 +58,13 @@ The format doesn't have to include every section — a month-and-year mask works
     <div class="form-control form-date-time" data-coreui-date-input data-coreui-format="MMMM yyyy" data-coreui-locale="en-US"></div>
   </div>`} />
 
-Week and quarter masks work the same way. A week mask (`yyyy-Www` — the uppercase `W` is a literal, `ww` the section) edits the ISO week directly and reports the Monday of that week; its year section holds the ISO week-numbering year, which can differ from the calendar year around January 1st. A quarter mask reports the first day of the quarter:
+Week and quarter masks work the same way. A week mask edits the ISO week directly and reports the Monday of that week; its year section holds the ISO week-numbering year, which can differ from the calendar year around January 1st. Combine a quoted label with the `ww` token for the native week input's presentation, or use `yyyy-Www` (the uppercase `W` is a literal) for the ISO wire format. A quarter mask reports the first day of the quarter:
 
 <Example pro code={`<div class="mb-3">
+    <label class="form-label">'Week' ww, yyyy</label>
+    <div class="form-control form-date-time" data-coreui-date-input data-coreui-format="'Week' ww, yyyy"></div>
+  </div>
+  <div class="mb-3">
     <label class="form-label">yyyy-Www</label>
     <div class="form-control form-date-time" data-coreui-date-input data-coreui-format="yyyy-Www"></div>
   </div>

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -42,7 +42,11 @@ parsing and no debounce: the field always holds a valid partial date.
 There is no `footer` option. Project a `<template data-coreui-template="footer">`
 child instead — its content is cloned into the dropdown. Buttons act through
 `data-coreui-picker-action` (`today`, `clear`, `reset`, `close`), so labels,
-order, and translations are yours.
+order, and translations are yours. Their state is yours too — the picker never
+disables a projected button. Instead, every programmatic date (the `today`
+action included) goes through the field's min/max validation: out of range, the
+field turns `is-invalid`, `errorChange` reports the reason, and
+`getDate()`/`dateChange` report `null` — the same outcome as typing that date.
 
 <Example pro code={`<div class="row">
     <div class="col-lg-5">

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -59,11 +59,13 @@ order, and translations are yours.
 ### Weeks
 
 Add `data-coreui-selection-type="week"` to select week numbers, and
-`data-coreui-show-week-number="true"` to show them in the grid. The field mask
-narrows to a week and year section (`2026-W29` — the same wire format the
-native `<input type="week">` submits), where the year is the ISO
-week-numbering year, which can differ from the calendar year around January
-1st. The reported `Date` is the Monday of the selected week.
+`data-coreui-show-week-number="true"` to show them in the grid. The field
+renders the native `<input type="week">` presentation — a fixed, non-editable
+localized label followed by the week and year sections (`Week 29, 2026`,
+`Tydzień 29, 2026`, …). The year is the ISO week-numbering year, which can
+differ from the calendar year around January 1st, and the reported `Date` is
+the Monday of the selected week. Prefer the ISO wire format in the field?
+Set `data-coreui-format="yyyy-Www"`.
 
 <Example pro code={`<div class="row">
     <div class="col-lg-5">

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -43,11 +43,10 @@ parsing and no debounce: the field always holds a valid partial date.
 There is no `footer` option. Project a `<template data-coreui-template="footer">`
 child instead — its content is cloned into the dropdown. Buttons act through
 `data-coreui-picker-action` (`today`, `clear`, `reset`, `close`), so labels,
-order, and translations are yours. Their state is yours too — the picker never
-disables a projected button. Instead, every programmatic date (the `today`
-action included) goes through the field's min/max validation: out of range, the
-field turns `is-invalid`, `errorChange` reports the reason, and
-`getDate()`/`dateChange` report `null` — the same outcome as typing that date.
+order, and translations are yours. A button opting into the `today` action
+opts into its state too: it is disabled at initialization when today falls
+outside `minDate`/`maxDate`/`disabledDates`. This is one-way — the picker only
+ever sets `disabled`, so a button you disable in the template stays disabled.
 
 <Example pro code={`<div class="row">
     <div class="col-lg-5">
@@ -61,11 +60,15 @@ field turns `is-invalid`, `errorChange` reports the reason, and
     </div>
   </div>`} />
 
-To gate a button on the range, the slot context exposes
-`isDateSelectable(date)` — it answers whether a date, expressed in the field's
-mask, passes the `minDate`/`maxDate`/`disabledDates` validation (a day mask
-checks the calendar day, so `new Date()` passes with a `maxDate` of today).
-Here `maxDate` is the end of last month, so Today gets disabled:
+Here `maxDate` is the end of last month, so the `today` button disables
+itself. The state of any other button is yours — the slot context exposes
+`isDateSelectable(date)`, which answers whether a date, expressed in the
+field's mask, passes the `minDate`/`maxDate`/`disabledDates` validation (a day
+mask checks the calendar day, so `new Date()` passes with a `maxDate` of
+today) — and every programmatic date still runs through the field's
+validation: out of range, the field turns `is-invalid`, `errorChange` reports
+the reason, and `getDate()`/`dateChange` report `null`, the same outcome as
+typing that date.
 
 <Example pro code={`<div class="row">
     <div class="col-lg-5">

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -59,7 +59,11 @@ order, and translations are yours.
 ### Weeks
 
 Add `data-coreui-selection-type="week"` to select week numbers, and
-`data-coreui-show-week-number="true"` to show them in the grid.
+`data-coreui-show-week-number="true"` to show them in the grid. The field mask
+narrows to a week and year section (`2026-W29` — the same wire format the
+native `<input type="week">` submits), where the year is the ISO
+week-numbering year, which can differ from the calendar year around January
+1st. The reported `Date` is the Monday of the selected week.
 
 <Example pro code={`<div class="row">
     <div class="col-lg-5">
@@ -70,15 +74,6 @@ Add `data-coreui-selection-type="week"` to select week numbers, and
         data-coreui-toggle="date-picker"></div>
     </div>
   </div>`} />
-
-<Callout color="warning">
-  **Week and quarter selection display the underlying date.** A section mask is
-  built from date sections (day / month / year), so it cannot render `2026W27`
-  or `2026Q1` the way the v1 text input did — the field shows the first day of
-  the selected week or quarter instead. The formatted value is still available:
-  `event.date` carries `"2026W27"`, `event.dateObject` the `Date`. Dedicated
-  week/quarter sections are an open design item for the rewrite.
-</Callout>
 
 ### Months
 
@@ -96,7 +91,10 @@ narrows to month and year automatically.
 
 ### Quarters
 
-Add `data-coreui-selection-type="quarter"` to select quarters.
+Add `data-coreui-selection-type="quarter"` to select quarters — the equivalent
+of the `<input type="quarter">` that HTML never shipped. The field mask narrows
+to a quarter and year section (`Q4 2026`), and the reported `Date` is the
+first day of the selected quarter.
 
 <Example pro code={`<div class="row">
     <div class="col-lg-5">
@@ -248,7 +246,8 @@ document direction.
 the format. Set it with `data-coreui-format` (or the `format` option), which the
 field forwards from the shell. The parser accepts both dayjs/moment-style tokens
 (`DD`, `MM`, `YYYY`, `YY`) and date-fns/Unicode-style tokens (`dd`, `MM`,
-`yyyy`, `yy`); any other character becomes a literal separator.
+`yyyy`, `yy`), plus `ww` for ISO week numbers and `q` (numeric) or `QQQ`
+(`Q1`–`Q4`) for quarters; any other character becomes a literal separator.
 
 <Example pro code={`<div class="row">
     <div class="col-sm-6 col-lg-5 mb-3 mb-sm-0">

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -7,6 +7,7 @@ description: "The v6 date picker: a section-based masked field composed with a c
 
 import datePickerFormats from './snippets/date-picker-formats.js?raw'
 import datePickerDisabledDates from './snippets/date-picker-disabled-dates.js?raw'
+import datePickerFooterToday from './snippets/date-picker-footer-today.js?raw'
 import datePickerWeekends from './snippets/date-picker-weekends.js?raw'
 
 <Callout color="warning">
@@ -59,6 +60,25 @@ field turns `is-invalid`, `errorChange` reports the reason, and
       </div>
     </div>
   </div>`} />
+
+To gate a button on the range, the slot context exposes
+`isDateSelectable(date)` — it answers whether a date, expressed in the field's
+mask, passes the `minDate`/`maxDate`/`disabledDates` validation (a day mask
+checks the calendar day, so `new Date()` passes with a `maxDate` of today).
+Here `maxDate` is the end of last month, so Today gets disabled:
+
+<Example pro code={`<div class="row">
+    <div class="col-lg-5">
+      <div id="myDatePickerFooterToday">
+        <template data-coreui-template="footer">
+          <button type="button" class="btn btn-sm btn-ghost-danger me-auto" data-coreui-picker-action="today">Today</button>
+          <button type="button" class="btn btn-sm btn-primary" data-coreui-picker-action="close">OK</button>
+        </template>
+      </div>
+    </div>
+  </div>`} sandboxJs={datePickerFooterToday} />
+
+<Code code={datePickerFooterToday} lang="js" />
 
 ### Weeks
 

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -60,10 +60,10 @@ closing is the footer's job.
 ### Weeks
 
 Add `data-coreui-selection-type="week"` to select week ranges, and
-`data-coreui-show-week-number="true"` to show week numbers. The field masks
-narrow to week and year sections (`2026-W29`, the native `<input type="week">`
-wire format) — see the [date picker](/forms/date-picker/#weeks) note on the
-ISO week-numbering year.
+`data-coreui-show-week-number="true"` to show week numbers. The fields render
+the native `<input type="week">` presentation (`Week 29, 2026`, with a
+localized fixed label) — see the [date picker](/forms/date-picker/#weeks)
+note on the ISO week-numbering year.
 
 <Example pro code={`<div class="row">
     <div class="col-lg-7">

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -60,7 +60,10 @@ closing is the footer's job.
 ### Weeks
 
 Add `data-coreui-selection-type="week"` to select week ranges, and
-`data-coreui-show-week-number="true"` to show week numbers.
+`data-coreui-show-week-number="true"` to show week numbers. The field masks
+narrow to week and year sections (`2026-W29`, the native `<input type="week">`
+wire format) — see the [date picker](/forms/date-picker/#weeks) note on the
+ISO week-numbering year.
 
 <Example pro code={`<div class="row">
     <div class="col-lg-7">
@@ -71,15 +74,6 @@ Add `data-coreui-selection-type="week"` to select week ranges, and
         data-coreui-toggle="date-range-picker"></div>
     </div>
   </div>`} />
-
-<Callout color="warning">
-  **Week and quarter selection display the underlying dates.** A section mask is
-  built from date sections, so it cannot render `2026W27` the way the v1 text
-  inputs did — the fields show the first day of the selected week or quarter.
-  The formatted value stays available on the event (`event.date`), alongside the
-  `Date` (`event.dateObject`). See the [date picker](/forms/date-picker/#weeks)
-  note.
-</Callout>
 
 ### Months
 
@@ -93,6 +87,8 @@ Add `data-coreui-selection-type="week"` to select week ranges, and
   </div>`} />
 
 ### Quarters
+
+The field masks narrow to quarter and year sections (`Q1 2026`).
 
 <Example pro code={`<div class="row">
     <div class="col-lg-7">

--- a/docs/src/content/docs/forms/snippets/date-picker-footer-today.js
+++ b/docs/src/content/docs/forms/snippets/date-picker-footer-today.js
@@ -4,8 +4,3 @@ const datePickerFooterToday = new coreui.DatePicker(myDatePickerFooterToday, {
   locale: 'en-US',
   maxDate: new Date(new Date().getFullYear(), new Date().getMonth(), 0)
 })
-
-const { isDateSelectable } = datePickerFooterToday.getContext()
-
-myDatePickerFooterToday.querySelector('[data-coreui-picker-action="today"]').disabled =
-  !isDateSelectable(new Date())

--- a/docs/src/content/docs/forms/snippets/date-picker-footer-today.js
+++ b/docs/src/content/docs/forms/snippets/date-picker-footer-today.js
@@ -1,0 +1,11 @@
+const myDatePickerFooterToday = document.getElementById('myDatePickerFooterToday')
+
+const datePickerFooterToday = new coreui.DatePicker(myDatePickerFooterToday, {
+  locale: 'en-US',
+  maxDate: new Date(new Date().getFullYear(), new Date().getMonth(), 0)
+})
+
+const { isDateSelectable } = datePickerFooterToday.getContext()
+
+myDatePickerFooterToday.querySelector('[data-coreui-picker-action="today"]').disabled =
+  !isDateSelectable(new Date())

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -210,12 +210,14 @@ behaviour, v5 is the reference. Mapping:
   `data-coreui-show-week-number` and `data-coreui-format` work on the picker
   element. `calendarOptions` / `inputOptions` remain as the programmatic escape
   hatch.
-- **Week and quarter selection display the underlying date.** A section mask is
-  built from date sections, so it cannot render `2026W27` or `2026Q1` the way
-  the v1 text input did — the field shows the first day of the selected week or
-  quarter. The formatted value stays available on the event (`event.date`).
-  Dedicated week/quarter sections are an open design item. Month and year
-  selection **do** adapt: the mask narrows to `MM/yyyy` and `yyyy`.
+- **Every selection type has a matching mask.** Month and year selection narrow
+  the mask to `MM/yyyy` and `yyyy`, week selection to `yyyy-Www` (`2026-W29` —
+  the native `<input type="week">` wire format, with the ISO week-numbering
+  year), and quarter selection to `QQQ yyyy` (`Q4 2026`). The v1 text input
+  rendered `2026W27`/`2026Q1`; the submitted value now follows the mask, and
+  the event still carries the v1-formatted string (`event.date`) next to the
+  `Date` (`event.dateObject`). The format parser gained `ww` (ISO week) and
+  `q`/`QQQ` (quarter) tokens for custom masks.
 - **Format comes from the mask.** `inputDateFormat` is replaced by `format`
   (forwarded to the field); `inputDateParse` still applies to pasted text.
 - **The calendar is built on first open, not at construction.** It accounts for

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -44,9 +44,9 @@ description: "Track and review changes to the CoreUI for Bootstrap source files,
 
 **The minimum supported browsers are now Chrome 123, Edge 123, Firefox 121,
 Safari 17.5 and iOS 17.5.** `light-dark()` sets the Chrome/Edge/Safari floor;
-`:has()` sets Firefox 121, since validation and focus states on Multi Select
-and Autocomplete, the sidebar navigation indicators, calendar ranges and the
-rating icons are all selected with it — and an unsupported `:has()` invalidates
+`:has()` sets Firefox 121, since validation and focus states on Multi Select,
+Autocomplete and the pickers, the sidebar navigation indicators, calendar
+ranges and the rating icons are all selected with it — and an unsupported `:has()` invalidates
 the entire rule it appears in. This is the floor the v6 color system already required in practice:
 theme decisions resolve in the browser via `light-dark()` and `color-mix()`
 with no fallback, so on older browsers dark mode did not work regardless of

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -231,7 +231,10 @@ behaviour, v5 is the reference. Mapping:
   (`setDate`, the `today` action, the initial `date` config) run through the
   same min/max validation as typed ones: out of range, the field turns
   `is-invalid`, `errorChange` fires, and `getDate()`/`dateChange` report
-  `null`. `dateChange` on the shells now always carries the validated value.
+  `null`. `dateChange` on the shells now always carries the validated value,
+  and the slot context exposes `isDateSelectable(date)` (`isTimeSelectable`
+  on the time picker) for computing a projected button's `disabled` in
+  userland.
 - **The calendar is built on first open, not at construction.** It accounts for
   ~83% of a date picker's DOM (and ~89% of a range picker's), and it is not
   observable before the popup opens, so the shells create it in `show()` and

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -224,17 +224,18 @@ behaviour, v5 is the reference. Mapping:
   quote).
 - **Format comes from the mask.** `inputDateFormat` is replaced by `format`
   (forwarded to the field); `inputDateParse` still applies to pasted text.
-- **Projected footer buttons are never disabled by the picker.** In v1 the
-  built-in Today button disabled itself when today fell outside
-  `minDate`/`maxDate`; the projected `data-coreui-picker-action="today"` button
-  is userland markup, so its state is yours. Instead, programmatic dates
-  (`setDate`, the `today` action, the initial `date` config) run through the
-  same min/max validation as typed ones: out of range, the field turns
-  `is-invalid`, `errorChange` fires, and `getDate()`/`dateChange` report
-  `null`. `dateChange` on the shells now always carries the validated value,
-  and the slot context exposes `isDateSelectable(date)` (`isTimeSelectable`
-  on the time picker) for computing a projected button's `disabled` in
-  userland.
+- **Footer buttons are projected, `today`/`now` actions keep the v1 gating.**
+  A projected button opting into the `today` action (`now` on the time picker)
+  is disabled at initialization when its target falls outside
+  `minDate`/`maxDate`/`disabledDates` — matching the v1 built-in button. This
+  is one-way: the picker only ever sets `disabled`, never re-enables. The
+  state of any other projected button is yours — the slot context exposes
+  `isDateSelectable(date)` (`isTimeSelectable` on the time picker) for
+  computing it. Programmatic dates (`setDate`, actions, the initial `date`
+  config) run through the same min/max validation as typed ones: out of
+  range, the field turns `is-invalid`, `errorChange` fires, and
+  `getDate()`/`dateChange` report `null`. `dateChange` on the shells always
+  carries the validated value.
 - **The calendar is built on first open, not at construction.** It accounts for
   ~83% of a date picker's DOM (and ~89% of a range picker's), and it is not
   observable before the popup opens, so the shells create it in `show()` and

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -224,6 +224,14 @@ behaviour, v5 is the reference. Mapping:
   quote).
 - **Format comes from the mask.** `inputDateFormat` is replaced by `format`
   (forwarded to the field); `inputDateParse` still applies to pasted text.
+- **Projected footer buttons are never disabled by the picker.** In v1 the
+  built-in Today button disabled itself when today fell outside
+  `minDate`/`maxDate`; the projected `data-coreui-picker-action="today"` button
+  is userland markup, so its state is yours. Instead, programmatic dates
+  (`setDate`, the `today` action, the initial `date` config) run through the
+  same min/max validation as typed ones: out of range, the field turns
+  `is-invalid`, `errorChange` fires, and `getDate()`/`dateChange` report
+  `null`. `dateChange` on the shells now always carries the validated value.
 - **The calendar is built on first open, not at construction.** It accounts for
   ~83% of a date picker's DOM (and ~89% of a range picker's), and it is not
   observable before the popup opens, so the shells create it in `show()` and

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -211,13 +211,17 @@ behaviour, v5 is the reference. Mapping:
   element. `calendarOptions` / `inputOptions` remain as the programmatic escape
   hatch.
 - **Every selection type has a matching mask.** Month and year selection narrow
-  the mask to `MM/yyyy` and `yyyy`, week selection to `yyyy-Www` (`2026-W29` —
-  the native `<input type="week">` wire format, with the ISO week-numbering
-  year), and quarter selection to `QQQ yyyy` (`Q4 2026`). The v1 text input
-  rendered `2026W27`/`2026Q1`; the submitted value now follows the mask, and
-  the event still carries the v1-formatted string (`event.date`) next to the
-  `Date` (`event.dateObject`). The format parser gained `ww` (ISO week) and
-  `q`/`QQQ` (quarter) tokens for custom masks.
+  the mask to `MM/yyyy` and `yyyy`. Week selection renders the native
+  `<input type="week">` presentation — a fixed localized label plus week and
+  year sections (`Week 29, 2026`, `Tydzień 29, 2026`), where the year is the
+  ISO week-numbering year. Quarter selection narrows to `QQQ yyyy`
+  (`Q4 2026`). The v1 text input rendered `2026W27`/`2026Q1`; the submitted
+  value now follows the mask (set `format="yyyy-Www"` for an ISO-style
+  field), and the event still carries the v1-formatted string (`event.date`)
+  next to the `Date` (`event.dateObject`). The format parser gained `ww`
+  (ISO week) and `q`/`QQQ` (quarter) tokens, plus quoted literals
+  (`'Week' ww` — fixed text that may contain token letters, `''` escapes a
+  quote).
 - **Format comes from the mask.** `inputDateFormat` is replaced by `format`
   (forwarded to the field); `inputDateParse` still applies to pasted text.
 - **The calendar is built on first open, not at construction.** It accounts for

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -495,6 +495,25 @@ assembles maps of CSS expressions and the browser resolves them.
 - Two silent duplicates were dropped along the way: `$nav-link-height` was
   declared twice (navbar and header blocks — the header copy is gone) and the
   calendar emitted `--cui-calendar-cell-week-number-color` twice.
+- **Time picker: the v1-only tokens are gone.** The rewritten shell has no
+  cleaner button and draws its indicator as an inline SVG on `currentColor`,
+  so nothing read them any more — `--cui-time-picker-cleaner-*` (5 tokens),
+  `--cui-time-picker-indicator-icon`, `--cui-time-picker-indicator-icon-size`,
+  `--cui-time-picker-gap` and `--cui-time-picker-placeholder-color`, together
+  with their Sass variables (`$time-picker-cleaner-icon-size-sm`/`-lg` were
+  also declared twice). `--cui-time-picker-indicator-icon-color` stays and now
+  carries the validation color as well. The validation state itself moved off
+  the root element: v1 recoloured the frame from `.time-picker.is-invalid` with
+  `!important` overrides, v2 reads it from the field inside the group, so
+  `$time-picker-invalid-border-color` / `$time-picker-valid-border-color` and
+  the matching indicator-icon variables are gone — theme the state through the
+  standard `$form-invalid-*` / `$form-valid-*` variables instead. Section
+  placeholders come from the field's `placeholders` option, not a colour token.
+- `$input-padding-x-lg` was removed: `.form-control-lg` reads
+  `--cui-btn-input-lg-padding-x` from the shared button/input token system, and
+  the time picker's dead `gap-lg` was the variable's last consumer.
+  `$input-padding-x`, `$input-padding-x-sm` and `$input-padding-y-*` are
+  unaffected.
 
 #### Theme tokens
 

--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -52,6 +52,7 @@ const CLASS_NAME_SHOW = 'show'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="date-picker"]'
 const SELECTOR_TEMPLATE_FOOTER = 'template[data-coreui-template="footer"]'
 const SELECTOR_ACTION = '[data-coreui-picker-action]'
+const SELECTOR_ACTION_TODAY = '[data-coreui-picker-action="today"]'
 
 // Icons live in JavaScript, not in CSS masks — the chips pattern: inline SVG on
 // currentColor, swappable through an option, sanitized like any user-provided
@@ -309,7 +310,23 @@ class DatePicker extends BaseComponent {
       const footer = document.createElement('div')
       footer.classList.add(CLASS_NAME_FOOTER)
       footer.append(this._footerTemplate.content.cloneNode(true))
+      this._disableUnselectableActions(footer)
       this._menu.append(footer)
+    }
+  }
+
+  // A button opting into the `today` action opts into its state too: it is
+  // disabled when today cannot be selected. One-way only — the picker never
+  // re-enables a projected button, so a `disabled` set in the template stays.
+  _disableUnselectableActions(container: HTMLElement): void {
+    if (this._input.isDateSelectable(new Date())) {
+      return
+    }
+
+    for (const button of SelectorEngine.find(SELECTOR_ACTION_TODAY, container)) {
+      if ('disabled' in button) {
+        (button as any).disabled = true
+      }
     }
   }
 

--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -207,6 +207,7 @@ class DatePicker extends BaseComponent {
       close: () => this.hide(),
       date: this.getDate(),
       disabled: this._config.disabled,
+      isDateSelectable: (date: Date | null) => this._input.isDateSelectable(date),
       reset: () => this.reset(),
       setDate: (date: Date | null) => this.setDate(date),
       today: () => this.today()

--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -233,15 +233,18 @@ class DatePicker extends BaseComponent {
     return { ...forwarded, ...overrides, ...extra }
   }
 
-  // A date mask can only express the sections it has: month/year selection get
-  // a narrower default mask, day (and the week/quarter types, whose value is the
-  // underlying day) keep the locale mask. An explicit `format` always wins.
+  // A date mask can only express the sections it has: every non-day selection
+  // type gets a default mask matching its granularity (week mirrors the
+  // <input type="week"> wire format) and day keeps the locale mask. An
+  // explicit `format` always wins.
   _resolveFormat(): any {
     if (this._config.format) {
       return this._config.format
     }
 
-    const byType = { month: 'MM/yyyy', year: 'yyyy' }
+    const byType = {
+      month: 'MM/yyyy', quarter: 'QQQ yyyy', week: 'yyyy-Www', year: 'yyyy'
+    }
 
     return (byType as Record<string, string>)[this._config.selectionType] ?? null
   }

--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -178,10 +178,13 @@ class DatePicker extends BaseComponent {
     return this._input.getDate()
   }
 
+  // The field validates the date against min/max — the emitted value and the
+  // calendar selection follow the validation outcome, not the argument.
   setDate(date: Date | null): void {
     this._input.update({ date })
-    this._calendar?.update({ startDate: date })
-    EventHandler.trigger(this._element, EVENT_DATE_CHANGE, { date })
+    const effectiveDate = this.getDate()
+    this._calendar?.update({ startDate: effectiveDate })
+    EventHandler.trigger(this._element, EVENT_DATE_CHANGE, { date: effectiveDate })
   }
 
   clear(): void {

--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -17,6 +17,7 @@ import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import Popup from './util/popup.js'
 import type { ComponentConfig } from './util/config.js'
+import { getWeekSectionsFromLocale } from './util/date-sections.js'
 import { defineJQueryPlugin } from './util/index.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 
@@ -235,18 +236,18 @@ class DatePicker extends BaseComponent {
 
   // A date mask can only express the sections it has: every non-day selection
   // type gets a default mask matching its granularity (week mirrors the
-  // <input type="week"> wire format) and day keeps the locale mask. An
-  // explicit `format` always wins.
+  // native week input's presentation, "Week 29, 2026") and day keeps the
+  // locale mask. An explicit `format` always wins.
   _resolveFormat(): any {
     if (this._config.format) {
       return this._config.format
     }
 
     const byType = {
-      month: 'MM/yyyy', quarter: 'QQQ yyyy', week: 'yyyy-Www', year: 'yyyy'
+      month: 'MM/yyyy', quarter: 'QQQ yyyy', week: getWeekSectionsFromLocale, year: 'yyyy'
     }
 
-    return (byType as Record<string, string>)[this._config.selectionType] ?? null
+    return (byType as Record<string, any>)[this._config.selectionType] ?? null
   }
 
   _sanitizeIcon(icon: string): string {

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -263,13 +263,15 @@ class DateRangePicker extends BaseComponent {
   }
 
   // See DatePicker._resolveFormat — a date mask can only express the sections
-  // it has, so month/year selection get a narrower default mask.
+  // it has, so every non-day selection type gets a matching default mask.
   _resolveFormat(): any {
     if (this._config.format) {
       return this._config.format
     }
 
-    const byType = { month: 'MM/yyyy', year: 'yyyy' }
+    const byType = {
+      month: 'MM/yyyy', quarter: 'QQQ yyyy', week: 'yyyy-Www', year: 'yyyy'
+    }
 
     return (byType as Record<string, string>)[this._config.selectionType] ?? null
   }

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -16,6 +16,7 @@ import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import Popup from './util/popup.js'
 import type { ComponentConfig } from './util/config.js'
+import { getWeekSectionsFromLocale } from './util/date-sections.js'
 import { defineJQueryPlugin } from './util/index.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 
@@ -270,10 +271,10 @@ class DateRangePicker extends BaseComponent {
     }
 
     const byType = {
-      month: 'MM/yyyy', quarter: 'QQQ yyyy', week: 'yyyy-Www', year: 'yyyy'
+      month: 'MM/yyyy', quarter: 'QQQ yyyy', week: getWeekSectionsFromLocale, year: 'yyyy'
     }
 
-    return (byType as Record<string, string>)[this._config.selectionType] ?? null
+    return (byType as Record<string, any>)[this._config.selectionType] ?? null
   }
 
   _setSelectEndDate(value: boolean): void {

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -211,13 +211,17 @@ class DateRangePicker extends BaseComponent {
     return this._endInput.getDate()
   }
 
+  // See DatePicker.setDate — the emitted values and the calendar selection
+  // follow the fields' validation outcome, not the arguments.
   setRange(startDate: Date | null, endDate: Date | null): void {
     this._startInput.update({ date: startDate })
     this._endInput.update({ date: endDate })
+    const effectiveStartDate = this.getStartDate()
+    const effectiveEndDate = this.getEndDate()
     this._selectEndDate = false
-    this._calendar?.update({ endDate, selectEndDate: false, startDate })
-    EventHandler.trigger(this._element, EVENT_START_DATE_CHANGE, { date: startDate })
-    EventHandler.trigger(this._element, EVENT_END_DATE_CHANGE, { date: endDate })
+    this._calendar?.update({ endDate: effectiveEndDate, selectEndDate: false, startDate: effectiveStartDate })
+    EventHandler.trigger(this._element, EVENT_START_DATE_CHANGE, { date: effectiveStartDate })
+    EventHandler.trigger(this._element, EVENT_END_DATE_CHANGE, { date: effectiveEndDate })
   }
 
   clear(): void {

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -238,6 +238,7 @@ class DateRangePicker extends BaseComponent {
       close: () => this.hide(),
       disabled: this._config.disabled,
       endDate: this.getEndDate(),
+      isDateSelectable: (date: Date | null) => this._startInput.isDateSelectable(date),
       reset: () => this.reset(),
       setRange: (startDate: Date | null, endDate: Date | null) => this.setRange(startDate, endDate),
       startDate: this.getStartDate()

--- a/js/src/date-time-picker.ts
+++ b/js/src/date-time-picker.ts
@@ -52,6 +52,7 @@ const CLASS_NAME_TIME_BODY = 'time-picker-body'
 const CLASS_NAME_TIME_PICKERS = 'date-picker-timepickers'
 
 const SELECTOR_ACTION = '[data-coreui-picker-action]'
+const SELECTOR_ACTION_TODAY = '[data-coreui-picker-action="today"]'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="date-time-picker"]'
 const SELECTOR_TEMPLATE_FOOTER = 'template[data-coreui-template="footer"]'
 
@@ -308,10 +309,26 @@ class DateTimePicker extends BaseComponent {
       const footer = document.createElement('div')
       footer.classList.add(CLASS_NAME_FOOTER)
       footer.append(this._footerTemplate.content.cloneNode(true))
+      this._disableUnselectableActions(footer)
       this._menu.append(footer)
     }
 
     this._element.append(this._menu)
+  }
+
+  // See DatePicker._disableUnselectableActions — a button opting into the
+  // `today` action is disabled (never re-enabled) when today cannot be
+  // selected.
+  _disableUnselectableActions(container: HTMLElement): void {
+    if (this._input.isDateSelectable(new Date())) {
+      return
+    }
+
+    for (const button of SelectorEngine.find(SELECTOR_ACTION_TODAY, container)) {
+      if ('disabled' in button) {
+        (button as any).disabled = true
+      }
+    }
   }
 
   // Both popup bodies are built on first open — see DatePicker._ensureCalendar.

--- a/js/src/date-time-picker.ts
+++ b/js/src/date-time-picker.ts
@@ -187,11 +187,14 @@ class DateTimePicker extends BaseComponent {
     return this._input.getDate()
   }
 
+  // See DatePicker.setDate — the emitted value and the calendar/time selection
+  // follow the field's validation outcome, not the argument.
   setDate(date: Date | null): void {
     this._input.update({ date })
-    this._calendar?.update({ startDate: date })
-    this._selection?.update({ time: date })
-    EventHandler.trigger(this._element, EVENT_DATE_CHANGE, { date })
+    const effectiveDate = this.getDate()
+    this._calendar?.update({ startDate: effectiveDate })
+    this._selection?.update({ time: effectiveDate })
+    EventHandler.trigger(this._element, EVENT_DATE_CHANGE, { date: effectiveDate })
   }
 
   today(): void {
@@ -349,7 +352,7 @@ class DateTimePicker extends BaseComponent {
 
     this._input.update({ date: merged })
     this._selection?.update({ time: merged })
-    EventHandler.trigger(this._element, EVENT_DATE_CHANGE, { date: merged })
+    EventHandler.trigger(this._element, EVENT_DATE_CHANGE, { date: this.getDate() })
   }
 
   _applyTime(time: Date | null): void {
@@ -363,7 +366,7 @@ class DateTimePicker extends BaseComponent {
 
     this._input.update({ date: merged })
     this._calendar?.update({ startDate: merged })
-    EventHandler.trigger(this._element, EVENT_DATE_CHANGE, { date: merged })
+    EventHandler.trigger(this._element, EVENT_DATE_CHANGE, { date: this.getDate() })
   }
 
   _createPopup(): void {

--- a/js/src/date-time-picker.ts
+++ b/js/src/date-time-picker.ts
@@ -218,6 +218,7 @@ class DateTimePicker extends BaseComponent {
       close: () => this.hide(),
       date: this.getDate(),
       disabled: this._config.disabled,
+      isDateSelectable: (date: Date | null) => this._input.isDateSelectable(date),
       reset: () => this.reset(),
       setDate: (date: Date | null) => this.setDate(date),
       today: () => this.today()

--- a/js/src/section-input.ts
+++ b/js/src/section-input.ts
@@ -21,6 +21,7 @@ import {
   getSectionBounds,
   getSectionsFromFormat,
   getSectionsFromString,
+  getWeekSectionMax,
   setSectionsFromDate
 } from './util/date-sections.js'
 import type { ComponentConfig } from './util/config.js'
@@ -119,7 +120,9 @@ const DefaultType: Record<string, string> = {
 
 const DefaultPlaceholders = {
   day: 'DD',
+  week: 'WW',
   month: 'MM',
+  quarter: 'Q',
   year: 'YYYY',
   hour: 'HH',
   minute: 'mm',
@@ -129,7 +132,9 @@ const DefaultPlaceholders = {
 
 const DefaultSectionLabels = {
   day: 'Day',
+  week: 'Week',
   month: 'Month',
+  quarter: 'Quarter',
   year: 'Year',
   hour: 'Hour',
   minute: 'Minute',
@@ -567,11 +572,13 @@ class SectionInput extends BaseComponent {
   }
 
   _updateDate(): void {
-    const daySection = this._sections.find(section => section.type === 'day')
-
-    if (daySection && daySection.value !== null && daySection.value > this._getSectionMax(daySection)) {
-      daySection.value = this._getSectionMax(daySection)
-      this._syncSections()
+    // Sections whose bounds depend on other sections (the day on the month and
+    // year, the week on the year) are clamped when those sections change.
+    for (const section of this._sections) {
+      if ((section.type === 'day' || section.type === 'week') && section.value !== null && section.value > this._getSectionMax(section)) {
+        section.value = this._getSectionMax(section)
+        this._syncSections()
+      }
     }
 
     const date = getDateFromSections(this._sections)
@@ -779,7 +786,15 @@ class SectionInput extends BaseComponent {
   }
 
   _getSectionMax(section: DateSection): number {
-    return section.type === 'day' ? getDaySectionMax(this._sections) : getSectionBounds(section).max
+    if (section.type === 'day') {
+      return getDaySectionMax(this._sections)
+    }
+
+    if (section.type === 'week') {
+      return getWeekSectionMax(this._sections)
+    }
+
+    return getSectionBounds(section).max
   }
 
   _isEditable(): boolean {

--- a/js/src/section-input.ts
+++ b/js/src/section-input.ts
@@ -174,6 +174,7 @@ class SectionInput extends BaseComponent {
     this._monthFormatter = new Intl.DateTimeFormat(this._config.locale, { month: 'long' })
 
     this._createSectionInput()
+    this._date = this._applyValidationState()
     this._addEventListeners()
 
     if (this._config.autofocus && !this._config.disabled) {
@@ -225,15 +226,19 @@ class SectionInput extends BaseComponent {
     this._config = { ...this._config, ...config }
     this._typeCheckConfig(this._config)
 
+    const previousDate = this._date
     this._date = this._config.date ? this._convertDate(this._config.date) : null
     this._minDate = this._convertDate(this._config.minDate)
     this._maxDate = this._convertDate(this._config.maxDate)
     this._sections = setSectionsFromDate(this._resolveSections(), this._date)
-    this._date = getDateFromSections(this._sections)
     this._draft = ''
     this._monthFormatter = new Intl.DateTimeFormat(this._config.locale, { month: 'long' })
 
     this._createSectionInput()
+    // validate like any other value change — a programmatic date outside
+    // min/max must end up in the same state as a typed one
+    this._date = previousDate
+    this._updateDate()
   }
 
   // Private
@@ -572,6 +577,23 @@ class SectionInput extends BaseComponent {
   }
 
   _updateDate(): void {
+    const nextDate = this._applyValidationState()
+
+    if (this._isSameDate(nextDate, this._date)) {
+      return
+    }
+
+    this._date = nextDate
+
+    EventHandler.trigger(this._element, this.constructor.eventName(this.constructor.CHANGE_EVENT_NAME), {
+      date: nextDate
+    })
+  }
+
+  // Applies the validation outcome to the field (validity class, hidden input,
+  // `errorChange`) and returns the effective date — null when the value is
+  // invalid. Runs on every value change, whether typed or programmatic.
+  _applyValidationState(): Date | null {
     // Sections whose bounds depend on other sections (the day on the month and
     // year, the week on the year) are clamped when those sections change.
     for (const section of this._sections) {
@@ -585,10 +607,9 @@ class SectionInput extends BaseComponent {
     const isFilled = this._sections.some(section => section.type !== 'literal' && section.value !== null)
     const error = this._getValidationError(date, isFilled)
     const isDisabled = error !== null && error !== 'incomplete'
-    const nextDate = isDisabled ? null : date
 
     this._element.classList.toggle(CLASS_NAME_FILLED, isFilled)
-    this._element.classList.toggle(CLASS_NAME_IS_INVALID, isDisabled)
+    this._element.classList.toggle(CLASS_NAME_IS_INVALID, isDisabled || this._config.invalid)
     this._setHiddenInputValue()
 
     if (error !== this._error) {
@@ -599,15 +620,7 @@ class SectionInput extends BaseComponent {
       })
     }
 
-    if (this._isSameDate(nextDate, this._date)) {
-      return
-    }
-
-    this._date = nextDate
-
-    EventHandler.trigger(this._element, this.constructor.eventName(this.constructor.CHANGE_EVENT_NAME), {
-      date: nextDate
-    })
+    return isDisabled ? null : date
   }
 
   _getValidationError(date: Date | null, isFilled: boolean): string | null {

--- a/js/src/section-input.ts
+++ b/js/src/section-input.ts
@@ -218,6 +218,20 @@ class SectionInput extends BaseComponent {
     return this._date
   }
 
+  // Answers whether a date, expressed in this field's mask, would pass
+  // validation. The granularity follows the mask: a day mask checks the
+  // midnight date (so "now" passes with a maxDate of today), a week mask the
+  // week's Monday, a date-time mask the exact time.
+  isDateSelectable(date: Date | null): boolean {
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+      return false
+    }
+
+    const normalized = getDateFromSections(setSectionsFromDate(this._sections, date))
+
+    return normalized !== null && this._getValidationError(normalized, true) === null
+  }
+
   update(config: any): void {
     if (typeof config !== 'object') {
       return

--- a/js/src/time-picker.ts
+++ b/js/src/time-picker.ts
@@ -45,6 +45,7 @@ const CLASS_NAME_SHOW = 'show'
 const CLASS_NAME_TIME_PICKER = 'time-picker'
 
 const SELECTOR_ACTION = '[data-coreui-picker-action]'
+const SELECTOR_ACTION_NOW = '[data-coreui-picker-action="now"]'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="time-picker"]'
 const SELECTOR_TEMPLATE_FOOTER = 'template[data-coreui-template="footer"]'
 
@@ -267,10 +268,26 @@ class TimePicker extends BaseComponent {
       const footer = document.createElement('div')
       footer.classList.add(CLASS_NAME_FOOTER)
       footer.append(this._footerTemplate.content.cloneNode(true))
+      this._disableUnselectableActions(footer)
       this._menu.append(footer)
     }
 
     this._element.append(this._menu)
+  }
+
+  // See DatePicker._disableUnselectableActions — a button opting into the
+  // `now` action is disabled (never re-enabled) when the current time cannot
+  // be selected.
+  _disableUnselectableActions(container: HTMLElement): void {
+    if (this._input.isDateSelectable(new Date())) {
+      return
+    }
+
+    for (const button of SelectorEngine.find(SELECTOR_ACTION_NOW, container)) {
+      if ('disabled' in button) {
+        (button as any).disabled = true
+      }
+    }
   }
 
   // The selection body is built on first open, like the pickers' calendar.

--- a/js/src/time-picker.ts
+++ b/js/src/time-picker.ts
@@ -192,6 +192,7 @@ class TimePicker extends BaseComponent {
       clear: () => this.clear(),
       close: () => this.hide(),
       disabled: this._config.disabled,
+      isTimeSelectable: (time: Date | null) => this._input.isDateSelectable(time),
       now: () => this.now(),
       reset: () => this.reset(),
       setTime: (time: Date | null) => this.setTime(time),

--- a/js/src/util/calendar.ts
+++ b/js/src/util/calendar.ts
@@ -844,7 +844,11 @@ export const getISOWeekNumberAndYear = (date: Date) : { weekNumber: number; year
   // Thursday in current week decides the year
   tempDate.setDate(tempDate.getDate() + 3 - ((tempDate.getDay() + 6) % 7))
 
-  const week1 = new Date(tempDate.getFullYear(), 0, 4)
+  // copy + setMonth keeps the full year — new Date(year, 0, 4) would map
+  // years below 100 to 19xx and derail the week math while a year section
+  // is still being typed
+  const week1 = new Date(tempDate)
+  week1.setMonth(0, 4)
 
   // Calculate full weeks to the date
   const weekNumber =

--- a/js/src/util/date-sections.ts
+++ b/js/src/util/date-sections.ts
@@ -5,7 +5,7 @@
  * --------------------------------------------------------------------------
  */
 
-import { parseYearSmart } from './calendar.js'
+import { getISOWeekNumberAndYear, parseYearSmart } from './calendar.js'
 import { convert12hTo24h, convert24hTo12h } from './time.js'
 
 export type DateSection = {
@@ -18,10 +18,15 @@ export type DateSection = {
   placeholder?: string
 }
 
+// Uppercase `W` is deliberately not a token, so masks can spell the ISO week
+// prefix as a literal: `yyyy-Www` renders "2026-W27".
 const TOKEN_TYPES: Record<string, string> = {
   d: 'day',
   D: 'day',
+  w: 'week',
   M: 'month',
+  q: 'quarter',
+  Q: 'quarter',
   y: 'year',
   Y: 'year',
   H: 'hour',
@@ -31,6 +36,8 @@ const TOKEN_TYPES: Record<string, string> = {
   A: 'meridiem',
   a: 'meridiem'
 }
+
+const QUARTER_NAMES = ['Q1', 'Q2', 'Q3', 'Q4']
 
 /**
  * Returns the localized month names in the grammatical form used inside a
@@ -104,6 +111,18 @@ const createSection = (char: string, tokenLength: number, locale = 'default', mo
     }
   }
 
+  if (type === 'quarter') {
+    if (tokenLength >= 3) {
+      return {
+        type, length: 1, padded: false, value: null, names: QUARTER_NAMES, placeholder: 'Q'.repeat(tokenLength)
+      }
+    }
+
+    return {
+      type, length: 1, padded: tokenLength > 1, value: null
+    }
+  }
+
   return {
     type, length: 2, padded: tokenLength > 1, value: null
   }
@@ -120,8 +139,16 @@ export const getSectionBounds = (section: DateSection): { min: number, max: numb
       return { min: 1, max: 31 }
     }
 
+    case 'week': {
+      return { min: 1, max: 53 }
+    }
+
     case 'month': {
       return { min: 1, max: 12 }
+    }
+
+    case 'quarter': {
+      return { min: 1, max: 4 }
     }
 
     case 'hour': {
@@ -394,6 +421,50 @@ export const getDaysInMonth = (year: number, month: number): number => {
 }
 
 /**
+ * Returns the number of ISO weeks in the given week-numbering year (52 or 53).
+ * @param {number} year The full week-numbering year.
+ * @returns {number} The week count.
+ */
+export const getISOWeeksInYear = (year: number): number => {
+  const date = new Date(2000, 0, 1)
+  // December 28th always belongs to the last ISO week of its year
+  date.setFullYear(year, 11, 28)
+  return getISOWeekNumberAndYear(date).weekNumber
+}
+
+/**
+ * Returns the Monday of the given ISO week.
+ * @param {number} year The full week-numbering year.
+ * @param {number} week The 1-based ISO week number.
+ * @returns {Date} The Monday starting the week.
+ */
+export const getDateOfISOWeek = (year: number, week: number): Date => {
+  const date = new Date(2000, 0, 1)
+  // January 4th always belongs to the first ISO week of its year
+  date.setFullYear(year, 0, 4)
+  date.setDate(date.getDate() - ((date.getDay() + 6) % 7) + ((week - 1) * 7))
+  return date
+}
+
+/**
+ * Returns the effective upper bound of the week section for the currently
+ * selected year. Falls back to 53 while the year is unknown (the year can
+ * still turn out to be a long one).
+ * @param {Array} sections The section and literal descriptors.
+ * @returns {number} The week count of the selected year.
+ */
+export const getWeekSectionMax = (sections: DateSection[]): number => {
+  const yearSection = sections.find(section => section.type === 'year')
+  const year = yearSection ? getFullYearFromSection(yearSection) : null
+
+  if (year === null) {
+    return getSectionBounds({ type: 'week' } as DateSection).max
+  }
+
+  return getISOWeeksInYear(year)
+}
+
+/**
  * Returns the effective upper bound of the day section for the currently
  * selected month and year. Falls back to 31 while the month is unknown and to
  * a leap year while the year is unknown (February can still turn out to have
@@ -442,9 +513,12 @@ export const getFullYearFromSection = (section: DateSection): number | null => {
 
 /**
  * Builds a Date from fully filled sections, clamping the day to the month's
- * length. Section types absent from the layout get defaults (1970-01-01 for
- * the date part — the `util/time.js` convention for time-only values — and
- * midnight for the time part). Returns null while any section is empty.
+ * length. A week section resolves to the Monday of the ISO week (the year
+ * section then holds the ISO week-numbering year) and a quarter section to
+ * the first day of the quarter. Section types absent from the layout get
+ * defaults (1970-01-01 for the date part — the `util/time.js` convention for
+ * time-only values — and midnight for the time part). Returns null while any
+ * section is empty.
  * @param {Array} sections The section and literal descriptors.
  * @returns {Date | null} The date or null when incomplete.
  */
@@ -469,7 +543,9 @@ export const getDateFromSections = (sections: DateSection[]): Date | null => {
   }
 
   const year = values.year === undefined ? 1970 : values.year
-  const month = values.month === undefined ? 1 : values.month
+  const month = values.month === undefined ?
+    (values.quarter === undefined ? 1 : ((values.quarter - 1) * 3) + 1) :
+    values.month
   const day = values.day === undefined ? 1 : values.day
   let hour = values.hour === undefined ? 0 : values.hour
 
@@ -477,57 +553,75 @@ export const getDateFromSections = (sections: DateSection[]): Date | null => {
     hour = convert12hTo24h(values.meridiem === 2 ? 'pm' : 'am', hour)
   }
 
-  const date = new Date(2000, 0, 1)
-  date.setFullYear(year, month - 1, Math.min(day, getDaysInMonth(year, month)))
+  const date = values.week === undefined ? new Date(2000, 0, 1) : getDateOfISOWeek(year, Math.min(values.week, getISOWeeksInYear(year)))
+
+  if (values.week === undefined) {
+    date.setFullYear(year, month - 1, Math.min(day, getDaysInMonth(year, month)))
+  }
+
   date.setHours(hour, values.minute === undefined ? 0 : values.minute, values.second === undefined ? 0 : values.second, 0)
   return date
 }
 
 /**
- * Returns a copy of the sections with values taken from the given date.
+ * Returns a copy of the sections with values taken from the given date. In a
+ * layout with a week section the year section holds the ISO week-numbering
+ * year, which can differ from the calendar year around January 1st.
  * @param {Array} sections The section and literal descriptors.
  * @param {Date | null} date The date to read values from, or null to clear.
  * @returns {Array} The updated sections.
  */
-export const setSectionsFromDate = (sections: DateSection[], date: Date | null): DateSection[] => sections.map(section => {
-  if (section.type === 'literal') {
-    return section
-  }
+export const setSectionsFromDate = (sections: DateSection[], date: Date | null): DateSection[] => {
+  const weekInfo = date && sections.some(section => section.type === 'week') ? getISOWeekNumberAndYear(date) : null
 
-  if (!date) {
-    return { ...section, value: null }
-  }
-
-  switch (section.type) {
-    case 'day': {
-      return { ...section, value: date.getDate() }
+  return sections.map(section => {
+    if (section.type === 'literal') {
+      return section
     }
 
-    case 'month': {
-      return { ...section, value: date.getMonth() + 1 }
+    if (!date) {
+      return { ...section, value: null }
     }
 
-    case 'hour': {
-      return { ...section, value: section.cycle === 'h12' ? convert24hTo12h(date.getHours()) : date.getHours() }
-    }
+    switch (section.type) {
+      case 'day': {
+        return { ...section, value: date.getDate() }
+      }
 
-    case 'minute': {
-      return { ...section, value: date.getMinutes() }
-    }
+      case 'week': {
+        return { ...section, value: weekInfo!.weekNumber }
+      }
 
-    case 'second': {
-      return { ...section, value: date.getSeconds() }
-    }
+      case 'month': {
+        return { ...section, value: date.getMonth() + 1 }
+      }
 
-    case 'meridiem': {
-      return { ...section, value: date.getHours() >= 12 ? 2 : 1 }
-    }
+      case 'quarter': {
+        return { ...section, value: Math.floor(date.getMonth() / 3) + 1 }
+      }
 
-    default: {
-      return { ...section, value: date.getFullYear() }
+      case 'hour': {
+        return { ...section, value: section.cycle === 'h12' ? convert24hTo12h(date.getHours()) : date.getHours() }
+      }
+
+      case 'minute': {
+        return { ...section, value: date.getMinutes() }
+      }
+
+      case 'second': {
+        return { ...section, value: date.getSeconds() }
+      }
+
+      case 'meridiem': {
+        return { ...section, value: date.getHours() >= 12 ? 2 : 1 }
+      }
+
+      default: {
+        return { ...section, value: weekInfo ? weekInfo.year : date.getFullYear() }
+      }
     }
-  }
-})
+  })
+}
 
 /**
  * Formats a section value for display, padding with zeros when the section is

--- a/js/src/util/date-sections.ts
+++ b/js/src/util/date-sections.ts
@@ -175,7 +175,9 @@ export const getSectionBounds = (section: DateSection): { min: number, max: numb
  * Accepts both dayjs/moment-style (`DD.MM.YYYY`) and date-fns/Unicode-style
  * (`dd.MM.yyyy`) tokens, including text month tokens (`MMM`, `MMMM`) and time
  * tokens (`HH`/`H` for the 23-hour cycle, `hh`/`h` for the 12-hour cycle,
- * `mm`, `ss`, `A`/`a`); any other character becomes a literal.
+ * `mm`, `ss`, `A`/`a`); any other character becomes a literal. Text wrapped in
+ * single quotes is always a literal — even token letters (`'Week' ww` renders
+ * "Week 29") — and a doubled quote (`''`) escapes the quote character itself.
  * @param {string} format The format string.
  * @param {string} [locale] The locale used to resolve month and day period names.
  * @param {string[] | null} [monthNames] Custom month names overriding the locale-derived ones.
@@ -188,6 +190,28 @@ export const getSectionsFromFormat = (format: string, locale = 'default', monthN
 
   while (index < format.length) {
     const char = format[index]
+
+    if (char === '\'') {
+      if (format[index + 1] === '\'') {
+        literal += '\''
+        index += 2
+        continue
+      }
+
+      index++
+
+      while (index < format.length) {
+        if (format[index] === '\'' && format[index + 1] !== '\'') {
+          index++
+          break
+        }
+
+        literal += format[index]
+        index += format[index] === '\'' ? 2 : 1
+      }
+
+      continue
+    }
 
     if (TOKEN_TYPES[char]) {
       if (literal) {
@@ -267,6 +291,32 @@ export const getSectionsFromLocale = (locale: string): DateSection[] =>
     month: '2-digit',
     day: '2-digit'
   }), locale)
+
+/**
+ * Returns the localized week-of-year label, capitalized the way the native
+ * week input renders it ("Week", "Tydzień", "Woche"). Falls back to "Week"
+ * where `Intl.DisplayNames` has no data.
+ * @param {string} locale The locale to use.
+ * @returns {string} The label.
+ */
+export const getWeekLabel = (locale: string): string => {
+  try {
+    const label = new Intl.DisplayNames(locale, { type: 'dateTimeField' }).of('weekOfYear')
+    return label ? label.charAt(0).toLocaleUpperCase(locale) + label.slice(1) : 'Week'
+  } catch {
+    return 'Week'
+  }
+}
+
+/**
+ * Derives the week mask from the locale, mirroring the native week input's
+ * presentation ("Week 29, 2026"): a fixed localized label, the ISO week
+ * number, and the ISO week-numbering year.
+ * @param {string} locale The locale to use.
+ * @returns {Array} The ordered list of section and literal descriptors.
+ */
+export const getWeekSectionsFromLocale = (locale: string): DateSection[] =>
+  getSectionsFromFormat(`'${getWeekLabel(locale).replaceAll('\'', '\'\'')}' ww, yyyy`, locale)
 
 /**
  * Derives the list of sections and literals from the locale's time format.

--- a/js/tests/unit/date-input.spec.js
+++ b/js/tests/unit/date-input.spec.js
@@ -628,6 +628,46 @@ describe('DateInput', () => {
       expect(spy).toHaveBeenCalledTimes(3)
     })
 
+    it('should validate a date set through the constructor', () => {
+      const dateInput = createDateInput({
+        date: new Date(2026, 6, 20),
+        maxDate: new Date(2026, 6, 14)
+      })
+
+      expect(dateInput._element.classList.contains('is-invalid')).toBeTrue()
+      expect(dateInput.getDate()).toBeNull()
+    })
+
+    it('should validate a date set through update() like a typed one', () => {
+      const dateInput = createDateInput({ maxDate: new Date(2026, 6, 14) })
+      const changeSpy = jasmine.createSpy('dateChange')
+      const errorSpy = jasmine.createSpy('errorChange')
+      dateInput._element.addEventListener('dateChange.coreui.date-input', changeSpy)
+      dateInput._element.addEventListener('errorChange.coreui.date-input', errorSpy)
+
+      dateInput.update({ date: new Date(2026, 6, 20) })
+
+      expect(dateInput._element.classList.contains('is-invalid')).toBeTrue()
+      expect(dateInput.getDate()).toBeNull()
+      expect(errorSpy.calls.mostRecent().args[0].error).toEqual('maxDate')
+      expect(changeSpy).not.toHaveBeenCalled()
+    })
+
+    it('should clear the invalid state when update() sets a date back in range', () => {
+      const dateInput = createDateInput({
+        date: new Date(2026, 6, 20),
+        maxDate: new Date(2026, 6, 14)
+      })
+      const changeSpy = jasmine.createSpy('dateChange')
+      dateInput._element.addEventListener('dateChange.coreui.date-input', changeSpy)
+
+      dateInput.update({ date: new Date(2026, 6, 10) })
+
+      expect(dateInput._element.classList.contains('is-invalid')).toBeFalse()
+      expect(dateInput.getDate()).toEqual(new Date(2026, 6, 10))
+      expect(changeSpy.calls.mostRecent().args[0].date).toEqual(new Date(2026, 6, 10))
+    })
+
     it('should report disabled dates through errorChange', () => {
       const dateInput = createDateInput({
         date: new Date(2026, 6, 14),

--- a/js/tests/unit/date-input.spec.js
+++ b/js/tests/unit/date-input.spec.js
@@ -628,6 +628,27 @@ describe('DateInput', () => {
       expect(spy).toHaveBeenCalledTimes(3)
     })
 
+    it('should answer whether a date would pass validation', () => {
+      const dateInput = createDateInput({
+        disabledDates: [new Date(2026, 6, 15)],
+        maxDate: new Date(2026, 6, 20),
+        minDate: new Date(2026, 6, 10)
+      })
+
+      expect(dateInput.isDateSelectable(new Date(2026, 6, 14))).toBeTrue()
+      expect(dateInput.isDateSelectable(new Date(2026, 6, 15))).toBeFalse()
+      expect(dateInput.isDateSelectable(new Date(2026, 6, 21))).toBeFalse()
+      expect(dateInput.isDateSelectable(new Date(2026, 6, 9))).toBeFalse()
+      expect(dateInput.isDateSelectable(null)).toBeFalse()
+      expect(dateInput.isDateSelectable(new Date('invalid'))).toBeFalse()
+    })
+
+    it('should normalize the checked date through the mask', () => {
+      const dateInput = createDateInput({ maxDate: new Date(2026, 6, 14) })
+
+      expect(dateInput.isDateSelectable(new Date(2026, 6, 14, 15, 30))).toBeTrue()
+    })
+
     it('should validate a date set through the constructor', () => {
       const dateInput = createDateInput({
         date: new Date(2026, 6, 20),

--- a/js/tests/unit/date-picker.spec.js
+++ b/js/tests/unit/date-picker.spec.js
@@ -154,6 +154,54 @@ describe('DatePicker', () => {
     })
   })
 
+  describe('selection types', () => {
+    it('should mask week selection in the input type="week" wire format', () => {
+      const picker = buildPicker({ selectionType: 'week', date: new Date(2026, 6, 14) })
+
+      expect(fixtureEl.querySelector('#picker input[type="hidden"]').value).toEqual('2026-W29')
+      expect(picker.getDate()).toEqual(new Date(2026, 6, 13))
+    })
+
+    it('should fill the week sections when a calendar week is selected', () => {
+      const picker = buildPicker({ selectionType: 'week', date: new Date(2026, 6, 14) })
+      const el = fixtureEl.querySelector('#picker')
+      let emitted = null
+      el.addEventListener('dateChange.coreui.date-picker', event => {
+        emitted = event.date
+      })
+
+      picker.show()
+      el.querySelector('.calendar-row[tabindex="0"] .calendar-cell').click()
+
+      expect(emitted).toMatch(/^\d{4}W\d{2}$/)
+      expect(el.querySelector('input[type="hidden"]').value).toEqual(emitted.replace('W', '-W'))
+    })
+
+    it('should keep the ISO week-numbering year around January 1st', () => {
+      const picker = buildPicker({ selectionType: 'week', date: new Date(2027, 0, 1) })
+
+      expect(fixtureEl.querySelector('#picker input[type="hidden"]').value).toEqual('2026-W53')
+      expect(picker.getDate()).toEqual(new Date(2026, 11, 28))
+    })
+
+    it('should mask quarter selection with the quarter name', () => {
+      const picker = buildPicker({ selectionType: 'quarter', date: new Date(2026, 10, 15) })
+
+      expect(fixtureEl.querySelector('#picker input[type="hidden"]').value).toEqual('Q4 2026')
+      expect(picker.getDate()).toEqual(new Date(2026, 9, 1))
+    })
+
+    it('should fill the quarter sections when a calendar quarter is selected', () => {
+      const picker = buildPicker({ selectionType: 'quarter', date: new Date(2026, 10, 15) })
+      const el = fixtureEl.querySelector('#picker')
+
+      picker.show()
+      el.querySelector('.calendar-cell[tabindex="0"]').click()
+
+      expect(el.querySelector('input[type="hidden"]').value).toMatch(/^Q[1-4] \d{4}$/)
+    })
+  })
+
   describe('calendar navigation', () => {
     it('should keep the popup open when navigating months', () => {
       const picker = buildPicker({ date: new Date(2026, 5, 15) })

--- a/js/tests/unit/date-picker.spec.js
+++ b/js/tests/unit/date-picker.spec.js
@@ -232,23 +232,42 @@ describe('DatePicker', () => {
       expect(el.querySelector('.form-date-time').classList.contains('is-invalid')).toBeTrue()
     })
 
-    it('should keep the projected today action consistent with validation', () => {
+    it('should disable a projected today action when today is not selectable', () => {
       const yesterday = new Date()
       yesterday.setDate(yesterday.getDate() - 1)
-      const picker = buildPicker({ maxDate: yesterday }, [
+      buildPicker({ maxDate: yesterday }, [
         '<div id="picker">',
         '  <template data-coreui-template="footer">',
         '    <button type="button" data-coreui-picker-action="today">Today</button>',
         '  </template>',
         '</div>'
       ].join(''))
-      const el = fixtureEl.querySelector('#picker')
 
-      picker.show()
-      el.querySelector('[data-coreui-picker-action="today"]').click()
+      expect(fixtureEl.querySelector('[data-coreui-picker-action="today"]').disabled).toBeTrue()
+    })
 
-      expect(picker.getDate()).toBeNull()
-      expect(el.querySelector('.form-date-time').classList.contains('is-invalid')).toBeTrue()
+    it('should keep a projected today action enabled when today is selectable', () => {
+      buildPicker({}, [
+        '<div id="picker">',
+        '  <template data-coreui-template="footer">',
+        '    <button type="button" data-coreui-picker-action="today">Today</button>',
+        '  </template>',
+        '</div>'
+      ].join(''))
+
+      expect(fixtureEl.querySelector('[data-coreui-picker-action="today"]').disabled).toBeFalse()
+    })
+
+    it('should not re-enable a today action disabled in the template', () => {
+      buildPicker({}, [
+        '<div id="picker">',
+        '  <template data-coreui-template="footer">',
+        '    <button type="button" data-coreui-picker-action="today" disabled>Today</button>',
+        '  </template>',
+        '</div>'
+      ].join(''))
+
+      expect(fixtureEl.querySelector('[data-coreui-picker-action="today"]').disabled).toBeTrue()
     })
 
     it('should emit and select a programmatic date within range', () => {

--- a/js/tests/unit/date-picker.spec.js
+++ b/js/tests/unit/date-picker.spec.js
@@ -155,15 +155,27 @@ describe('DatePicker', () => {
   })
 
   describe('selection types', () => {
-    it('should mask week selection in the input type="week" wire format', () => {
-      const picker = buildPicker({ selectionType: 'week', date: new Date(2026, 6, 14) })
+    it('should mask week selection like the native week input', () => {
+      const picker = buildPicker({ locale: 'en-US', selectionType: 'week', date: new Date(2026, 6, 14) })
 
-      expect(fixtureEl.querySelector('#picker input[type="hidden"]').value).toEqual('2026-W29')
+      expect(fixtureEl.querySelector('#picker input[type="hidden"]').value).toEqual('Week 29, 2026')
       expect(picker.getDate()).toEqual(new Date(2026, 6, 13))
     })
 
+    it('should localize the fixed week label', () => {
+      buildPicker({ locale: 'pl-PL', selectionType: 'week', date: new Date(2026, 6, 14) })
+
+      expect(fixtureEl.querySelector('#picker input[type="hidden"]').value).toEqual('Tydzień 29, 2026')
+    })
+
+    it('should let an explicit format override the week mask', () => {
+      buildPicker({ format: 'yyyy-Www', selectionType: 'week', date: new Date(2026, 6, 14) })
+
+      expect(fixtureEl.querySelector('#picker input[type="hidden"]').value).toEqual('2026-W29')
+    })
+
     it('should fill the week sections when a calendar week is selected', () => {
-      const picker = buildPicker({ selectionType: 'week', date: new Date(2026, 6, 14) })
+      const picker = buildPicker({ locale: 'en-US', selectionType: 'week', date: new Date(2026, 6, 14) })
       const el = fixtureEl.querySelector('#picker')
       let emitted = null
       el.addEventListener('dateChange.coreui.date-picker', event => {
@@ -174,13 +186,13 @@ describe('DatePicker', () => {
       el.querySelector('.calendar-row[tabindex="0"] .calendar-cell').click()
 
       expect(emitted).toMatch(/^\d{4}W\d{2}$/)
-      expect(el.querySelector('input[type="hidden"]').value).toEqual(emitted.replace('W', '-W'))
+      expect(el.querySelector('input[type="hidden"]').value).toEqual(`Week ${emitted.slice(5)}, ${emitted.slice(0, 4)}`)
     })
 
     it('should keep the ISO week-numbering year around January 1st', () => {
-      const picker = buildPicker({ selectionType: 'week', date: new Date(2027, 0, 1) })
+      const picker = buildPicker({ locale: 'en-US', selectionType: 'week', date: new Date(2027, 0, 1) })
 
-      expect(fixtureEl.querySelector('#picker input[type="hidden"]').value).toEqual('2026-W53')
+      expect(fixtureEl.querySelector('#picker input[type="hidden"]').value).toEqual('Week 53, 2026')
       expect(picker.getDate()).toEqual(new Date(2026, 11, 28))
     })
 

--- a/js/tests/unit/date-picker.spec.js
+++ b/js/tests/unit/date-picker.spec.js
@@ -214,6 +214,59 @@ describe('DatePicker', () => {
     })
   })
 
+  describe('min/max validation', () => {
+    it('should propagate field validation to a programmatic date beyond maxDate', () => {
+      const yesterday = new Date()
+      yesterday.setDate(yesterday.getDate() - 1)
+      const picker = buildPicker({ maxDate: yesterday })
+      const el = fixtureEl.querySelector('#picker')
+      let emitted = 'not-fired'
+      el.addEventListener('dateChange.coreui.date-picker', event => {
+        emitted = event.date
+      })
+
+      picker.setDate(new Date())
+
+      expect(picker.getDate()).toBeNull()
+      expect(emitted).toBeNull()
+      expect(el.querySelector('.form-date-time').classList.contains('is-invalid')).toBeTrue()
+    })
+
+    it('should keep the projected today action consistent with validation', () => {
+      const yesterday = new Date()
+      yesterday.setDate(yesterday.getDate() - 1)
+      const picker = buildPicker({ maxDate: yesterday }, [
+        '<div id="picker">',
+        '  <template data-coreui-template="footer">',
+        '    <button type="button" data-coreui-picker-action="today">Today</button>',
+        '  </template>',
+        '</div>'
+      ].join(''))
+      const el = fixtureEl.querySelector('#picker')
+
+      picker.show()
+      el.querySelector('[data-coreui-picker-action="today"]').click()
+
+      expect(picker.getDate()).toBeNull()
+      expect(el.querySelector('.form-date-time').classList.contains('is-invalid')).toBeTrue()
+    })
+
+    it('should emit and select a programmatic date within range', () => {
+      const picker = buildPicker({ maxDate: new Date(2026, 6, 31) })
+      const el = fixtureEl.querySelector('#picker')
+      let emitted = null
+      el.addEventListener('dateChange.coreui.date-picker', event => {
+        emitted = event.date
+      })
+
+      picker.setDate(new Date(2026, 6, 14))
+
+      expect(picker.getDate()).toEqual(new Date(2026, 6, 14))
+      expect(emitted).toEqual(new Date(2026, 6, 14))
+      expect(el.querySelector('.form-date-time').classList.contains('is-invalid')).toBeFalse()
+    })
+  })
+
   describe('calendar navigation', () => {
     it('should keep the popup open when navigating months', () => {
       const picker = buildPicker({ date: new Date(2026, 5, 15) })

--- a/js/tests/unit/date-picker.spec.js
+++ b/js/tests/unit/date-picker.spec.js
@@ -285,7 +285,7 @@ describe('DatePicker', () => {
       const picker = buildPicker({ date: new Date(2026, 5, 15) })
       const context = picker.getContext()
 
-      expect(Object.keys(context).toSorted()).toEqual(['clear', 'close', 'date', 'disabled', 'reset', 'setDate', 'today'])
+      expect(Object.keys(context).toSorted()).toEqual(['clear', 'close', 'date', 'disabled', 'isDateSelectable', 'reset', 'setDate', 'today'])
       expect(context.date).toEqual(new Date(2026, 5, 15))
       expect(context.disabled).toBeFalse()
     })
@@ -296,6 +296,30 @@ describe('DatePicker', () => {
       picker.getContext().clear()
 
       expect(picker.getDate()).toBeNull()
+    })
+
+    it('should answer date selectability through the context', () => {
+      const picker = buildPicker({
+        disabledDates: [new Date(2026, 6, 15)],
+        maxDate: new Date(2026, 6, 20),
+        minDate: new Date(2026, 6, 10)
+      })
+      const { isDateSelectable } = picker.getContext()
+
+      expect(isDateSelectable(new Date(2026, 6, 14))).toBeTrue()
+      expect(isDateSelectable(new Date(2026, 6, 15))).toBeFalse()
+      expect(isDateSelectable(new Date(2026, 6, 21))).toBeFalse()
+      expect(isDateSelectable(new Date(2026, 6, 9))).toBeFalse()
+      expect(isDateSelectable(null)).toBeFalse()
+    })
+
+    it('should check selectability at the mask granularity', () => {
+      // a raw comparison of "now" against a midnight maxDate would fail here
+      const midnight = new Date()
+      midnight.setHours(0, 0, 0, 0)
+      const picker = buildPicker({ maxDate: midnight })
+
+      expect(picker.getContext().isDateSelectable(new Date())).toBeTrue()
     })
 
     it('should set today through the context', () => {

--- a/js/tests/unit/date-range-picker.spec.js
+++ b/js/tests/unit/date-range-picker.spec.js
@@ -99,6 +99,30 @@ describe('DateRangePicker', () => {
     })
   })
 
+  describe('selection types', () => {
+    it('should mask a week range in the input type="week" wire format', () => {
+      buildPicker({
+        selectionType: 'week',
+        startDate: new Date(2026, 6, 14),
+        endDate: new Date(2026, 7, 5)
+      })
+
+      const values = [...fixtureEl.querySelectorAll('#picker input[type="hidden"]')].map(input => input.value)
+      expect(values).toEqual(['2026-W29', '2026-W32'])
+    })
+
+    it('should mask a quarter range with the quarter names', () => {
+      buildPicker({
+        selectionType: 'quarter',
+        startDate: new Date(2026, 1, 10),
+        endDate: new Date(2026, 10, 15)
+      })
+
+      const values = [...fixtureEl.querySelectorAll('#picker input[type="hidden"]')].map(input => input.value)
+      expect(values).toEqual(['Q1 2026', 'Q4 2026'])
+    })
+  })
+
   describe('range selection', () => {
     it('should update both fields, emit both events, and close after the end date', () => {
       const picker = buildPicker()

--- a/js/tests/unit/date-range-picker.spec.js
+++ b/js/tests/unit/date-range-picker.spec.js
@@ -204,7 +204,7 @@ describe('DateRangePicker', () => {
       const picker = buildPicker()
       const context = picker.getContext()
 
-      expect(Object.keys(context).toSorted()).toEqual(['clear', 'close', 'disabled', 'endDate', 'reset', 'setRange', 'startDate'])
+      expect(Object.keys(context).toSorted()).toEqual(['clear', 'close', 'disabled', 'endDate', 'isDateSelectable', 'reset', 'setRange', 'startDate'])
     })
 
     it('should set a range through the context and emit both events', () => {

--- a/js/tests/unit/date-range-picker.spec.js
+++ b/js/tests/unit/date-range-picker.spec.js
@@ -100,15 +100,16 @@ describe('DateRangePicker', () => {
   })
 
   describe('selection types', () => {
-    it('should mask a week range in the input type="week" wire format', () => {
+    it('should mask a week range like the native week input', () => {
       buildPicker({
+        locale: 'en-US',
         selectionType: 'week',
         startDate: new Date(2026, 6, 14),
         endDate: new Date(2026, 7, 5)
       })
 
       const values = [...fixtureEl.querySelectorAll('#picker input[type="hidden"]')].map(input => input.value)
-      expect(values).toEqual(['2026-W29', '2026-W32'])
+      expect(values).toEqual(['Week 29, 2026', 'Week 32, 2026'])
     })
 
     it('should mask a quarter range with the quarter names', () => {

--- a/js/tests/unit/date-time-picker.spec.js
+++ b/js/tests/unit/date-time-picker.spec.js
@@ -163,6 +163,20 @@ describe('DateTimePicker', () => {
       expect(picker._popup.isShown).toBeFalse()
     })
 
+    it('should disable a projected today action when today is not selectable', () => {
+      const yesterday = new Date()
+      yesterday.setDate(yesterday.getDate() - 1)
+      buildPicker({ maxDate: yesterday }, [
+        '<div id="picker">',
+        '  <template data-coreui-template="footer">',
+        '    <button type="button" data-coreui-picker-action="today">Today</button>',
+        '  </template>',
+        '</div>'
+      ].join(''))
+
+      expect(fixtureEl.querySelector('[data-coreui-picker-action="today"]').disabled).toBeTrue()
+    })
+
     it('should keep the value when the time half reports without a date set', () => {
       const picker = buildPicker()
 

--- a/js/tests/unit/date-time-picker.spec.js
+++ b/js/tests/unit/date-time-picker.spec.js
@@ -178,7 +178,7 @@ describe('DateTimePicker', () => {
       const picker = buildPicker()
 
       expect(Object.keys(picker.getContext()).toSorted())
-        .toEqual(['clear', 'close', 'date', 'disabled', 'reset', 'setDate', 'today'])
+        .toEqual(['clear', 'close', 'date', 'disabled', 'isDateSelectable', 'reset', 'setDate', 'today'])
     })
 
     it('should clear through the context', () => {

--- a/js/tests/unit/time-picker.spec.js
+++ b/js/tests/unit/time-picker.spec.js
@@ -218,5 +218,29 @@ describe('TimePicker', () => {
 
       expect(picker.getTime()).toBeNull()
     })
+
+    it('should disable a projected now action when the current time is not selectable', () => {
+      buildPicker({ maxDate: new Date(1969, 11, 31) }, [
+        '<div id="picker">',
+        '  <template data-coreui-template="footer">',
+        '    <button type="button" data-coreui-picker-action="now">Now</button>',
+        '  </template>',
+        '</div>'
+      ].join(''))
+
+      expect(fixtureEl.querySelector('[data-coreui-picker-action="now"]').disabled).toBeTrue()
+    })
+
+    it('should keep a projected now action enabled when the current time is selectable', () => {
+      buildPicker({}, [
+        '<div id="picker">',
+        '  <template data-coreui-template="footer">',
+        '    <button type="button" data-coreui-picker-action="now">Now</button>',
+        '  </template>',
+        '</div>'
+      ].join(''))
+
+      expect(fixtureEl.querySelector('[data-coreui-picker-action="now"]').disabled).toBeFalse()
+    })
   })
 })

--- a/js/tests/unit/time-picker.spec.js
+++ b/js/tests/unit/time-picker.spec.js
@@ -116,7 +116,7 @@ describe('TimePicker', () => {
       const picker = buildPicker()
 
       expect(Object.keys(picker.getContext()).toSorted())
-        .toEqual(['clear', 'close', 'disabled', 'now', 'reset', 'setTime', 'time'])
+        .toEqual(['clear', 'close', 'disabled', 'isTimeSelectable', 'now', 'reset', 'setTime', 'time'])
     })
 
     it('should clear and set the time through the context', () => {

--- a/js/tests/unit/util/calendar.spec.js
+++ b/js/tests/unit/util/calendar.spec.js
@@ -314,6 +314,16 @@ describe('Calendar Utilities', () => {
       const week = getISOWeekNumberAndYear(date)
       expect(week.weekNumber).toBe(23)
     })
+
+    it('should handle years below 100 without the 19xx date mapping', () => {
+      const date = new Date(2000, 0, 1)
+      date.setFullYear(22, 5, 15)
+
+      const week = getISOWeekNumberAndYear(date)
+      expect(week.weekNumber).toBeGreaterThanOrEqual(1)
+      expect(week.weekNumber).toBeLessThanOrEqual(53)
+      expect(week.year).toBe(22)
+    })
   })
 
   describe('isDateDisabled', () => {

--- a/js/tests/unit/util/date-sections.spec.js
+++ b/js/tests/unit/util/date-sections.spec.js
@@ -5,17 +5,20 @@ import {
   formatSections,
   formatSectionValue,
   getDateFromSections,
+  getDateOfISOWeek,
   getDateSections,
   getDateTimeSectionsFromLocale,
   getDaysInMonth,
   getDaySectionMax,
   getFullYearFromSection,
   getIncrementedSectionValue,
+  getISOWeeksInYear,
   getSectionBounds,
   getSectionsFromFormat,
   getSectionsFromLocale,
   getSectionsFromString,
   getTimeSectionsFromLocale,
+  getWeekSectionMax,
   setSectionsFromDate
 } from '../../../src/util/date-sections.js'
 
@@ -42,6 +45,11 @@ describe('Date Sections Utilities', () => {
       expect(getSectionBounds({ type: 'minute' })).toEqual({ min: 0, max: 59 })
       expect(getSectionBounds({ type: 'second' })).toEqual({ min: 0, max: 59 })
       expect(getSectionBounds({ type: 'meridiem' })).toEqual({ min: 1, max: 2 })
+    })
+
+    it('should return bounds for week and quarter', () => {
+      expect(getSectionBounds({ type: 'week' })).toEqual({ min: 1, max: 53 })
+      expect(getSectionBounds({ type: 'quarter' })).toEqual({ min: 1, max: 4 })
     })
   })
 
@@ -124,6 +132,30 @@ describe('Date Sections Utilities', () => {
 
       expect(sections.filter(section => section.type !== 'literal').map(section => section.type))
         .toEqual(['day', 'month', 'year', 'hour', 'minute'])
+    })
+
+    it('should parse week tokens and keep the uppercase W as a literal', () => {
+      const sections = getSectionsFromFormat('yyyy-Www')
+
+      expect(sections.map(section => section.type)).toEqual(['year', 'literal', 'week'])
+      expect(sections[1].value).toBe('-W')
+      expect(sections[2].padded).toBe(true)
+    })
+
+    it('should parse numeric quarter tokens', () => {
+      const sections = getSectionsFromFormat('q yyyy')
+
+      expect(sections.map(section => section.type)).toEqual(['quarter', 'literal', 'year'])
+      expect(sections[0].names).toBeUndefined()
+      expect(sections[0].padded).toBe(false)
+    })
+
+    it('should create text quarter sections with names', () => {
+      const section = getSectionsFromFormat('QQQ yyyy')[0]
+
+      expect(section.type).toBe('quarter')
+      expect(section.names).toEqual(['Q1', 'Q2', 'Q3', 'Q4'])
+      expect(section.placeholder).toBe('QQQ')
     })
   })
 
@@ -333,6 +365,35 @@ describe('Date Sections Utilities', () => {
     })
   })
 
+  describe('getISOWeeksInYear', () => {
+    it('should return 52 or 53 depending on the year', () => {
+      expect(getISOWeeksInYear(2026)).toBe(53)
+      expect(getISOWeeksInYear(2025)).toBe(52)
+      expect(getISOWeeksInYear(2020)).toBe(53)
+    })
+  })
+
+  describe('getDateOfISOWeek', () => {
+    it('should return the Monday of the ISO week', () => {
+      expect(getDateOfISOWeek(2026, 1)).toEqual(new Date(2025, 11, 29))
+      expect(getDateOfISOWeek(2026, 53)).toEqual(new Date(2026, 11, 28))
+      expect(getDateOfISOWeek(2030, 20)).toEqual(new Date(2030, 4, 13))
+    })
+  })
+
+  describe('getWeekSectionMax', () => {
+    const layout = year => getSectionsFromFormat('yyyy-Www').map(section => (section.type === 'year' ? { ...section, value: year } : section))
+
+    it('should return 53 while the year is unknown', () => {
+      expect(getWeekSectionMax(layout(null))).toBe(53)
+    })
+
+    it('should return the week count of the selected year', () => {
+      expect(getWeekSectionMax(layout(2026))).toBe(53)
+      expect(getWeekSectionMax(layout(2025))).toBe(52)
+    })
+  })
+
   describe('getFullYearFromSection', () => {
     it('should return null for empty sections', () => {
       expect(getFullYearFromSection({ type: 'year', length: 4, value: null })).toBeNull()
@@ -388,6 +449,24 @@ describe('Date Sections Utilities', () => {
 
       expect(getDateFromSections(combined)).toEqual(new Date(2026, 6, 14, 9, 5))
     })
+
+    it('should resolve a week section to the Monday of the ISO week', () => {
+      const week = setSectionsFromDate(getSectionsFromFormat('yyyy-Www'), new Date(2026, 6, 14))
+
+      expect(getDateFromSections(week)).toEqual(new Date(2026, 6, 13))
+    })
+
+    it('should clamp the week to the week count of the year', () => {
+      const week = getSectionsFromFormat('yyyy-Www').map(section => ({ ...section, value: section.type === 'year' ? 2025 : (section.type === 'week' ? 53 : section.value) }))
+
+      expect(getDateFromSections(week)).toEqual(getDateOfISOWeek(2025, 52))
+    })
+
+    it('should resolve a quarter section to the first day of the quarter', () => {
+      const quarter = setSectionsFromDate(getSectionsFromFormat('QQQ yyyy'), new Date(2026, 10, 15))
+
+      expect(getDateFromSections(quarter)).toEqual(new Date(2026, 9, 1))
+    })
   })
 
   describe('setSectionsFromDate', () => {
@@ -401,6 +480,24 @@ describe('Date Sections Utilities', () => {
       const sections = setSectionsFromDate(setSectionsFromDate(getSectionsFromFormat('dd.MM.yyyy'), new Date(2026, 6, 14)), null)
 
       expect(sections.filter(section => section.type !== 'literal').every(section => section.value === null)).toBeTrue()
+    })
+
+    it('should fill the ISO week number and week-numbering year in week layouts', () => {
+      const sections = setSectionsFromDate(getSectionsFromFormat('yyyy-Www'), new Date(2027, 0, 1))
+
+      expect(sections.filter(section => section.type !== 'literal').map(section => section.value)).toEqual([2026, 53])
+    })
+
+    it('should keep the calendar year in layouts without a week section', () => {
+      const sections = setSectionsFromDate(getSectionsFromFormat('dd.MM.yyyy'), new Date(2027, 0, 1))
+
+      expect(sections.filter(section => section.type !== 'literal').map(section => section.value)).toEqual([1, 1, 2027])
+    })
+
+    it('should fill the quarter from the date', () => {
+      const sections = setSectionsFromDate(getSectionsFromFormat('QQQ yyyy'), new Date(2026, 10, 15))
+
+      expect(sections.filter(section => section.type !== 'literal').map(section => section.value)).toEqual([4, 2026])
     })
   })
 
@@ -438,6 +535,18 @@ describe('Date Sections Utilities', () => {
       const sections = setSectionsFromDate(getSectionsFromFormat('dd.MM.yyyy'), new Date(2026, 6, 4))
 
       expect(formatSections(sections)).toBe('04.07.2026')
+    })
+
+    it('should serialize week layouts in the input type="week" wire format', () => {
+      const sections = setSectionsFromDate(getSectionsFromFormat('yyyy-Www'), new Date(2026, 6, 14))
+
+      expect(formatSections(sections)).toBe('2026-W29')
+    })
+
+    it('should serialize text quarter layouts with the quarter name', () => {
+      const sections = setSectionsFromDate(getSectionsFromFormat('QQQ yyyy'), new Date(2026, 10, 15))
+
+      expect(formatSections(sections)).toBe('Q4 2026')
     })
   })
 
@@ -489,6 +598,18 @@ describe('Date Sections Utilities', () => {
       const sections = getSectionsFromString('2:30 PM', getSectionsFromFormat('hh:mm A', 'en-US'))
 
       expect(sections.filter(section => section.type !== 'literal').map(section => section.value)).toEqual([2, 30, 2])
+    })
+
+    it('should match week strings', () => {
+      const sections = getSectionsFromString('2026-W29', getSectionsFromFormat('yyyy-Www'))
+
+      expect(sections.filter(section => section.type !== 'literal').map(section => section.value)).toEqual([2026, 29])
+    })
+
+    it('should match quarter names in text quarter layouts', () => {
+      const sections = getSectionsFromString('Q4 2026', getSectionsFromFormat('QQQ yyyy'))
+
+      expect(sections.filter(section => section.type !== 'literal').map(section => section.value)).toEqual([4, 2026])
     })
   })
 })

--- a/js/tests/unit/util/date-sections.spec.js
+++ b/js/tests/unit/util/date-sections.spec.js
@@ -402,6 +402,13 @@ describe('Date Sections Utilities', () => {
       expect(getISOWeeksInYear(2025)).toBe(52)
       expect(getISOWeeksInYear(2020)).toBe(53)
     })
+
+    it('should stay in bounds for the partial years of a section being typed', () => {
+      for (const year of [2, 20, 202]) {
+        expect(getISOWeeksInYear(year)).toBeGreaterThanOrEqual(52)
+        expect(getISOWeeksInYear(year)).toBeLessThanOrEqual(53)
+      }
+    })
   })
 
   describe('getDateOfISOWeek', () => {

--- a/js/tests/unit/util/date-sections.spec.js
+++ b/js/tests/unit/util/date-sections.spec.js
@@ -18,7 +18,9 @@ import {
   getSectionsFromLocale,
   getSectionsFromString,
   getTimeSectionsFromLocale,
+  getWeekLabel,
   getWeekSectionMax,
+  getWeekSectionsFromLocale,
   setSectionsFromDate
 } from '../../../src/util/date-sections.js'
 
@@ -156,6 +158,35 @@ describe('Date Sections Utilities', () => {
       expect(section.type).toBe('quarter')
       expect(section.names).toEqual(['Q1', 'Q2', 'Q3', 'Q4'])
       expect(section.placeholder).toBe('QQQ')
+    })
+
+    it('should keep quoted text as a literal even when it contains token letters', () => {
+      const sections = getSectionsFromFormat('\'Tydzień\' ww, yyyy')
+
+      expect(sections.map(section => section.type)).toEqual(['literal', 'week', 'literal', 'year'])
+      expect(sections[0].value).toBe('Tydzień ')
+      expect(sections[2].value).toBe(', ')
+    })
+
+    it('should unescape doubled quotes inside and outside quoted text', () => {
+      expect(getSectionsFromFormat('d\'\'M')[1].value).toBe('\'')
+      expect(getSectionsFromFormat('\'It\'\'s\' d')[0].value).toBe('It\'s ')
+    })
+  })
+
+  describe('getWeekLabel', () => {
+    it('should return the capitalized localized week label', () => {
+      expect(getWeekLabel('en-US')).toBe('Week')
+      expect(getWeekLabel('pl-PL')).toBe('Tydzień')
+    })
+  })
+
+  describe('getWeekSectionsFromLocale', () => {
+    it('should mirror the native week input presentation', () => {
+      const sections = setSectionsFromDate(getWeekSectionsFromLocale('en-US'), new Date(2026, 6, 14))
+
+      expect(sections.map(section => section.type)).toEqual(['literal', 'week', 'literal', 'year'])
+      expect(formatSections(sections)).toBe('Week 29, 2026')
     })
   })
 

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -844,7 +844,6 @@ $input-padding-x-sm:                    $input-btn-padding-x-sm !default;
 $input-font-size-sm:                    $input-btn-font-size-sm !default;
 
 $input-padding-y-lg:                    $input-btn-padding-y-lg !default;
-$input-padding-x-lg:                    $input-btn-padding-x-lg !default;
 $input-font-size-lg:                    $input-btn-font-size-lg !default;
 
 $input-bg:                              var(--#{$prefix}body-bg) !default;
@@ -984,7 +983,6 @@ $placeholder-opacity-min:           .2 !default;
 
 // Carousel
 
-
 // scss-docs-start sidebar-toggler
 $sidebar-toggler-width:             .5rem !default;
 $sidebar-toggler-height:            .5rem !default;
@@ -1027,9 +1025,6 @@ $time-picker-border-radius:                 $input-border-radius !default;
 $time-picker-border-radius-sm:              $input-border-radius-sm !default;
 $time-picker-border-radius-lg:              $input-border-radius-lg !default;
 
-$time-picker-invalid-border-color:          var(--#{$prefix}form-invalid-border-color) !default;
-$time-picker-valid-border-color:            var(--#{$prefix}form-valid-border-color) !default;
-
 $time-picker-disabled-color:                $input-disabled-color !default;
 $time-picker-disabled-bg:                   $input-disabled-bg !default;
 $time-picker-disabled-border-color:         $input-disabled-border-color !default;
@@ -1039,40 +1034,11 @@ $time-picker-focus-bg:                      $input-focus-bg !default;
 $time-picker-focus-border-color:            $input-focus-border-color !default;
 $time-picker-focus-ring:              $input-btn-focus-ring !default;
 
-$time-picker-placeholder-color:             var(--#{$prefix}secondary-color) !default;
-
-$time-picker-gap:                           $input-padding-x !default;
-
-$time-picker-gap-sm:                        $input-padding-x-sm !default;
-
-$time-picker-gap-lg:                        $input-padding-x-lg !default;
-
-$time-picker-cleaner-width:                 1.25rem !default;
-$time-picker-cleaner-icon-color:            var(--#{$prefix}tertiary-color) !default;
-$time-picker-cleaner-icon:                  url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' role='img'><polygon fill='#000' points='348.071 141.302 260.308 229.065 172.545 141.302 149.917 163.929 237.681 251.692 149.917 339.456 172.545 362.083 260.308 274.32 348.071 362.083 370.699 339.456 282.935 251.692 370.699 163.929 348.071 141.302'></polygon><path fill='#000' d='M425.706,86.294A240,240,0,0,0,86.294,425.706,240,240,0,0,0,425.706,86.294ZM256,464C141.309,464,48,370.691,48,256S141.309,48,256,48s208,93.309,208,208S370.691,464,256,464Z'></path></svg>") !default;
-$time-picker-cleaner-icon-hover-color:      var(--#{$prefix}body-color) !default;
-$time-picker-cleaner-icon-size:             1rem !default;
-$time-picker-cleaner-icon-size-sm:          .875rem !default;
-$time-picker-cleaner-icon-size-lg:          1.25rem !default;
-
-$time-picker-cleaner-width-sm:              1rem !default;
-$time-picker-cleaner-width-lg:              1.5rem !default;
-$time-picker-cleaner-icon-size-sm:          .875rem !default;
-$time-picker-cleaner-icon-size-lg:          1.25rem !default;
-
 $time-picker-indicator-width:               1.25rem !default;
 $time-picker-indicator-icon-color:          var(--#{$prefix}tertiary-color) !default;
-$time-picker-indicator-icon:                url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' role='img'><polygon fill='#000' points='271.514 95.5 239.514 95.5 239.514 273.611 355.127 328.559 368.864 299.657 271.514 253.389 271.514 95.5'></polygon><path fill='#000' d='M256,16C123.452,16,16,123.452,16,256S123.452,496,256,496,496,388.548,496,256,388.548,16,256,16Zm0,448C141.125,464,48,370.875,48,256S141.125,48,256,48s208,93.125,208,208S370.875,464,256,464Z'></path></svg>") !default;
-$time-picker-indicator-invalid-icon-color:  var(--#{$prefix}form-invalid-color) !default;
-$time-picker-indicator-invalid-icon:        $time-picker-indicator-icon !default;
-$time-picker-indicator-valid-icon-color:    var(--#{$prefix}form-valid-color) !default;
-$time-picker-indicator-valid-icon:          $time-picker-indicator-icon !default;
-$time-picker-indicator-icon-size:           1rem !default;
 
 $time-picker-indicator-width-sm:            1rem !default;
 $time-picker-indicator-width-lg:            1.5rem !default;
-$time-picker-indicator-icon-size-sm:        .875rem !default;
-$time-picker-indicator-icon-size-lg:        1.25rem !default;
 
 $time-picker-dropdown-bg:                   var(--#{$prefix}body-bg) !default;
 $time-picker-dropdown-border-color:         var(--#{$prefix}border-color) !default;

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -1,5 +1,3 @@
-@use "sass:color";
-@use "sass:math";
 @use "functions/defaults" as *;
 @use "functions/escape-svg" as *;
 @use "mixins/border-radius" as *;
@@ -56,19 +54,10 @@ $time-picker-tokens: defaults(
     --#{$prefix}control-focus-bg: #{$time-picker-focus-bg},
     --#{$prefix}control-focus-border-color: #{$time-picker-focus-border-color},
     --#{$prefix}control-focus-ring: #{$time-picker-focus-ring},
-    --#{$prefix}time-picker-placeholder-color: #{$time-picker-placeholder-color},
     --#{$prefix}control-padding-y: #{$time-picker-padding-y},
     --#{$prefix}control-padding-x: #{$time-picker-padding-x},
-    --#{$prefix}time-picker-gap: #{$time-picker-gap},
     --#{$prefix}time-picker-indicator-width: #{$time-picker-indicator-width},
-    --#{$prefix}time-picker-indicator-icon: #{escape-svg($time-picker-indicator-icon)},
     --#{$prefix}time-picker-indicator-icon-color: #{$time-picker-indicator-icon-color},
-    --#{$prefix}time-picker-indicator-icon-size: #{$time-picker-indicator-icon-size},
-    --#{$prefix}time-picker-cleaner-width: #{$time-picker-cleaner-width},
-    --#{$prefix}time-picker-cleaner-icon: #{escape-svg($time-picker-cleaner-icon)},
-    --#{$prefix}time-picker-cleaner-icon-color: #{$time-picker-cleaner-icon-color},
-    --#{$prefix}time-picker-cleaner-icon-hover-color: #{$time-picker-cleaner-icon-hover-color},
-    --#{$prefix}time-picker-cleaner-icon-size: #{$time-picker-cleaner-icon-size},
     --#{$prefix}time-picker-body-padding: #{$time-picker-body-padding},
     --#{$prefix}time-picker-footer-border-width: #{$time-picker-footer-border-width},
     --#{$prefix}time-picker-footer-border-color: #{$time-picker-footer-border-color},
@@ -102,25 +91,6 @@ $time-picker-tokens: defaults(
   *:not(.time-picker) > .time-picker-dropdown {
     @include tokens($time-picker-tokens);
 
-    &.is-invalid {
-      $focus-ring: $input-focus-width solid color-mix(in srgb, #{$time-picker-invalid-border-color} #{math.percentage($input-btn-focus-color-opacity)}, transparent);
-
-      --#{$prefix}control-border-color: #{$time-picker-invalid-border-color} !important; // stylelint-disable-line declaration-no-important
-      --#{$prefix}time-picker-indicator-icon-color: #{$time-picker-indicator-invalid-icon-color} !important; // stylelint-disable-line declaration-no-important
-      --#{$prefix}time-picker-indicator-icon: #{escape-svg($time-picker-indicator-invalid-icon)} !important; // stylelint-disable-line declaration-no-important
-      --#{$prefix}control-focus-border-color: #{$time-picker-invalid-border-color} !important; // stylelint-disable-line declaration-no-important
-      --#{$prefix}control-focus-ring: #{$focus-ring} !important; // stylelint-disable-line declaration-no-important
-    }
-
-    &.is-valid {
-      $focus-ring: $input-focus-width solid color-mix(in srgb, #{$time-picker-valid-border-color} #{math.percentage($input-btn-focus-color-opacity)}, transparent);
-
-      --#{$prefix}control-border-color: #{$time-picker-valid-border-color} !important; // stylelint-disable-line declaration-no-important
-      --#{$prefix}time-picker-indicator-icon-color: #{$time-picker-indicator-valid-icon-color} !important; // stylelint-disable-line declaration-no-important
-      --#{$prefix}time-picker-indicator-icon: #{escape-svg($time-picker-indicator-valid-icon)} !important; // stylelint-disable-line declaration-no-important
-      --#{$prefix}control-focus-border-color: #{$time-picker-valid-border-color} !important; // stylelint-disable-line declaration-no-important
-      --#{$prefix}control-focus-ring: #{$focus-ring} !important; // stylelint-disable-line declaration-no-important
-    }
   }
 
   // The shell mirrors the date picker's frame while reading the
@@ -312,11 +282,7 @@ $time-picker-tokens: defaults(
     --#{$prefix}control-padding-x: #{$time-picker-padding-x-sm};
     --#{$prefix}control-font-size: #{$time-picker-font-size-sm};
     --#{$prefix}control-border-radius: #{$time-picker-border-radius-sm};
-    --#{$prefix}time-picker-gap: #{$time-picker-gap-sm};
-    --#{$prefix}time-picker-cleaner-width: #{$time-picker-cleaner-width-sm};
-    --#{$prefix}time-picker-cleaner-icon-size: #{$time-picker-cleaner-icon-size-sm};
     --#{$prefix}time-picker-indicator-width: #{$time-picker-indicator-width-sm};
-    --#{$prefix}time-picker-indicator-icon-size: #{$time-picker-indicator-icon-size-sm};
   }
 
   .time-picker-lg {
@@ -324,10 +290,6 @@ $time-picker-tokens: defaults(
     --#{$prefix}control-padding-x: #{$time-picker-padding-x-lg};
     --#{$prefix}control-font-size: #{$time-picker-font-size-lg};
     --#{$prefix}control-border-radius: #{$time-picker-border-radius-lg};
-    --#{$prefix}time-picker-gap: #{$time-picker-gap-lg};
-    --#{$prefix}time-picker-cleaner-width: #{$time-picker-cleaner-width-lg};
-    --#{$prefix}time-picker-cleaner-icon-size: #{$time-picker-cleaner-icon-size-lg};
     --#{$prefix}time-picker-indicator-width: #{$time-picker-indicator-width-lg};
-    --#{$prefix}time-picker-indicator-icon-size: #{$time-picker-indicator-icon-size-lg};
   }
 }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -146,6 +146,30 @@ $form-feedback-tokens: defaults(
     }
   }
 
+  // In a picker the input group is the frame and the field inside draws no
+  // border of its own, so the state has to reach the group — custom properties
+  // set on the field would only inherit downwards. The indicator button sits
+  // where the validation icon would go, so the icon is suppressed and the
+  // indicator carries the color instead (see .form-password above).
+  .date-picker-input-group,
+  .time-picker-input-group {
+    &:has(.form-date-time.is-#{$state}) {
+      --#{$prefix}control-border-color: #{$border-color};
+      --#{$prefix}control-focus-border-color: #{$border-color};
+      --#{$prefix}control-focus-ring: #{$focus-ring};
+      --#{$prefix}date-picker-indicator-color: #{$color};
+      --#{$prefix}time-picker-indicator-icon-color: #{$color};
+    }
+
+    @if $enable-validation-icons {
+      .form-date-time {
+        @include form-validation-state-selector($state) {
+          background-image: none;
+        }
+      }
+    }
+  }
+
   // stylelint-disable-next-line selector-no-qualifying-type
   textarea.form-control {
     @include form-validation-state-selector($state) {


### PR DESCRIPTION
Closes the last selection-type gap in the pickers rewrite (gate condition 3): `selectionType="week"` and `selectionType="quarter"` now render dedicated masked sections — the equivalents of the native `<input type="week">` and of the `<input type="quarter">` HTML never shipped — instead of falling back to the underlying day mask.

## Format engine (`util/date-sections`)

- New section types with tokens: `ww` (ISO week number, 1–53) and `q` / `QQQ` (numeric quarter or `Q1`–`Q4` names). Uppercase `W` deliberately stays a literal so masks can spell the ISO prefix: `yyyy-Www` renders `2026-W29`.
- **Quoted literals**, date-fns style: text in single quotes is always a fixed, non-editable literal even when it contains token letters (`'Week' ww` renders `Week 29`); `''` escapes the quote character.
- In a week layout the year section holds the **ISO week-numbering year** (which differs from the calendar year around January 1st — `2027-01-01` edits as week 53 of 2026), and the value resolves to the Monday of the selected week. A quarter layout resolves to the first day of the quarter.
- The week bound follows the selected year (52 vs 53 ISO weeks) via new `getISOWeeksInYear` / `getDateOfISOWeek` / `getWeekSectionMax` helpers, mirroring the day-in-month clamping.

## Shells

- `selectionType="week"` defaults to the **native week input's presentation**: a fixed localized label plus week and year sections — `Week 29, 2026`, `Tydzień 29, 2026`, `Woche 29, 2026` (`getWeekLabel` via `Intl.DisplayNames` `dateTimeField: weekOfYear`, capitalized, `Week` fallback). An explicit `format` still wins — `format="yyyy-Www"` gives the ISO-style field.
- `selectionType="quarter"` defaults to `QQQ yyyy` (`Q4 2026`) — in both DatePicker and DateRangePicker.
- `SectionInput` gains week/quarter placeholders, spinbutton labels, and year-dependent week clamping.

## Docs

- `date-picker` / `date-range-picker` pages: the "underlying date" warning callouts are gone; the Weeks/Quarters sections document the native-style presentation and the ISO-format opt-in.
- `date-input`: quoted-literal syntax and week/quarter mask examples; the "isn't supported" note removed.
- Migration guide entry updated in the same cycle (living document rule).

## Tests

40 new cases: token parsing incl. quoted literals, ISO week math (round trips, 52/53-week years, week-year edges), localized week label, build/fill from sections, serialization, paste, and picker integration for both shells (incl. `pl-PL` localization and the explicit-format override). Full gate green: lint, typecheck, 2922 unit tests, dist, bundlewatch PASS.

## Programmatic dates validate like typed ones

`SectionInput.update()` rebuilt the field without running validation, so a programmatic date outside min/max (`setDate`, the projected `today` action, the initial `date` config) rendered as valid and reached the form value — while typing the same date flagged the field invalid and nulled the value. The validation pass is now extracted into `_applyValidationState()` and runs in the constructor and at the end of `update()` (preserving the previous date so `dateChange`/`errorChange` reflect the actual transition), and the shells emit `dateChange` — and update the calendar/time selection — with the **validated** value.

Projected footer buttons stay userland by design (the picker never disables them); the footer docs and the migration guide document that contract.

## Slot context: `isDateSelectable(date)`

A button opting into the `today` action (`now` on the time picker) opts into the library's click semantics — so it now opts into the state those semantics imply: it is **disabled while the footer template is cloned** when its target falls outside `minDate`/`maxDate`/`disabledDates`, matching the v1 built-in button. One-way only — the picker never re-enables a projected button, so a `disabled` set in the template stays.

For buttons with custom actions, the field gains `isDateSelectable(date)` — it expresses the date in the field's mask and answers whether it passes `minDate`/`maxDate`/`disabledDates` validation. The granularity follows the mask: a day mask checks the calendar day (so `new Date()` passes with a `maxDate` of today — no midnight trap), a week mask the week's Monday, a date-time mask the exact time. Every shell exposes it through `getContext()` (`isTimeSelectable` on the time picker), and the date picker docs gained a runnable example: a projected Today button disabled via the context when today is out of range.




## Validation border on the picker frame

Reported on the branch: `date-input` painted a red border on `is-invalid`, the pickers did not. The picker's input group is the frame and the field inside it draws no border of its own, so the state never reached anything visible — the validation mixin sets `--cui-control-border-color` **on the field**, and custom properties only inherit downwards.

The group now picks the state up with `:has(.form-date-time.is-{valid,invalid})`, reusing the same tokens as `.form-control`, so the color is identical to the standalone field. Per the styling doctrine's "validation icon wrinkle": the icon would land under the indicator button, so it is suppressed inside pickers and the inline-SVG indicator carries the color through `currentColor` instead — the same shape as the existing `.form-password` block in the mixin.

Verified in a real browser across all four shells plus the valid state: identical `rgb(229, 83, 83)` on the standalone field and every picker frame, green on valid, indicator recolored, background icon suppressed inside pickers only. `:has()` is already inside the declared browser floor (#667), and the migration guide's `:has()` rationale now lists the pickers.


### Time picker: v1 styling leftovers removed

Removing the frame bug uncovered dead code in the same family, so it goes with it. The rewritten shell has no cleaner button and draws its indicator as an inline SVG on `currentColor`, and validation now lives on the field rather than the root, so nothing read any of this:

- `.time-picker.is-invalid` / `.is-valid` — recoloured the frame from the **root** with `!important` overrides. v2 never puts that class on the root.
- `--cui-time-picker-cleaner-*` (5 tokens), `-indicator-icon`, `-indicator-icon-size`, `-gap`, `-placeholder-color` and their Sass variables, plus the `sm`/`lg` blocks that set them. `$time-picker-cleaner-icon-size-sm`/`-lg` were declared twice — both copies go.
- `$input-padding-x-lg`, orphaned once the dead `gap-lg` went (`.form-control-lg` reads `--cui-btn-input-lg-padding-x`).
- Two imports the file no longer needs: `sass:math`, and `sass:color` which was already unused.

`--cui-time-picker-indicator-icon-color` stays and now carries the validation color too. `fusv` is green with zero unused variables, and the browser check confirms invalid/valid borders, indicator color and `sm`/`lg` sizing (31/38/48 px) are unchanged. Documented under "Design-token maps" in the migration guide.
