### PR TITLE
fix(build): compile the entry points, not the whole scss tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "npm-run-all --parallel watch docs-serve",
     "bundlewatch": "bundlewatch --config .bundlewatch.config.json",
     "css": "npm-run-all css-compile css-prefix css-minify",
-    "css-compile": "sass --style expanded --source-map --embed-sources --no-error-css scss/:dist/css/",
+    "css-compile": "sass --style expanded --source-map --embed-sources --no-error-css scss/coreui.scss:dist/css/coreui.css scss/coreui-grid.scss:dist/css/coreui-grid.css scss/coreui-reboot.scss:dist/css/coreui-reboot.css scss/coreui-utilities.scss:dist/css/coreui-utilities.css scss/themes/bootstrap/bootstrap.scss:dist/css/themes/bootstrap/bootstrap.css",
     "css-lint": "npm-run-all --aggregate-output --continue-on-error --parallel css-lint-*",
     "css-lint-stylelint": "stylelint \"**/*.{css,scss}\" --cache --cache-location .cache/.stylelintcache",
     "css-lint-vars": "fusv scss/",


### PR DESCRIPTION
`dist/css` had six folders in it that nobody asked for.

## What happened

`css-compile` ran in directory mode:

```
sass --style expanded --source-map --embed-sources --no-error-css scss/:dist/css/
```

which compiles **every file in the tree that is not a partial**. The v6 reorganisation added barrel files — `scss/{buttons,content,forms,helpers,layout,mixins}/index.scss`, pure `@forward` aggregators — and because they have no leading underscore, each became an entry point and emitted a stylesheet of its own.

The result, per build:

| folder | `index.css` |
| --- | --- |
| `forms/` | 66 956 B — a second copy of the whole forms layer |
| `buttons/` | 41 183 B |
| `content/` | 19 127 B |
| `layout/` | 19 144 B |
| `helpers/` | 11 204 B |
| `mixins/` | **39 B** — mixins emit no CSS |

24 files with their minified variants and source maps, roughly 157 kB before minification. They were **not gitignored**, and `files` ships `dist/{css,js}/**/*.{css,js,map}` — so they were headed for the published package, source maps and all (and `--embed-sources` puts the full Sass into those).

## The fix

Name the five real entry points, which is exactly what upstream Bootstrap does — their `css-compile` lists `bootstrap.scss`, `bootstrap-grid.scss`, `bootstrap-reboot.scss` and `bootstrap-utilities.scss`, and their `scss/forms/index.scss` and `scss/helpers/index.scss` barrels are spelled the same way ours are. Directory mode was the difference, not the file naming — worth keeping in mind, since renaming the barrels to `_index.scss` would have diverged from a structure we deliberately track.

## Verification

Compiled the same tree both ways and diffed:

```
IDENTYCZNY  coreui.css
IDENTYCZNY  coreui-grid.css
IDENTYCZNY  coreui-reboot.css
IDENTYCZNY  coreui-utilities.css
IDENTYCZNY  themes/bootstrap/bootstrap.css
```

Byte-identical, all five. The only difference in the output tree is the six barrels that stop being written.

Plus stylelint, bundlewatch and the local pre-push gate (lint → dist → typecheck → sass suite → class API → bundlewatch → js tests).

⚠️ **No GitHub CI on this PR** — Actions have produced no runs across the org since 13:26 UTC, so nothing was scheduled for this branch. The evidence above is local.