### PR TITLE
refactor(utilities)!: one property map replaces css-var, css-variable-name and local-vars

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -674,6 +674,57 @@ Upstream v6 does the same, with a `mask-icon()` mixin.
   the root color tokens, which already switch in dark mode.
 - `.btn-primary`, `.btn-outline-*`, `.btn-ghost-*` class APIs are unchanged.
 
+#### Utilities API: one `property` map replaces `css-var`, `css-variable-name` and `local-vars`
+
+<span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+
+Three keys said one thing between them — *a utility may write custom
+properties, real properties, or both* — and `property` now says it alone. Give
+it a map: a `null` entry receives the utility's value, everything else is
+written as declared.
+
+```diff
+  "background-color": (
+-   property: background-color,
+-   local-vars: ("bg-opacity": 1),
++   property: (
++     --#{$prefix}bg: null,
++     --#{$prefix}bg-opacity: 1,
++     background-color: color-mix(in srgb, var(--#{$prefix}bg) calc(var(--#{$prefix}bg-opacity) * 100%), transparent),
++   ),
+    class: bg,
+    values: $utilities-bg-colors
+  )
+
+  "bg-opacity": (
+-   css-var: true,
++   property: (--#{$prefix}bg-opacity: null),
+    class: bg-opacity,
+    values: (25: .25, 50: .5, 75: .75)
+  )
+```
+
+The class API does not change — `.bg-primary` and `.bg-opacity-50` still exist
+and still compose. What changes is where the translucency expression lives:
+
+- **`$utilities-text-colors`, `$utilities-bg-colors`, `$utilities-border-colors`
+  and `$utilities-links-underline` now carry plain colour references**
+  (`var(--cui-primary)`) instead of a `color-mix()` expression per entry. The
+  expression is written once, in the utility's `property` map. If you built a
+  map of your own by calling `translucent-css-var()`, call the new
+  `color-var-ref()` instead — same arguments, without the wrapper.
+- **`.text-muted`, `.text-black-50`, `.text-white-50` and `.text-body-secondary`
+  now respond to `.text-opacity-*`.** They rendered the same colour before and
+  render the same colour now; they simply went through the plain value and so
+  ignored the opacity knob every other colour utility honoured.
+- Every custom property a utility assigns is registered
+  `@property { inherits: false }`, which now covers `--cui-bg`, `--cui-text`,
+  `--cui-border` and `--cui-link-underline` as well — so a colour set on a
+  container cannot leak into a descendant that only carries an opacity class.
+
+`at-property: false` still opts a utility out of that registration, for the one
+case that writes an inheriting global token (`.focus-ring-*`).
+
 #### Utilities API: child selectors and attribute selectors (new)
 
 Two keys join the `$utilities` API, ported from Bootstrap's v6 branch:

--- a/docs/src/content/docs/utilities/api.mdx
+++ b/docs/src/content/docs/utilities/api.mdx
@@ -9,16 +9,15 @@ The `$utilities` map contains all our utilities and is later merged with your cu
 
 | Option | Type | Default&nbsp;value | Description |
 | --- | --- | --- | --- |
