### PR TITLE
feat(ChipInput)!: take the frame class instead of asking for it

### DIFF
--- a/docs/src/content/docs/forms/chip-input.mdx
+++ b/docs/src/content/docs/forms/chip-input.mdx
@@ -34,7 +34,7 @@ Use the Bootstrap Chip Input component when you need:
 
 Wrap chips and add `data-coreui-chip-input` to enable behavior.
 
-<Example code={`<div class="form-control-group chip-input" data-coreui-chip-input data-coreui-name="chipInputBasicExample" data-coreui-placeholder="Add a skill...">
+<Example code={`<div class="chip-input" data-coreui-chip-input data-coreui-name="chipInputBasicExample" data-coreui-placeholder="Add a skill...">
     <label class="chip-input-label" for="skillsInputBasic">Skills:</label>
     <span class="chip">JavaScript</span>
     <span class="chip">TypeScript</span>
@@ -46,7 +46,7 @@ Wrap chips and add `data-coreui-chip-input` to enable behavior.
 </Callout>
 
 ```html
-<div class="form-control-group chip-input" data-coreui-chip-input data-coreui-placeholder="Add a skill...">
+<div class="chip-input" data-coreui-chip-input data-coreui-placeholder="Add a skill...">
   <label class="chip-input-label" for="skillsInputBasic">Skills:</label>
   <span class="chip">JavaScript</span>
   <span class="chip">TypeScript</span>
@@ -59,7 +59,7 @@ Wrap chips and add `data-coreui-chip-input` to enable behavior.
 
 Use contextual chip classes inside Bootstrap 5 Chip Input to represent categories, status, or priority.
 
-<Example code={`<div class="form-control-group chip-input" data-coreui-chip-input data-coreui-name="issues" data-coreui-placeholder="Add label...">
+<Example code={`<div class="chip-input" data-coreui-chip-input data-coreui-name="issues" data-coreui-placeholder="Add label...">
     <span class="chip chip-primary">Feature</span>
     <span class="chip chip-success">Approved</span>
     <span class="chip chip-warning">Needs review</span>
@@ -68,7 +68,7 @@ Use contextual chip classes inside Bootstrap 5 Chip Input to represent categorie
 
 In the example below, the chip color is assigned dynamically based on the chip text using the `chipClassName` callback. Each value (e.g., `Feature` or `Blocking`) maps to a contextual class, so chips remain visually consistent even when added programmatically.
 
-<Example code={`<div id="chipVariants" class="form-control-group chip-input"></div>`} sandboxJs={chipVariants} />
+<Example code={`<div id="chipVariants" class="chip-input"></div>`} sandboxJs={chipVariants} />
 
 The JavaScript below initializes the example:
 
@@ -78,17 +78,17 @@ The JavaScript below initializes the example:
 
 Use `chip-input-sm` and `chip-input-lg` to match surrounding form controls. Default size is provided by `.chip-input` without a size modifier.
 
-<Example code={`<div class="form-control-group chip-input chip-input-sm mb-3" data-coreui-chip-input data-coreui-placeholder="Add small tag...">
+<Example code={`<div class="chip-input chip-input-sm mb-3" data-coreui-chip-input data-coreui-placeholder="Add small tag...">
     <label class="chip-input-label" for="skillsInputSm">Small</label>
     <span class="chip">HTML</span>
   </div>
 
-  <div class="form-control-group chip-input mb-3" data-coreui-chip-input data-coreui-placeholder="Add default tag...">
+  <div class="chip-input mb-3" data-coreui-chip-input data-coreui-placeholder="Add default tag...">
     <label class="chip-input-label" for="skillsInputMd">Default</label>
     <span class="chip">JavaScript</span>
   </div>
 
-  <div class="form-control-group chip-input chip-input-lg" data-coreui-chip-input data-coreui-placeholder="Add large tag...">
+  <div class="chip-input chip-input-lg" data-coreui-chip-input data-coreui-placeholder="Add large tag...">
     <label class="chip-input-label" for="skillsInputLg">Large</label>
     <span class="chip">TypeScript</span>
   </div>`} />
@@ -97,7 +97,7 @@ Use `chip-input-sm` and `chip-input-lg` to match surrounding form controls. Defa
 
 Start with just the input and let users add chips as they type.
 
-<Example code={`<div class="form-control-group chip-input" data-coreui-chip-input data-coreui-name="tags" data-coreui-placeholder="Start typing tags..."></div>`} />
+<Example code={`<div class="chip-input" data-coreui-chip-input data-coreui-name="tags" data-coreui-placeholder="Start typing tags..."></div>`} />
 
 ## With label
 
@@ -105,7 +105,7 @@ Use a standard form label for accessibility.
 
 <Example code={`<div class="mb-3">
     <label class="form-label" for="techStackInput">Tech stack</label>
-    <div class="form-control-group chip-input" data-coreui-chip-input data-coreui-name="techStack" data-coreui-placeholder="Add package...">
+    <div class="chip-input" data-coreui-chip-input data-coreui-name="techStack" data-coreui-placeholder="Add package...">
       <span class="chip">Vue</span>
       <span class="chip">Vite</span>
     </div>
@@ -118,7 +118,7 @@ Set disabled state on the component to make the input and managed chips non-inte
 You can use either the `disabled` class or the `data-coreui-disabled="true"` option.
 For disabled, non-removable chips, combine it with `data-coreui-removable="false"`.
 
-<Example code={`<div class="form-control-group chip-input" data-coreui-chip-input data-coreui-disabled="true" data-coreui-removable="false" data-coreui-placeholder="Input disabled">
+<Example code={`<div class="chip-input" data-coreui-chip-input data-coreui-disabled="true" data-coreui-removable="false" data-coreui-placeholder="Input disabled">
     <span class="chip">Read only</span>
     <span class="chip">Locked</span>
   </div>`} />
@@ -128,7 +128,7 @@ For disabled, non-removable chips, combine it with `data-coreui-removable="false
 Use readonly state when chips should stay visible and focusable, but values must not change.
 Set `data-coreui-readonly="true"` (or `readonly: true` in JavaScript) to block adding and removing chips.
 
-<Example code={`<div class="form-control-group chip-input" data-coreui-chip-input data-coreui-readonly="true" data-coreui-placeholder="Read-only values">
+<Example code={`<div class="chip-input" data-coreui-chip-input data-coreui-readonly="true" data-coreui-placeholder="Read-only values">
     <span class="chip">JavaScript</span>
     <span class="chip">TypeScript</span>
   </div>`} />
@@ -138,7 +138,7 @@ Set `data-coreui-readonly="true"` (or `readonly: true` in JavaScript) to block a
 Enable selection for chips managed by Chip Input.
 In this example, `select.coreui.chip-input` updates a live list of selected values below the field.
 
-<Example code={`<div id="chipSelectable" class="form-control-group chip-input">
+<Example code={`<div id="chipSelectable" class="chip-input">
     <span class="chip">Design</span>
     <span class="chip">Backend</span>
     <span class="chip active">QA</span>
@@ -155,7 +155,7 @@ Initialize the Bootstrap Chip Input component via data attributes or JavaScript.
 Add `data-coreui-chip-input` to initialize the chip input component. Options can be passed as `data-coreui-*` attributes.
 
 ```html
-<div class="form-control-group chip-input" data-coreui-chip-input data-coreui-name="skills" data-coreui-placeholder="Add tags..." data-coreui-separator=","></div>
+<div class="chip-input" data-coreui-chip-input data-coreui-name="skills" data-coreui-placeholder="Add tags..." data-coreui-separator=","></div>
 ```
 
 When initialized, Chip Input creates a hidden input to submit values with the form.  

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -309,6 +309,19 @@ input group, target `.form-control-group` instead. A hand-authored group — a
 password field, a chip input — is now a first-class child of `.input-group`
 and needs no wrapper of its own.
 
+#### Chip Input takes the frame class itself
+
+<span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+
+```diff
+- <div class="form-control-group chip-input" data-coreui-chip-input>
++ <div class="chip-input" data-coreui-chip-input>
+```
+
+A chip input has no control to wrap — the element *is* the frame — so it adds
+`.form-control-group` to itself rather than asking you to write both. Writing
+both still works; the component only removes on `dispose()` a class it added.
+
 #### Password Input and Number Input build their own frame
 
 <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/js/src/chip-input.ts
+++ b/js/src/chip-input.ts
@@ -32,6 +32,7 @@ const SELECTOR_CHIP_REMOVE = '.chip-remove'
 
 const CLASS_NAME_DISABLED = 'disabled'
 const CLASS_NAME_CHIP_INPUT_FIELD = 'chip-input-field'
+const CLASS_NAME_GROUP = 'form-control-group'
 
 type ChipInputConfig = ChipSetConfig & {
   create: boolean
@@ -80,12 +81,19 @@ class ChipInput extends ChipSet {
   protected declare _uniqueId: string
   protected declare _hiddenInput: HTMLInputElement | null
   protected declare _input: HTMLInputElement
+  private _addedGroupClass = false
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
     super(element, config)
 
     this._uniqueId = this._config.id ?? getUID(NAME)
     this._hiddenInput = null
+
+    // The element is the frame: unlike the components that wrap a control, a
+    // chip input has nothing to wrap, so it takes the frame class itself and
+    // the author writes only what the field is.
+    this._addedGroupClass = !this._element.classList.contains(CLASS_NAME_GROUP)
+    this._element.classList.add(CLASS_NAME_GROUP)
 
     this._input = SelectorEngine.findOne('input', this._element as ParentNode) as HTMLInputElement
     if (this._input) {
@@ -132,6 +140,14 @@ class ChipInput extends ChipSet {
 
   focus(): void {
     this._input?.focus()
+  }
+
+  override dispose(): void {
+    if (this._addedGroupClass) {
+      this._element.classList.remove(CLASS_NAME_GROUP)
+    }
+
+    super.dispose()
   }
 
   // Private

--- a/js/tests/unit/chip-input.spec.js
+++ b/js/tests/unit/chip-input.spec.js
@@ -4,6 +4,36 @@ import ChipSet from '../../src/chip-set.js'
 import { clearFixture, getFixture } from '../helpers/fixture.js'
 
 describe('ChipInput', () => {
+  describe('the frame', () => {
+    it('should take the frame class itself', () => {
+      fixtureEl.innerHTML = '<div class="chip-input"></div>'
+      const element = fixtureEl.querySelector('.chip-input')
+      const chipInput = new ChipInput(element) // eslint-disable-line no-unused-vars
+
+      expect(element.classList.contains('form-control-group')).toBe(true)
+    })
+
+    it('should give the class back on dispose', () => {
+      fixtureEl.innerHTML = '<div class="chip-input"></div>'
+      const element = fixtureEl.querySelector('.chip-input')
+      const chipInput = new ChipInput(element)
+
+      chipInput.dispose()
+
+      expect(element.classList.contains('form-control-group')).toBe(false)
+    })
+
+    it('should leave a class the author wrote', () => {
+      fixtureEl.innerHTML = '<div class="form-control-group chip-input"></div>'
+      const element = fixtureEl.querySelector('.chip-input')
+      const chipInput = new ChipInput(element)
+
+      chipInput.dispose()
+
+      expect(element.classList.contains('form-control-group')).toBe(true)
+    })
+  })
+
   let fixtureEl
 
   beforeAll(() => {

--- a/js/tests/visual/field-components.spec.js
+++ b/js/tests/visual/field-components.spec.js
@@ -281,7 +281,7 @@ describe('multi select', () => {
 
 describe('chip input', () => {
   it('with chips', async () => {
-    mount('<div id="host" class="form-control-group chip-input"></div>')
+    mount('<div id="host" class="chip-input"></div>')
     const ci = new ChipInput(container.querySelector('#host'), {})
     ci.add('Angular')
     ci.add('Bootstrap')


### PR DESCRIPTION
The last component in the family still asking the author to assemble the frame.

```diff
- <div class="form-control-group chip-input" data-coreui-chip-input>
+ <div class="chip-input" data-coreui-chip-input>
```

Password Input and Number Input build the frame they need around the control they wrap. A chip input has nothing to wrap — the element **is** the frame — so it adds `.form-control-group` to itself rather than asking for both.

Writing both still works: `dispose()` only removes a class the component added, so existing markup stays valid while the docs move to the short form.

## Verification

85 chip-input unit tests, three of them new and covering exactly the three states this can be in: the class added to a bare element, given back on `dispose()`, and left alone when the author wrote it themselves.

Full suites (2976 unit, 33 visual — the visual one now compares against committed Linux baselines as well), docs rebuilt, migration guide updated.