### PR TITLE
feat(utilities): child and attribute selectors, and the four utilities they unlock

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -674,6 +674,28 @@ Upstream v6 does the same, with a `mask-icon()` mixin.
   the root color tokens, which already switch in dark mode.
 - `.btn-primary`, `.btn-outline-*`, `.btn-ghost-*` class APIs are unchanged.
 
+#### Utilities API: child selectors and attribute selectors (new)
+
+Two keys join the `$utilities` API, ported from Bootstrap's v6 branch:
+
+- **`child-selector`** makes a utility style the children of the element it is
+  applied to instead of the element itself, wrapped in `:where()` so it adds no
+  specificity. This is what the new spacing and divider utilities are built on.
+- **`selector`** (`class`, `attr-starts`, `attr-includes`) writes an attribute
+  selector rather than a class, so one rule can serve a whole family of classes.
+
+They bring four new utilities with them, all responsive and direction-aware:
+
+| class | what it does |
+| --- | --- |
+| `.space-x-*`, `.space-y-*` | margin between children — `gap` without needing a flex or grid container |
+| `.divide-x`, `.divide-y` (+ `-0`) | a border between children, none on the outer edges |
+
+Nothing existing changes; these are additions. See
+[the utilities API](/utilities/api/#child-selector),
+[spacing](/utilities/spacing/#space-between) and
+[borders](/utilities/borders/#divide).
+
 #### Utilities API: theme variants and the `rtl` key removed
 
 <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/docs/src/content/docs/utilities/api.mdx
+++ b/docs/src/content/docs/utilities/api.mdx
@@ -150,6 +150,71 @@ Output:
 .invisible { visibility: hidden !important; }
 ```
 
+### Child selector
+
+Some utilities describe the relationship between an element's children rather
+than the element itself — spacing *between* items, or a divider *between* them.
+Give such a utility a `child-selector`, and the generated rule targets the
+children:
+
+```scss
+$utilities: (
+  "space-x": (
+    property: margin-inline-end,
+    class: space-x,
+    child-selector: "> :not(:last-child)",
+    values: $spacers
+  )
+);
+```
+
+Output:
+
+```css
+:where(.space-x-3 > :not(:last-child)) { margin-inline-end: 1rem !important; }
+```
+
+The rule is wrapped in `:where()`, which contributes **no specificity**. That is
+deliberate: a child that carries a margin utility of its own, or a component
+with its own spacing, keeps winning without needing `!important` or a longer
+selector.
+
+### Selector type
+
+By default a utility writes a class selector. Set `selector` to `attr-starts` or
+`attr-includes` and it writes an attribute selector instead, so a single rule
+serves a whole family of classes — useful when the class only has to set a
+custom property that one shared rule then reads:
+
+```scss
+$utilities: (
+  "aspect-ratio": (
+    property: --#{$prefix}ratio,
+    class: ratio,
+    values: (1x1: 1, 16x9: calc(16 / 9))
+  ),
+  "aspect-ratio-attr": (
+    property: aspect-ratio,
+    class: "ratio-",
+    selector: "attr-includes",
+    values: var(--#{$prefix}ratio)
+  )
+);
+```
+
+Output:
+
+```css
+.ratio-1x1 { --cui-ratio: 1; }
+.ratio-16x9 { --cui-ratio: calc(16 / 9); }
+[class*="ratio-"] { aspect-ratio: var(--cui-ratio) !important; }
+```
+
+`attr-starts` matches `[class^="…"]` (the class begins with the name),
+`attr-includes` matches `[class*="…"]` (it appears anywhere in the attribute, so
+it also works when the utility is not the first class). Both require a `class`
+key — that is the string they match on.
+
 ### CSS variable utilities
 
 Set the `css-var` boolean option to `true` and the API will generate local CSS variables for the given selector instead of the usual `property: value` rules. Add an optional `css-variable-name` to set a different CSS variable name than the class name.

--- a/docs/src/content/docs/utilities/borders.mdx
+++ b/docs/src/content/docs/utilities/borders.mdx
@@ -151,6 +151,37 @@ Use the scaling classes for larger or smaller rounded corners. Sizes range from 
   <svg class="docs-placeholder-img rounded-circle" width="75" height="75" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Completely round image" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Completely round image</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
   <svg class="docs-placeholder-img rounded-pill" width="150" height="75" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Rounded pill image" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Rounded pill image</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>`} />
 
+## Divide
+
+`divide-x` and `divide-y` draw a border *between* children — every child except
+the first gets a border on its leading edge — so a list of rows or a row of
+actions gets its separators without a border on the outer edges and without
+marking up the last item differently.
+
+<Example code={`<div class="divide-y border rounded">
+    <div class="p-2">First</div>
+    <div class="p-2">Second</div>
+    <div class="p-2">Third</div>
+  </div>`} />
+
+`divide-x` separates along the inline axis and follows the writing direction.
+
+<Example code={`<div class="d-flex divide-x border rounded">
+    <div class="p-2">First</div>
+    <div class="p-2">Second</div>
+    <div class="p-2">Third</div>
+  </div>`} />
+
+The dividers take the global `--cui-border-width`, `--cui-border-style`
+and `--cui-border-color`, so they follow a theme like every other border.
+Both are responsive (`.divide-y-md`), and `.divide-x-0` / `.divide-y-0` remove
+the dividers at a breakpoint.
+
+<Callout color="info">
+  The rule is wrapped in `:where()` and therefore adds no specificity — a child
+  with its own border wins on its own.
+</Callout>
+
 ## Customizing
 
 ### CSS variables
@@ -172,5 +203,7 @@ Use the scaling classes for larger or smaller rounded corners. Sizes range from 
 Border utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <ScssDocs file="scss/_utilities.scss" capture="utils-borders" />
+
+<ScssDocs file="scss/_utilities.scss" capture="utils-divide" />
 
 <ScssDocs file="scss/_utilities.scss" capture="utils-border-radius" />

--- a/docs/src/content/docs/utilities/spacing.mdx
+++ b/docs/src/content/docs/utilities/spacing.mdx
@@ -125,6 +125,38 @@ Support includes responsive options for all of CoreUI's grid breakpoints, as wel
     <div class="p-2">Grid item 4</div>
   </div>`} />
 
+## Space between
+
+`gap` needs a flex or grid container. When the layout is plain flow — stacked
+blocks, an inline row of links — `space-x-*` and `space-y-*` put the spacing on
+the children themselves: every child except the last one gets a margin.
+
+<Example code={`<div class="space-y-3">
+    <div class="p-2 border">First</div>
+    <div class="p-2 border">Second</div>
+    <div class="p-2 border">Third</div>
+  </div>`} />
+
+`space-x-*` does the same along the inline axis. It reads the writing direction,
+so in a right-to-left document the spacing lands on the correct side without
+another class.
+
+<Example code={`<div class="space-x-3">
+    <a href="#">First</a>
+    <a href="#">Second</a>
+    <a href="#">Third</a>
+  </div>`} />
+
+Both are responsive (`.space-y-md-4`) and take the same `0`–`5` steps from the
+`$spacers` map as every other spacing utility.
+
+<Callout color="info">
+  The generated rule is wrapped in `:where()`, so it adds **no specificity**: a
+  child that sets its own margin — a utility, or a component that ships with
+  one — still wins, and you never need `!important` to escape the container's
+  spacing.
+</Callout>
+
 ## Sass
 
 ### Maps
@@ -138,3 +170,5 @@ Spacing utilities are declared via Sass map and then generated with our utilitie
 Spacing utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <ScssDocs file="scss/_utilities.scss" capture="utils-spacing" />
+
+<ScssDocs file="scss/_utilities.scss" capture="utils-space" />

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -552,6 +552,44 @@ $utilities: map.merge(
       values: $spacers
     ),
     // scss-docs-end utils-spacing
+    // scss-docs-start utils-space
+    "space-x": (
+      responsive: true,
+      property: margin-inline-end,
+      class: space-x,
+      child-selector: "> :not(:last-child)",
+      values: $spacers
+    ),
+    "space-y": (
+      responsive: true,
+      property: margin-block-end,
+      class: space-y,
+      child-selector: "> :not(:last-child)",
+      values: $spacers
+    ),
+    // scss-docs-end utils-space
+    // scss-docs-start utils-divide
+    "divide-x": (
+      responsive: true,
+      property: border-inline-start,
+      class: divide-x,
+      child-selector: "> :not(:first-child)",
+      values: (
+        null: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color),
+        0: 0,
+      )
+    ),
+    "divide-y": (
+      responsive: true,
+      property: border-block-start,
+      class: divide-y,
+      child-selector: "> :not(:first-child)",
+      values: (
+        null: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color),
+        0: 0,
+      )
+    ),
+    // scss-docs-end utils-divide
     // Text
     // scss-docs-start utils-text
     "font-family": (

--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -71,6 +71,27 @@
     $values: list.zip($values, $values);
   }
 
+  // A utility normally writes a class. `attr-starts` / `attr-includes` write an
+  // attribute selector instead, which lets one rule serve a whole family of
+  // classes; both need `class` to build the substring to match.
+  // stylelint-disable-next-line scss/at-function-named-arguments, @stylistic/function-whitespace-after
+  $selector-type: if(sass(map.has-key($utility, selector)): map.get($utility, selector); else: "class");
+  $valid-selectors: "class", "attr-starts", "attr-includes";
+
+  @if not list.index($valid-selectors, $selector-type) {
+    @error "Invalid `selector` value `#{$selector-type}`. Must be one of: #{$valid-selectors}.";
+  }
+
+  @if $selector-type != "class" and not map.has-key($utility, class) {
+    @error "Utility with `selector: #{$selector-type}` requires a `class` key.";
+  }
+
+  // A utility that styles the children of the element it is applied to, rather
+  // than the element itself — `.space-x-3 > :not(:last-child)`. Wrapped in
+  // `:where()` so it adds no specificity and anything the child carries itself
+  // still wins.
+  $child-selector: map.get($utility, child-selector);
+
   @each $key, $value in $values {
     $properties: map.get($utility, property);
 
@@ -102,20 +123,32 @@
 
     $is-css-var: map.get($utility, css-var);
     $is-local-vars: map.get($utility, local-vars);
+    $class-name: $property-class + $infix + $property-class-modifier;
+
+    $selector: ".#{$class-name}";
+    @if $selector-type == "attr-starts" {
+      $selector: "[class^=\"#{$property-class + $infix}\"]";
+    } @else if $selector-type == "attr-includes" {
+      $selector: "[class*=\"#{$property-class + $infix}\"]";
+    }
+
+    @if $child-selector {
+      $selector: ":where(#{$selector} #{$child-selector})";
+    }
 
     @if $value != null {
       @if $is-css-var {
-        .#{$property-class + $infix + $property-class-modifier} {
+        #{$selector} {
           --#{$prefix}#{$css-variable-name}: #{$value};
         }
 
         @each $pseudo in $state {
-          .#{$property-class + $infix + $property-class-modifier}-#{$pseudo}:#{$pseudo} {
+          .#{$class-name}-#{$pseudo}:#{$pseudo} {
             --#{$prefix}#{$css-variable-name}: #{$value};
           }
         }
       } @else {
-        .#{$property-class + $infix + $property-class-modifier} {
+        #{$selector} {
           @each $property in $properties {
             @if $is-local-vars {
               @each $local-var, $variable in $is-local-vars {
@@ -136,7 +169,7 @@
         }
 
         @each $pseudo in $state {
-          .#{$property-class + $infix + $property-class-modifier}-#{$pseudo}:#{$pseudo} {
+          .#{$class-name}-#{$pseudo}:#{$pseudo} {
             @each $property in $properties {
               @if $is-local-vars {
                 @each $local-var, $variable in $is-local-vars {

--- a/scss/tests/mixins/_utilities.test.scss
+++ b/scss/tests/mixins/_utilities.test.scss
@@ -270,6 +270,55 @@
       }
     }
 
+    @include describe("child-selector") {
+      @include it("styles the children instead of the element, without adding specificity") {
+        @include test-generate-utility(
+          (
+            property: margin-inline-end,
+            class: space-x,
+            child-selector: "> :not(:last-child)",
+            values: 1rem
+          )
+        ) {
+          :where(.space-x-1rem > :not(:last-child)) {
+            margin-inline-end: 1rem;
+          }
+        }
+      }
+    }
+
+    @include describe("selector") {
+      @include it("writes an attribute selector that matches a family of classes") {
+        @include test-generate-utility(
+          (
+            property: aspect-ratio,
+            class: "ratio-",
+            selector: "attr-includes",
+            values: var(--cui-ratio)
+          )
+        ) {
+          [class*="ratio-"] {
+            aspect-ratio: var(--cui-ratio);
+          }
+        }
+      }
+
+      @include it("matches only where the class starts with the given name") {
+        @include test-generate-utility(
+          (
+            property: aspect-ratio,
+            class: "ratio-",
+            selector: "attr-starts",
+            values: var(--cui-ratio)
+          )
+        ) {
+          [class^="ratio-"] {
+            aspect-ratio: var(--cui-ratio);
+          }
+        }
+      }
+    }
+
     @include describe("css-var & state") {
       @include it("Generates a rule with for each state with a CSS variable") {
         @include test-generate-utility(


### PR DESCRIPTION
Continues the alignment with Bootstrap's `v6-dev` utilities API, after #675 removed the keys that had no future (`dark-mode`, `rtl`). These are the two it added.

## The gap in the generator

It could only write a class that styles the element the class sits on. That leaves a whole shape of utility unexpressible: the ones that describe what happens **between** children. People fake them today with `gap` — which needs a flex or grid container — or by marking up the last item differently.

## Two keys

**`child-selector`** — the rule targets the children, wrapped in `:where()`:

```scss
"space-x": (
  property: margin-inline-end,
  class: space-x,
  child-selector: "> :not(:last-child)",
  values: $spacers
)
```

```css
:where(.space-x-3 > :not(:last-child)) { margin-inline-end: 1rem !important; }
```

The `:where()` is the load-bearing part: **zero specificity**, so a child that carries its own margin utility, or a component that ships with one, still wins — no `!important`, no longer selector.

**`selector`** (`class` | `attr-starts` | `attr-includes`) — writes `[class^="…"]` or `[class*="…"]` instead of a class, so one rule can serve a family of classes while the classes themselves only set a custom property. Both spellings require a `class` key (that is the string they match), and an invalid value is an `@error`, not a silent miss.

## Four utilities

| class | what it does |
| --- | --- |
| `.space-x-*`, `.space-y-*` | margin between children, `0`–`5` from `$spacers` |
| `.divide-x`, `.divide-y` (+ `-0`) | a border between children, none on the outer edges |

All responsive, all on logical properties (`margin-inline-end`, `border-inline-start`), so they follow the writing direction with no second class — and with #682 already merged, that works in the same stylesheet.

The dividers read `--cui-border-width`/`-style`/`-color`, so they follow a theme like every other border.

## Docs

- [Utilities API](/utilities/api/): new **Child selector** and **Selector type** sections, each with input and output.
- [Spacing](/utilities/spacing/): **Space between**, next to `gap`, with the specificity note and both `<ScssDocs>` captures.
- [Borders](/utilities/borders/): **Divide**, same shape.
- Migration guide: an entry under the utilities API changes.

## Verification

`npm run css`, stylelint, fusv, the Sass suite (**46 specs**, three new: `child-selector`, `attr-includes`, `attr-starts`), the class API guard, bundlewatch (`coreui.min.css` 44.12 kB < 45.5 kB budget — the four utilities cost ~0.6 kB gzip) and a full `docs:build` (139 pages, no broken links).