-| [`property`](#property) | **Required** | – | Name of the property, this can be a string or an array of strings (e.g., horizontal paddings or margins). |
+| [`property`](#property) | **Required** | – | Name of the property, a space-separated list of them, or a [map](#property-map) spelling out every declaration the rule writes. |
 | [`values`](#values) | **Required** | – | List of values, or a map if you don't want the class name to be the same as the value. If `null` is used as map key, `class` is not prepended to the class name. |
 | [`class`](#class) | Optional | null | Name of the generated class. If not provided and `property` is an array of strings, `class` will default to the first element of the `property` array. If not provided and `property` is a string, the `values` keys are used for the `class` names. |
-| [`css-var`](#css-variable-utilities) | Optional | `false` | Boolean to generate CSS variables instead of CSS rules. |
-| [`css-variable-name`](#css-variable-utilities) | Optional | null | Custom un-prefixed name for the CSS variable inside the ruleset. |
-| [`local-vars`](#local-css-variables) | Optional | null | Map of local CSS variables to generate in addition to the CSS rules. |
+| [`child-selector`](#child-selector) | Optional | null | Selector for the children to style instead of the element itself, wrapped in `:where()`. |
+| [`selector`](#selector-type) | Optional | `class` | `class`, `attr-starts` or `attr-includes` — whether the rule is written as a class or as an attribute selector. |
 | [`state`](#states) | Optional | null | List of pseudo-class variants (e.g., `:hover` or `:focus`) to generate. |
 | [`responsive`](#responsive) | Optional | `false` | Boolean indicating if responsive classes should be generated. |
 | [`print`](#print) | Optional | `false` | Boolean indicating if print classes need to be generated. |
-| `rtl` | Optional | `true` | Boolean indicating if utility should be kept in RTL. |
+| `at-property` | Optional | `true` | Set to `false` to keep the utility's custom properties inheriting (see [property map](#property-map)). |
 
 ## API explained
 
@@ -215,55 +214,23 @@ Output:
 it also works when the utility is not the first class). Both require a `class`
 key — that is the string they match on.
 
-### CSS variable utilities
+### Property map
 
-Set the `css-var` boolean option to `true` and the API will generate local CSS variables for the given selector instead of the usual `property: value` rules. Add an optional `css-variable-name` to set a different CSS variable name than the class name.
-
-Consider our `.text-opacity-*` utilities. If we add the `css-variable-name` option, we'll get a custom output.
-
-```scss
-$utilities: (
-  "text-opacity": (
-    css-var: true,
-    css-variable-name: text-alpha,
-    class: text-opacity,
-    values: (
-      25: .25,
-      50: .5,
-      75: .75,
-      100: 1
-    )
-  ),
-);
-```
-
-Output:
-
-```css
-.text-opacity-25 { --cui-text-opacity: .25; }
-.text-opacity-50 { --cui-text-opacity: .5; }
-.text-opacity-75 { --cui-text-opacity: .75; }
-.text-opacity-100 { --cui-text-opacity: 1; }
-```
-
-### Local CSS variables
-
-Use the `local-vars` option to specify a Sass map that will generate local CSS variables within the utility class's ruleset. Please note that it may require additional work to consume those local CSS variables in the generated CSS rules. For example, consider our `.bg-*` utilities:
+`property` is usually one property name, or a space-separated list of them. It
+can also be a **map**, which spells out exactly what the rule writes and in what
+order. An entry whose value is `null` receives the utility's value; every other
+entry is written as declared:
 
 ```scss
 $utilities: (
   "background-color": (
-    property: background-color,
-    class: bg,
-    local-vars: (
-      "bg-opacity": 1
+    property: (
+      --#{$prefix}bg: null,
+      --#{$prefix}bg-opacity: 1,
+      background-color: color-mix(in srgb, var(--#{$prefix}bg) calc(var(--#{$prefix}bg-opacity) * 100%), transparent),
     ),
-    values: map-merge(
-      $utilities-bg-colors,
-      (
-        "transparent": transparent
-      )
-    )
+    class: bg,
+    values: $utilities-bg-colors
   )
 );
 ```
@@ -272,10 +239,47 @@ Output:
 
 ```css
 .bg-primary {
+  --cui-bg: var(--cui-primary);
   --cui-bg-opacity: 1;
-  background-color: rgba(var(--cui-primary-rgb), var(--cui-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--cui-bg) calc(var(--cui-bg-opacity) * 100%), transparent) !important;
 }
 ```
+
+This is what lets a utility **store its value in a custom property and consume
+it in the same rule**. The gain is that the expression around the value — here
+the translucency formula — is written once, in the map, instead of being baked
+into every entry of `values`; the values only have to name a colour. A companion
+utility then modifies the result by setting the same custom property:
+
+```scss
+$utilities: (
+  "bg-opacity": (
+    property: (--#{$prefix}bg-opacity: null),
+    class: bg-opacity,
+    values: (25: .25, 50: .5, 75: .75)
+  )
+);
+```
+
+```css
+.bg-opacity-50 { --cui-bg-opacity: .5; }
+```
+
+Note what that composition does **not** rely on: the two rules touch different
+properties, so `.bg-primary.bg-opacity-50` works regardless of which one the
+stylesheet declares first, and `.bg-opacity-50` on its own simply sets a variable
+nobody reads rather than producing an invalid declaration.
+
+A map with only custom properties in it is the way to write a utility that sets
+no real property at all — which is what `bg-opacity` above is.
+
+<Callout color="info">
+  Every custom property a utility assigns to is registered with
+  `@property { inherits: false }`, so the value applies to the element that
+  carries the class and does not leak into its descendants. A utility that
+  deliberately writes an inheriting token — `.focus-ring-*` sets the global
+  `--cui-focus-ring-color` — opts out with `at-property: false`.
+</Callout>
 
 ### States
 

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -4,6 +4,7 @@
 @forward "functions/color-contrast";
 @forward "functions/color-contrast-variables";
 @forward "functions/color-scheme";
+@forward "functions/color-var-ref";
 @forward "functions/contrast-ratio";
 @forward "functions/defaults";
 @forward "functions/escape-svg";

--- a/scss/_maps.scss
+++ b/scss/_maps.scss
@@ -80,7 +80,7 @@ $utilities-text: map.merge(
     "body": $body-color
   )
 ) !default;
-$utilities-text-colors: map-loop($utilities-text, translucent-css-var, "$prefix", "$key", "text") !default;
+$utilities-text-colors: map-loop($utilities-text, color-var-ref, "$prefix", "$key", "text") !default;
 
 $utilities-text-emphasis-colors: (
   "primary-emphasis": var(--#{$prefix}primary-text-emphasis),
@@ -103,7 +103,7 @@ $utilities-bg: map.merge(
     "body": $body-bg
   )
 ) !default;
-$utilities-bg-colors: map-loop($utilities-bg, translucent-css-var, "$prefix", "$key", "bg") !default;
+$utilities-bg-colors: map-loop($utilities-bg, color-var-ref, "$prefix", "$key", "bg") !default;
 
 $utilities-bg-subtle: (
   "primary-subtle": var(--#{$prefix}primary-bg-subtle),
@@ -125,7 +125,7 @@ $utilities-border: map.merge(
     "white": $white
   )
 ) !default;
-$utilities-border-colors: map-loop($utilities-border, translucent-css-var, "$prefix", "$key", "border") !default;
+$utilities-border-colors: map-loop($utilities-border, color-var-ref, "$prefix", "$key", "border") !default;
 
 $utilities-border-subtle: (
   "primary-subtle": var(--#{$prefix}primary-border-subtle),
@@ -139,7 +139,7 @@ $utilities-border-subtle: (
 ) !default;
 // scss-docs-end utilities-border-colors
 
-$utilities-links-underline: map-loop($utilities-colors, translucent-css-var, "$prefix", "$key", "link-underline") !default;
+$utilities-links-underline: map-loop($utilities-colors, color-var-ref, "$prefix", "$key", "link-underline") !default;
 
 // stylelint-disable-next-line scss/at-function-named-arguments
 $negative-spacers: if(sass($enable-negative-margins): negativify-map($spacers)) !default;

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -94,8 +94,7 @@ $utilities: map.merge(
     // scss-docs-end utils-shadow
     // scss-docs-start utils-focus-ring
     "focus-ring": (
-      css-var: true,
-      css-variable-name: focus-ring-color,
+      property: (--#{$prefix}focus-ring-color: null),
       // Writes the global :root token, so it stays inheriting — see
       // generate-utility-at-properties().
       at-property: false,
@@ -175,11 +174,12 @@ $utilities: map.merge(
       ),
     ),
     "border-color": (
-      property: border-color,
-      class: border,
-      local-vars: (
-        "border-opacity": 1
+      property: (
+        --#{$prefix}border: null,
+        --#{$prefix}border-opacity: 1,
+        border-color: color-mix(in srgb, var(--#{$prefix}border) calc(var(--#{$prefix}border-opacity) * 100%), transparent),
       ),
+      class: border,
       values: $utilities-border-colors
     ),
     "border-top-color": (
@@ -237,7 +237,7 @@ $utilities: map.merge(
       values: $utilities-border-subtle
     ),
     "border-opacity": (
-      css-var: true,
+      property: (--#{$prefix}border-opacity: null),
       class: border-opacity,
       values: (
         10: .1,
@@ -671,11 +671,12 @@ $utilities: map.merge(
     // scss-docs-end utils-text
     // scss-docs-start utils-color
     "color": (
-      property: color,
-      class: text,
-      local-vars: (
-        "text-opacity": 1
+      property: (
+        --#{$prefix}text: null,
+        --#{$prefix}text-opacity: 1,
+        color: color-mix(in srgb, var(--#{$prefix}text) calc(var(--#{$prefix}text-opacity) * 100%), transparent),
       ),
+      class: text,
       values: map.merge(
         $utilities-text-colors,
         (
@@ -691,7 +692,7 @@ $utilities: map.merge(
       )
     ),
     "text-opacity": (
-      css-var: true,
+      property: (--#{$prefix}text-opacity: null),
       class: text-opacity,
       values: (
         25: .25,
@@ -708,7 +709,7 @@ $utilities: map.merge(
     // scss-docs-end utils-color
     // scss-docs-start utils-links
     "link-opacity": (
-      css-var: true,
+      property: (--#{$prefix}link-opacity: null),
       class: link-opacity,
       state: hover,
       values: (
@@ -730,20 +731,21 @@ $utilities: map.merge(
       )
     ),
     "link-underline": (
-      property: text-decoration-color,
-      class: link-underline,
-      local-vars: (
-        "link-underline-opacity": 1
+      property: (
+        --#{$prefix}link-underline: null,
+        --#{$prefix}link-underline-opacity: 1,
+        text-decoration-color: color-mix(in srgb, var(--#{$prefix}link-underline) calc(var(--#{$prefix}link-underline-opacity) * 100%), transparent),
       ),
+      class: link-underline,
       values: map.merge(
         $utilities-links-underline,
         (
-          null: color-mix(in srgb, var(--#{$prefix}link-color) calc(var(--#{$prefix}link-underline-opacity, 1) * 100%), transparent),
+          null: var(--#{$prefix}link-color),
         )
       )
     ),
     "link-underline-opacity": (
-      css-var: true,
+      property: (--#{$prefix}link-underline-opacity: null),
       class: link-underline-opacity,
       state: hover,
       values: (
@@ -758,22 +760,23 @@ $utilities: map.merge(
     // scss-docs-end utils-links
     // scss-docs-start utils-bg-color
     "background-color": (
-      property: background-color,
-      class: bg,
-      local-vars: (
-        "bg-opacity": 1
+      property: (
+        --#{$prefix}bg: null,
+        --#{$prefix}bg-opacity: 1,
+        background-color: color-mix(in srgb, var(--#{$prefix}bg) calc(var(--#{$prefix}bg-opacity) * 100%), transparent),
       ),
+      class: bg,
       values: map.merge(
         $utilities-bg-colors,
         (
           "transparent": transparent,
-          "body-secondary": color-mix(in srgb, var(--#{$prefix}secondary-bg) calc(var(--#{$prefix}bg-opacity) * 100%), transparent),
-          "body-tertiary": color-mix(in srgb, var(--#{$prefix}tertiary-bg) calc(var(--#{$prefix}bg-opacity) * 100%), transparent),
+          "body-secondary": var(--#{$prefix}secondary-bg),
+          "body-tertiary": var(--#{$prefix}tertiary-bg),
         )
       )
     ),
     "bg-opacity": (
-      css-var: true,
+      property: (--#{$prefix}bg-opacity: null),
       class: bg-opacity,
       values: (
         10: .1,

--- a/scss/functions/_color-var-ref.scss
+++ b/scss/functions/_color-var-ref.scss
@@ -1,0 +1,16 @@
+// The colour token a utility points at, without the translucency expression
+// around it. The utilities that expose an `*-opacity` knob write that
+// expression once, in their `property` map, so their values only have to name
+// the colour.
+
+@function color-var-ref($prefix, $identifier, $target) {
+  @if $identifier == "body" {
+    $suffix: "bg";
+    @if $target == "text" {
+      $suffix: "color";
+    }
+    @return var(--#{$prefix}#{$identifier}-#{$suffix});
+  }
+
+  @return var(--#{$prefix}#{$identifier});
+}

--- a/scss/functions/_maps.scss
+++ b/scss/functions/_maps.scss
@@ -2,6 +2,7 @@
 @use "sass:map";
 @use "sass:meta";
 @use "color" as *;
+@use "color-var-ref" as *;
 @use "translucent-css-var" as *;
 @use "to-rgb" as *;
 @use "../config" as *;

--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -37,26 +37,55 @@
 
   @each $key, $utility in $utilities {
     @if meta.type-of($utility) == "map" and map.get($utility, at-property) != false {
-      @if map.get($utility, css-var) {
-        // stylelint-disable-next-line scss/at-function-named-arguments, @stylistic/function-whitespace-after
-        $name: if(sass(map.has-key($utility, css-variable-name)): map.get($utility, css-variable-name); else: map.get($utility, class));
-        @if $name != null {
-          $names: append-unique($names, $name);
-        }
-      }
+      $properties: map.get($utility, property);
 
-      @if map.has-key($utility, local-vars) {
-        @each $local-var, $value in map.get($utility, local-vars) {
-          $names: append-unique($names, $local-var);
+      @if meta.type-of($properties) == "map" {
+        @each $property, $declared in $properties {
+          @if string.slice($property, 1, 2) == "--" {
+            $names: append-unique($names, $property);
+          }
         }
       }
     }
   }
 
   @each $name in $names {
-    @property --#{$prefix}#{$name} {
+    @property #{$name} {
       syntax: "*";
       inherits: false;
+    }
+  }
+}
+
+// What a utility rule writes. With a `property` map the entries are taken in
+// order — a `null` entry receives the utility's value, anything else is written
+// as declared; otherwise every listed property takes the value, and a value map
+// lets one class set several related properties at once (`.text-lg` sets both
+// font-size and line-height).
+@mixin declarations($property-map, $properties, $value) {
+  @if $property-map {
+    @each $property, $declared in $property-map {
+      // stylelint-disable-next-line scss/at-function-named-arguments, @stylistic/function-whitespace-after
+      $actual: if(sass(meta.type-of($value) == "map" and map.has-key($value, $property)): map.get($value, $property); else: if(sass($declared == null): $value; else: $declared));
+
+      @if $actual != null {
+        @if string.slice($property, 1, 2) == "--" {
+          #{$property}: #{$actual};
+        } @else {
+          // stylelint-disable-next-line scss/at-function-named-arguments
+          #{$property}: $actual if(sass($enable-important-utilities): !important);
+        }
+      }
+    }
+  } @else {
+    @each $property in $properties {
+      @if meta.type-of($value) == "map" {
+        // stylelint-disable-next-line scss/at-function-named-arguments
+        #{$property}: map.get($value, $property) if(sass($enable-important-utilities): !important);
+      } @else {
+        // stylelint-disable-next-line scss/at-function-named-arguments
+        #{$property}: $value if(sass($enable-important-utilities): !important);
+      }
     }
   }
 }
@@ -95,6 +124,14 @@
   @each $key, $value in $values {
     $properties: map.get($utility, property);
 
+    // `property` as a map declares exactly what the rule writes, in order: a
+    // `null` entry receives the utility's value, anything else is written
+    // literally. That is what lets a utility store its value in a custom
+    // property and consume it in the same rule, so the expression around it is
+    // written once here instead of once per value.
+    // stylelint-disable-next-line scss/at-function-named-arguments
+    $property-map: if(sass(meta.type-of($properties) == "map"): $properties; else: null);
+
     // Multiple properties are possible, for example with vertical or horizontal margins or paddings
     @if meta.type-of($properties) == "string" {
       $properties: list.append((), $properties);
@@ -102,13 +139,10 @@
 
     // Use custom class if present
     // stylelint-disable-next-line scss/at-function-named-arguments, @stylistic/function-whitespace-after
-    $property-class: if(sass(map.has-key($utility, class)): map.get($utility, class); else: list.nth($properties, 1));
+    $property-class: if(sass(map.has-key($utility, class)): map.get($utility, class); else: if(sass($property-map): null; else: list.nth($properties, 1)));
     // stylelint-disable-next-line scss/at-function-named-arguments
     $property-class: if(sass($property-class == null): ""; else: $property-class);
 
-    // Use custom CSS variable name if present, otherwise default to `class`
-    // stylelint-disable-next-line scss/at-function-named-arguments, @stylistic/function-whitespace-after
-    $css-variable-name: if(sass(map.has-key($utility, css-variable-name)): map.get($utility, css-variable-name); else: map.get($utility, class));
 
     // State params to generate pseudo-classes
     // stylelint-disable-next-line scss/at-function-named-arguments, @stylistic/function-whitespace-after
@@ -121,8 +155,6 @@
     // stylelint-disable-next-line scss/at-function-named-arguments
     $property-class-modifier: if(sass($key): if(sass($property-class == "" and $infix == ""): ""; else: "-") + $key; else: "");
 
-    $is-css-var: map.get($utility, css-var);
-    $is-local-vars: map.get($utility, local-vars);
     $class-name: $property-class + $infix + $property-class-modifier;
 
     $selector: ".#{$class-name}";
@@ -137,49 +169,13 @@
     }
 
     @if $value != null {
-      @if $is-css-var {
-        #{$selector} {
-          --#{$prefix}#{$css-variable-name}: #{$value};
-        }
+      #{$selector} {
+        @include declarations($property-map, $properties, $value);
+      }
 
-        @each $pseudo in $state {
-          .#{$class-name}-#{$pseudo}:#{$pseudo} {
-            --#{$prefix}#{$css-variable-name}: #{$value};
-          }
-        }
-      } @else {
-        #{$selector} {
-          @each $property in $properties {
-            @if $is-local-vars {
-              @each $local-var, $variable in $is-local-vars {
-                --#{$prefix}#{$local-var}: #{$variable};
-              }
-            }
-            @if meta.type-of($value) == "map" {
-              // A property map: each property takes its own key from the value,
-              // so one class can set several related properties at once
-              // (.text-lg sets both font-size and line-height).
-              // stylelint-disable-next-line scss/at-function-named-arguments
-              #{$property}: map.get($value, $property) if(sass($enable-important-utilities): !important);
-            } @else {
-              // stylelint-disable-next-line scss/at-function-named-arguments
-              #{$property}: $value if(sass($enable-important-utilities): !important);
-            }
-          }
-        }
-
-        @each $pseudo in $state {
-          .#{$class-name}-#{$pseudo}:#{$pseudo} {
-            @each $property in $properties {
-              @if $is-local-vars {
-                @each $local-var, $variable in $is-local-vars {
-                  --#{$prefix}#{$local-var}: #{$variable};
-                }
-              }
-              // stylelint-disable-next-line scss/at-function-named-arguments
-              #{$property}: $value if(sass($enable-important-utilities): !important);
-            }
-          }
+      @each $pseudo in $state {
+        .#{$class-name}-#{$pseudo}:#{$pseudo} {
+          @include declarations($property-map, $properties, $value);
         }
       }
     }

--- a/scss/tests/mixins/_utilities.test.scss
+++ b/scss/tests/mixins/_utilities.test.scss
@@ -204,32 +204,12 @@
       }
     }
 
-    @include describe("css-var"){
-      @include it("sets a CSS variable instead of the property") {
+    @include describe("property map") {
+      @include it("writes a custom property instead of a real one") {
         @include test-generate-utility(
           (
-            property: padding,
-            css-variable-name: padding,
-            css-var: true,
-            values: 1rem 2rem
-          )
-        ) {
-          .padding-1rem {
-            --cui-padding: 1rem;
-          }
-
-          .padding-2rem {
-            --cui-padding: 2rem;
-          }
-        }
-      }
-
-      @include it("defaults to class") {
-        @include test-generate-utility(
-          (
-            property: padding,
+            property: (--cui-padding: null),
             class: padding,
-            css-var: true,
             values: 1rem 2rem
           )
         ) {
@@ -242,29 +222,47 @@
           }
         }
       }
-    }
 
-    @include describe("local-vars") {
-      @include it("generates the listed variables") {
+      @include it("takes the utility value where the entry is null and writes the rest as declared") {
         @include test-generate-utility(
           (
-            property: color,
-            class: desaturated-color,
-            local-vars: (
-              color-opacity: 1,
-              color-saturation: .25
+            property: (
+              --cui-bg: null,
+              --cui-bg-opacity: 1,
+              background-color: color-mix(in srgb, var(--cui-bg) calc(var(--cui-bg-opacity) * 100%), transparent),
             ),
-            values: (
-              blue: hsla(192deg, var(--cui-color-saturation), 0, var(--cui-color-opacity))
-            )
+            class: bg,
+            values: (blue: var(--cui-blue))
           )
         ) {
-          .desaturated-color-blue {
-            --cui-color-opacity: 1;
-            // Sass compilation will put a leading zero so we want to keep that one
-            // stylelint-disable-next-line @stylistic/number-leading-zero
-            --cui-color-saturation: 0.25;
-            color: hsla(192deg, var(--cui-color-saturation), 0, var(--cui-color-opacity));
+          .bg-blue {
+            --cui-bg: var(--cui-blue);
+            --cui-bg-opacity: 1;
+            // stylelint-disable-next-line function-disallowed-list
+            background-color: color-mix(in srgb, var(--cui-bg) calc(var(--cui-bg-opacity) * 100%), transparent);
+          }
+        }
+      }
+
+      @include it("keeps the state variants") {
+        @include test-generate-utility(
+          (
+            property: (--cui-padding: null),
+            class: padding,
+            values: 1rem,
+            state: hover focus,
+          )
+        ) {
+          .padding-1rem {
+            --cui-padding: 1rem;
+          }
+
+          .padding-1rem-hover:hover {
+            --cui-padding: 1rem;
+          }
+
+          .padding-1rem-focus:focus {
+            --cui-padding: 1rem;
           }
         }
       }
@@ -318,33 +316,6 @@
         }
       }
     }
-
-    @include describe("css-var & state") {
-      @include it("Generates a rule with for each state with a CSS variable") {
-        @include test-generate-utility(
-          (
-            property: padding,
-            css-var: true,
-            css-variable-name: padding,
-            values: 1rem,
-            state: hover focus,
-          )
-        ) {
-          .padding-1rem {
-            --cui-padding: 1rem;
-          }
-
-          .padding-1rem-hover:hover {
-            --cui-padding: 1rem;
-          }
-
-          .padding-1rem-focus:focus {
-            --cui-padding: 1rem;
-          }
-        }
-      }
-    }
-
   }
 
   @include describe("$infix") {


### PR DESCRIPTION
The last piece of the utilities API alignment, and the one with a real payoff behind it.

## Why

Three keys said one thing between them — *a utility may write custom properties, real properties, or both* — and each covered a different half, so the generator carried two nearly identical branches.

But the key count was never the point. The four colour utilities baked the translucency expression into **every single value**, through `translucent-css-var()`:

```scss
// $utilities-bg-colors, one entry per colour
"primary": color-mix(in srgb, var(--cui-primary) calc(var(--cui-bg-opacity) * 100%), transparent),
"secondary": color-mix(in srgb, var(--cui-secondary) calc(var(--cui-bg-opacity) * 100%), transparent),
// …and again for text, border and link-underline
```

The same formula, written once per colour across four maps. Changing the translucency model meant editing a function and re-deriving four maps.

## What

`property` accepts a map. A `null` entry receives the utility's value; everything else is written as declared, in order — so a utility can store its value in a custom property and consume it in the same rule:

```scss
"background-color": (
  property: (
    --#{$prefix}bg: null,
    --#{$prefix}bg-opacity: 1,
    background-color: color-mix(in srgb, var(--#{$prefix}bg) calc(var(--#{$prefix}bg-opacity) * 100%), transparent),
  ),
  class: bg,
  values: $utilities-bg-colors   // now plain colour refs
)
```

The formula is written **once**. The values map is a map of colours again.

## Deliberately not Bootstrap's shape

Theirs inverts it the other way: `.bg-primary` sets `--bg` and applies it plainly, while `.bg-50` re-declares `background-color` with the formula. That costs two things we keep:

- **No source-order dependency.** Their two rules both declare `background-color` at equal specificity, so the opacity class only wins by standing later in the file. Ours touch different properties.
- **No invalid rule in isolation.** Their `.bg-50` without a colour class resolves `var(--bg)` to nothing and drops the declaration. Our `.bg-opacity-50` just sets a variable nobody reads.

We take their win (one formula) without their trade-offs.

## Consequences worth naming

- **`.text-muted`, `.text-black-50`, `.text-white-50`, `.text-body-secondary` now honour `.text-opacity-*`.** Same colour rendered as before; they were simply the entries that bypassed the formula and so ignored the knob every other colour utility honoured.
- **`--cui-bg`, `--cui-text`, `--cui-border`, `--cui-link-underline` join the `@property { inherits: false }` registrations** — required, or a colour set on a container would leak into a descendant carrying only an opacity class.
- **Sass API:** the four `$utilities-*-colors` maps now carry plain colour references. A custom map built with `translucent-css-var()` should use the new `color-var-ref()` — same arguments, without the wrapper.

The **class API is unchanged**: `.bg-primary`, `.bg-opacity-50` and friends exist and compose exactly as before.

## Verification

Declaration-by-declaration diff of the compiled CSS against the previous build:

- **0 declarations lost**
- **60 added**: 52 custom properties (`--cui-bg`/`-text`/`-border`/`-link-underline`, one per colour class) + the 4 new `@property` blocks
- **52 changed**, all four colour properties, every one of them the same edit — the literal colour moving out of the formula into the variable the formula now reads

Plus `npm run css`, stylelint, fusv, the Sass suite (45 specs, the `css-var`/`local-vars` specs rewritten onto the property map), the class API guard, bundlewatch (`coreui.min.css` 44.17 kB < 45.5 kB) and a full docs build (139 pages, no broken links).

## Docs

- [Utilities API](/utilities/api/): the `css-var` / `css-variable-name` / `local-vars` sections are replaced by one **Property map** section covering both shapes, the composition guarantee and the `@property` registration; the options table is rebuilt (it still listed `rtl`, removed two PRs ago).
- Migration guide: the diff above, the behaviour change on the four text utilities, and the `translucent-css-var()` → `color-var-ref()` note.