### PR TITLE
refactor(Toast)!: move the transition to CSS with @starting-style

### DIFF
--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -41,10 +41,6 @@ Bootstrap toasts are as flexible as you need and require very little markup. At 
     </div>
   </div>`} />
 
-<Callout color="warning">
-Previously, our scripts dynamically added the `.hide` class to fully hide a toast (using `display:none` instead of just `opacity:0`). This is no longer necessary. However, for backwards compatibility, our script will still toggle the class (even though there is no practical reason to do so) until the next major version.
-</Callout>
-
 ### Live example
 
 Click the button below to display a toast (positioned with our utilities in the lower right corner) that is hidden by default.
@@ -152,6 +148,22 @@ Building on the previous example, you can design various toast color schemes usi
         Hello, world! This is a toast message.
       </div>
       <button type="button" class="btn-close btn-close-white me-2 m-auto" data-coreui-dismiss="toast" aria-label="Close"></button>
+    </div>
+  </div>`} />
+
+### Instant
+
+By default, toasts fade in and out. To disable the animation, add `.toast-instant` to the toast. The `show` and `hide` methods then finish immediately, so `shown.coreui.toast` and `hidden.coreui.toast` fire right away.
+
+<Example class=" bg-body-tertiary" code={`<div class="toast toast-instant" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast-header">
+      <svg class="docs-placeholder-img rounded me-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
+      <strong class="me-auto">CoreUI for Bootstrap</strong>
+      <small>11 mins ago</small>
+      <button type="button" class="btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>
+    </div>
+    <div class="toast-body">
+      This toast appears and disappears instantly.
     </div>
   </div>`} />
 
@@ -297,13 +309,12 @@ Dismissal can be achieved with the `data` attribute on a button **within the toa
 
 ### Options
 
-Options can be passed using data attributes or JavaScript. To do this, append an option name to `data-coreui-`, such as `data-coreui-animation="{value}"`. Remember to convert the case of the option name from "_camelCase_" to "_kebab-case_" when using data attributes. For instance, you should write `data-coreui-custom-class="beautifier"` rather than `data-coreui-customClass="beautifier"`.
+Options can be passed using data attributes or JavaScript. To do this, append an option name to `data-coreui-`, such as `data-coreui-autohide="{value}"`. Remember to convert the case of the option name from "_camelCase_" to "_kebab-case_" when using data attributes. For instance, you should write `data-coreui-custom-class="beautifier"` rather than `data-coreui-customClass="beautifier"`.
 
 Starting with CoreUI 4.2.6, all components support an **experimental** reserved data attribute named `data-coreui-config`, which can contain simple component configurations as a JSON string. If an element has attributes `data-coreui-config='{"delay":50, "title":689}'` and `data-coreui-title="Custom Title"`, then the final value for `title` will be `Custom Title`, as the standard data attributes will take precedence over values specified in `data-coreui-config`. Moreover, existing data attributes can also hold JSON values like `data-coreui-delay='{"show":50, "hide":250}'`.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| `animation` | boolean | `true` | Adds a CSS fade transition to the toast |
 | `autohide` | boolean | `true` | Hides the Bootstrap toast automatically |
 | `delay` | number | `5000` | Sets delay before hiding the toast (ms) |
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -504,6 +504,23 @@ adornment in the library — so the button needs no icon markup at all:
   invalid on it (axe `aria-allowed-attr`); the native `disabled`/`readonly`
   states on the inner `<input>` carry the semantics.
 
+#### Toast
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The fade moved to CSS.** Toast was the last component driving its animation
+  from JavaScript — it toggled `.fade`, forced a reflow, then juggled `.show`,
+  `.showing` and a deprecated `.hide` class to fake an exit. Menu and the picker
+  popup already express this with `@starting-style` and a discrete `display`
+  transition, and Toast now does the same. JavaScript only toggles `.show`.
+  - The `animation` option and `data-coreui-animation` are gone. Add
+    `.toast-instant` to skip the animation.
+  - `.showing` and the deprecated `.hide` class are gone, and toasts no longer
+    get the generic `.fade` class. Replace any CSS or tests that depend on them.
+  - The transition is tuned with `--cui-toast-transition-duration` and
+    `--cui-toast-transition-timing`.
+  - `isShown()` returns `false` as soon as `hide()` is called, rather than when
+    the fade-out ends.
+
 ### Sass architecture & design tokens
 
 v6 adopts the Bootstrap v6 SCSS architecture: CSS cascade layers, per-component

