### PR TITLE
docs(MultiSelect): put the version badge under the heading, not after the prose

### DIFF
--- a/docs/src/content/docs/components/offcanvas.mdx
+++ b/docs/src/content/docs/components/offcanvas.mdx
@@ -129,7 +129,7 @@ When the backdrop is set to static, the Bootstrap offcanvas will remain open whe
 
 ## Dark offcanvas
 
- <AddedIn version="4.2.6" />
+<AddedIn version="4.2.6" />
 
 Change the appearance of offcanvas elements using utilities to better match various contexts, such as dark navbars. Here, we add `.text-bg-dark` to the `.offcanvas` and `.btn-close-white` to `.btn-close` for proper styling with a dark offcanvas. If there are dropdowns inside, consider also adding `.dropdown-menu-dark` to `.dropdown-menu`.
 

--- a/docs/src/content/docs/forms/multi-select.mdx
+++ b/docs/src/content/docs/forms/multi-select.mdx
@@ -159,7 +159,9 @@ If you want to display selected options as tags, add the `data-coreui-selection-
 
 ### Chips
 
-Add `data-coreui-selection-type="chips"` to render selected options as [Chip](/components/chip/) components — each selection becomes a real chip with the standard chip styling and a labelled remove button. <AddedIn version="6.0.0" />
+<AddedIn version="6.0.0" />
+
+Add `data-coreui-selection-type="chips"` to render selected options as [Chip](/components/chip/) components — each selection becomes a real chip with the standard chip styling and a labelled remove button.
 
 <Example pro code={`<select id="multiple-select-chips" data-coreui-multi-select multiple data-coreui-selection-type="chips" data-coreui-search="true">
     <option value="0">Angular</option>


### PR DESCRIPTION
Spotted by mrholek. The chips section had `<AddedIn version="6.0.0" />` trailing its description:

```diff
  ### Chips

- Add `data-coreui-selection-type="chips"` to render selected options as … a labelled remove button. <AddedIn version="6.0.0" />
+ <AddedIn version="6.0.0" />
+
+ Add `data-coreui-selection-type="chips"` to render selected options as … a labelled remove button.
```

Every other section on the page — *Global search* two headings above, for instance — states the version first and then describes the feature. Trailing it means a reader finds out it is new only after reading what it does.

Rendered order confirmed on the built page: heading → "Added in v6.0.0" → prose.

Swept the rest of the docs for the same shape. Two other hits:

- **offcanvas** had the badge on its own line but with a stray leading space — normalised.
- **alerts** keeps its inline badge: there it marks a single bullet in a list as new, not a whole section, which is a different thing and reads correctly as it is.