### PR TITLE
chore: drop the dead linkinator check from the docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,11 +42,3 @@ jobs:
 
       - name: Validate HTML
         run: npm run docs-vnu
-
-      - name: Run linkinator
-        uses: JustinBeckwith/linkinator-action@7b6b0bc671f6264e1a8daa4488a5bd91ce61dcd4 # v2.4.2
-        with:
-          paths: _site
-          recurse: true
-          verbosity: error
-          skip: "^http://localhost"


### PR DESCRIPTION
Removes the linkinator step from the docs workflow — it has not checked anything since the docs moved to Astro.

Evidence: on the latest `main` run the step reports `Scanned total of 0 links!`. The Astro build puts the site at the root of `_site`, while the pages link to the production base path (`/bootstrap/docs/…`), so served from `_site` as the server root nothing resolves and nothing gets crawled.

It stayed invisible because scanning zero links exits 0. Dependabot bumping `linkinator-action` 2.4.2 → 2.4.5 (which pulls linkinator 8) surfaced it: the step suddenly crawled 3 links and failed on `_site/bootstrap/docs/getting-started/introduction/ - HTTP 404`, blocking the github-actions group PR.

Rather than keep a green step that verifies nothing, drop it. Restoring real link checking means serving the build under its base path — worth doing as its own change if we want that coverage back.