--- a/js/src/toast.ts
+++ b/js/src/toast.ts
@@ -12,7 +12,7 @@ import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler, { type CoreUIEvent } from './dom/event-handler.js'
 import { enableDismissTrigger } from './util/component-functions.js'
-import { defineJQueryPlugin, reflow } from './util/index.js'
+import { defineJQueryPlugin } from './util/index.js'
 
 /**
  * Constants
@@ -31,19 +31,15 @@ const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 
-const CLASS_NAME_FADE = 'fade'
-const CLASS_NAME_HIDE = 'hide' // @deprecated - kept here only for backwards compatibility
+const CLASS_NAME_INSTANT = 'toast-instant'
 const CLASS_NAME_SHOW = 'show'
-const CLASS_NAME_SHOWING = 'showing'
 
 const DefaultType = {
-  animation: 'boolean',
   autohide: 'boolean',
   delay: 'number'
 }
 
 const Default = {
-  animation: true,
   autohide: true,
   delay: 5000
 }
@@ -53,7 +49,6 @@ const Default = {
  */
 
 type ToastConfig = {
-  animation: boolean
   autohide: boolean
   delay: number
 }
@@ -99,22 +94,15 @@ class Toast extends BaseComponent {
 
     this._clearTimeout()
 
-    if (this._config.animation) {
-      this._element.classList.add(CLASS_NAME_FADE)
-    }
-
     const complete = () => {
-      this._element.classList.remove(CLASS_NAME_SHOWING)
       EventHandler.trigger(this._element, EVENT_SHOWN)
 
       this._maybeScheduleHide()
     }
 
-    this._element.classList.remove(CLASS_NAME_HIDE) // @deprecated
-    reflow(this._element)
-    this._element.classList.add(CLASS_NAME_SHOW, CLASS_NAME_SHOWING)
+    this._element.classList.add(CLASS_NAME_SHOW)
 
-    this._queueCallback(complete, this._element, this._config.animation)
+    this._queueCallback(complete, this._element, this._isAnimated())
   }
 
   hide(): void {
@@ -129,13 +117,13 @@ class Toast extends BaseComponent {
     }
 
     const complete = () => {
-      this._element.classList.add(CLASS_NAME_HIDE) // @deprecated
-      this._element.classList.remove(CLASS_NAME_SHOWING, CLASS_NAME_SHOW)
       EventHandler.trigger(this._element, EVENT_HIDDEN)
     }
 
-    this._element.classList.add(CLASS_NAME_SHOWING)
-    this._queueCallback(complete, this._element, this._config.animation)
+    // Removing .show starts the fade-out. The discrete `display` transition
+    // keeps the toast laid out until the fade finishes.
+    this._element.classList.remove(CLASS_NAME_SHOW)
+    this._queueCallback(complete, this._element, this._isAnimated())
   }
 
   override dispose(): void {
@@ -153,6 +141,10 @@ class Toast extends BaseComponent {
   }
 
   // Private
+  _isAnimated(): boolean {
+    return !this._element.classList.contains(CLASS_NAME_INSTANT)
+  }
+
   _maybeScheduleHide(): void {
     if (!this._config.autohide) {
       return

--- a/js/tests/unit/toast.spec.js
+++ b/js/tests/unit/toast.spec.js
@@ -65,7 +65,7 @@ describe('Toast', () => {
     it('should close toast when close element with data-coreui-dismiss attribute is set', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [
-          '<div class="toast" data-coreui-delay="1" data-coreui-autohide="false" data-coreui-animation="false">',
+          '<div class="toast toast-instant" data-coreui-delay="1" data-coreui-autohide="false">',
           '  <button type="button" class="ms-2 mb-1 btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>',
           '</div>'
         ].join('')
@@ -98,7 +98,7 @@ describe('Toast', () => {
       Toast.Default.delay = defaultDelay
 
       fixtureEl.innerHTML = [
-        '<div class="toast" data-coreui-autohide="false" data-coreui-animation="false">',
+        '<div class="toast toast-instant" data-coreui-autohide="false">',
         '  <button type="button" class="ms-2 mb-1 btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>',
         '</div>'
       ].join('')
@@ -139,32 +139,31 @@ describe('Toast', () => {
       })
     })
 
-    it('should not add fade class', () => {
-      return new Promise(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="toast" data-coreui-delay="1" data-coreui-animation="false">',
-          '  <div class="toast-body">',
-          '    a simple toast',
-          '  </div>',
-          '</div>'
-        ].join('')
+    it('should trigger shown synchronously when the toast is instant', () => {
+      fixtureEl.innerHTML = [
+        '<div class="toast toast-instant" data-coreui-autohide="false">',
+        '  <div class="toast-body">',
+        '    a simple toast',
+        '  </div>',
+        '</div>'
+      ].join('')
 
-        const toastEl = fixtureEl.querySelector('.toast')
-        const toast = new Toast(toastEl)
+      const toastEl = fixtureEl.querySelector('.toast')
+      const toast = new Toast(toastEl)
+      const spy = jasmine.createSpy('shown')
 
-        toastEl.addEventListener('shown.coreui.toast', () => {
-          expect(toastEl).not.toHaveClass('fade')
-          resolve()
-        })
+      toastEl.addEventListener('shown.coreui.toast', spy)
 
-        toast.show()
-      })
+      toast.show()
+
+      expect(spy).toHaveBeenCalled()
+      expect(toastEl).toHaveClass('show')
     })
 
     it('should not trigger shown if show is prevented', () => {
       return new Promise((resolve, reject) => {
         fixtureEl.innerHTML = [
-          '<div class="toast" data-coreui-delay="1" data-coreui-animation="false">',
+          '<div class="toast toast-instant" data-coreui-delay="1">',
           '  <div class="toast-body">',
           '    a simple toast',
           '  </div>',
@@ -437,6 +436,27 @@ describe('Toast', () => {
       })
     })
 
+    it('should trigger hidden synchronously when the toast is instant', () => {
+      fixtureEl.innerHTML = [
+        '<div class="toast toast-instant show" data-coreui-autohide="false">',
+        '  <div class="toast-body">',
+        '    a simple toast',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const toastEl = fixtureEl.querySelector('.toast')
+      const toast = new Toast(toastEl)
+      const spy = jasmine.createSpy('hidden')
+
+      toastEl.addEventListener('hidden.coreui.toast', spy)
+
+      toast.hide()
+
+      expect(spy).toHaveBeenCalled()
+      expect(toastEl).not.toHaveClass('show')
+    })
+
     it('should do nothing when we call hide on a non shown toast', () => {
       fixtureEl.innerHTML = '<div></div>'
 
@@ -453,7 +473,7 @@ describe('Toast', () => {
     it('should not trigger hidden if hide is prevented', () => {
       return new Promise((resolve, reject) => {
         fixtureEl.innerHTML = [
-          '<div class="toast" data-coreui-delay="1" data-coreui-animation="false">',
+          '<div class="toast toast-instant" data-coreui-delay="1">',
           '  <div class="toast-body">',
           '    a simple toast',
           '  </div>',

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -1,6 +1,7 @@
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/tokens" as *;
+@use "mixins/transition" as *;
 @use "config" as *;
 
 // stylelint-disable custom-property-no-missing-var-function
@@ -17,6 +18,8 @@ $toast-border-color:                var(--#{$prefix}border-color-translucent) !d
 $toast-border-radius:               var(--#{$prefix}border-radius) !default;
 $toast-box-shadow:                  var(--#{$prefix}box-shadow) !default;
 $toast-spacing:                     $container-padding-x !default;
+$toast-transition-duration:         .15s !default;
+$toast-transition-timing:           linear !default;
 
 $toast-header-color:                var(--#{$prefix}secondary-color) !default;
 $toast-header-background-color:     color-mix(in srgb, var(--#{$prefix}body-bg) 85%, transparent) !default;
@@ -44,6 +47,8 @@ $toast-tokens: defaults(
     --#{$prefix}toast-header-bg: #{$toast-header-background-color},
     --#{$prefix}toast-header-border-color: #{$toast-header-border-color},
     --#{$prefix}toast-font-size: $toast-font-size,
+    --#{$prefix}toast-transition-duration: #{$toast-transition-duration},
+    --#{$prefix}toast-transition-timing: #{$toast-transition-timing},
   ),
   $toast-tokens
 );
@@ -52,6 +57,7 @@ $toast-tokens: defaults(
   .toast {
     @include tokens($toast-tokens);
 
+    display: none;
     width: var(--#{$prefix}toast-max-width);
     max-width: 100%;
     font-size: var(--#{$prefix}toast-font-size);
@@ -63,12 +69,28 @@ $toast-tokens: defaults(
     box-shadow: var(--#{$prefix}toast-box-shadow);
     @include border-radius(var(--#{$prefix}toast-border-radius));
 
-    &.showing {
+    // `display` is what makes a toast appear, and it cannot be interpolated, so
+    // `allow-discrete` keeps it laid out until the fade-out finishes. Add
+    // `.toast-instant` to skip the animation.
+    &:not(.toast-instant) {
       opacity: 0;
+      @include transition(
+        opacity var(--#{$prefix}toast-transition-duration) var(--#{$prefix}toast-transition-timing),
+        display var(--#{$prefix}toast-transition-duration) allow-discrete
+      );
     }
 
-    &:not(.show) {
-      display: none;
+    &.show {
+      display: block;
+      opacity: 1;
+    }
+  }
+
+  // The toast is not rendered before `.show` lands, so the fade-in needs an
+  // explicit state to animate FROM: the base rule cannot express it.
+  @starting-style {
+    .toast:not(.toast-instant).show {
+      opacity: 0;
     }
   }
 


### PR DESCRIPTION
Toast was the last component in the library driving its animation from JavaScript: it toggled `.fade`, forced a reflow, then juggled `.show`, `.showing` and a deprecated `.hide` class to fake an exit animation. Menu and the picker popup already express this in CSS, so Toast now does the same — `@starting-style` supplies the state to animate from, and a discrete `display` transition keeps the toast laid out until the fade-out finishes. JavaScript only toggles `.show`.

Compiled output:

```css
.toast { display: none; … }
.toast:not(.toast-instant) {
  opacity: 0;
  transition: opacity var(--cui-toast-transition-duration) var(--cui-toast-transition-timing),
              display var(--cui-toast-transition-duration) allow-discrete;
}
.toast.show { display: block; opacity: 1; }
@starting-style { .toast:not(.toast-instant).show { opacity: 0; } }
```

`display: block` on `.show` is what the toast rendered as before (the base rule only said `:not(.show) { display: none }`), so nothing moves on the page.

## Breaking

- The `animation` option and `data-coreui-animation` are gone. Add `.toast-instant` to skip the animation.
- `.showing` and the deprecated `.hide` class are gone, and toasts no longer take the generic `.fade` class. The stale "we still toggle `.hide` for backwards compatibility" callout goes with them.
- `isShown()` returns `false` as soon as `hide()` is called, rather than when the fade-out ends.

Recorded in the v6 migration guide; docs get an Instant section and lose the `animation` row.

## Worth a look before merging

**`.toast-instant` is the first `-instant` class in this tree.** Upstream introduced it alongside `.dialog-instant` / `.drawer-instant`, which we do not have — our Modal and Offcanvas still take animation from the `.fade` class in markup, and Tooltip still has an `animation` option. If you would rather keep `animation` as the public knob for now, say so and I will drive the class from the option instead of dropping it.

## Not covered by tests

The unit suite exercises the JS (32 specs, incl. two new ones asserting `shown`/`hidden` fire synchronously for an instant toast), but it does not load the compiled CSS, so `@starting-style` and the discrete `display` transition are unverified by automation. Toast is not in the visual suite yet — a candidate when that suite grows.

## Unrelated observation

Every toast example in the docs (v5 and v6, and upstream too) is markup without `.show`, which `.toast { display: none }` hides — the published page at coreui.io/bootstrap/docs/components/toasts renders empty boxes held open by `.docs-example-toasts { min-height: 240px }`. Not touched here; worth its own fix.

Ported from twbs/bootstrap#42783.