### PR TITLE
fix(Sass): route the last two direction overrides through ltr-rtl()

### DIFF
--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -1,5 +1,6 @@
 @use "config" as *;
 @use "functions" as *;
+@use "mixins/ltr-rtl" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/box-shadow" as *;
 @use "mixins/tokens" as *;
@@ -290,11 +291,7 @@ $menu-tokens: defaults(
       border-color: currentcolor;
       border-style: solid;
       border-width: 0 .125em .125em 0;
-      transform: rotate(-45deg);
-
-      [dir="rtl"] & {
-        transform: rotate(135deg);
-      }
+      @include ltr-rtl("transform", rotate(-45deg), null, rotate(135deg));
     }
 
     > .menu {

--- a/scss/utilities/_api.scss
+++ b/scss/utilities/_api.scss
@@ -2,6 +2,7 @@
 @use "sass:meta";
 @use "../utilities" as *;
 @use "../layout/breakpoints" as *;
+@use "../mixins/ltr-rtl" as *;
 @use "../mixins/utilities" as *;
 @use "../config" as *;
 
@@ -32,13 +33,15 @@
   // other way to sit on that line. Tied to the utility itself, so disabling it
   // takes the override with it.
   @if meta.type-of(map.get($utilities, "translate-middle")) == "map" {
-    *[dir="rtl"] {
-      .translate-middle {
+    .translate-middle {
+      @include rtl() {
         // stylelint-disable-next-line scss/at-function-named-arguments
         transform: translate(50%, -50%) if(sass($enable-important-utilities): !important);
       }
+    }
 
-      .translate-middle-x {
+    .translate-middle-x {
+      @include rtl() {
         // stylelint-disable-next-line scss/at-function-named-arguments
         transform: translateX(50%) if(sass($enable-important-utilities): !important);
       }


### PR DESCRIPTION
Follow-up to #675 and #682, which crossed each other.

Two direction overrides were written as bare `[dir="rtl"]` rules instead of `ltr-rtl()` calls, so they ignored `$enable-ltr`/`$enable-rtl`:

- `.translate-middle` / `.translate-middle-x` — added in #675, before #682 made the mixin the single mechanism.
- the submenu chevron in `_menu.scss` — predates both.

An LTR-only build (`$enable-rtl: false`) still shipped them, and an RTL-only build (`$enable-ltr: false`) could not get the mirrored value as its base, which is the whole point of that mode.

Verified: default build unchanged (both overrides still emitted), `$enable-rtl: false` now drops them (`grep -c 'dir=rtl] .translate-middle'` goes 2 → 0, submenu 1 → 0). Sass suite 43/43, class API guard, stylelint.