### PR TITLE
refactor(Collapse)!: drop the toggle option

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -42,7 +42,7 @@
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "104.75kB"
+      "maxSize": "105kB"
     },
     {
       "path": "./dist/js/coreui.esm.min.js",
@@ -50,7 +50,7 @@
     },
     {
       "path": "./dist/js/coreui.js",
-      "maxSize": "105.5kB"
+      "maxSize": "105.75kB"
     },
     {
       "path": "./dist/js/coreui.min.js",

--- a/docs/src/content/docs/components/carousel.mdx
+++ b/docs/src/content/docs/components/carousel.mdx
@@ -304,7 +304,7 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 You can create a carousel instance with the carousel constructor, for example, to initialize with additional options and start cycling through items:

--- a/docs/src/content/docs/components/collapse.mdx
+++ b/docs/src/content/docs/components/collapse.mdx
@@ -127,7 +127,6 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 `parent` | selector, jQuery object, DOM element | `null` | If parent is provided, then all collapsible elements under the specified parent will be closed when this collapsible item is shown. (similar to traditional accordion behavior - this is dependent on the `card` class). The attribute has to be set on the target collapsible area. |
-`toggle` | boolean | `true` | Toggles the collapsible element on invocation |
 
 ### Methods
 
@@ -141,12 +140,11 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 Activates your content as a collapsible element. Accepts an optional options `object`.
 
-You can create a collapse instance with the constructor, for example:
+The constructor keeps the state that your markup declares. Add `.show` to open the element, and leave it off to keep the element closed. Call `show()`, `hide()` or `toggle()` to change the state.
 
 ```js
-const bsCollapse = new coreui.Collapse('#myCollapse', {
-  toggle: false
-})
+const bsCollapse = new coreui.Collapse('#myCollapse')
+bsCollapse.show()
 ```
 
 | Method | Description |

--- a/docs/src/content/docs/components/collapse.mdx
+++ b/docs/src/content/docs/components/collapse.mdx
@@ -131,12 +131,12 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 ### Methods
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 Activates your content as a collapsible element. Accepts an optional options `object`.

--- a/docs/src/content/docs/components/list-group.mdx
+++ b/docs/src/content/docs/components/list-group.mdx
@@ -346,12 +346,12 @@ To make tabs panel fade in, add `.fade` to each `.tab-pane`. The first tab pane 
 
 #### constructor
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 Activates your content as a tab element.

--- a/docs/src/content/docs/components/modal.mdx
+++ b/docs/src/content/docs/components/modal.mdx
@@ -733,12 +733,12 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 ### Methods
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 #### Passing options

--- a/docs/src/content/docs/components/navs-tabs.mdx
+++ b/docs/src/content/docs/components/navs-tabs.mdx
@@ -537,12 +537,12 @@ To make tabs fade in, add `.fade` to each `.tab-pane`. The first tab pane must a
 
 ### Methods
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 #### constructor

--- a/docs/src/content/docs/components/offcanvas.mdx
+++ b/docs/src/content/docs/components/offcanvas.mdx
@@ -279,12 +279,12 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 ### Methods
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 Activates your content as an offcanvas element and accepts an optional options `object`.  

--- a/docs/src/content/docs/components/popovers.mdx
+++ b/docs/src/content/docs/components/popovers.mdx
@@ -201,12 +201,12 @@ const popover = new coreui.Popover(element, {
 
 ### Methods
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 | Method | Description |

--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -320,12 +320,12 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 ### Methods
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 | Method | Description |

--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -41,10 +41,6 @@ Bootstrap toasts are as flexible as you need and require very little markup. At 
     </div>
   </div>`} />
 
-<Callout color="warning">
-Previously, our scripts dynamically added the `.hide` class to fully hide a toast (using `display:none` instead of just `opacity:0`). This is no longer necessary. However, for backwards compatibility, our script will still toggle the class (even though there is no practical reason to do so) until the next major version.
-</Callout>
-
 ### Live example
 
 Click the button below to display a toast (positioned with our utilities in the lower right corner) that is hidden by default.
@@ -152,6 +148,22 @@ Building on the previous example, you can design various toast color schemes usi
         Hello, world! This is a toast message.
       </div>
       <button type="button" class="btn-close btn-close-white me-2 m-auto" data-coreui-dismiss="toast" aria-label="Close"></button>
+    </div>
+  </div>`} />
+
+### Instant
+
+By default, toasts fade in and out. To disable the animation, add `.toast-instant` to the toast. The `show` and `hide` methods then finish immediately, so `shown.coreui.toast` and `hidden.coreui.toast` fire right away.
+
+<Example class=" bg-body-tertiary" code={`<div class="toast toast-instant" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast-header">
+      <svg class="docs-placeholder-img rounded me-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
+      <strong class="me-auto">CoreUI for Bootstrap</strong>
+      <small>11 mins ago</small>
+      <button type="button" class="btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>
+    </div>
+    <div class="toast-body">
+      This toast appears and disappears instantly.
     </div>
   </div>`} />
 
@@ -297,13 +309,12 @@ Dismissal can be achieved with the `data` attribute on a button **within the toa
 
 ### Options
 
-Options can be passed using data attributes or JavaScript. To do this, append an option name to `data-coreui-`, such as `data-coreui-animation="{value}"`. Remember to convert the case of the option name from "_camelCase_" to "_kebab-case_" when using data attributes. For instance, you should write `data-coreui-custom-class="beautifier"` rather than `data-coreui-customClass="beautifier"`.
+Options can be passed using data attributes or JavaScript. To do this, append an option name to `data-coreui-`, such as `data-coreui-autohide="{value}"`. Remember to convert the case of the option name from "_camelCase_" to "_kebab-case_" when using data attributes. For instance, you should write `data-coreui-custom-class="beautifier"` rather than `data-coreui-customClass="beautifier"`.
 
 Starting with CoreUI 4.2.6, all components support an **experimental** reserved data attribute named `data-coreui-config`, which can contain simple component configurations as a JSON string. If an element has attributes `data-coreui-config='{"delay":50, "title":689}'` and `data-coreui-title="Custom Title"`, then the final value for `title` will be `Custom Title`, as the standard data attributes will take precedence over values specified in `data-coreui-config`. Moreover, existing data attributes can also hold JSON values like `data-coreui-delay='{"show":50, "hide":250}'`.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| `animation` | boolean | `true` | Adds a CSS fade transition to the toast |
 | `autohide` | boolean | `true` | Hides the Bootstrap toast automatically |
 | `delay` | number | `5000` | Sets delay before hiding the toast (ms) |
 

--- a/docs/src/content/docs/components/tooltips.mdx
+++ b/docs/src/content/docs/components/tooltips.mdx
@@ -210,12 +210,12 @@ const tooltip = new coreui.Tooltip(element, {
 
 ### Methods
 
-<Callout color="danger">
-#### Asynchronous methods and transitions
+<Callout color="info">
+#### Promises and transitions
 
-All our API methods are **asynchronous** and initiate a **transition**. They return to the caller as soon as the transition begins but **before it concludes**. Furthermore, a method call on a **transitioning component will be ignored**.
+**Methods that show or hide a component return a promise.** The promise resolves when the transition ends, so `await` continues at the same moment a `shown.coreui.*` or `hidden.coreui.*` listener runs. The methods still return immediately and never block the caller. A call on a component that is already transitioning does nothing and resolves right away.
 
-[Refer to our JavaScript documentation for further details](/getting-started/javascript/#asynchronous-functions-and-transitions).
+[Refer to our JavaScript documentation for further details](/getting-started/javascript/#promises-and-transitions).
 </Callout>
 
 | Method | Description |

--- a/docs/src/content/docs/getting-started/javascript.mdx
+++ b/docs/src/content/docs/getting-started/javascript.mdx
@@ -141,21 +141,57 @@ const offcanvas = coreui.Offcanvas.getInstance('#myOffcanvas')
 const alert = coreui.Alert.getOrCreateInstance('#myAlert')
 ```
 
-### Asynchronous functions and transitions
+### Promises and transitions
 
-All programmatic API methods are **asynchronous** and return to the caller once the transition is started but **before it ends**.
+All programmatic API methods are **asynchronous** and return to the caller once the transition is started, but **before it ends**.
 
-In order to execute an action once the transition is complete, you can listen to the corresponding event.
+Methods that show or hide a component return a **promise**. The promise resolves when the transition ends, so you can `await` the method instead of listening for an event.
 
 ```js
-const myCollapseEl = document.getElementById('myCollapse')
+const collapse = coreui.Collapse.getOrCreateInstance('#myCollapse')
 
-myCollapseEl.addEventListener('shown.coreui.collapse', event => {
-  // Action to execute once the collapsible area is expanded
+await collapse.show()
+// The collapsible area is now expanded
+```
+
+These methods return a promise:
+
+| Method | Components |
+| --- | --- |
+| `show`, `hide`, `toggle` | Collapse, Menu, Modal, Offcanvas, Popover, Sidebar, Tooltip |
+| `show`, `hide` | Toast |
+| `show` | Tab |
+| `close` | Alert |
+
+The promise resolves with no value. It resolves at the same moment the matching `shown.coreui.*`, `hidden.coreui.*` or `closed.coreui.*` event fires, so both styles run your code at the same time. Use the event when you must react to every change, including ones your own code did not start.
+
+```js
+const offcanvasEl = document.getElementById('myOffcanvas')
+const offcanvas = coreui.Offcanvas.getOrCreateInstance(offcanvasEl)
+
+// Await the method you called…
+await offcanvas.hide()
+saveState()
+
+// …or listen for every hide, whoever started it
+offcanvasEl.addEventListener('hidden.coreui.offcanvas', () => {
+  saveState()
 })
 ```
 
-In addition a method call on a **transitioning component will be ignored**.
+Because each method returns a promise, you can run steps in order without nesting listeners.
+
+```js
+const modal = coreui.Modal.getOrCreateInstance('#myModal')
+const toast = coreui.Toast.getOrCreateInstance('#myToast')
+
+await modal.hide()
+await toast.show()
+```
+
+The promise also resolves when the call does nothing — for example when the component is already open, when a listener calls `preventDefault()` on the `show.coreui.*` event, or when you dispose the component mid-transition. `await` therefore never hangs, but it also does not tell you whether the state changed. Check the state yourself when that matters.
+
+In addition a method call on a **transitioning component will be ignored**. For the promise-returning methods above, such a call resolves immediately. It does not wait for the running transition to end.
 
 ```js
 const myCarouselEl = document.getElementById('myCarousel')
@@ -171,15 +207,26 @@ carousel.to('2') // !! Will be ignored, as the transition to the slide 1 is not 
 
 #### `dispose` method
 
-While it may seem correct to use the `dispose` method immediately after `hide()`, it will lead to incorrect results. Here's an example of the problem use:
+Do not call `dispose` immediately after `hide()`. The hide transition is still running at that point, so the component tears down mid-transition. Await the promise first:
 
 ```js
-const myModal = document.querySelector('#myModal')
-myModal.hide() // it is asynchronous
+const toast = coreui.Toast.getInstance('#myToast')
 
-myModal.addEventListener('shown.coreui.hidden', event => {
-  myModal.dispose()
+await toast.hide()
+toast.dispose()
+```
+
+The event-based equivalent also works:
+
+```js
+const myToast = document.querySelector('#myToast')
+const toast = coreui.Toast.getInstance(myToast)
+
+myToast.addEventListener('hidden.coreui.toast', () => {
+  toast.dispose()
 })
+
+toast.hide()
 ```
 
 ### Default settings

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -504,6 +504,23 @@ adornment in the library — so the button needs no icon markup at all:
   invalid on it (axe `aria-allowed-attr`); the native `disabled`/`readonly`
   states on the inner `<input>` carry the semantics.
 
+#### Toast
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The fade moved to CSS.** Toast was the last component driving its animation
+  from JavaScript — it toggled `.fade`, forced a reflow, then juggled `.show`,
+  `.showing` and a deprecated `.hide` class to fake an exit. Menu and the picker
+  popup already express this with `@starting-style` and a discrete `display`
+  transition, and Toast now does the same. JavaScript only toggles `.show`.
+  - The `animation` option and `data-coreui-animation` are gone. Add
+    `.toast-instant` to skip the animation.
+  - `.showing` and the deprecated `.hide` class are gone, and toasts no longer
+    get the generic `.fade` class. Replace any CSS or tests that depend on them.
+  - The transition is tuned with `--cui-toast-transition-duration` and
+    `--cui-toast-transition-timing`.
+  - `isShown()` returns `false` as soon as `hide()` is called, rather than when
+    the fade-out ends.
+
 ### Sass architecture & design tokens
 
 v6 adopts the Bootstrap v6 SCSS architecture: CSS cascade layers, per-component

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -530,6 +530,23 @@ adornment in the library — so the button needs no icon markup at all:
   invalid on it (axe `aria-allowed-attr`); the native `disabled`/`readonly`
   states on the inner `<input>` carry the semantics.
 
+#### Collapse
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The `toggle` option is gone.** It made the constructor change the state the
+  markup declares, which surprised people — so nearly every caller passed
+  `toggle: false`. The constructor now always keeps the declared state; add
+  `.show` to start open, and call `show()`, `hide()` or `toggle()` to change it.
+
+  ```diff
+  - const collapse = new coreui.Collapse('#myCollapse', { toggle: false })
+  + const collapse = new coreui.Collapse('#myCollapse')
+  ```
+
+  Callers that relied on the constructor toggling need an explicit call:
+  `new coreui.Collapse(el).toggle()`. `data-coreui-toggle` on a *trigger* is
+  unrelated and unchanged.
+
 #### Toast
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -126,6 +126,32 @@ They are no longer part of the published package. Use the built bundle instead:
 or, if you are already resolving the package by name, `import { Tooltip } from
 '@coreui/coreui-pro'` — `module` points at the same ESM bundle.
 
+#### Lifecycle methods return a promise
+
+`show()`, `hide()`, `toggle()` and `close()` returned before the transition
+ended, so continuing after one meant listening for `shown.coreui.*` /
+`hidden.coreui.*`. They now return a promise that resolves at the same moment
+that event fires, so you can `await` the method instead:
+
+```diff
+- myCollapseEl.addEventListener('shown.coreui.collapse', () => {
+-   // the area is expanded
+- })
+- collapse.show()
++ await collapse.show()
++ // the area is expanded
+```
+
+Collapse, Menu, Modal, Offcanvas, Popover, Sidebar and Tooltip return one from
+`show`/`hide`/`toggle`, Toast from `show`/`hide`, Tab from `show`, and Alert
+from `close`. The event path is unchanged and still the right tool when you must
+react to changes your own code did not start.
+
+The promise always settles — a call that does nothing (already open, a prevented
+`show.coreui.*`, an instance disposed mid-transition) resolves right away rather
+than stranding the caller. It resolves with no value, so it tells you the call
+finished, not whether the state changed.
+
 ### Components
 
 #### Autocomplete and Multi Select share one options menu

--- a/js/src/alert.ts
+++ b/js/src/alert.ts
@@ -37,7 +37,7 @@ class Alert extends BaseComponent {
   }
 
   // Public
-  close(): void {
+  async close(): Promise<void> {
     const closeEvent = EventHandler.trigger(this._element, EVENT_CLOSE)
 
     if (closeEvent!.defaultPrevented) {
@@ -47,7 +47,7 @@ class Alert extends BaseComponent {
     this._element.classList.remove(CLASS_NAME_SHOW)
 
     const isAnimated = this._element.classList.contains(CLASS_NAME_FADE)
-    this._queueCallback(() => this._destroyElement(), this._element, isAnimated)
+    await this._queueCallback(() => this._destroyElement(), this._element, isAnimated)
   }
 
   // Private

--- a/js/src/base-component.ts
+++ b/js/src/base-component.ts
@@ -53,8 +53,22 @@ class BaseComponent extends Config {
   }
 
   // Private
-  _queueCallback(callback: () => void, element: Element, isAnimated = true): void {
-    executeAfterTransition(callback, element, isAnimated)
+
+  // Runs `callback` once the transition on `element` ends, and resolves afterwards.
+  // Lifecycle methods return this promise, so `await instance.show()` continues at the
+  // same moment a `shown.coreui.*` listener would run.
+  _queueCallback(callback: () => void, element: Element, isAnimated = true): Promise<void> {
+    return new Promise(resolve => {
+      executeAfterTransition(() => {
+        // Don't run the completion callback if the instance was disposed mid-transition.
+        // Still settle the promise, so an awaiting caller resumes instead of hanging.
+        if (this._element) {
+          callback()
+        }
+
+        resolve()
+      }, element, isAnimated)
+    })
   }
 
   override _getConfig(config?: ComponentConfig | null): ComponentConfig {

--- a/js/src/collapse.ts
+++ b/js/src/collapse.ts
@@ -117,15 +117,11 @@ class Collapse extends BaseComponent {
   }
 
   // Public
-  toggle(): void {
-    if (this._isShown()) {
-      this.hide()
-    } else {
-      this.show()
-    }
+  toggle(): Promise<void> {
+    return this._isShown() ? this.hide() : this.show()
   }
 
-  show(): void {
+  async show(): Promise<void> {
     if (this._isTransitioning || this._isShown()) {
       return
     }
@@ -176,11 +172,15 @@ class Collapse extends BaseComponent {
     const capitalizedDimension = dimension[0].toUpperCase() + dimension.slice(1)
     const scrollSize = `scroll${capitalizedDimension}`
 
-    this._queueCallback(complete, this._element, true)
+    // Register the completion callback first, then set the target size to start the
+    // transition. Awaiting here instead would stop the size from ever being applied.
+    const transition = this._queueCallback(complete, this._element, true)
     this._element.style[dimension as any] = `${(this._element as any)[scrollSize]}px`
+
+    await transition
   }
 
-  hide(): void {
+  async hide(): Promise<void> {
     if (this._isTransitioning || !this._isShown()) {
       return
     }
@@ -218,7 +218,7 @@ class Collapse extends BaseComponent {
 
     this._element.style[dimension as any] = ''
 
-    this._queueCallback(complete, this._element, true)
+    await this._queueCallback(complete, this._element, true)
   }
 
   // Private

--- a/js/src/collapse.ts
+++ b/js/src/collapse.ts
@@ -47,13 +47,11 @@ const SELECTOR_ACTIVES = '.collapse.show, .collapse.collapsing'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="collapse"]'
 
 const Default = {
-  parent: null,
-  toggle: true
+  parent: null
 }
 
 const DefaultType = {
-  parent: '(null|element)',
-  toggle: 'boolean'
+  parent: '(null|element)'
 }
 
 /**
@@ -62,7 +60,6 @@ const DefaultType = {
 
 type CollapseConfig = {
   parent: string | Element | null
-  toggle: boolean
 }
 
 /**
@@ -97,10 +94,6 @@ class Collapse extends BaseComponent {
     if (!this._config.parent) {
       this._addAriaAndCollapsedClass(this._triggerArray, this._isShown())
     }
-
-    if (this._config.toggle) {
-      this.toggle()
-    }
   }
 
   // Getters
@@ -132,7 +125,7 @@ class Collapse extends BaseComponent {
     if (this._config.parent) {
       activeChildren = this._getFirstLevelChildren(SELECTOR_ACTIVES)
         .filter(element => element !== this._element)
-        .map(element => Collapse.getOrCreateInstance(element, { toggle: false }))
+        .map(element => Collapse.getOrCreateInstance(element))
     }
 
     if (activeChildren.length && activeChildren[0]._isTransitioning) {
@@ -227,7 +220,6 @@ class Collapse extends BaseComponent {
   }
 
   override _configAfterMerge(config: ComponentConfig): ComponentConfig {
-    (config as any).toggle = Boolean((config as any).toggle) // Coerce string values
     config.parent = getElement(config.parent)
     return config
   }
@@ -271,13 +263,8 @@ class Collapse extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    const _config: Record<string, unknown> = {}
-    if (typeof config === 'string' && /show|hide/.test(config)) {
-      _config.toggle = false
-    }
-
     return this.each(function (this: HTMLElement) {
-      const data: any = Collapse.getOrCreateInstance(this, _config)
+      const data: any = Collapse.getOrCreateInstance(this)
 
       if (typeof config === 'string') {
         if (typeof data[config as string] === 'undefined') {
@@ -301,7 +288,7 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
   }
 
   for (const element of SelectorEngine.getMultipleElementsFromSelector(this)) {
-    Collapse.getOrCreateInstance(element, { toggle: false }).toggle()
+    Collapse.getOrCreateInstance(element).toggle()
   }
 })
 

--- a/js/src/menu.ts
+++ b/js/src/menu.ts
@@ -234,11 +234,11 @@ class Menu extends BaseComponent {
   }
 
   // Public
-  toggle(): void {
+  toggle(): Promise<void> {
     return this._isShown() ? this.hide() : this.show()
   }
 
-  show(): void {
+  async show(): Promise<void> {
     if (isDisabled(this._element) || this._isShown()) {
       return
     }
@@ -276,7 +276,7 @@ class Menu extends BaseComponent {
     EventHandler.trigger(this._element, this.constructor.eventName('shown'), relatedTarget)
   }
 
-  hide(): void {
+  async hide(): Promise<void> {
     if (isDisabled(this._element) || !this._isShown()) {
       return
     }

--- a/js/src/modal.ts
+++ b/js/src/modal.ts
@@ -102,11 +102,11 @@ class Modal extends BaseComponent {
   }
 
   // Public
-  toggle(relatedTarget?: HTMLElement | null): any {
+  toggle(relatedTarget?: HTMLElement | null): Promise<void> {
     return this._isShown ? this.hide() : this.show(relatedTarget)
   }
 
-  show(relatedTarget?: HTMLElement | null): void {
+  async show(relatedTarget?: HTMLElement | null): Promise<void> {
     if (this._isShown || this._isTransitioning) {
       return
     }
@@ -128,10 +128,15 @@ class Modal extends BaseComponent {
 
     this._adjustDialog()
 
-    this._backdrop.show(() => this._showElement(relatedTarget))
+    // The backdrop reports its own transition through a callback, so the element
+    // is only shown once it has settled — resolving with `_showElement` adopts
+    // the modal's own transition on top of it.
+    await new Promise<void>(resolve => {
+      this._backdrop.show(() => resolve(this._showElement(relatedTarget)))
+    })
   }
 
-  hide(): void {
+  async hide(): Promise<void> {
     if (!this._isShown || this._isTransitioning) {
       return
     }
@@ -148,7 +153,9 @@ class Modal extends BaseComponent {
 
     this._element.classList.remove(CLASS_NAME_SHOW)
 
-    this._queueCallback(() => this._hideModal(), this._element, this._isAnimated())
+    await new Promise<void>(resolve => {
+      this._queueCallback(() => resolve(this._hideModal()), this._element, this._isAnimated())
+    })
   }
 
   dispose(): any {
@@ -193,7 +200,7 @@ class Modal extends BaseComponent {
     })
   }
 
-  _showElement(relatedTarget?: HTMLElement | null): void {
+  async _showElement(relatedTarget?: HTMLElement | null): Promise<void> {
     // try to append dynamic modal
     if (!document.body.contains(this._element)) {
       document.body.append(this._element)
@@ -225,7 +232,7 @@ class Modal extends BaseComponent {
       })
     }
 
-    this._queueCallback(transitionComplete, this._dialog!, this._isAnimated())
+    await this._queueCallback(transitionComplete, this._dialog!, this._isAnimated())
   }
 
   _addEventListeners(): void {
@@ -267,18 +274,21 @@ class Modal extends BaseComponent {
     })
   }
 
-  _hideModal(): any {
+  async _hideModal(): Promise<void> {
     this._element.style.display = 'none'
     this._element.setAttribute('aria-hidden', true as unknown as string)
     this._element.removeAttribute('aria-modal')
     this._element.removeAttribute('role')
     this._isTransitioning = false
 
-    this._backdrop.hide(() => {
-      document.body.classList.remove(CLASS_NAME_OPEN)
-      this._resetAdjustments()
-      this._scrollBar.reset()
-      EventHandler.trigger(this._element, EVENT_HIDDEN)
+    await new Promise<void>(resolve => {
+      this._backdrop.hide(() => {
+        document.body.classList.remove(CLASS_NAME_OPEN)
+        this._resetAdjustments()
+        this._scrollBar.reset()
+        EventHandler.trigger(this._element, EVENT_HIDDEN)
+        resolve()
+      })
     })
   }
 

--- a/js/src/offcanvas.ts
+++ b/js/src/offcanvas.ts
@@ -94,11 +94,11 @@ class Offcanvas extends BaseComponent {
   }
 
   // Public
-  toggle(relatedTarget?: HTMLElement | null): any {
+  toggle(relatedTarget?: HTMLElement | null): Promise<void> {
     return this._isShown ? this.hide() : this.show(relatedTarget)
   }
 
-  show(relatedTarget?: HTMLElement | null): void {
+  async show(relatedTarget?: HTMLElement | null): Promise<void> {
     if (this._isShown) {
       return
     }
@@ -130,10 +130,10 @@ class Offcanvas extends BaseComponent {
       EventHandler.trigger(this._element, EVENT_SHOWN, { relatedTarget })
     }
 
-    this._queueCallback(completeCallBack, this._element, true)
+    await this._queueCallback(completeCallBack, this._element, true)
   }
 
-  hide(): void {
+  async hide(): Promise<void> {
     if (!this._isShown) {
       return
     }
@@ -162,7 +162,7 @@ class Offcanvas extends BaseComponent {
       EventHandler.trigger(this._element, EVENT_HIDDEN)
     }
 
-    this._queueCallback(completeCallback, this._element, true)
+    await this._queueCallback(completeCallback, this._element, true)
   }
 
   dispose(): any {

--- a/js/src/sidebar.ts
+++ b/js/src/sidebar.ts
@@ -101,7 +101,7 @@ class Sidebar extends BaseComponent {
 
   // Public
 
-  show(): void {
+  async show(): Promise<void> {
     EventHandler.trigger(this._element, EVENT_SHOW)
 
     if (this._element.classList.contains(CLASS_NAME_HIDE)) {
@@ -129,10 +129,10 @@ class Sidebar extends BaseComponent {
       }
     }
 
-    this._queueCallback(complete, this._element, true)
+    await this._queueCallback(complete, this._element, true)
   }
 
-  hide(): void {
+  async hide(): Promise<void> {
     EventHandler.trigger(this._element, EVENT_HIDE)
 
     if (this._element.classList.contains(CLASS_NAME_SHOW)) {
@@ -159,16 +159,11 @@ class Sidebar extends BaseComponent {
       }
     }
 
-    this._queueCallback(complete, this._element, true)
+    await this._queueCallback(complete, this._element, true)
   }
 
-  toggle(): void {
-    if (this._isVisible()) {
-      this.hide()
-      return
-    }
-
-    this.show()
+  toggle(): Promise<void> {
+    return this._isVisible() ? this.hide() : this.show()
   }
 
   narrow(): void {

--- a/js/src/tab.ts
+++ b/js/src/tab.ts
@@ -82,7 +82,8 @@ class Tab extends BaseComponent {
   }
 
   // Public
-  show(): void { // Shows this elem and deactivate the active sibling if exists
+  // Shows this elem and deactivate the active sibling if exists
+  async show(): Promise<void> {
     const innerElem = this._element
     if (this._elemIsActive(innerElem)) {
       return
@@ -102,11 +103,11 @@ class Tab extends BaseComponent {
     }
 
     this._deactivate(active, innerElem)
-    this._activate(innerElem, active)
+    await this._activate(innerElem, active)
   }
 
   // Private
-  _activate(element: HTMLElement | null, relatedElem?: HTMLElement | null): void {
+  async _activate(element: HTMLElement | null, relatedElem?: HTMLElement | null): Promise<void> {
     if (!element) {
       return
     }
@@ -129,10 +130,10 @@ class Tab extends BaseComponent {
       })
     }
 
-    this._queueCallback(complete, element, element.classList.contains(CLASS_NAME_FADE))
+    await this._queueCallback(complete, element, element.classList.contains(CLASS_NAME_FADE))
   }
 
-  _deactivate(element: HTMLElement | null, relatedElem?: HTMLElement | null): void {
+  async _deactivate(element: HTMLElement | null, relatedElem?: HTMLElement | null): Promise<void> {
     if (!element) {
       return
     }
@@ -154,7 +155,7 @@ class Tab extends BaseComponent {
       EventHandler.trigger(element, EVENT_HIDDEN, { relatedTarget: relatedElem })
     }
 
-    this._queueCallback(complete, element, element.classList.contains(CLASS_NAME_FADE))
+    await this._queueCallback(complete, element, element.classList.contains(CLASS_NAME_FADE))
   }
 
   _keydown(event: CoreUIEvent): void {

--- a/js/src/toast.ts
+++ b/js/src/toast.ts
@@ -12,7 +12,7 @@ import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler, { type CoreUIEvent } from './dom/event-handler.js'
 import { enableDismissTrigger } from './util/component-functions.js'
-import { defineJQueryPlugin, reflow } from './util/index.js'
+import { defineJQueryPlugin } from './util/index.js'
 
 /**
  * Constants
@@ -31,19 +31,15 @@ const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 
-const CLASS_NAME_FADE = 'fade'
-const CLASS_NAME_HIDE = 'hide' // @deprecated - kept here only for backwards compatibility
+const CLASS_NAME_INSTANT = 'toast-instant'
 const CLASS_NAME_SHOW = 'show'
-const CLASS_NAME_SHOWING = 'showing'
 
 const DefaultType = {
-  animation: 'boolean',
   autohide: 'boolean',
   delay: 'number'
 }
 
 const Default = {
-  animation: true,
   autohide: true,
   delay: 5000
 }
@@ -53,7 +49,6 @@ const Default = {
  */
 
 type ToastConfig = {
-  animation: boolean
   autohide: boolean
   delay: number
 }
@@ -99,22 +94,15 @@ class Toast extends BaseComponent {
 
     this._clearTimeout()
 
-    if (this._config.animation) {
-      this._element.classList.add(CLASS_NAME_FADE)
-    }
-
     const complete = () => {
-      this._element.classList.remove(CLASS_NAME_SHOWING)
       EventHandler.trigger(this._element, EVENT_SHOWN)
 
       this._maybeScheduleHide()
     }
 
-    this._element.classList.remove(CLASS_NAME_HIDE) // @deprecated
-    reflow(this._element)
-    this._element.classList.add(CLASS_NAME_SHOW, CLASS_NAME_SHOWING)
+    this._element.classList.add(CLASS_NAME_SHOW)
 
-    this._queueCallback(complete, this._element, this._config.animation)
+    this._queueCallback(complete, this._element, this._isAnimated())
   }
 
   hide(): void {
@@ -129,13 +117,13 @@ class Toast extends BaseComponent {
     }
 
     const complete = () => {
-      this._element.classList.add(CLASS_NAME_HIDE) // @deprecated
-      this._element.classList.remove(CLASS_NAME_SHOWING, CLASS_NAME_SHOW)
       EventHandler.trigger(this._element, EVENT_HIDDEN)
     }
 
-    this._element.classList.add(CLASS_NAME_SHOWING)
-    this._queueCallback(complete, this._element, this._config.animation)
+    // Removing .show starts the fade-out. The discrete `display` transition
+    // keeps the toast laid out until the fade finishes.
+    this._element.classList.remove(CLASS_NAME_SHOW)
+    this._queueCallback(complete, this._element, this._isAnimated())
   }
 
   override dispose(): void {
@@ -153,6 +141,10 @@ class Toast extends BaseComponent {
   }
 
   // Private
+  _isAnimated(): boolean {
+    return !this._element.classList.contains(CLASS_NAME_INSTANT)
+  }
+
   _maybeScheduleHide(): void {
     if (!this._config.autohide) {
       return

--- a/js/src/toast.ts
+++ b/js/src/toast.ts
@@ -85,7 +85,7 @@ class Toast extends BaseComponent {
   }
 
   // Public
-  show(): void {
+  async show(): Promise<void> {
     const showEvent = EventHandler.trigger(this._element, EVENT_SHOW)
 
     if (showEvent!.defaultPrevented) {
@@ -102,10 +102,10 @@ class Toast extends BaseComponent {
 
     this._element.classList.add(CLASS_NAME_SHOW)
 
-    this._queueCallback(complete, this._element, this._isAnimated())
+    await this._queueCallback(complete, this._element, this._isAnimated())
   }
 
-  hide(): void {
+  async hide(): Promise<void> {
     if (!this.isShown()) {
       return
     }
@@ -123,7 +123,7 @@ class Toast extends BaseComponent {
     // Removing .show starts the fade-out. The discrete `display` transition
     // keeps the toast laid out until the fade finishes.
     this._element.classList.remove(CLASS_NAME_SHOW)
-    this._queueCallback(complete, this._element, this._isAnimated())
+    await this._queueCallback(complete, this._element, this._isAnimated())
   }
 
   override dispose(): void {

--- a/js/src/tooltip.ts
+++ b/js/src/tooltip.ts
@@ -156,6 +156,7 @@ class Tooltip extends BaseComponent {
   protected declare _config: TooltipConfig
   protected declare _isEnabled: boolean
   protected declare _timeout: number
+  protected declare _resolveTimeout: (() => void) | null
   protected declare _isHovered: boolean | null
   protected declare _activeTrigger: Record<string, boolean>
   protected declare _floatingCleanup: (() => void) | null
@@ -177,6 +178,7 @@ class Tooltip extends BaseComponent {
     // Private
     this._isEnabled = true
     this._timeout = 0
+    this._resolveTimeout = null
     this._isHovered = null
     this._activeTrigger = {}
     this._floatingCleanup = null
@@ -223,21 +225,16 @@ class Tooltip extends BaseComponent {
     this._isEnabled = !this._isEnabled
   }
 
-  toggle(): void {
+  toggle(): Promise<void> {
     if (!this._isEnabled) {
-      return
+      return Promise.resolve()
     }
 
-    if (this._isShown()) {
-      this._leave()
-      return
-    }
-
-    this._enter()
+    return this._isShown() ? this._leave() : this._enter()
   }
 
   override dispose(): void {
-    clearTimeout(this._timeout)
+    this._clearTimeout()
 
     this._removeEscapeListener()
 
@@ -318,10 +315,10 @@ class Tooltip extends BaseComponent {
       this._isHovered = false
     }
 
-    this._queueCallback(complete, this.tip!, this._isAnimated()!)
+    await this._queueCallback(complete, this.tip!, this._isAnimated()!)
   }
 
-  hide(): void {
+  async hide(): Promise<void> {
     if (!this._isShown()) {
       return
     }
@@ -362,7 +359,7 @@ class Tooltip extends BaseComponent {
       EventHandler.trigger(this._element, this.constructor.eventName(EVENT_HIDDEN))
     }
 
-    this._queueCallback(complete, this.tip!, this._isAnimated()!)
+    await this._queueCallback(complete, this.tip!, this._isAnimated()!)
   }
 
   update(): void {
@@ -737,38 +734,54 @@ class Tooltip extends BaseComponent {
     this._element.removeAttribute('title')
   }
 
-  protected _enter(): void {
+  protected _enter(): Promise<void> {
     if (this._isShown() || this._isHovered) {
       this._isHovered = true
-      return
+      return Promise.resolve()
     }
 
     this._isHovered = true
 
-    this._setTimeout(() => {
-      if (this._isHovered) {
-        this.show()
-      }
-    }, (this._config.delay as { show: number, hide: number }).show)
+    return this._setTimeout(
+      () => this._isHovered ? this.show() : undefined,
+      (this._config.delay as { show: number, hide: number }).show
+    )
   }
 
-  protected _leave(): void {
+  protected _leave(): Promise<void> {
     if (this._isWithActiveTrigger()) {
-      return
+      return Promise.resolve()
     }
 
     this._isHovered = false
 
-    this._setTimeout(() => {
-      if (!this._isHovered) {
-        this.hide()
-      }
-    }, (this._config.delay as { show: number, hide: number }).hide)
+    return this._setTimeout(
+      () => this._isHovered ? undefined : this.hide(),
+      (this._config.delay as { show: number, hide: number }).hide
+    )
   }
 
-  protected _setTimeout(handler: () => void, timeout: number): void {
+  protected _setTimeout(handler: () => void | Promise<void>, timeout: number): Promise<void> {
+    this._clearTimeout()
+
+    return new Promise(resolve => {
+      this._resolveTimeout = resolve
+      this._timeout = setTimeout(() => {
+        this._resolveTimeout = null
+        resolve(handler())
+      }, timeout)
+    })
+  }
+
+  // Cancels the pending hover delay. The superseded promise resolves right away, so a
+  // caller awaiting `toggle()` resumes instead of waiting on a timer that never fires.
+  protected _clearTimeout(): void {
     clearTimeout(this._timeout)
-    this._timeout = setTimeout(handler, timeout)
+
+    if (this._resolveTimeout) {
+      this._resolveTimeout()
+      this._resolveTimeout = null
+    }
   }
 
   protected _isWithActiveTrigger(): boolean {

--- a/js/tests/types/consumer.ts
+++ b/js/tests/types/consumer.ts
@@ -37,6 +37,19 @@ toast.dispose()
 tooltip.update()
 popover.setContent({ '.popover-body': 'Updated' })
 
+// Show, hide, toggle and close return a promise that settles once the component
+// finishes, so callers can await them instead of listening for `shown.coreui.*`.
+const closing: Promise<void> = alert.close()
+const modalShowing: Promise<void> = modal.show()
+const modalHiding: Promise<void> = modal.hide()
+const modalToggling: Promise<void> = modal.toggle()
+const toastShowing: Promise<void> = toast.show()
+const tooltipToggling: Promise<void> = tooltip.toggle()
+const popoverShowing: Promise<void> = popover.show()
+
+// @ts-expect-error — the promise resolves to void, not a component
+const wrongResolution: Promise<Modal> = modal.show()
+
 // PRO components.
 const calendar = new Calendar(element, { calendars: 2, locale: 'en-US' })
 calendar.update({ selectionType: 'week' })
@@ -52,5 +65,6 @@ const values: string[] = chipSet.getValues()
 const chip: Chip | null = Chip.getInstance(element)
 
 export {
-  alert, chip, chipSet, datePicker, instance, multiSelect, name, orCreated, selection, toast, values, version
+  alert, chip, chipSet, closing, datePicker, instance, modalHiding, modalShowing, modalToggling, multiSelect, name,
+  orCreated, popoverShowing, selection, toast, toastShowing, tooltipToggling, values, version, wrongResolution
 }

--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -123,9 +123,7 @@ describe('Collapse', () => {
       fixtureEl.innerHTML = '<div class="show"></div>'
 
       const collapseEl = fixtureEl.querySelector('.show')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       const spy = spyOn(collapse, 'hide')
 
@@ -155,8 +153,7 @@ describe('Collapse', () => {
 
         const collapseList = [].concat(...fixtureEl.querySelectorAll('.collapse'))
           .map(el => new Collapse(el, {
-            parent,
-            toggle: false
+            parent
           }))
 
         collapseEl2.addEventListener('shown.coreui.collapse', () => {
@@ -177,9 +174,7 @@ describe('Collapse', () => {
       const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       collapse._isTransitioning = true
       collapse.show()
@@ -193,9 +188,7 @@ describe('Collapse', () => {
       const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       collapse.show()
 
@@ -207,9 +200,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse" style="height: 0px;"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         collapseEl.addEventListener('show.coreui.collapse', () => {
           expect(collapseEl.style.height).toEqual('0px')
@@ -229,9 +220,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse collapse-horizontal" style="width: 0px;"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         collapseEl.addEventListener('show.coreui.collapse', () => {
           expect(collapseEl.style.width).toEqual('0px')
@@ -259,9 +248,7 @@ describe('Collapse', () => {
 
         const el1 = fixtureEl.querySelector('#collapse1')
         const el2 = fixtureEl.querySelector('#collapse2')
-        const collapse = new Collapse(el1, {
-          toggle: false
-        })
+        const collapse = new Collapse(el1)
 
         el1.addEventListener('shown.coreui.collapse', () => {
           expect(el1).toHaveClass('show')
@@ -380,7 +367,8 @@ describe('Collapse', () => {
           collapse.hide()
         })
 
-        collapse.show()
+        // The element starts shown, so close it to begin the hide/show cycle
+        collapse.hide()
       })
     })
 
@@ -389,9 +377,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         const expectEnd = () => {
           setTimeout(() => {
@@ -421,9 +407,7 @@ describe('Collapse', () => {
       const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       collapse._isTransitioning = true
       collapse.hide()
@@ -437,9 +421,7 @@ describe('Collapse', () => {
       const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       collapse.hide()
 
@@ -451,9 +433,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse show"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         collapseEl.addEventListener('hidden.coreui.collapse', () => {
           expect(collapseEl).not.toHaveClass('show')
@@ -470,9 +450,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse show"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         const expectEnd = () => {
           setTimeout(() => {
@@ -500,9 +478,7 @@ describe('Collapse', () => {
       fixtureEl.innerHTML = '<div class="collapse show"></div>'
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       expect(Collapse.getInstance(collapseEl)).toEqual(collapse)
 
@@ -1034,11 +1010,11 @@ describe('Collapse', () => {
 
       expect(Collapse.getInstance(div)).toBeNull()
       const collapse = Collapse.getOrCreateInstance(div, {
-        toggle: false
+        parent: fixtureEl
       })
       expect(collapse).toBeInstanceOf(Collapse)
 
-      expect(collapse._config.toggle).toBeFalse()
+      expect(collapse._config.parent).toEqual(fixtureEl)
     })
 
     it('should return the instance when exists without given configuration', () => {
@@ -1046,17 +1022,17 @@ describe('Collapse', () => {
 
       const div = fixtureEl.querySelector('div')
       const collapse = new Collapse(div, {
-        toggle: false
+        parent: fixtureEl
       })
       expect(Collapse.getInstance(div)).toEqual(collapse)
 
       const collapse2 = Collapse.getOrCreateInstance(div, {
-        toggle: true
+        parent: null
       })
       expect(collapse).toBeInstanceOf(Collapse)
       expect(collapse2).toEqual(collapse)
 
-      expect(collapse2._config.toggle).toBeFalse()
+      expect(collapse2._config.parent).toEqual(fixtureEl)
     })
   })
 })

--- a/js/tests/unit/promise-api.spec.js
+++ b/js/tests/unit/promise-api.spec.js
@@ -47,7 +47,7 @@ describe('Promise-returning API', () => {
       fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
 
       const collapseEl = fixtureEl.querySelector('.collapse')
-      const collapse = new Collapse(collapseEl, { toggle: false })
+      const collapse = new Collapse(collapseEl)
 
       expect(await orderOf(collapseEl, 'shown.coreui.collapse', () => collapse.show()))
         .toEqual(['shown.coreui.collapse', 'resolved'])
@@ -147,7 +147,7 @@ describe('Promise-returning API', () => {
       fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
 
       const collapseEl = fixtureEl.querySelector('.collapse')
-      const collapse = new Collapse(collapseEl, { toggle: false })
+      const collapse = new Collapse(collapseEl)
       const shownSpy = jasmine.createSpy('shown')
 
       collapseEl.addEventListener('show.coreui.collapse', event => {
@@ -165,7 +165,7 @@ describe('Promise-returning API', () => {
       fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
 
       const collapseEl = fixtureEl.querySelector('.collapse')
-      const collapse = new Collapse(collapseEl, { toggle: false })
+      const collapse = new Collapse(collapseEl)
 
       await collapse.show()
 
@@ -182,7 +182,7 @@ describe('Promise-returning API', () => {
       fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
 
       const collapseEl = fixtureEl.querySelector('.collapse')
-      const collapse = new Collapse(collapseEl, { toggle: false })
+      const collapse = new Collapse(collapseEl)
       const shownSpy = jasmine.createSpy('shown')
 
       collapseEl.addEventListener('shown.coreui.collapse', shownSpy)
@@ -218,7 +218,7 @@ describe('Promise-returning API', () => {
       fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
 
       const collapseEl = fixtureEl.querySelector('.collapse')
-      const collapse = new Collapse(collapseEl, { toggle: false })
+      const collapse = new Collapse(collapseEl)
 
       await collapse.show()
       expect(collapseEl).toHaveClass('show')

--- a/js/tests/unit/promise-api.spec.js
+++ b/js/tests/unit/promise-api.spec.js
@@ -1,0 +1,231 @@
+import Alert from '../../src/alert.js'
+import Collapse from '../../src/collapse.js'
+import Modal from '../../src/modal.js'
+import Offcanvas from '../../src/offcanvas.js'
+import Tab from '../../src/tab.js'
+import Toast from '../../src/toast.js'
+import Tooltip from '../../src/tooltip.js'
+import { clearBodyAndDocument, clearFixture, getFixture } from '../helpers/fixture.js'
+
+/**
+ * Every method that shows or hides a component returns a promise. The promise settles
+ * once the component finishes, so `await instance.show()` resumes at the same moment a
+ * `shown.coreui.*` listener would run. These specs pin down that contract.
+ */
+
+describe('Promise-returning API', () => {
+  let fixtureEl
+
+  beforeAll(() => {
+    fixtureEl = getFixture()
+  })
+
+  afterEach(() => {
+    clearFixture()
+    clearBodyAndDocument()
+    document.body.classList.remove('modal-open')
+
+    for (const element of document.querySelectorAll('.modal-backdrop, .offcanvas-backdrop, .tooltip')) {
+      element.remove()
+    }
+  })
+
+  // Runs `action` and records whether `eventName` fired before the promise settled.
+  // A method that resolved too early would produce ['resolved', <eventName>].
+  const orderOf = async (element, eventName, action) => {
+    const order = []
+
+    element.addEventListener(eventName, () => order.push(eventName))
+    await action()
+    order.push('resolved')
+
+    return order
+  }
+
+  describe('resolves after the lifecycle event', () => {
+    it('Collapse show, hide, and toggle', async () => {
+      fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
+
+      const collapseEl = fixtureEl.querySelector('.collapse')
+      const collapse = new Collapse(collapseEl, { toggle: false })
+
+      expect(await orderOf(collapseEl, 'shown.coreui.collapse', () => collapse.show()))
+        .toEqual(['shown.coreui.collapse', 'resolved'])
+      expect(await orderOf(collapseEl, 'hidden.coreui.collapse', () => collapse.hide()))
+        .toEqual(['hidden.coreui.collapse', 'resolved'])
+      expect(await orderOf(collapseEl, 'shown.coreui.collapse', () => collapse.toggle()))
+        .toEqual(['shown.coreui.collapse', 'resolved'])
+    })
+
+    it('Toast show and hide', async () => {
+      fixtureEl.innerHTML = '<div class="toast" data-coreui-autohide="false"></div>'
+
+      const toastEl = fixtureEl.querySelector('.toast')
+      const toast = new Toast(toastEl)
+
+      expect(await orderOf(toastEl, 'shown.coreui.toast', () => toast.show()))
+        .toEqual(['shown.coreui.toast', 'resolved'])
+      expect(await orderOf(toastEl, 'hidden.coreui.toast', () => toast.hide()))
+        .toEqual(['hidden.coreui.toast', 'resolved'])
+    })
+
+    it('Modal show and hide', async () => {
+      fixtureEl.innerHTML = '<div class="modal"><div class="modal-dialog"></div></div>'
+
+      const modalEl = fixtureEl.querySelector('.modal')
+      const modal = new Modal(modalEl)
+
+      expect(await orderOf(modalEl, 'shown.coreui.modal', () => modal.show()))
+        .toEqual(['shown.coreui.modal', 'resolved'])
+      expect(await orderOf(modalEl, 'hidden.coreui.modal', () => modal.hide()))
+        .toEqual(['hidden.coreui.modal', 'resolved'])
+    })
+
+    it('Offcanvas show and hide', async () => {
+      fixtureEl.innerHTML = '<div class="offcanvas"></div>'
+
+      const offcanvasEl = fixtureEl.querySelector('.offcanvas')
+      const offcanvas = new Offcanvas(offcanvasEl)
+
+      expect(await orderOf(offcanvasEl, 'shown.coreui.offcanvas', () => offcanvas.show()))
+        .toEqual(['shown.coreui.offcanvas', 'resolved'])
+      expect(await orderOf(offcanvasEl, 'hidden.coreui.offcanvas', () => offcanvas.hide()))
+        .toEqual(['hidden.coreui.offcanvas', 'resolved'])
+    })
+
+    it('Tab show', async () => {
+      fixtureEl.innerHTML = [
+        '<ul class="nav" role="tablist">',
+        '  <li><button type="button" data-coreui-target="#home" role="tab">Home</button></li>',
+        '  <li><button type="button" id="triggerProfile" data-coreui-target="#profile" role="tab">Profile</button></li>',
+        '</ul>',
+        '<ul>',
+        '  <li id="home" role="tabpanel"></li>',
+        '  <li id="profile" role="tabpanel"></li>',
+        '</ul>'
+      ].join('')
+
+      const triggerEl = fixtureEl.querySelector('#triggerProfile')
+      const tab = new Tab(triggerEl)
+
+      expect(await orderOf(triggerEl, 'shown.coreui.tab', () => tab.show()))
+        .toEqual(['shown.coreui.tab', 'resolved'])
+      expect(fixtureEl.querySelector('#profile')).toHaveClass('active')
+    })
+
+    it('Alert close', async () => {
+      fixtureEl.innerHTML = '<div class="alert"></div>'
+
+      const alertEl = fixtureEl.querySelector('.alert')
+      const alert = new Alert(alertEl)
+
+      expect(await orderOf(alertEl, 'closed.coreui.alert', () => alert.close()))
+        .toEqual(['closed.coreui.alert', 'resolved'])
+      expect(alertEl.parentNode).toBeNull()
+    })
+
+    it('Tooltip show, hide, and toggle', async () => {
+      fixtureEl.innerHTML = '<a href="#" title="tooltip">Trigger</a>'
+
+      const triggerEl = fixtureEl.querySelector('a')
+      const tooltip = new Tooltip(triggerEl)
+
+      expect(await orderOf(triggerEl, 'shown.coreui.tooltip', () => tooltip.show()))
+        .toEqual(['shown.coreui.tooltip', 'resolved'])
+      expect(await orderOf(triggerEl, 'hidden.coreui.tooltip', () => tooltip.hide()))
+        .toEqual(['hidden.coreui.tooltip', 'resolved'])
+
+      // `toggle()` goes through the hover delay timer, so it has to thread the promise
+      // through that timer to stay truthful
+      expect(await orderOf(triggerEl, 'shown.coreui.tooltip', () => tooltip.toggle()))
+        .toEqual(['shown.coreui.tooltip', 'resolved'])
+    })
+  })
+
+  describe('resolves without hanging when the call does nothing', () => {
+    it('a prevented show event still settles', async () => {
+      fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
+
+      const collapseEl = fixtureEl.querySelector('.collapse')
+      const collapse = new Collapse(collapseEl, { toggle: false })
+      const shownSpy = jasmine.createSpy('shown')
+
+      collapseEl.addEventListener('show.coreui.collapse', event => {
+        event.preventDefault()
+      })
+      collapseEl.addEventListener('shown.coreui.collapse', shownSpy)
+
+      await collapse.show()
+
+      expect(shownSpy).not.toHaveBeenCalled()
+      expect(collapseEl).not.toHaveClass('show')
+    })
+
+    it('showing an already shown component settles', async () => {
+      fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
+
+      const collapseEl = fixtureEl.querySelector('.collapse')
+      const collapse = new Collapse(collapseEl, { toggle: false })
+
+      await collapse.show()
+
+      const shownSpy = jasmine.createSpy('shown')
+      collapseEl.addEventListener('shown.coreui.collapse', shownSpy)
+
+      await collapse.show()
+
+      expect(shownSpy).not.toHaveBeenCalled()
+      expect(collapseEl).toHaveClass('show')
+    })
+
+    it('disposing mid-transition settles the pending promise', async () => {
+      fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
+
+      const collapseEl = fixtureEl.querySelector('.collapse')
+      const collapse = new Collapse(collapseEl, { toggle: false })
+      const shownSpy = jasmine.createSpy('shown')
+
+      collapseEl.addEventListener('shown.coreui.collapse', shownSpy)
+
+      const showing = collapse.show()
+      collapse.dispose()
+
+      await showing
+
+      expect(shownSpy).not.toHaveBeenCalled()
+    })
+
+    it('disposing a tooltip during its show delay settles the pending promise', async () => {
+      fixtureEl.innerHTML = '<a href="#" title="tooltip">Trigger</a>'
+
+      const triggerEl = fixtureEl.querySelector('a')
+      const tooltip = new Tooltip(triggerEl, { delay: { show: 5000, hide: 0 } })
+      const shownSpy = jasmine.createSpy('shown')
+
+      triggerEl.addEventListener('shown.coreui.tooltip', shownSpy)
+
+      const toggling = tooltip.toggle()
+      tooltip.dispose()
+
+      await toggling
+
+      expect(shownSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('sequencing', () => {
+    it('awaits a full show and hide cycle without listeners', async () => {
+      fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
+
+      const collapseEl = fixtureEl.querySelector('.collapse')
+      const collapse = new Collapse(collapseEl, { toggle: false })
+
+      await collapse.show()
+      expect(collapseEl).toHaveClass('show')
+
+      await collapse.hide()
+      expect(collapseEl).not.toHaveClass('show')
+      expect(collapseEl).not.toHaveClass('collapsing')
+    })
+  })
+})

--- a/js/tests/unit/toast.spec.js
+++ b/js/tests/unit/toast.spec.js
@@ -65,7 +65,7 @@ describe('Toast', () => {
     it('should close toast when close element with data-coreui-dismiss attribute is set', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [
-          '<div class="toast" data-coreui-delay="1" data-coreui-autohide="false" data-coreui-animation="false">',
+          '<div class="toast toast-instant" data-coreui-delay="1" data-coreui-autohide="false">',
           '  <button type="button" class="ms-2 mb-1 btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>',
           '</div>'
         ].join('')
@@ -98,7 +98,7 @@ describe('Toast', () => {
       Toast.Default.delay = defaultDelay
 
       fixtureEl.innerHTML = [
-        '<div class="toast" data-coreui-autohide="false" data-coreui-animation="false">',
+        '<div class="toast toast-instant" data-coreui-autohide="false">',
         '  <button type="button" class="ms-2 mb-1 btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>',
         '</div>'
       ].join('')
@@ -139,32 +139,31 @@ describe('Toast', () => {
       })
     })
 
-    it('should not add fade class', () => {
-      return new Promise(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="toast" data-coreui-delay="1" data-coreui-animation="false">',
-          '  <div class="toast-body">',
-          '    a simple toast',
-          '  </div>',
-          '</div>'
-        ].join('')
+    it('should trigger shown synchronously when the toast is instant', () => {
+      fixtureEl.innerHTML = [
+        '<div class="toast toast-instant" data-coreui-autohide="false">',
+        '  <div class="toast-body">',
+        '    a simple toast',
+        '  </div>',
+        '</div>'
+      ].join('')
 
-        const toastEl = fixtureEl.querySelector('.toast')
-        const toast = new Toast(toastEl)
+      const toastEl = fixtureEl.querySelector('.toast')
+      const toast = new Toast(toastEl)
+      const spy = jasmine.createSpy('shown')
 
-        toastEl.addEventListener('shown.coreui.toast', () => {
-          expect(toastEl).not.toHaveClass('fade')
-          resolve()
-        })
+      toastEl.addEventListener('shown.coreui.toast', spy)
 
-        toast.show()
-      })
+      toast.show()
+
+      expect(spy).toHaveBeenCalled()
+      expect(toastEl).toHaveClass('show')
     })
 
     it('should not trigger shown if show is prevented', () => {
       return new Promise((resolve, reject) => {
         fixtureEl.innerHTML = [
-          '<div class="toast" data-coreui-delay="1" data-coreui-animation="false">',
+          '<div class="toast toast-instant" data-coreui-delay="1">',
           '  <div class="toast-body">',
           '    a simple toast',
           '  </div>',
@@ -437,6 +436,27 @@ describe('Toast', () => {
       })
     })
 
+    it('should trigger hidden synchronously when the toast is instant', () => {
+      fixtureEl.innerHTML = [
+        '<div class="toast toast-instant show" data-coreui-autohide="false">',
+        '  <div class="toast-body">',
+        '    a simple toast',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const toastEl = fixtureEl.querySelector('.toast')
+      const toast = new Toast(toastEl)
+      const spy = jasmine.createSpy('hidden')
+
+      toastEl.addEventListener('hidden.coreui.toast', spy)
+
+      toast.hide()
+
+      expect(spy).toHaveBeenCalled()
+      expect(toastEl).not.toHaveClass('show')
+    })
+
     it('should do nothing when we call hide on a non shown toast', () => {
       fixtureEl.innerHTML = '<div></div>'
 
@@ -453,7 +473,7 @@ describe('Toast', () => {
     it('should not trigger hidden if hide is prevented', () => {
       return new Promise((resolve, reject) => {
         fixtureEl.innerHTML = [
-          '<div class="toast" data-coreui-delay="1" data-coreui-animation="false">',
+          '<div class="toast toast-instant" data-coreui-delay="1">',
           '  <div class="toast-body">',
           '    a simple toast',
           '  </div>',

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -1,6 +1,7 @@
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/tokens" as *;
+@use "mixins/transition" as *;
 @use "config" as *;
 
 // stylelint-disable custom-property-no-missing-var-function
@@ -17,6 +18,8 @@ $toast-border-color:                var(--#{$prefix}border-color-translucent) !d
 $toast-border-radius:               var(--#{$prefix}border-radius) !default;
 $toast-box-shadow:                  var(--#{$prefix}box-shadow) !default;
 $toast-spacing:                     $container-padding-x !default;
+$toast-transition-duration:         .15s !default;
+$toast-transition-timing:           linear !default;
 
 $toast-header-color:                var(--#{$prefix}secondary-color) !default;
 $toast-header-background-color:     color-mix(in srgb, var(--#{$prefix}body-bg) 85%, transparent) !default;
@@ -44,6 +47,8 @@ $toast-tokens: defaults(
     --#{$prefix}toast-header-bg: #{$toast-header-background-color},
     --#{$prefix}toast-header-border-color: #{$toast-header-border-color},
     --#{$prefix}toast-font-size: $toast-font-size,
+    --#{$prefix}toast-transition-duration: #{$toast-transition-duration},
+    --#{$prefix}toast-transition-timing: #{$toast-transition-timing},
   ),
   $toast-tokens
 );
@@ -52,6 +57,7 @@ $toast-tokens: defaults(
   .toast {
     @include tokens($toast-tokens);
 
+    display: none;
     width: var(--#{$prefix}toast-max-width);
     max-width: 100%;
     font-size: var(--#{$prefix}toast-font-size);
@@ -63,12 +69,28 @@ $toast-tokens: defaults(
     box-shadow: var(--#{$prefix}toast-box-shadow);
     @include border-radius(var(--#{$prefix}toast-border-radius));
 
-    &.showing {
+    // `display` is what makes a toast appear, and it cannot be interpolated, so
+    // `allow-discrete` keeps it laid out until the fade-out finishes. Add
+    // `.toast-instant` to skip the animation.
+    &:not(.toast-instant) {
       opacity: 0;
+      @include transition(
+        opacity var(--#{$prefix}toast-transition-duration) var(--#{$prefix}toast-transition-timing),
+        display var(--#{$prefix}toast-transition-duration) allow-discrete
+      );
     }
 
-    &:not(.show) {
-      display: none;
+    &.show {
+      display: block;
+      opacity: 1;
+    }
+  }
+
+  // The toast is not rendered before `.show` lands, so the fade-in needs an
+  // explicit state to animate FROM: the base rule cannot express it.
+  @starting-style {
+    .toast:not(.toast-instant).show {
+      opacity: 0;
     }
   }
 


### PR DESCRIPTION
> **Stacked on #708** (which is stacked on #707). Merge those first; I will retarget this at `v6-dev` afterwards.

The `toggle` option made the constructor change the state the markup declares. That surprised people, so almost every caller passed `toggle: false` — including our own data API handler, the accordion's `_getFirstLevelChildren` wiring, the jQuery bridge, and 15 call sites in our own spec.

The constructor now always keeps the declared state:

```diff
- const collapse = new coreui.Collapse('#myCollapse', { toggle: false })
+ const collapse = new coreui.Collapse('#myCollapse')
+ collapse.show()
```

`data-coreui-toggle="collapse"` on a *trigger* is a different thing and is unchanged.

Removing it also deletes the `_configAfterMerge` string coercion (`config.toggle = Boolean(config.toggle)`) and empties the jQuery interface's `_config` juggling, which existed only to pass `toggle: false` for `show`/`hide`.

## Tests

`should not change tab tabpanels descendants on accordion` needed a real fix rather than a find-and-replace: its element starts `.show`, and it relied on the constructor's auto-toggle to close it before calling `show()`. Without that, `show()` is a no-op on an already-open element and the hide/show cycle never starts (the spec times out — confirmed before fixing). It now starts the cycle with an explicit `hide()`, as upstream did. The `getOrCreateInstance` specs asserted on `_config.toggle`; they assert on `_config.parent` instead.

Collapse suite: 43 specs, green.

Ported from twbs/bootstrap#42799.