### PR TITLE
docs(utilities): show the responsive space and divide patterns

### DIFF
--- a/docs/src/content/docs/utilities/borders.mdx
+++ b/docs/src/content/docs/utilities/borders.mdx
@@ -174,8 +174,20 @@ marking up the last item differently.
 
 The dividers take the global `--cui-border-width`, `--cui-border-style`
 and `--cui-border-color`, so they follow a theme like every other border.
-Both are responsive (`.divide-y-md`), and `.divide-x-0` / `.divide-y-0` remove
-the dividers at a breakpoint.
+
+Both are responsive, which is what makes a list that changes direction work: the
+dividers can switch axis at a breakpoint instead of being written twice.
+
+<Example code={`<div class="d-md-flex divide-y divide-y-md-0 divide-x-md border rounded">
+    <div class="p-2">First</div>
+    <div class="p-2">Second</div>
+    <div class="p-2">Third</div>
+  </div>`} />
+
+`divide-y` separates the stacked rows, `divide-y-md-0` removes those separators
+once the items line up, and `divide-x-md` draws them between the columns
+instead. The `-0` step exists for both axes at every breakpoint, so a divider
+can be dropped anywhere it stops making sense.
 
 <Callout color="info">
   The rule is wrapped in `:where()` and therefore adds no specificity — a child

--- a/docs/src/content/docs/utilities/spacing.mdx
+++ b/docs/src/content/docs/utilities/spacing.mdx
@@ -147,8 +147,19 @@ another class.
     <a href="#">Third</a>
   </div>`} />
 
-Both are responsive (`.space-y-md-4`) and take the same `0`–`5` steps from the
-`$spacers` map as every other spacing utility.
+Both are responsive and take the same `0`–`5` steps from the `$spacers` map as
+every other spacing utility. Combining the two axes is the usual reason to reach
+for them: a stack on small screens that becomes a row further up needs the
+spacing to change axis with it.
+
+<Example code={`<div class="d-md-flex space-y-3 space-y-md-0 space-x-md-3">
+    <div class="p-2 border">First</div>
+    <div class="p-2 border">Second</div>
+    <div class="p-2 border">Third</div>
+  </div>`} />
+
+`space-y-3` spaces the stack, `space-y-md-0` drops that spacing once the items
+sit in a row, and `space-x-md-3` takes over along the inline axis.
 
 <Callout color="info">
   The generated rule is wrapped in `:where()`, so it adds **no specificity**: a


### PR DESCRIPTION
Follow-up to #684, which documented `.space-x-*`/`.space-y-*` and `.divide-x`/`.divide-y` but only asserted their responsive variants in prose.

That is the case people actually reach for these utilities for — a stack on small screens that becomes a row further up, where the spacing or the divider has to change axis with it — so each section now shows it:

```html
<div class="d-md-flex space-y-3 space-y-md-0 space-x-md-3">
<div class="d-md-flex divide-y divide-y-md-0 divide-x-md border rounded">
```

with a sentence naming what each of the three classes does.

Every class used is verified against the compiled CSS (`space-y-md-0`, `space-x-md-3`, `divide-y-md-0`, `divide-x-md`), and the built site renders both as live examples with those rules present in the docs stylesheet. Full `docs-build`: 139 pages, no broken links.