### PR TITLE
docs(PasswordInput): fix example indentation and point customization at the frame

### DIFF
--- a/docs/src/content/docs/forms/password-input.mdx
+++ b/docs/src/content/docs/forms/password-input.mdx
@@ -76,9 +76,9 @@ Use the `readonly` attribute to make the input non-editable but still selectable
 
 <Example pro code={`<div class="form-control-group">
     <input type="password" class="form-control" placeholder="Readonly password input" value="Readonly input here..." readonly>
-      <button type="button" class="form-control-action" data-coreui-toggle="password" aria-pressed="false" aria-label="Toggle password visibility">
-        <span class="form-password-action-icon"></span>
-      </button>
+    <button type="button" class="form-control-action" data-coreui-toggle="password" aria-pressed="false" aria-label="Toggle password visibility">
+      <span class="form-password-action-icon"></span>
+    </button>
   </div>`} />
 
 ## Usage
@@ -87,23 +87,45 @@ Via data attributes, the password input plugin toggles visibility of the passwor
 
 ```html
 <div class="form-control-group">
-  <input type="password" class="form-control" placeholder="Readonly password input" value="Readonly input here..." readonly>
-    <button type="button" class="form-control-action" data-coreui-toggle="password" aria-pressed="false" aria-label="Toggle password visibility">
-      <span class="form-password-action-icon"></span>
-    </button>
+  <input type="password" class="form-control" placeholder="Enter your password">
+  <button type="button" class="form-control-action" data-coreui-toggle="password" aria-pressed="false" aria-label="Toggle password visibility">
+    <span class="form-password-action-icon"></span>
+  </button>
 </div>
 ```
 
 ## Customization options
 
-### SASS variables
+A password field is an `<input>` and a toggle button inside a
+[`form-control-group`](/forms/form-control-group/), so almost everything you
+would want to change lives on those two, not here. This page owns exactly one
+thing: the icon that swaps when the password becomes visible.
 
-Customize the appearance of the Bootstrap Password Input using the following SASS variables:
+### CSS variables
 
-Variables prefixed with `$input-*` are shared across most Bootstrap form controls.
+The frame — its padding, colours, border, focus ring and the size of the toggle
+button — is the group's, and it reads the shared `--#{prefix}control-*`
+properties. Set them on `.form-control-group` to restyle one field, or globally
+to restyle every field component at once:
+
+<ScssDocs file="scss/forms/_form-control-group.scss" capture="form-control-group-tokens" />
+
+The toggle icon is this component's own:
+
+<ScssDocs file="scss/forms/_form-password.scss" capture="form-password-icon-tokens" />
+
+### Sass variables
+
+`$input-*` are shared across every form control:
 
 <ScssDocs file="scss/_config.scss" capture="form-input-variables" />
 
-Variables like `$form-password-*` apply specifically to password input wrappers.
+`$form-control-group-*` cover the frame and its adornments:
+
+<ScssDocs file="scss/forms/_form-control-group.scss" capture="form-control-group-variables" />
+
+`$form-password-*` are the two toggle icons, and nothing else — the wrapper
+variables that used to live here went to the group when the password field
+moved onto it:
 
 <ScssDocs file="scss/forms/_form-password.scss" capture="form-password-variables" />


### PR DESCRIPTION
Three fixes on the password input page.

**Indentation.** The *Readonly state* example and the *Usage* snippet indented the toggle `<button>` one level deeper than the `<input>` it sits beside, so the markup read as if the button were inside the input.

**The Usage snippet was a copy of the readonly example.** It demonstrated the data API with `readonly`, a value of `"Readonly input here..."` and a placeholder saying "Readonly password input" — none of which has anything to do with `data-coreui-toggle="password"`. It is a plain password field now.

**Customization was describing a wrapper that no longer exists.** The section said `$form-password-*` are the variables for "password input wrappers". Since the field moved onto `.form-control-group`, `_form-password.scss` holds exactly two variables — the show and hide icons — and everything a reader would actually want to change (padding, colours, border, focus ring, the size of the toggle button) belongs to the group.

The section now says that plainly and captures the right sources: `--cui-control-*` and `$form-control-group-*` for the frame, `--cui-form-password-icon-*` and `$form-password-*` for the icon that swaps with the input's type.

Verified with a full `docs-build`: 139 pages, no broken links, and the new `<ScssDocs>` captures render.

Related: coreui/astro-docs#60 gives adjacent `.form-control-group` demos the margin they lost when the v5 `.form-password` wrapper went away — that is why two password fields in one example currently sit flush.