### PR TITLE
refactor(Collapse)!: drop the toggle option

### DIFF
--- a/docs/src/content/docs/components/collapse.mdx
+++ b/docs/src/content/docs/components/collapse.mdx
@@ -127,7 +127,6 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 `parent` | selector, jQuery object, DOM element | `null` | If parent is provided, then all collapsible elements under the specified parent will be closed when this collapsible item is shown. (similar to traditional accordion behavior - this is dependent on the `card` class). The attribute has to be set on the target collapsible area. |
-`toggle` | boolean | `true` | Toggles the collapsible element on invocation |
 
 ### Methods
 
@@ -141,12 +140,11 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 Activates your content as a collapsible element. Accepts an optional options `object`.
 
-You can create a collapse instance with the constructor, for example:
+The constructor keeps the state that your markup declares. Add `.show` to open the element, and leave it off to keep the element closed. Call `show()`, `hide()` or `toggle()` to change the state.
 
 ```js
-const bsCollapse = new coreui.Collapse('#myCollapse', {
-  toggle: false
-})
+const bsCollapse = new coreui.Collapse('#myCollapse')
+bsCollapse.show()
 ```
 
 | Method | Description |

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -530,6 +530,23 @@ adornment in the library — so the button needs no icon markup at all:
   invalid on it (axe `aria-allowed-attr`); the native `disabled`/`readonly`
   states on the inner `<input>` carry the semantics.
 
