### PR TITLE
refactor(Sass): nest the field components' state rules

### DIFF
--- a/scss/_autocomplete.scss
+++ b/scss/_autocomplete.scss
@@ -4,12 +4,19 @@
 @layer components {
   .autocomplete {
     position: relative;
-  }
 
-  // The popup takes the focus away from the group, but the control is still
-  // active — so the frame keeps its focus treatment while it is open.
-  .autocomplete.show .form-control-group {
-    @include form-control-group-focus();
+    &.show {
+      // The popup takes the focus away from the group, but the control is
+      // still active, so the frame keeps its focus treatment while it is open.
+      .form-control-group {
+        @include form-control-group-focus();
+      }
+
+      // The chevron turns when the popup opens.
+      .form-control-action {
+        transform: rotate(180deg);
+      }
+    }
   }
 
   // The ghost completion drawn behind the text.
@@ -21,10 +28,5 @@
     height: 100%;
     pointer-events: none;
     opacity: .5;
-  }
-
-  // The chevron turns when the popup opens.
-  .autocomplete.show .form-control-action {
-    transform: rotate(180deg);
   }
 }

--- a/scss/_date-picker.scss
+++ b/scss/_date-picker.scss
@@ -36,12 +36,12 @@ $date-picker-tokens: defaults(
 
   .date-picker {
     position: relative;
-  }
 
-  // The popup takes the focus away from the group, but the control is still
-  // active — so the frame keeps its focus treatment while it is open.
-  .date-picker.show .form-control-group {
-    @include form-control-group-focus();
+    // The popup takes the focus away from the group, but the control is still
+    // active — so the frame keeps its focus treatment while it is open.
+    &.show .form-control-group {
+      @include form-control-group-focus();
+    }
   }
 
   // The panel declares its own tokens rather than inheriting them from the

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -37,18 +37,18 @@ $time-picker-tokens: defaults(
 @layer components {
   .time-picker {
     position: relative;
+
+    // The popup takes the focus away from the group, but the control is still
+    // active — so the frame keeps its focus treatment while it is open.
+    &.show .form-control-group {
+      @include form-control-group-focus();
+    }
   }
 
   // See .date-picker-popup: the panel owns its tokens so it survives being
   // teleported or portaled away from the field.
   .time-picker-popup {
     @include tokens($time-picker-tokens);
-  }
-
-  // The popup takes the focus away from the group, but the control is still
-  // active — so the frame keeps its focus treatment while it is open.
-  .time-picker.show .form-control-group {
-    @include form-control-group-focus();
   }
 
   .time-picker-body {

--- a/scss/forms/_form-multi-select.scss
+++ b/scss/forms/_form-multi-select.scss
@@ -28,16 +28,26 @@ $form-multi-select-tokens: defaults(
     @include tokens($form-multi-select-tokens);
 
     position: relative;
+
+    // The popup takes the focus away from the group, and a native focus on the
+    // overlaid select does the same, but the control is still active — so the
+    // frame keeps its focus treatment either way.
+    &.show,
+    &:has(> select:focus) {
+      .form-control-group {
+        @include form-control-group-focus();
+      }
+    }
+
+    // The chevron turns when the popup opens.
+    &.show .form-control-action {
+      transform: rotate(180deg);
+    }
   }
 
   // Tags wrap onto their own rows inside the frame's padding, like chips do.
   .form-multi-select .form-control-group {
     flex-wrap: wrap;
-  }
-
-  .form-multi-select.show .form-control-group,
-  .form-multi-select:has(> select:focus) .form-control-group {
-    @include form-control-group-focus();
   }
 
   // The native select stays in the DOM as an invisible overlay covering the control
@@ -106,11 +116,6 @@ $form-multi-select-tokens: defaults(
     .form-multi-select-selection-tags & {
       padding: calc(var(--#{$prefix}control-padding-y) - .25rem) calc(var(--#{$prefix}control-padding-x) - .25rem); // stylelint-disable-line function-disallowed-list
     }
-  }
-
-  // The chevron turns when the popup opens.
-  .form-multi-select.show .form-control-action {
-    transform: rotate(180deg);
   }
 
 }


### PR DESCRIPTION
Raised by mrholek looking at `_autocomplete.scss`: why is this

```scss
.autocomplete { position: relative; }

.autocomplete.show .form-control-group { @include form-control-group-focus(); }

.autocomplete.show .form-control-action { transform: rotate(180deg); }
```

not this

```scss
.autocomplete {
  position: relative;

  &.show {
    .form-control-group { @include form-control-group-focus(); }
    .form-control-action { transform: rotate(180deg); }
  }
}
```

**No reason.** Nothing enforced the flat form — `.stylelintrc` sets no nesting limit — and the rest of the codebase nests state exactly this way (`&.disabled` in `_form-control-group.scss`, `&.show` in `_menu.scss`), as does upstream Bootstrap in its own `_menu.scss`. Nested, a reader gets the whole state in one place: here is the field, and here is what changes when it opens.

All four field families wrote it flat, so all four are nested here — fixing only autocomplete would trade one inconsistency for another.

## Output unchanged

Compared declaration by declaration, since a byte diff is too strict for a reordering:

```
deklaracji: przed 8163  po 8163
USUNIĘTYCH 0  DODANYCH 0  ZMIENIONYCH 0
zmieniło pozycję: 67
```

Order only matters when two rules of equal specificity set the same property on the same element. The 67 that moved share no property with anything they crossed — `.form-multi-select .form-control-group` sets `flex-wrap`, the focus rule it crossed sets colours and outline; `.time-picker-popup` is the only declarer of its tokens. The visual suite confirms it: 33 baselines, unchanged.

Plus stylelint, fusv, the Sass suite and the class API guard.