### PR TITLE
refactor(Sass): gate transitions behind prefers-reduced-motion: no-preference

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1243,3 +1243,11 @@ Prefer the `.d-sidebar-narrow*` names in new markup.
   `.is-valid` on the group behave exactly as on a `.form-control`, and the
   state also propagates from the control inside it. The per-family
   `!important` overrides that forced the invalid border in v5 are gone.
+- **Transitions are emitted inside `prefers-reduced-motion: no-preference`.**
+  The `transition()` mixin used to emit a transition and then switch it off
+  again under `prefers-reduced-motion: reduce`, so every animated rule shipped
+  an override block. It now emits the transition inside a `no-preference` query
+  instead, which drops those blocks. The trade-off: a browser that does not
+  support the media feature gets no transition at all. Rules that force
+  `transition: none` stay outside the query — they disable motion on purpose,
+  so they have to reach every reader.

--- a/scss/mixins/_transition.scss
+++ b/scss/mixins/_transition.scss
@@ -16,13 +16,17 @@
   }
 
   @if $enable-transitions {
-    @if list.nth($transition, 1) != null {
-      transition: $transition;
-    }
+    $first: list.nth($transition, 1);
 
-    @if $enable-reduced-motion and list.nth($transition, 1) != null and list.nth($transition, 1) != none {
-      @media (prefers-reduced-motion: reduce) {
-        transition: none;
+    @if $first != null {
+      // `none` disables motion on purpose, so it must reach every reader. It
+      // arrives bare or as `none !important`, hence the list test.
+      @if $enable-reduced-motion and not list.index($first, none) {
+        @media (prefers-reduced-motion: no-preference) {
+          transition: $transition;
+        }
+      } @else {
+        transition: $transition;
       }
     }
   }

--- a/scss/tests/mixins/_transition.test.scss
+++ b/scss/tests/mixins/_transition.test.scss
@@ -1,0 +1,138 @@
+// stylelint-disable property-disallowed-list
+@use "../../config" as *;
+@use "../../mixins/transition" as *;
+
+// Store original values
+$original-enable-transitions: $enable-transitions;
+$original-enable-reduced-motion: $enable-reduced-motion;
+
+$enable-transitions: true !global;
+$enable-reduced-motion: true !global;
+
+@include describe("transition mixin") {
+  @include it("emits the transition behind a no-preference query") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include transition(color .15s ease-in-out);
+        }
+      }
+
+      @include expect() {
+        @media (prefers-reduced-motion: no-preference) {
+          .test {
+            transition: color .15s ease-in-out;
+          }
+        }
+      }
+    }
+  }
+
+  @include it("keeps a forced none outside the query") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include transition(none);
+        }
+      }
+
+      @include expect() {
+        .test {
+          transition: none;
+        }
+      }
+    }
+  }
+
+  @include it("keeps a forced none !important outside the query") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include transition(none !important);
+        }
+      }
+
+      @include expect() {
+        .test {
+          transition: none !important;
+        }
+      }
+    }
+  }
+
+  @include it("falls back to $transition-base without arguments") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include transition();
+        }
+      }
+
+      @include expect() {
+        @media (prefers-reduced-motion: no-preference) {
+          .test {
+            transition: all .2s ease-in-out;
+          }
+        }
+      }
+    }
+  }
+
+  @include it("handles null values by emitting nothing") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include transition(null);
+        }
+      }
+
+      @include expect() {
+        .test { // stylelint-disable-line block-no-empty
+        }
+      }
+    }
+  }
+
+  @include it("respects $enable-reduced-motion variable") {
+    $enable-reduced-motion: false !global;
+
+    @include assert() {
+      @include output() {
+        .test {
+          @include transition(color .15s ease-in-out);
+        }
+      }
+
+      @include expect() {
+        .test {
+          transition: color .15s ease-in-out;
+        }
+      }
+    }
+
+    $enable-reduced-motion: true !global;
+  }
+
+  @include it("respects $enable-transitions variable") {
+    $enable-transitions: false !global;
+
+    @include assert() {
+      @include output() {
+        .test {
+          @include transition(color .15s ease-in-out);
+        }
+      }
+
+      @include expect() {
+        .test { // stylelint-disable-line block-no-empty
+        }
+      }
+    }
+
+    $enable-transitions: true !global;
+  }
+}
+
+// Restore original values
+$enable-transitions: $original-enable-transitions !global;
+$enable-reduced-motion: $original-enable-reduced-motion !global;


### PR DESCRIPTION
The `transition()` mixin emitted a transition, then switched it off again in a `prefers-reduced-motion: reduce` query. Every animated rule therefore paid for an override block. The mixin now emits the transition inside a `no-preference` query instead.

Compiled `coreui.css` (compressed): **411 073 → 410 526 B**, 57 `reduce` override blocks gone. The four that remain are `animation` rules (progress, placeholder, spinner) — those genuinely turn motion off and are untouched.

Rules that force `transition: none` stay outside the query: they disable motion on purpose, so they have to reach reduced-motion readers too. The old guard tested `!= none`, which missed `none !important` because Sass passes it as a two-item list; `list.index()` catches both spellings.

Trade-off, recorded in the migration guide: a browser without support for the media feature now gets no transition. Every browser above our floors supports it.

New `scss/tests/mixins/_transition.test.scss` covers the emitted shape, both `none` spellings, the `$transition-base` fallback, `null`, and the `$enable-transitions` / `$enable-reduced-motion` switches.

## Upstream

Adapted from twbs/bootstrap#42781. **The other half of that PR does not apply here.** Upstream composed `--*-transition: var(--*-transition-property) var(--*-transition-timing)`, which puts a property list and one duration into the `transition` shorthand — where the duration binds to the last property only, so a button animated `box-shadow` and left `color`, `background-color` and `border-color` at `0s`. Our tokens carry a duration per property (`color .15s ease-in-out, background-color .15s ease-in-out, …`), so that bug never existed in this tree and the `transition-props()` mixin has nothing to fix. Splitting our tokens into property/duration/timing is a token-architecture question, not a bug fix, and is left out.