+#### Collapse
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The `toggle` option is gone.** It made the constructor change the state the
+  markup declares, which surprised people — so nearly every caller passed
+  `toggle: false`. The constructor now always keeps the declared state; add
+  `.show` to start open, and call `show()`, `hide()` or `toggle()` to change it.
+
+  ```diff
+  - const collapse = new coreui.Collapse('#myCollapse', { toggle: false })
+  + const collapse = new coreui.Collapse('#myCollapse')
+  ```
+
+  Callers that relied on the constructor toggling need an explicit call:
+  `new coreui.Collapse(el).toggle()`. `data-coreui-toggle` on a *trigger* is
+  unrelated and unchanged.
+
 #### Toast
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/js/src/collapse.ts
+++ b/js/src/collapse.ts
@@ -47,13 +47,11 @@ const SELECTOR_ACTIVES = '.collapse.show, .collapse.collapsing'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="collapse"]'
 
 const Default = {
-  parent: null,
-  toggle: true
+  parent: null
 }
 
 const DefaultType = {
-  parent: '(null|element)',
-  toggle: 'boolean'
+  parent: '(null|element)'
 }
 
 /**
@@ -62,7 +60,6 @@ const DefaultType = {
 
 type CollapseConfig = {
   parent: string | Element | null
-  toggle: boolean
 }
 
 /**
@@ -97,10 +94,6 @@ class Collapse extends BaseComponent {
     if (!this._config.parent) {
       this._addAriaAndCollapsedClass(this._triggerArray, this._isShown())
     }
-
-    if (this._config.toggle) {
-      this.toggle()
-    }
   }
 
   // Getters
@@ -132,7 +125,7 @@ class Collapse extends BaseComponent {
     if (this._config.parent) {
       activeChildren = this._getFirstLevelChildren(SELECTOR_ACTIVES)
         .filter(element => element !== this._element)
-        .map(element => Collapse.getOrCreateInstance(element, { toggle: false }))
+        .map(element => Collapse.getOrCreateInstance(element))
     }
 
     if (activeChildren.length && activeChildren[0]._isTransitioning) {
@@ -227,7 +220,6 @@ class Collapse extends BaseComponent {
   }
 
   override _configAfterMerge(config: ComponentConfig): ComponentConfig {
-    (config as any).toggle = Boolean((config as any).toggle) // Coerce string values
     config.parent = getElement(config.parent)
     return config
   }
@@ -271,13 +263,8 @@ class Collapse extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    const _config: Record<string, unknown> = {}
-    if (typeof config === 'string' && /show|hide/.test(config)) {
-      _config.toggle = false
-    }
-
     return this.each(function (this: HTMLElement) {
-      const data: any = Collapse.getOrCreateInstance(this, _config)
+      const data: any = Collapse.getOrCreateInstance(this)
 
       if (typeof config === 'string') {
         if (typeof data[config as string] === 'undefined') {
@@ -301,7 +288,7 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
   }
 
   for (const element of SelectorEngine.getMultipleElementsFromSelector(this)) {
-    Collapse.getOrCreateInstance(element, { toggle: false }).toggle()
+    Collapse.getOrCreateInstance(element).toggle()
   }
 })
 

--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -123,9 +123,7 @@ describe('Collapse', () => {
       fixtureEl.innerHTML = '<div class="show"></div>'
 
       const collapseEl = fixtureEl.querySelector('.show')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       const spy = spyOn(collapse, 'hide')
 
@@ -155,8 +153,7 @@ describe('Collapse', () => {
 
         const collapseList = [].concat(...fixtureEl.querySelectorAll('.collapse'))
           .map(el => new Collapse(el, {
-            parent,
-            toggle: false
+            parent
           }))
 
         collapseEl2.addEventListener('shown.coreui.collapse', () => {
@@ -177,9 +174,7 @@ describe('Collapse', () => {
       const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       collapse._isTransitioning = true
       collapse.show()
@@ -193,9 +188,7 @@ describe('Collapse', () => {
       const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       collapse.show()
 
@@ -207,9 +200,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse" style="height: 0px;"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         collapseEl.addEventListener('show.coreui.collapse', () => {
           expect(collapseEl.style.height).toEqual('0px')
@@ -229,9 +220,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse collapse-horizontal" style="width: 0px;"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         collapseEl.addEventListener('show.coreui.collapse', () => {
           expect(collapseEl.style.width).toEqual('0px')
@@ -259,9 +248,7 @@ describe('Collapse', () => {
 
         const el1 = fixtureEl.querySelector('#collapse1')
         const el2 = fixtureEl.querySelector('#collapse2')
-        const collapse = new Collapse(el1, {
-          toggle: false
-        })
+        const collapse = new Collapse(el1)
 
         el1.addEventListener('shown.coreui.collapse', () => {
           expect(el1).toHaveClass('show')
@@ -380,7 +367,8 @@ describe('Collapse', () => {
           collapse.hide()
         })
 
-        collapse.show()
+        // The element starts shown, so close it to begin the hide/show cycle
+        collapse.hide()
       })
     })
 
@@ -389,9 +377,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         const expectEnd = () => {
           setTimeout(() => {
@@ -421,9 +407,7 @@ describe('Collapse', () => {
       const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       collapse._isTransitioning = true
       collapse.hide()
@@ -437,9 +421,7 @@ describe('Collapse', () => {
       const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       collapse.hide()
 
@@ -451,9 +433,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse show"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         collapseEl.addEventListener('hidden.coreui.collapse', () => {
           expect(collapseEl).not.toHaveClass('show')
@@ -470,9 +450,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse show"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         const expectEnd = () => {
           setTimeout(() => {
@@ -500,9 +478,7 @@ describe('Collapse', () => {
       fixtureEl.innerHTML = '<div class="collapse show"></div>'
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       expect(Collapse.getInstance(collapseEl)).toEqual(collapse)
 
@@ -1034,11 +1010,11 @@ describe('Collapse', () => {
 
       expect(Collapse.getInstance(div)).toBeNull()
       const collapse = Collapse.getOrCreateInstance(div, {
-        toggle: false
+        parent: fixtureEl
       })
       expect(collapse).toBeInstanceOf(Collapse)
 
-      expect(collapse._config.toggle).toBeFalse()
+      expect(collapse._config.parent).toEqual(fixtureEl)
     })
 
     it('should return the instance when exists without given configuration', () => {
@@ -1046,17 +1022,17 @@ describe('Collapse', () => {
 
       const div = fixtureEl.querySelector('div')
       const collapse = new Collapse(div, {
-        toggle: false
+        parent: fixtureEl
       })
       expect(Collapse.getInstance(div)).toEqual(collapse)
 
       const collapse2 = Collapse.getOrCreateInstance(div, {
-        toggle: true
+        parent: null
       })
       expect(collapse).toBeInstanceOf(Collapse)
       expect(collapse2).toEqual(collapse)
 
-      expect(collapse2._config.toggle).toBeFalse()
+      expect(collapse2._config.parent).toEqual(fixtureEl)
     })
   })
 })

--- a/js/tests/unit/promise-api.spec.js
+++ b/js/tests/unit/promise-api.spec.js
@@ -47,7 +47,7 @@ describe('Promise-returning API', () => {
       fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
 
       const collapseEl = fixtureEl.querySelector('.collapse')
-      const collapse = new Collapse(collapseEl, { toggle: false })
+      const collapse = new Collapse(collapseEl)
 
       expect(await orderOf(collapseEl, 'shown.coreui.collapse', () => collapse.show()))
         .toEqual(['shown.coreui.collapse', 'resolved'])
@@ -147,7 +147,7 @@ describe('Promise-returning API', () => {
       fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
 
       const collapseEl = fixtureEl.querySelector('.collapse')
-      const collapse = new Collapse(collapseEl, { toggle: false })
+      const collapse = new Collapse(collapseEl)
       const shownSpy = jasmine.createSpy('shown')
 
       collapseEl.addEventListener('show.coreui.collapse', event => {
@@ -165,7 +165,7 @@ describe('Promise-returning API', () => {
       fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
 
       const collapseEl = fixtureEl.querySelector('.collapse')
-      const collapse = new Collapse(collapseEl, { toggle: false })
+      const collapse = new Collapse(collapseEl)
 
       await collapse.show()
 
@@ -182,7 +182,7 @@ describe('Promise-returning API', () => {
       fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
 
       const collapseEl = fixtureEl.querySelector('.collapse')
-      const collapse = new Collapse(collapseEl, { toggle: false })
+      const collapse = new Collapse(collapseEl)
       const shownSpy = jasmine.createSpy('shown')
 
       collapseEl.addEventListener('shown.coreui.collapse', shownSpy)
@@ -218,7 +218,7 @@ describe('Promise-returning API', () => {
       fixtureEl.innerHTML = '<div class="collapse"><div>content</div></div>'
 
       const collapseEl = fixtureEl.querySelector('.collapse')
-      const collapse = new Collapse(collapseEl, { toggle: false })
+      const collapse = new Collapse(collapseEl)
 
       await collapse.show()
       expect(collapseEl).toHaveClass('show')


### PR DESCRIPTION
Replaces #709, which GitHub closed automatically when its base branch (`feat/promise-lifecycle-api-v6`, PR #708) was deleted on merge. Same commit, rebased onto `v6-dev`.

The `toggle` option made the constructor change the state the markup declares. That surprised people, so almost every caller passed `toggle: false` — including our own data API handler, the accordion's `_getFirstLevelChildren` wiring, the jQuery bridge, and 15 call sites in our own spec.

The constructor now always keeps the declared state:

```diff
- const collapse = new coreui.Collapse('#myCollapse', { toggle: false })
+ const collapse = new coreui.Collapse('#myCollapse')
+ collapse.show()
```

`data-coreui-toggle="collapse"` on a *trigger* is a different thing and is unchanged.

Removing it also deletes the `_configAfterMerge` string coercion (`config.toggle = Boolean(config.toggle)`) and empties the jQuery interface's `_config` juggling, which existed only to pass `toggle: false` for `show`/`hide`.

## Tests

`should not change tab tabpanels descendants on accordion` needed a real fix rather than a find-and-replace: its element starts `.show`, and it relied on the constructor's auto-toggle to close it before calling `show()`. Without that, `show()` is a no-op on an already-open element and the hide/show cycle never starts (the spec times out — confirmed before fixing). It now starts the cycle with an explicit `hide()`, as upstream did. The `getOrCreateInstance` specs asserted on `_config.toggle`; they assert on `_config.parent` instead.

Ported from twbs/bootstrap#42799.