### PR TITLE
fix(DatePicker,DateRangePicker): honor string minDate/maxDate outside the calendar grid

### DIFF
--- a/js/src/date-range-picker.js
+++ b/js/src/date-range-picker.js
@@ -412,7 +412,7 @@ class DateRangePicker extends BaseComponent {
         let formatedDate = date
 
         if (date instanceof Date && date.getTime()) {
-          if (isDateDisabled(date, this._config.minDate, this._config.maxDate, this._config.disabledDates)) {
+          if (isDateDisabled(date, this._getMinDate(), this._getMaxDate(), this._config.disabledDates)) {
             return // Don't update if date is disabled
           }
 
@@ -474,7 +474,7 @@ class DateRangePicker extends BaseComponent {
         let formatedDate = date
 
         if (date instanceof Date && date.getTime()) {
-          if (date && isDateDisabled(date, this._config.minDate, this._config.maxDate, this._config.disabledDates)) {
+          if (date && isDateDisabled(date, this._getMinDate(), this._getMaxDate(), this._config.disabledDates)) {
             return // Don't update if date is disabled
           }
 
@@ -883,7 +883,12 @@ class DateRangePicker extends BaseComponent {
       todayButtonEl.type = 'button'
       todayButtonEl.textContent = this._config.todayButton
 
-      if (isDateDisabled(new Date(), this._config.minDate, this._config.maxDate, this._config.disabledDates)) {
+      // compare today at midnight — with the current time of day, a
+      // `maxDate` of today (converted to midnight) would disable the button
+      const today = new Date()
+      today.setHours(0, 0, 0, 0)
+
+      if (isDateDisabled(today, this._getMinDate(), this._getMaxDate(), this._config.disabledDates)) {
         todayButtonEl.disabled = true
       }
 
@@ -1002,6 +1007,18 @@ class DateRangePicker extends BaseComponent {
     }
 
     this._popper = Popper.createPopper(this._togglerElement, this._menu, popperConfig)
+  }
+
+  // `minDate`/`maxDate` may come from a data attribute as a string — the
+  // calendar converts its own copies, but every comparison made by the picker
+  // itself needs the same conversion (a Date compared to a string is always
+  // false).
+  _getMinDate() {
+    return convertToDateObject(this._config.minDate, this._config.selectionType)
+  }
+
+  _getMaxDate() {
+    return convertToDateObject(this._config.maxDate, this._config.selectionType)
   }
 
   _parseDate(str) {

--- a/js/tests/unit/date-range-picker.spec.js
+++ b/js/tests/unit/date-range-picker.spec.js
@@ -861,6 +861,77 @@ describe('DateRangePicker', () => {
       expect(todayBtn.disabled).toBeFalse()
     })
 
+    it('should disable today button when maxDate is a string in the past', () => {
+      fixtureEl.innerHTML = '<div></div>'
+      const div = fixtureEl.querySelector('div')
+      const yesterday = new Date()
+      yesterday.setDate(yesterday.getDate() - 1)
+      const dateRangePicker = new DateRangePicker(div, { // eslint-disable-line no-unused-vars
+        footer: true,
+        todayButton: 'Today',
+        maxDate: `${yesterday.getFullYear()}-${String(yesterday.getMonth() + 1).padStart(2, '0')}-${String(yesterday.getDate()).padStart(2, '0')}`
+      })
+
+      const footer = div.querySelector('.date-picker-footer')
+      const todayBtn = Array.from(footer.querySelectorAll('button')).find(b => b.innerHTML === 'Today')
+      expect(todayBtn.disabled).toBeTrue()
+    })
+
+    it('should not disable today button when maxDate is today', () => {
+      fixtureEl.innerHTML = '<div></div>'
+      const div = fixtureEl.querySelector('div')
+      const today = new Date()
+      const dateRangePicker = new DateRangePicker(div, { // eslint-disable-line no-unused-vars
+        footer: true,
+        todayButton: 'Today',
+        maxDate: `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+      })
+
+      const footer = div.querySelector('.date-picker-footer')
+      const todayBtn = Array.from(footer.querySelectorAll('button')).find(b => b.innerHTML === 'Today')
+      expect(todayBtn.disabled).toBeFalse()
+    })
+
+    it('should not accept a typed date beyond a string maxDate', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div></div>'
+        const div = fixtureEl.querySelector('div')
+        const dateRangePicker = new DateRangePicker(div, {
+          inputOnChangeDelay: 50,
+          locale: 'en-US',
+          maxDate: '2023-01-20'
+        })
+
+        dateRangePicker._startInput.value = '01/25/2023'
+        dateRangePicker._startInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+        setTimeout(() => {
+          expect(dateRangePicker._startDate).toBeNull()
+          resolve()
+        }, 150)
+      })
+    })
+
+    it('should not accept a typed date before a string minDate', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div></div>'
+        const div = fixtureEl.querySelector('div')
+        const dateRangePicker = new DateRangePicker(div, {
+          inputOnChangeDelay: 50,
+          locale: 'en-US',
+          minDate: '2023-01-10'
+        })
+
+        dateRangePicker._startInput.value = '01/05/2023'
+        dateRangePicker._startInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+        setTimeout(() => {
+          expect(dateRangePicker._startDate).toBeNull()
+          resolve()
+        }, 150)
+      })
+    })
+
     it('should not set end date on today click when range is false', () => {
       fixtureEl.innerHTML = '<div></div>'
       const div = fixtureEl.querySelector('div')


### PR DESCRIPTION
The calendar converts its own copies of `minDate`/`maxDate` (`calendar.js:786`), so the grid always worked — but the picker itself compared the **raw config values** in three places:

- the Today button disabled check (`date-range-picker.js:886`)
- start input validation (`:415`)
- end input validation (`:477`)

With a data-attribute string (`data-coreui-max-date="2026-08-10"`), `Date < string` coerces to `NaN` and is always `false` — so the Today button never disabled and a typed date outside the range was accepted from the keyboard.

**Fix:** convert once via `_getMinDate()` / `_getMaxDate()` (`convertToDateObject` with the picker's `selectionType`) and use them in all three call sites. The Today check now also compares **today at midnight** — previously a `maxDate` of today (converted to midnight) disabled the button because `new Date()` carries the current time of day.

`DatePicker` inherits from `DateRangePicker`, so both are covered. Cross-framework: React and Vue already convert at the call sites but shared the midnight defect — fixed in the same-named branches (`coreui-react-pro`, `coreui-vue-pro`). Angular declares `minDate: input<Date | null>` (no string form) and has no built-in Today button — not affected. The v6 line converts min/max once in `SectionInput`'s constructor — not affected.

Tests: string `maxDate` in the past disables Today, string `maxDate` of today keeps it enabled, typed dates beyond string `maxDate` / before string `minDate` are rejected.