### PR TITLE
fix(Sidebar): stop dispose() from tearing down listeners it does not own

### DIFF
--- a/js/src/sidebar.ts
+++ b/js/src/sidebar.ts
@@ -61,6 +61,8 @@ class Sidebar extends BaseComponent {
   protected declare _narrow: boolean
   protected declare _unfoldable: boolean
   protected declare _backdrop: Backdrop
+  protected declare _clickOutHandler: (event: Event) => void
+  protected declare _resizeHandler: () => void
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
     super(element)
@@ -72,6 +74,14 @@ class Sidebar extends BaseComponent {
     this._narrow = this._isNarrow()
     this._unfoldable = this._isUnfoldable()
     this._backdrop = this._initializeBackDrop()
+    this._clickOutHandler = event => this._clickOutListener(event)
+    this._resizeHandler = () => {
+      if (this._isMobile() && this._isVisible()) {
+        this.hide()
+        this._backdrop = this._initializeBackDrop()
+      }
+    }
+
     this._addEventListeners()
   }
 
@@ -208,7 +218,8 @@ class Sidebar extends BaseComponent {
   }
 
   override dispose(): void {
-    EventHandler.off(window, EVENT_KEY)
+    this._removeClickOutListener()
+    EventHandler.off(window, EVENT_RESIZE, this._resizeHandler)
 
     super.dispose()
   }
@@ -257,13 +268,11 @@ class Sidebar extends BaseComponent {
   }
 
   _addClickOutListener(): void {
-    EventHandler.on(document, EVENT_CLICK_DATA_API, event => {
-      this._clickOutListener(event)
-    })
+    EventHandler.on(document, EVENT_CLICK_DATA_API, this._clickOutHandler)
   }
 
   _removeClickOutListener(): void {
-    EventHandler.off(document, EVENT_CLICK_DATA_API)
+    EventHandler.off(document, EVENT_CLICK_DATA_API, this._clickOutHandler)
   }
 
   // Sidebar navigation
@@ -294,12 +303,7 @@ class Sidebar extends BaseComponent {
       this.hide()
     })
 
-    EventHandler.on(window, EVENT_RESIZE, () => {
-      if (this._isMobile() && this._isVisible()) {
-        this.hide()
-        this._backdrop = this._initializeBackDrop()
-      }
-    })
+    EventHandler.on(window, EVENT_RESIZE, this._resizeHandler)
   }
 
   // Static

--- a/js/tests/unit/sidebar.spec.js
+++ b/js/tests/unit/sidebar.spec.js
@@ -526,6 +526,29 @@ describe('Sidebar', () => {
       })
     })
 
+    describe('_removeClickOutListener', () => {
+      it('should keep the click out listener of another instance', () => {
+        fixtureEl.innerHTML = [
+          '<div class="sidebar first"></div>',
+          '<div class="sidebar second"></div>',
+          '<div class="outside"></div>'
+        ].join('')
+        const first = new Sidebar('.first')
+        const second = new Sidebar('.second')
+        const outsideEl = fixtureEl.querySelector('.outside')
+        const spyFirstHide = spyOn(first, 'hide')
+        const spySecondHide = spyOn(second, 'hide')
+
+        first._addClickOutListener()
+        second._addClickOutListener()
+        second._removeClickOutListener()
+        outsideEl.click()
+
+        expect(spyFirstHide).toHaveBeenCalled()
+        expect(spySecondHide).not.toHaveBeenCalled()
+      })
+    })
+
     describe('_addEventListeners', () => {
       it('should add click out listener for mobile visible sidebar', () => {
         fixtureEl.innerHTML = '<div class="sidebar"></div>'
@@ -690,6 +713,32 @@ describe('Sidebar', () => {
       }
 
       expect(calledOnDisposedInstance).toBeFalse()
+    })
+
+    it('should remove the click out listener', () => {
+      fixtureEl.innerHTML = '<div class="sidebar"></div><input type="checkbox" class="outside">'
+      const sidebar = new Sidebar('.sidebar')
+      const outsideEl = fixtureEl.querySelector('.outside')
+      const spyHide = spyOn(sidebar, 'hide')
+
+      sidebar._addClickOutListener()
+      sidebar.dispose()
+      outsideEl.click()
+
+      expect(spyHide).not.toHaveBeenCalled()
+      expect(outsideEl.checked).toBeTrue()
+    })
+
+    it('should keep the window load data api handler', () => {
+      fixtureEl.innerHTML = '<div class="sidebar"></div>'
+      const sidebarEl = fixtureEl.querySelector('.sidebar')
+      const sidebar = new Sidebar(sidebarEl)
+      const spySidebarInterface = spyOn(Sidebar, 'sidebarInterface')
+
+      sidebar.dispose()
+      window.dispatchEvent(new Event('load'))
+
+      expect(spySidebarInterface).toHaveBeenCalledWith(sidebarEl)
     })
   })
 })


### PR DESCRIPTION
Two `EventHandler.off()` calls in `Sidebar` remove more than the instance registered.

**The click-out listener leaks.** `show()` registers a handler on `document` that `preventDefault()`s and `stopPropagation()`s every click landing outside `.sidebar`. It was an anonymous closure, so there was no reference to remove:

- `dispose()` never touched it, so a disposed sidebar keeps cancelling clicks across the whole document and calling `hide()` on itself
- `_removeClickOutListener()` passed no handler, so it removed *every* sidebar-namespaced click handler on `document` — hiding one sidebar disabled the click-out of every other instance

**`dispose()` disables the data API for the whole page.** It called `EventHandler.off(window, EVENT_KEY)`, and `EVENT_KEY` is the bare namespace (`.coreui.sidebar`), so the namespace form also removed the module-level `load.coreui.sidebar.data-api` handler — the one that initialises every `.sidebar` on the page. Disposing a single instance switched that off for all of them.

Both listeners now go through stable references held on the instance, and `dispose()` removes them by handler.

Three specs cover it, all of which fail on the current sources:

- `_removeClickOutListener > should keep the click out listener of another instance`
- `dispose > should remove the click out listener`
- `dispose > should keep the window load data api handler`

The last one is how the data-api bug surfaced: it was invisible until a spec called `dispose()` before the existing Data API test.

The same fix for the v5 line is coming to `main` (`coreui` and `coreui-pro`), where the leak is also what made the Karma suite flaky.