### PR TITLE
feat(JavaScript): return a promise from the lifecycle methods

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "./dist/js/coreui.bundle.js",
-      "maxSize": "115.75kB"
+      "maxSize": "116kB"
     },
     {
       "path": "./dist/js/coreui.bundle.min.js",
@@ -42,15 +42,15 @@
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "104.75kB"
+      "maxSize": "105kB"
     },
     {
       "path": "./dist/js/coreui.esm.min.js",
-      "maxSize": "75.25kB"
+      "maxSize": "75.5kB"
     },
     {
       "path": "./dist/js/coreui.js",
-      "maxSize": "105.5kB"
+      "maxSize": "105.75kB"
     },
     {
       "path": "./dist/js/coreui.min.js",

--- a/docs/src/content/docs/components/carousel.mdx
+++ b/docs/src/content/docs/components/carousel.mdx
@@ -304,7 +304,7 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 You can create a carousel instance with the carousel constructor, for example, to initialize with additional options and start cycling through items:

--- a/docs/src/content/docs/components/collapse.mdx
+++ b/docs/src/content/docs/components/collapse.mdx
@@ -131,12 +131,12 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 ### Methods
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 Activates your content as a collapsible element. Accepts an optional options `object`.

--- a/docs/src/content/docs/components/list-group.mdx
+++ b/docs/src/content/docs/components/list-group.mdx
@@ -346,12 +346,12 @@ To make tabs panel fade in, add `.fade` to each `.tab-pane`. The first tab pane 
 
 #### constructor
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 Activates your content as a tab element.

--- a/docs/src/content/docs/components/modal.mdx
+++ b/docs/src/content/docs/components/modal.mdx
@@ -733,12 +733,12 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 ### Methods
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 #### Passing options

--- a/docs/src/content/docs/components/navs-tabs.mdx
+++ b/docs/src/content/docs/components/navs-tabs.mdx
@@ -537,12 +537,12 @@ To make tabs fade in, add `.fade` to each `.tab-pane`. The first tab pane must a
 
 ### Methods
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 #### constructor

--- a/docs/src/content/docs/components/offcanvas.mdx
+++ b/docs/src/content/docs/components/offcanvas.mdx
@@ -279,12 +279,12 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 ### Methods
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 Activates your content as an offcanvas element and accepts an optional options `object`.  

--- a/docs/src/content/docs/components/popovers.mdx
+++ b/docs/src/content/docs/components/popovers.mdx
@@ -201,12 +201,12 @@ const popover = new coreui.Popover(element, {
 
 ### Methods
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 | Method | Description |

--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -320,12 +320,12 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 ### Methods
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 | Method | Description |

--- a/docs/src/content/docs/components/tooltips.mdx
+++ b/docs/src/content/docs/components/tooltips.mdx
@@ -210,12 +210,12 @@ const tooltip = new coreui.Tooltip(element, {
 
 ### Methods
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 | Method | Description |

--- a/docs/src/content/docs/getting-started/javascript.mdx
+++ b/docs/src/content/docs/getting-started/javascript.mdx
@@ -141,21 +141,57 @@ const offcanvas = coreui.Offcanvas.getInstance('#myOffcanvas')
 const alert = coreui.Alert.getOrCreateInstance('#myAlert')
 ```
 
-### Asynchronous functions and transitions
+### Promises and transitions
 
-All programmatic API methods are **asynchronous** and return to the caller once the transition is started but **before it ends**.
+All programmatic API methods are **asynchronous** and return to the caller once the transition is started, but **before it ends**.
 
-In order to execute an action once the transition is complete, you can listen to the corresponding event.
+Methods that show or hide a component return a **promise**. The promise resolves when the transition ends, so you can `await` the method instead of listening for an event.
 
 ```js
-const myCollapseEl = document.getElementById('myCollapse')
+const collapse = coreui.Collapse.getOrCreateInstance('#myCollapse')
 
-myCollapseEl.addEventListener('shown.coreui.collapse', event => {
-  // Action to execute once the collapsible area is expanded
+await collapse.show()
+// The collapsible area is now expanded
+```
+
+These methods return a promise:
+
+| Method | Components |
+| --- | --- |
+| `show`, `hide`, `toggle` | Collapse, Menu, Modal, Offcanvas, Popover, Sidebar, Tooltip |
+| `show`, `hide` | Toast |
+| `show` | Tab |
+| `close` | Alert |
+
+The promise resolves with no value. It resolves at the same moment the matching `shown.coreui.*`, `hidden.coreui.*` or `closed.coreui.*` event fires, so both styles run your code at the same time. Use the event when you must react to every change, including ones your own code did not start.
+
+```js
+const offcanvasEl = document.getElementById('myOffcanvas')
+const offcanvas = coreui.Offcanvas.getOrCreateInstance(offcanvasEl)
+
+// Await the method you called…
+await offcanvas.hide()
+saveState()
+
+// …or listen for every hide, whoever started it
+offcanvasEl.addEventListener('hidden.coreui.offcanvas', () => {
+  saveState()
 })
 ```
 
-In addition a method call on a **transitioning component will be ignored**.
+Because each method returns a promise, you can run steps in order without nesting listeners.
+
+```js
+const modal = coreui.Modal.getOrCreateInstance('#myModal')
+const toast = coreui.Toast.getOrCreateInstance('#myToast')
+
+await modal.hide()
+await toast.show()
+```
+
+The promise also resolves when the call does nothing — for example when the component is already open, when a listener calls `preventDefault()` on the `show.coreui.*` event, or when you dispose the component mid-transition. `await` therefore never hangs, but it also does not tell you whether the state changed. Check the state yourself when that matters.
+
+In addition a method call on a **transitioning component will be ignored**. For the promise-returning methods above, such a call resolves immediately. It does not wait for the running transition to end.
 
 ```js
 const myCarouselEl = document.getElementById('myCarousel')
@@ -171,15 +207,26 @@ carousel.to('2') // !! Will be ignored, as the transition to the slide 1 is not 
 
 #### `dispose` method
 
-While it may seem correct to use the `dispose` method immediately after `hide()`, it will lead to incorrect results. Here's an example of the problem use:
+Do not call `dispose` immediately after `hide()`. The hide transition is still running at that point, so the component tears down mid-transition. Await the promise first:
 
 ```js
-const myModal = document.querySelector('#myModal')
-myModal.hide() // it is asynchronous
+const toast = coreui.Toast.getInstance('#myToast')
 
-myModal.addEventListener('shown.coreui.hidden', event => {
-  myModal.dispose()
+await toast.hide()
+toast.dispose()
+```
+
+The event-based equivalent also works:
+
+```js
+const myToast = document.querySelector('#myToast')
+const toast = coreui.Toast.getInstance(myToast)
+
+myToast.addEventListener('hidden.coreui.toast', () => {
+  toast.dispose()
 })
+
+toast.hide()
 ```
 
 ### Default settings

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -126,6 +126,32 @@ They are no longer part of the published package. Use the built bundle instead:
 or, if you are already resolving the package by name, `import { Tooltip } from
 '@coreui/coreui-pro'` — `module` points at the same ESM bundle.
 
+#### Lifecycle methods return a promise
+
+`show()`, `hide()`, `toggle()` and `close()` returned before the transition
+ended, so continuing after one meant listening for `shown.coreui.*` /
+`hidden.coreui.*`. They now return a promise that resolves at the same moment
+that event fires, so you can `await` the method instead:
+
+```diff
+- myCollapseEl.addEventListener('shown.coreui.collapse', () => {
+-   // the area is expanded
+- })
+- collapse.show()
++ await collapse.show()
++ // the area is expanded
+```
+
+Collapse, Menu, Modal, Offcanvas, Popover, Sidebar and Tooltip return one from
+`show`/`hide`/`toggle`, Toast from `show`/`hide`, Tab from `show`, and Alert
+from `close`. The event path is unchanged and still the right tool when you must
+react to changes your own code did not start.
+
+The promise always settles — a call that does nothing (already open, a prevented
+`show.coreui.*`, an instance disposed mid-transition) resolves right away rather
+than stranding the caller. It resolves with no value, so it tells you the call
+finished, not whether the state changed.
+
 ### Components
 
 #### Autocomplete and Multi Select share one options menu

--- a/js/src/alert.ts
+++ b/js/src/alert.ts
@@ -37,7 +37,7 @@ class Alert extends BaseComponent {
   }
 
   // Public
-  close(): void {
+  async close(): Promise<void> {
     const closeEvent = EventHandler.trigger(this._element, EVENT_CLOSE)
 
     if (closeEvent!.defaultPrevented) {
@@ -47,7 +47,7 @@ class Alert extends BaseComponent {
     this._element.classList.remove(CLASS_NAME_SHOW)
 
     const isAnimated = this._element.classList.contains(CLASS_NAME_FADE)
-    this._queueCallback(() => this._destroyElement(), this._element, isAnimated)
+    await this._queueCallback(() => this._destroyElement(), this._element, isAnimated)
   }
 
   // Private

--- a/js/src/base-component.ts
+++ b/js/src/base-component.ts
@@ -53,8 +53,22 @@ class BaseComponent extends Config {
   }
 
   // Private
-  _queueCallback(callback: () => void, element: Element, isAnimated = true): void {
-    executeAfterTransition(callback, element, isAnimated)
+
+  // Runs `callback` once the transition on `element` ends, and resolves afterwards.
+  // Lifecycle methods return this promise, so `await instance.show()` continues at the
+  // same moment a `shown.coreui.*` listener would run.
+  _queueCallback(callback: () => void, element: Element, isAnimated = true): Promise<void> {
+    return new Promise(resolve => {
+      executeAfterTransition(() => {
+        // Don't run the completion callback if the instance was disposed mid-transition.
+        // Still settle the promise, so an awaiting caller resumes instead of hanging.
+        if (this._element) {
+          callback()
+        }
+
+        resolve()
+      }, element, isAnimated)
+    })
   }
 
   override _getConfig(config?: ComponentConfig | null): ComponentConfig {

--- a/js/src/collapse.ts
+++ b/js/src/collapse.ts
@@ -117,15 +117,11 @@ class Collapse extends BaseComponent {
   }
 
   // Public
-  toggle(): void {
-    if (this._isShown()) {
-      this.hide()
-    } else {
-      this.show()
-    }
+  toggle(): Promise<void> {
+    return this._isShown() ? this.hide() : this.show()
   }
 
-  show(): void {
+  async show(): Promise<void> {
     if (this._isTransitioning || this._isShown()) {
       return
     }
@@ -176,11 +172,15 @@ class Collapse extends BaseComponent {
     const capitalizedDimension = dimension[0].toUpperCase() + dimension.slice(1)
     const scrollSize = `scroll${capitalizedDimension}`
 
-    this._queueCallback(complete, this._element, true)
+    // Register the completion callback first, then set the target size to start the
+    // transition. Awaiting here instead would stop the size from ever being applied.
+    const transition = this._queueCallback(complete, this._element, true)
     this._element.style[dimension as any] = `${(this._element as any)[scrollSize]}px`
+
+    await transition
   }
 
-  hide(): void {
+  async hide(): Promise<void> {
     if (this._isTransitioning || !this._isShown()) {
       return
     }
@@ -218,7 +218,7 @@ class Collapse extends BaseComponent {
 
     this._element.style[dimension as any] = ''
 
-    this._queueCallback(complete, this._element, true)
+    await this._queueCallback(complete, this._element, true)
   }
 
   // Private

--- a/js/src/menu.ts
+++ b/js/src/menu.ts
@@ -234,11 +234,11 @@ class Menu extends BaseComponent {
   }
 
   // Public
-  toggle(): void {
+  toggle(): Promise<void> {
     return this._isShown() ? this.hide() : this.show()
   }
 
-  show(): void {
+  async show(): Promise<void> {
     if (isDisabled(this._element) || this._isShown()) {
       return
     }
@@ -276,7 +276,7 @@ class Menu extends BaseComponent {
     EventHandler.trigger(this._element, this.constructor.eventName('shown'), relatedTarget)
   }
 
-  hide(): void {
+  async hide(): Promise<void> {
     if (isDisabled(this._element) || !this._isShown()) {
       return
     }

--- a/js/src/modal.ts
+++ b/js/src/modal.ts
@@ -102,11 +102,11 @@ class Modal extends BaseComponent {
   }
 
   // Public
-  toggle(relatedTarget?: HTMLElement | null): any {
+  toggle(relatedTarget?: HTMLElement | null): Promise<void> {
     return this._isShown ? this.hide() : this.show(relatedTarget)
   }
 
-  show(relatedTarget?: HTMLElement | null): void {
+  async show(relatedTarget?: HTMLElement | null): Promise<void> {
     if (this._isShown || this._isTransitioning) {
       return
     }
@@ -128,10 +128,15 @@ class Modal extends BaseComponent {
 
     this._adjustDialog()
 
-    this._backdrop.show(() => this._showElement(relatedTarget))
+    // The backdrop reports its own transition through a callback, so the element
+    // is only shown once it has settled — resolving with `_showElement` adopts
+    // the modal's own transition on top of it.
+    await new Promise<void>(resolve => {
+      this._backdrop.show(() => resolve(this._showElement(relatedTarget)))
+    })
   }
 
-  hide(): void {
+  async hide(): Promise<void> {
     if (!this._isShown || this._isTransitioning) {
       return
     }
@@ -148,7 +153,9 @@ class Modal extends BaseComponent {
 
     this._element.classList.remove(CLASS_NAME_SHOW)
 
-    this._queueCallback(() => this._hideModal(), this._element, this._isAnimated())
+    await new Promise<void>(resolve => {
+      this._queueCallback(() => resolve(this._hideModal()), this._element, this._isAnimated())
+    })
   }
 
   dispose(): any {
@@ -193,7 +200,7 @@ class Modal extends BaseComponent {
     })
   }
 
-  _showElement(relatedTarget?: HTMLElement | null): void {
+  async _showElement(relatedTarget?: HTMLElement | null): Promise<void> {
     // try to append dynamic modal
     if (!document.body.contains(this._element)) {
       document.body.append(this._element)
@@ -225,7 +232,7 @@ class Modal extends BaseComponent {
       })
     }
 
-    this._queueCallback(transitionComplete, this._dialog!, this._isAnimated())
+    await this._queueCallback(transitionComplete, this._dialog!, this._isAnimated())
   }
 
   _addEventListeners(): void {
@@ -267,18 +274,21 @@ class Modal extends BaseComponent {
     })
   }
 
-  _hideModal(): any {
+  async _hideModal(): Promise<void> {
     this._element.style.display = 'none'
     this._element.setAttribute('aria-hidden', true as unknown as string)
     this._element.removeAttribute('aria-modal')
     this._element.removeAttribute('role')
     this._isTransitioning = false
 
-    this._backdrop.hide(() => {
-      document.body.classList.remove(CLASS_NAME_OPEN)
-      this._resetAdjustments()
-      this._scrollBar.reset()
-      EventHandler.trigger(this._element, EVENT_HIDDEN)
+    await new Promise<void>(resolve => {
+      this._backdrop.hide(() => {
+        document.body.classList.remove(CLASS_NAME_OPEN)
+        this._resetAdjustments()
+        this._scrollBar.reset()
+        EventHandler.trigger(this._element, EVENT_HIDDEN)
+        resolve()
+      })
     })
   }
 

--- a/js/src/offcanvas.ts
+++ b/js/src/offcanvas.ts
@@ -94,11 +94,11 @@ class Offcanvas extends BaseComponent {
   }
 
   // Public
-  toggle(relatedTarget?: HTMLElement | null): any {
+  toggle(relatedTarget?: HTMLElement | null): Promise<void> {
     return this._isShown ? this.hide() : this.show(relatedTarget)
   }
 
-  show(relatedTarget?: HTMLElement | null): void {
+  async show(relatedTarget?: HTMLElement | null): Promise<void> {
     if (this._isShown) {
       return
     }
@@ -130,10 +130,10 @@ class Offcanvas extends BaseComponent {
       EventHandler.trigger(this._element, EVENT_SHOWN, { relatedTarget })
     }
 
-    this._queueCallback(completeCallBack, this._element, true)
+    await this._queueCallback(completeCallBack, this._element, true)
   }
 
-  hide(): void {
+  async hide(): Promise<void> {
     if (!this._isShown) {
       return
     }
@@ -162,7 +162,7 @@ class Offcanvas extends BaseComponent {
       EventHandler.trigger(this._element, EVENT_HIDDEN)
     }
 
-    this._queueCallback(completeCallback, this._element, true)
+    await this._queueCallback(completeCallback, this._element, true)
   }
 
   dispose(): any {

--- a/js/src/sidebar.ts
+++ b/js/src/sidebar.ts
@@ -101,7 +101,7 @@ class Sidebar extends BaseComponent {
 
   // Public
 
-  show(): void {
+  async show(): Promise<void> {
     EventHandler.trigger(this._element, EVENT_SHOW)
 
     if (this._element.classList.contains(CLASS_NAME_HIDE)) {
@@ -129,10 +129,10 @@ class Sidebar extends BaseComponent {
       }
     }
 
-    this._queueCallback(complete, this._element, true)
+    await this._queueCallback(complete, this._element, true)
   }
 
-  hide(): void {
+  async hide(): Promise<void> {
     EventHandler.trigger(this._element, EVENT_HIDE)
 
     if (this._element.classList.contains(CLASS_NAME_SHOW)) {
@@ -159,16 +159,11 @@ class Sidebar extends BaseComponent {
       }
     }
 
-    this._queueCallback(complete, this._element, true)
+    await this._queueCallback(complete, this._element, true)
   }
 
-  toggle(): void {
-    if (this._isVisible()) {
-      this.hide()
-      return
-    }
-
-    this.show()
+  toggle(): Promise<void> {
+    return this._isVisible() ? this.hide() : this.show()
   }
 
   narrow(): void {

--- a/js/src/tab.ts
+++ b/js/src/tab.ts
@@ -82,7 +82,8 @@ class Tab extends BaseComponent {
   }
 
   // Public
-  show(): void { // Shows this elem and deactivate the active sibling if exists
+  // Shows this elem and deactivate the active sibling if exists
+  async show(): Promise<void> {
     const innerElem = this._element
     if (this._elemIsActive(innerElem)) {
       return
@@ -102,11 +103,11 @@ class Tab extends BaseComponent {
     }
 
     this._deactivate(active, innerElem)
-    this._activate(innerElem, active)
+    await this._activate(innerElem, active)
   }
 
   // Private
-  _activate(element: HTMLElement | null, relatedElem?: HTMLElement | null): void {
+  async _activate(element: HTMLElement | null, relatedElem?: HTMLElement | null): Promise<void> {
     if (!element) {
       return
     }
@@ -129,10 +130,10 @@ class Tab extends BaseComponent {
       })
     }
 
-    this._queueCallback(complete, element, element.classList.contains(CLASS_NAME_FADE))
+    await this._queueCallback(complete, element, element.classList.contains(CLASS_NAME_FADE))
   }
 
-  _deactivate(element: HTMLElement | null, relatedElem?: HTMLElement | null): void {
+  async _deactivate(element: HTMLElement | null, relatedElem?: HTMLElement | null): Promise<void> {
     if (!element) {
       return
     }
@@ -154,7 +155,7 @@ class Tab extends BaseComponent {
       EventHandler.trigger(element, EVENT_HIDDEN, { relatedTarget: relatedElem })
     }
 
-    this._queueCallback(complete, element, element.classList.contains(CLASS_NAME_FADE))
+    await this._queueCallback(complete, element, element.classList.contains(CLASS_NAME_FADE))
   }
 
   _keydown(event: CoreUIEvent): void {

--- a/js/src/toast.ts
+++ b/js/src/toast.ts
@@ -85,7 +85,7 @@ class Toast extends BaseComponent {
   }
 
   // Public
-  show(): void {
+  async show(): Promise<void> {
     const showEvent = EventHandler.trigger(this._element, EVENT_SHOW)
 
     if (showEvent!.defaultPrevented) {
@@ -102,10 +102,10 @@ class Toast extends BaseComponent {
 
     this._element.classList.add(CLASS_NAME_SHOW)
 
-    this._queueCallback(complete, this._element, this._isAnimated())
+    await this._queueCallback(complete, this._element, this._isAnimated())
   }
 
-  hide(): void {
+  async hide(): Promise<void> {
     if (!this.isShown()) {
       return
     }
@@ -123,7 +123,7 @@ class Toast extends BaseComponent {
     // Removing .show starts the fade-out. The discrete `display` transition
     // keeps the toast laid out until the fade finishes.
     this._element.classList.remove(CLASS_NAME_SHOW)
-    this._queueCallback(complete, this._element, this._isAnimated())
+    await this._queueCallback(complete, this._element, this._isAnimated())
   }
 
   override dispose(): void {

--- a/js/src/tooltip.ts
+++ b/js/src/tooltip.ts
@@ -156,6 +156,7 @@ class Tooltip extends BaseComponent {
   protected declare _config: TooltipConfig
   protected declare _isEnabled: boolean
   protected declare _timeout: number
+  protected declare _resolveTimeout: (() => void) | null
   protected declare _isHovered: boolean | null
   protected declare _activeTrigger: Record<string, boolean>
   protected declare _floatingCleanup: (() => void) | null
@@ -177,6 +178,7 @@ class Tooltip extends BaseComponent {
     // Private
     this._isEnabled = true
     this._timeout = 0
+    this._resolveTimeout = null
     this._isHovered = null
     this._activeTrigger = {}
     this._floatingCleanup = null
@@ -223,21 +225,16 @@ class Tooltip extends BaseComponent {
     this._isEnabled = !this._isEnabled
   }
 
-  toggle(): void {
+  toggle(): Promise<void> {
     if (!this._isEnabled) {
-      return
+      return Promise.resolve()
     }
 
-    if (this._isShown()) {
-      this._leave()
-      return
-    }
-
-    this._enter()
+    return this._isShown() ? this._leave() : this._enter()
   }
 
   override dispose(): void {
-    clearTimeout(this._timeout)
+    this._clearTimeout()
 
     this._removeEscapeListener()
 
@@ -318,10 +315,10 @@ class Tooltip extends BaseComponent {
       this._isHovered = false
     }
 
-    this._queueCallback(complete, this.tip!, this._isAnimated()!)
+    await this._queueCallback(complete, this.tip!, this._isAnimated()!)
   }
 
-  hide(): void {
+  async hide(): Promise<void> {
     if (!this._isShown()) {
       return
     }
@@ -362,7 +359,7 @@ class Tooltip extends BaseComponent {
       EventHandler.trigger(this._element, this.constructor.eventName(EVENT_HIDDEN))
     }
 
-    this._queueCallback(complete, this.tip!, this._isAnimated()!)
+    await this._queueCallback(complete, this.tip!, this._isAnimated()!)
   }
 
   update(): void {
@@ -737,38 +734,54 @@ class Tooltip extends BaseComponent {
     this._element.removeAttribute('title')
   }
 
-  protected _enter(): void {
+  protected _enter(): Promise<void> {
     if (this._isShown() || this._isHovered) {
       this._isHovered = true
-      return
+      return Promise.resolve()
     }
 
     this._isHovered = true
 
-    this._setTimeout(() => {
-      if (this._isHovered) {
-        this.show()
-      }
-    }, (this._config.delay as { show: number, hide: number }).show)
+    return this._setTimeout(
+      () => this._isHovered ? this.show() : undefined,
+      (this._config.delay as { show: number, hide: number }).show
+    )
   }
 
-  protected _leave(): void {
+  protected _leave(): Promise<void> {
     if (this._isWithActiveTrigger()) {
-      return
+      return Promise.resolve()
     }
 
     this._isHovered = false
 
-    this._setTimeout(() => {
-      if (!this._isHovered) {
-        this.hide()
-      }
-    }, (this._config.delay as { show: number, hide: number }).hide)
+    return this._setTimeout(
+      () => this._isHovered ? undefined : this.hide(),
+      (this._config.delay as { show: number, hide: number }).hide
+    )
   }
 
-  protected _setTimeout(handler: () => void, timeout: number): void {
+  protected _setTimeout(handler: () => void | Promise<void>, timeout: number): Promise<void> {
+    this._clearTimeout()
+
+    return new Promise(resolve => {
+      this._resolveTimeout = resolve
+      this._timeout = setTimeout(() => {
+        this._resolveTimeout = null
+        resolve(handler())
+      }, timeout)
+    })
+  }
+
+  // Cancels the pending hover delay. The superseded promise resolves right away, so a
+  // caller awaiting `toggle()` resumes instead of waiting on a timer that never fires.
+  protected _clearTimeout(): void {
     clearTimeout(this._timeout)
-    this._timeout = setTimeout(handler, timeout)
+
+    if (this._resolveTimeout) {
+      this._resolveTimeout()
+      this._resolveTimeout = null
+    }
   }
 
   protected _isWithActiveTrigger(): boolean {

--- a/js/tests/types/consumer.ts
+++ b/js/tests/types/consumer.ts
@@ -37,6 +37,19 @@ toast.dispose()
 tooltip.update()
 popover.setContent({ '.popover-body': 'Updated' })
 
+// Show, hide, toggle and close return a promise that settles once the component
+// finishes, so callers can await them instead of listening for `shown.coreui.*`.
+const closing: Promise<void> = alert.close()
+const modalShowing: Promise<void> = modal.show()
+const modalHiding: Promise<void> = modal.hide()
+const modalToggling: Promise<void> = modal.toggle()
+const toastShowing: Promise<void> = toast.show()
+const tooltipToggling: Promise<void> = tooltip.toggle()
+const popoverShowing: Promise<void> = popover.show()
+
+// @ts-expect-error — the promise resolves to void, not a component
+const wrongResolution: Promise<Modal> = modal.show()
+
 // PRO components.
 const calendar = new Calendar(element, { calendars: 2, locale: 'en-US' })
 calendar.update({ selectionType: 'week' })
@@ -52,5 +65,6 @@ const values: string[] = chipSet.getValues()
 const chip: Chip | null = Chip.getInstance(element)
 
 export {
-  alert, chip, chipSet, datePicker, instance, multiSelect, name, orCreated, selection, toast, values, version
+  alert, chip, chipSet, closing, datePicker, instance, modalHiding, modalShowing, modalToggling, multiSelect, name,
+  orCreated, popoverShowing, selection, toast, toastShowing, tooltipToggling, values, version, wrongResolution
 }

--- a/js/tests/unit/promise-api.spec.js
+++ b/js/tests/unit/promise-api.spec.js
@@ -1,0 +1,231 @@
+import Alert from '../../src/alert.js'
+import Collapse from '../../src/collapse.js'
+import Modal from '../../src/modal.js'
+import Offcanvas from '../../src/offcanvas.js'
+import Tab from '../../src/tab.js'
+import Toast from '../../src/toast.js'
+import Tooltip from '../../src/tooltip.js'
+import { clearBodyAndDocument, clearFixture, getFixture } from '../helpers/fixture.js'
+
+/**
+ * Every method that shows or hides a component returns a promise. The promise settles
+ * once the component finishes, so `await instance.show()` resumes at the same moment a
+ * `shown.coreui.*` listener would run. These specs pin down that contract.
+ */
+
+describe('Promise-returning API', () => {
+  let fixtureEl
+
+  beforeAll(() => {
+    fixtureEl = getFixture()
+  })
+
+  afterEach(() => {
+    clearFixture()
+    clearBodyAndDocument()
+    document.body.classList.remove('modal-open')
+
+    for (const element of document.querySelectorAll('.modal-backdrop, .offcanvas-backdrop, .tooltip')) {
+      element.remove()
+    }
+  })
+
+  // Runs `action` and records whether `eventName` fired before the promise settled.
+  // A method that resolved too early would produce ['resolved', <eventName>].
+  const orderOf = async (element, eventName, action) => {
+    const order = []
+
+    element.addEventListener(eventName, () => order.push(eventName))
+    await action()
+    order.push('resolved')
+
+    return order
+  }
+
+  describe('resolves after the lifecycle event', () => {
+    it('Collapse show, hide, and toggle', async () => {
+      fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
+
+      const collapseEl = fixtureEl.querySelector('.collapse')
+      const collapse = new Collapse(collapseEl, { toggle: false })
+
+      expect(await orderOf(collapseEl, 'shown.coreui.collapse', () => collapse.show()))
+        .toEqual(['shown.coreui.collapse', 'resolved'])
+      expect(await orderOf(collapseEl, 'hidden.coreui.collapse', () => collapse.hide()))
+        .toEqual(['hidden.coreui.collapse', 'resolved'])
+      expect(await orderOf(collapseEl, 'shown.coreui.collapse', () => collapse.toggle()))
+        .toEqual(['shown.coreui.collapse', 'resolved'])
+    })
+
+    it('Toast show and hide', async () => {
+      fixtureEl.innerHTML = '<div class="toast" data-coreui-autohide="false"></div>'
+
+      const toastEl = fixtureEl.querySelector('.toast')
+      const toast = new Toast(toastEl)
+
+      expect(await orderOf(toastEl, 'shown.coreui.toast', () => toast.show()))
+        .toEqual(['shown.coreui.toast', 'resolved'])
+      expect(await orderOf(toastEl, 'hidden.coreui.toast', () => toast.hide()))
+        .toEqual(['hidden.coreui.toast', 'resolved'])
+    })
+
+    it('Modal show and hide', async () => {
+      fixtureEl.innerHTML = '<div class="modal"><div class="modal-dialog"></div></div>'
+
+      const modalEl = fixtureEl.querySelector('.modal')
+      const modal = new Modal(modalEl)
+
+      expect(await orderOf(modalEl, 'shown.coreui.modal', () => modal.show()))
+        .toEqual(['shown.coreui.modal', 'resolved'])
+      expect(await orderOf(modalEl, 'hidden.coreui.modal', () => modal.hide()))
+        .toEqual(['hidden.coreui.modal', 'resolved'])
+    })
+
+    it('Offcanvas show and hide', async () => {
+      fixtureEl.innerHTML = '<div class="offcanvas"></div>'
+
+      const offcanvasEl = fixtureEl.querySelector('.offcanvas')
+      const offcanvas = new Offcanvas(offcanvasEl)
+
+      expect(await orderOf(offcanvasEl, 'shown.coreui.offcanvas', () => offcanvas.show()))
+        .toEqual(['shown.coreui.offcanvas', 'resolved'])
+      expect(await orderOf(offcanvasEl, 'hidden.coreui.offcanvas', () => offcanvas.hide()))
+        .toEqual(['hidden.coreui.offcanvas', 'resolved'])
+    })
+
+    it('Tab show', async () => {
+      fixtureEl.innerHTML = [
+        '<ul class="nav" role="tablist">',
+        '  <li><button type="button" data-coreui-target="#home" role="tab">Home</button></li>',
+        '  <li><button type="button" id="triggerProfile" data-coreui-target="#profile" role="tab">Profile</button></li>',
+        '</ul>',
+        '<ul>',
+        '  <li id="home" role="tabpanel"></li>',
+        '  <li id="profile" role="tabpanel"></li>',
+        '</ul>'
+      ].join('')
+
+      const triggerEl = fixtureEl.querySelector('#triggerProfile')
+      const tab = new Tab(triggerEl)
+
+      expect(await orderOf(triggerEl, 'shown.coreui.tab', () => tab.show()))
+        .toEqual(['shown.coreui.tab', 'resolved'])
+      expect(fixtureEl.querySelector('#profile')).toHaveClass('active')
+    })
+
+    it('Alert close', async () => {
+      fixtureEl.innerHTML = '<div class="alert"></div>'
+
+      const alertEl = fixtureEl.querySelector('.alert')
+      const alert = new Alert(alertEl)
+
+      expect(await orderOf(alertEl, 'closed.coreui.alert', () => alert.close()))
+        .toEqual(['closed.coreui.alert', 'resolved'])
+      expect(alertEl.parentNode).toBeNull()
+    })
+
+    it('Tooltip show, hide, and toggle', async () => {
+      fixtureEl.innerHTML = '<a href="#" title="tooltip">Trigger</a>'
+
+      const triggerEl = fixtureEl.querySelector('a')
+      const tooltip = new Tooltip(triggerEl)
+
+      expect(await orderOf(triggerEl, 'shown.coreui.tooltip', () => tooltip.show()))
+        .toEqual(['shown.coreui.tooltip', 'resolved'])
+      expect(await orderOf(triggerEl, 'hidden.coreui.tooltip', () => tooltip.hide()))
+        .toEqual(['hidden.coreui.tooltip', 'resolved'])
+
+      // `toggle()` goes through the hover delay timer, so it has to thread the promise
+      // through that timer to stay truthful
+      expect(await orderOf(triggerEl, 'shown.coreui.tooltip', () => tooltip.toggle()))
+        .toEqual(['shown.coreui.tooltip', 'resolved'])
+    })
+  })
+
+  describe('resolves without hanging when the call does nothing', () => {
+    it('a prevented show event still settles', async () => {
+      fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
+
+      const collapseEl = fixtureEl.querySelector('.collapse')
+      const collapse = new Collapse(collapseEl, { toggle: false })
+      const shownSpy = jasmine.createSpy('shown')
+
+      collapseEl.addEventListener('show.coreui.collapse', event => {
+        event.preventDefault()
+      })
+      collapseEl.addEventListener('shown.coreui.collapse', shownSpy)
+
+      await collapse.show()
+
+      expect(shownSpy).not.toHaveBeenCalled()
+      expect(collapseEl).not.toHaveClass('show')
+    })
+
+    it('showing an already shown component settles', async () => {
+      fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
+
+      const collapseEl = fixtureEl.querySelector('.collapse')
+      const collapse = new Collapse(collapseEl, { toggle: false })
+
+      await collapse.show()
+
+      const shownSpy = jasmine.createSpy('shown')
+      collapseEl.addEventListener('shown.coreui.collapse', shownSpy)
+
+      await collapse.show()
+
+      expect(shownSpy).not.toHaveBeenCalled()
+      expect(collapseEl).toHaveClass('show')
+    })
+
+    it('disposing mid-transition settles the pending promise', async () => {
+      fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
+
+      const collapseEl = fixtureEl.querySelector('.collapse')
+      const collapse = new Collapse(collapseEl, { toggle: false })
+      const shownSpy = jasmine.createSpy('shown')
+
+      collapseEl.addEventListener('shown.coreui.collapse', shownSpy)
+
+      const showing = collapse.show()
+      collapse.dispose()
+
+      await showing
+
+      expect(shownSpy).not.toHaveBeenCalled()
+    })
+
+    it('disposing a tooltip during its show delay settles the pending promise', async () => {
+      fixtureEl.innerHTML = '<a href="#" title="tooltip">Trigger</a>'
+
+      const triggerEl = fixtureEl.querySelector('a')
+      const tooltip = new Tooltip(triggerEl, { delay: { show: 5000, hide: 0 } })
+      const shownSpy = jasmine.createSpy('shown')
+
+      triggerEl.addEventListener('shown.coreui.tooltip', shownSpy)
+
+      const toggling = tooltip.toggle()
+      tooltip.dispose()
+
+      await toggling
+
+      expect(shownSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('sequencing', () => {
+    it('awaits a full show and hide cycle without listeners', async () => {
+      fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
+
+      const collapseEl = fixtureEl.querySelector('.collapse')
+      const collapse = new Collapse(collapseEl, { toggle: false })
+
+      await collapse.show()
+      expect(collapseEl).toHaveClass('show')
+
+      await collapse.hide()
+      expect(collapseEl).not.toHaveClass('show')
+      expect(collapseEl).not.toHaveClass('collapsing')
+    })
+  })
+})


### PR DESCRIPTION
> **Stacked on #707** — base is `refactor/toast-css-transitions-v6`, so the diff shown here is only this change. Merge #707 first; I will retarget this at `v6-dev` afterwards.

`show()`, `hide()`, `toggle()` and `close()` returned before the transition ended, so continuing after one meant listening for `shown.coreui.*` / `hidden.coreui.*`. `_queueCallback` now returns a promise and each component awaits it:

```js
await collapse.show()
// the area is expanded
```

| Method | Components |
| --- | --- |
| `show`, `hide`, `toggle` | Collapse, Menu, Modal, Offcanvas, Popover, Sidebar, Tooltip |
| `show`, `hide` | Toast |
| `show` | Tab |
| `close` | Alert |

Carousel keeps its own cue-based API (`next`/`prev`/`to`), as upstream left it. The event path is unchanged and stays the right tool for reacting to changes your own code did not start.

**The promise always settles.** A call that does nothing — already open, a listener that prevents `show.coreui.*`, an instance disposed mid-transition — resolves right away instead of stranding the caller. The last case needed one more thing: `_queueCallback` now skips the completion callback when the instance is gone (`this._element` nulled by `dispose()`), which it did not do before. Without that the callback ran against a disposed instance and threw inside the transition handler.

Two components needed more than an `await`:

- **Modal** reports its backdrop through callbacks, so `show()`/`hide()` wrap those in a promise and adopt `_showElement()` / `_hideModal()`, which are now async themselves. `hidden.coreui.modal` fires from inside the backdrop's hide callback, so this is what makes the promise truthful.
- **Tooltip** resolves through the hover delay timer: `_setTimeout` returns a promise and keeps its `resolve`, and `_clearTimeout` settles a superseded timer so an awaited `toggle()` cannot wait on a timer that will never fire.
- **Collapse.show** registers the completion callback *before* setting the target size — awaiting first would stop the size from ever being applied.

## Tests

New `js/tests/unit/promise-api.spec.js` (12 specs) pins the contract: for each component it asserts the lifecycle event fires **before** the promise settles (a method resolving early would produce `['resolved', 'shown.coreui.*']`), plus the no-op cases (prevented event, already shown, disposed mid-transition, tooltip disposed during its show delay) and a show/hide cycle awaited without any listener. `js/tests/types/consumer.ts` asserts the `Promise<void>` types survive declaration emit, with a `@ts-expect-error` proving the promise does not resolve to the component.

Full suite: 57 files, 2991 tests, green.

## Bundle size

The wrappers cost a few hundred bytes, and `coreui.js` / `coreui.esm.js` were sitting exactly on their ceilings, so both budgets go up one 0.25 kB step (`104.75 → 105 kB`, `105.5 → 105.75 kB`). Everything else stays inside its existing budget.

Ported from twbs/bootstrap#42802, adapted to the components this tree has.