### PR TITLE
fix(DateTimePicker): scope the panel's layout to the panel, not to the field

### DIFF
--- a/scss/_date-picker.scss
+++ b/scss/_date-picker.scss
@@ -52,17 +52,15 @@ $date-picker-tokens: defaults(
   // to its content.
   .date-picker-popup {
     @include tokens($date-picker-tokens);
-  }
 
-  .date-picker-body {
-    display: flex;
-  }
+    // The date-time picker puts the calendar and the time body side by side. The
+    // time body's layout rules are global but read --#{$prefix}time-picker-* custom
+    // properties that _time-picker.scss only defines on `.time-picker`, and this
+    // shell's root is a date picker — so the ones the body needs are declared here.
+    // They belong on the panel rather than on the field's root for the same reason
+    // the tokens above do; only the date-time picker's panel holds these elements,
+    // so the scope stays exact.
 
-  // the date-time picker puts the calendar and the time body side by side. The
-  // time body's layout rules are global but read --#{$prefix}time-picker-* custom
-  // properties that _time-picker.scss only defines on `.time-picker`; this shell's
-  // root is a date picker, so the ones the body needs are declared here.
-  .date-time-picker {
     .date-picker-timepickers {
       display: flex;
       border-inline-start: var(--#{$prefix}date-picker-footer-border-width) solid var(--#{$prefix}date-picker-footer-border-color);
@@ -86,6 +84,10 @@ $date-picker-tokens: defaults(
       --#{$prefix}time-picker-inline-select-padding-x: #{$time-picker-inline-select-padding-x};
       --#{$prefix}time-picker-inline-select-padding-y: #{$time-picker-inline-select-padding-y};
     }
+  }
+
+  .date-picker-body {
+    display: flex;
   }
 
   .date-picker-ranges {


### PR DESCRIPTION
`.date-time-picker .date-picker-timepickers` and the `--cui-time-picker-*` properties the time body needs sat under the field's root, so they stop applying the moment the panel leaves it — which `container` does by teleporting it, and which a framework port does by default when it renders the panel through a portal.

The result: the calendar and the time body stack instead of sitting side by side, and the columns lose the properties that size them. Measured in the React port, whose panel is portaled by default: the panel went 1442 px tall (five columns stacked) instead of 388 px.

The panel already owns its tokens for exactly this reason — the comment above `.date-picker-popup` in this file spells it out. These two blocks move onto it as well. The scope stays exact: a `.date-picker-timepickers`, and a `.time-picker-body` inside a date picker panel, exist only in the date-time picker.

Found while porting the v2 pickers to React (coreui-react-pro#83).