### PR TITLE
fix(Button): expose aria-pressed on every toggle button

### DIFF
--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -190,29 +190,33 @@ Visually, these toggle buttons are identical to the [checkbox toggle buttons](/f
 
 ### Toggle states
 
-Add `data-coreui-toggle="button"` to toggle a button's `active` state. If you're pre-toggling a button, you must manually add the `.active` class **and** `aria-pressed="true"` to the `<button>`.
+Add `data-coreui-toggle="button"` to toggle a button's `active` state. Also add `aria-pressed` so assistive technologies announce the control as a toggle button. Use `aria-pressed="false"` for the default state. If you're pre-toggling a button, add the `.active` class **and** `aria-pressed="true"`.
 
 <Example code={`<div class="d-flex gap-1 mb-3">
-    <button type="button" class="btn" data-coreui-toggle="button">Toggle button</button>
+    <button type="button" class="btn" data-coreui-toggle="button" aria-pressed="false">Toggle button</button>
     <button type="button" class="btn active" data-coreui-toggle="button" aria-pressed="true">Active toggle button</button>
-    <button type="button" class="btn" disabled data-coreui-toggle="button">Disabled toggle button</button>
+    <button type="button" class="btn" disabled data-coreui-toggle="button" aria-pressed="false">Disabled toggle button</button>
   </div>
   <div class="d-flex gap-1">
-    <button type="button" class="btn btn-primary" data-coreui-toggle="button">Toggle button</button>
+    <button type="button" class="btn btn-primary" data-coreui-toggle="button" aria-pressed="false">Toggle button</button>
     <button type="button" class="btn btn-primary active" data-coreui-toggle="button" aria-pressed="true">Active toggle button</button>
-    <button type="button" class="btn btn-primary" disabled data-coreui-toggle="button">Disabled toggle button</button>
+    <button type="button" class="btn btn-primary" disabled data-coreui-toggle="button" aria-pressed="false">Disabled toggle button</button>
   </div>`} />
 
 <Example code={`<div class="d-flex gap-1 mb-3">
-    <a href="#" class="btn" role="button" data-coreui-toggle="button">Toggle link</a>
+    <a href="#" class="btn" role="button" data-coreui-toggle="button" aria-pressed="false">Toggle link</a>
     <a href="#" class="btn active" role="button" data-coreui-toggle="button" aria-pressed="true">Active toggle link</a>
-    <a class="btn disabled" aria-disabled="true" role="button" data-coreui-toggle="button">Disabled toggle link</a>
+    <a class="btn disabled" aria-disabled="true" role="button" data-coreui-toggle="button" aria-pressed="false">Disabled toggle link</a>
   </div>
   <div class="d-flex gap-1">
-    <a href="#" class="btn btn-primary" role="button" data-coreui-toggle="button">Toggle link</a>
+    <a href="#" class="btn btn-primary" role="button" data-coreui-toggle="button" aria-pressed="false">Toggle link</a>
     <a href="#" class="btn btn-primary active" role="button" data-coreui-toggle="button" aria-pressed="true">Active toggle link</a>
-    <a class="btn btn-primary disabled" aria-disabled="true" role="button" data-coreui-toggle="button">Disabled toggle link</a>
+    <a class="btn btn-primary disabled" aria-disabled="true" role="button" data-coreui-toggle="button" aria-pressed="false">Disabled toggle link</a>
   </div>`} />
+
+<Callout color="info">
+`aria-pressed` has no default value. A button without it is announced as a plain button, not as a toggle. As a safety net, CoreUI adds the missing attribute to every `[data-coreui-toggle="button"]` on `DOMContentLoaded`, using the `.active` class to pick the value. Write it in your markup anyway, so the state is correct before our JavaScript runs.
+</Callout>
 
 ### Methods
 

--- a/js/src/button.ts
+++ b/js/src/button.ts
@@ -10,7 +10,8 @@
 
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
-import { defineJQueryPlugin } from './util/index.js'
+import SelectorEngine from './dom/selector-engine.js'
+import { defineJQueryPlugin, setAriaAttribute } from './util/index.js'
 
 /**
  * Constants
@@ -24,6 +25,7 @@ const DATA_API_KEY = '.data-api'
 const CLASS_NAME_ACTIVE = 'active'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="button"]'
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
+const EVENT_DOM_CONTENT_LOADED = `DOMContentLoaded${EVENT_KEY}${DATA_API_KEY}`
 
 /**
  * Class definition
@@ -38,7 +40,7 @@ class Button extends BaseComponent {
   // Public
   toggle(): void {
     // Toggle class and sync the `aria-pressed` attribute with the return value of the `.toggle()` method
-    this._element.setAttribute('aria-pressed', this._element.classList.toggle(CLASS_NAME_ACTIVE) as unknown as string)
+    setAriaAttribute(this._element, 'aria-pressed', this._element.classList.toggle(CLASS_NAME_ACTIVE))
   }
 
   // Static
@@ -56,6 +58,17 @@ class Button extends BaseComponent {
 /**
  * Data API implementation
  */
+
+// A toggle button must always expose `aria-pressed`. Without it, assistive technology
+// reads the control as a plain button and never announces the pressed state.
+// See https://www.w3.org/WAI/ARIA/apg/patterns/button/
+EventHandler.on(document, EVENT_DOM_CONTENT_LOADED, () => {
+  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
+    if (!element.hasAttribute('aria-pressed')) {
+      setAriaAttribute(element, 'aria-pressed', element.classList.contains(CLASS_NAME_ACTIVE))
+    }
+  }
+})
 
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, event => {
   event.preventDefault()

--- a/js/src/util/index.ts
+++ b/js/src/util/index.ts
@@ -160,6 +160,13 @@ const isDisabled = (element: Element | null | undefined): boolean => {
   return element.hasAttribute('disabled') && element.getAttribute('disabled') !== 'false'
 }
 
+// ARIA state attributes take the strings 'true' and 'false', but we track those
+// states as booleans. This keeps the conversion in one place, so callers do not
+// have to reach for a cast to satisfy `setAttribute`.
+const setAriaAttribute = (element: Element, name: string, value: boolean): void => {
+  element.setAttribute(name, String(value))
+}
+
 const findShadowRoot = (element: Node): ShadowRoot | null => {
   if (!document.documentElement.attachShadow) {
     return null
@@ -324,6 +331,7 @@ export {
   onDOMContentLoaded,
   parseSelector,
   reflow,
+  setAriaAttribute,
   triggerTransitionEnd,
   toType
 }

--- a/js/tests/unit/button.spec.js
+++ b/js/tests/unit/button.spec.js
@@ -59,6 +59,22 @@ describe('Button', () => {
 
       expect(btnTestParent).toHaveClass('active')
     })
+
+    it('should add a missing aria-pressed based on the active class', () => {
+      fixtureEl.innerHTML = [
+        '<button class="btn" data-coreui-toggle="button">btn</button>',
+        '<button class="btn active" data-coreui-toggle="button">active btn</button>',
+        '<button class="btn" data-coreui-toggle="button" aria-pressed="true">pre-set btn</button>'
+      ].join('')
+
+      const [defaultBtn, activeBtn, preSetBtn] = fixtureEl.querySelectorAll('.btn')
+
+      document.dispatchEvent(new Event('DOMContentLoaded'))
+
+      expect(defaultBtn.getAttribute('aria-pressed')).toEqual('false')
+      expect(activeBtn.getAttribute('aria-pressed')).toEqual('true')
+      expect(preSetBtn.getAttribute('aria-pressed')).toEqual('true')
+    })
   })
 
   describe('toggle', () => {
@@ -75,6 +91,16 @@ describe('Button', () => {
 
       expect(btnEl.getAttribute('aria-pressed')).toEqual('true')
       expect(btnEl).toHaveClass('active')
+    })
+
+    it('should set aria-pressed when the attribute is missing', () => {
+      fixtureEl.innerHTML = '<button class="btn" data-coreui-toggle="button"></button>'
+
+      const btnEl = fixtureEl.querySelector('.btn')
+
+      btnEl.click()
+
+      expect(btnEl.getAttribute('aria-pressed')).toEqual('true')
     })
   })
 


### PR DESCRIPTION
`aria-pressed` has no default value. A toggle button that ships without it is announced as a plain button and its pressed state is never conveyed — and in our markup the attribute only appeared once `toggle()` had run, so the very first announcement was wrong.

- Adds the missing attribute to every `[data-coreui-toggle="button"]` on `DOMContentLoaded`, reading the `.active` class to pick the value. An author-supplied `aria-pressed` is left alone.
- Documents the attribute in the Toggle states examples, so the state is correct before our JavaScript runs, with a callout explaining the safety net.
- Adds `setAriaAttribute` to `js/src/util`, which keeps the boolean-to-string conversion in one place and drops the `as unknown as string` cast `toggle()` needed to satisfy `setAttribute`.

Tests cover all three markup cases (missing / missing + `.active` / pre-set) plus a click on a button that never declared the attribute.

## Parity

React's `CButton` already renders `aria-pressed` whenever `toggle` is set (`CButton.tsx:113`), so there is no gap to close there. The v5 vanilla line carries the same defect and gets an entry in the backport register.

Ported from twbs/bootstrap#42797.