### PR TITLE
feat(Navbar, Table)!: components that answer to their own width

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "52.75kB"
+      "maxSize": "53.5kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "44.5kB"
+      "maxSize": "45kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/components/navbar.mdx
+++ b/docs/src/content/docs/components/navbar.mdx
@@ -427,6 +427,10 @@ Navbars can use `.navbar-toggler`, `.navbar-collapse`, and `.navbar-expand{-sm|-
 
 For navbars that never collapse, add the `.navbar-expand` class on the navbar. For navbars that always collapse, don't add any `.navbar-expand` class.
 
+<Callout color="info">
+**The breakpoint is the navbar's own width, not the window's.** Every `.navbar` is a [query container](/utilities/container-queries/), so `.navbar-expand-lg` collapses when the navbar itself is narrower than `lg`. A navbar in a sidebar or a narrow dashboard column collapses there while a full-width one on the same page stays expanded — which is what you wanted from it in the first place. Nothing changes for a navbar that spans the page: its width *is* the viewport's.
+</Callout>
+
 ### Toggler
 
 Navbar togglers are left-aligned by default, but should they follow a sibling element like a `.navbar-brand`, they'll automatically be aligned to the far right. Reversing your markup will reverse the placement of the toggler. Below are examples of different toggle styles.

--- a/docs/src/content/docs/content/tables.mdx
+++ b/docs/src/content/docs/content/tables.mdx
@@ -374,6 +374,8 @@ You can also put the `<caption>` on the top of the table with `.caption-top`.
 
 Responsive tables allow tables to be scrolled horizontally with ease. Make any table responsive across all viewports by wrapping a `.table` with `.table-responsive`. Or, pick a maximum breakpoint with which to have a responsive table up to by using `.table-responsive{-sm|-md|-lg|-xl|-xxl}`.
 
+Every `.table-responsive*` is also a [query container](/utilities/container-queries/), which is what [stacked tables](#stacked-tables) below query to decide when to break rows into blocks.
+
 <Callout color="warning">
 ##### Vertical clipping/truncation
 
@@ -465,6 +467,39 @@ Use `.table-responsive{-sm|-md|-lg|-xl|-xxl}` as needed to create responsive tab
   </table>
 </div>
 ```
+
+## Stacked tables
+
+A table that scrolls sideways is still a table; on a narrow screen it is often easier to read one record at a time. Add `.table-stacked{-sm|-md|-lg|-xl|-xxl}` next to `.table` to turn each row into a block below that breakpoint — the header is hidden from sight (it stays in the accessibility tree) and every cell carries its own label.
+
+Two things are required: a `.table-responsive*` ancestor, because that is the query container the class measures, and a `data-cell` attribute on every `<td>` after the first, which supplies the label the hidden header would have given. The first cell is treated as the record's title and needs no label.
+
+<Example html={[`<div class="table-responsive">`, `    <table class="table table-stacked-md">`, `      <thead>`, `        <tr>`, `          <th scope="col">Name</th>`, `          <th scope="col">Role</th>`, `          <th scope="col">Email</th>`, `        </tr>`, `      </thead>`, `      <tbody>`, `        <tr>`, `          <td>Mark Otto</td>`, `          <td data-cell="Role">Maintainer</td>`, `          <td data-cell="Email">mark@example.com</td>`, `        </tr>`, `        <tr>`, `          <td>Jacob Thornton</td>`, `          <td data-cell="Role">Designer</td>`, `          <td data-cell="Email">jacob@example.com</td>`, `        </tr>`, `      </tbody>`, `    </table>`, `  </div>`]} />
+
+```html
+<div class="table-responsive">
+  <table class="table table-stacked-md">
+    <thead>
+      <tr>
+        <th scope="col">Name</th>
+        <th scope="col">Role</th>
+        <th scope="col">Email</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Mark Otto</td>
+        <td data-cell="Role">Maintainer</td>
+        <td data-cell="Email">mark@example.com</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+```
+
+<Callout color="info">
+Because the breakpoint is read from the `.table-responsive*` wrapper rather than the window, a stacked table inside a narrow column stacks there while the same markup in the main content area stays a table.
+</Callout>
 
 ## Customization
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -597,6 +597,34 @@ adornment in the library — so the button needs no icon markup at all:
   the value; an attribute you wrote yourself is left alone. Write it in your
   markup anyway, so the state is correct before our JavaScript runs.
 
+#### Navbar
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`.navbar-expand-*` reads the navbar's own width, not the viewport's.** Every
+  `.navbar` is a [query container](/utilities/container-queries/) now, so a
+  navbar in a sidebar or a narrow dashboard column collapses there while a
+  full-width one on the same page stays expanded. For a navbar that spans the
+  page — which is most of them — nothing changes, because its width *is* the
+  viewport's.
+- **`flex-wrap: nowrap` and `justify-content: flex-start` moved from
+  `.navbar-expand-*` onto its inner `.container*`.** A container query styles
+  descendants of the container, never the container itself, and the inner
+  container is where those two properties took effect anyway (the navbar's
+  children inherit `flex-wrap`). A navbar written **without** an inner
+  `.container`, `.container-fluid` or `.container-{breakpoint}` no longer gets
+  them — wrap its content, the way every example in these docs does.
+
+#### Tables
+
+- **`.table-responsive*` is a query container.** It still scrolls horizontally
+  below its breakpoint; the addition is that things inside it can now respond to
+  its width.
+- **New: `.table-stacked{-sm|-md|-lg|-xl|-xxl}`** turns rows into stacked blocks
+  below the breakpoint, reading the width from the `.table-responsive*` wrapper.
+  Give every `<td>` past the first a `data-cell` attribute for its label; the
+  header is hidden visually and kept in the accessibility tree. See
+  [Stacked tables](/content/tables/#stacked-tables).
+
 #### Toast
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -128,6 +128,23 @@ $navbar-dark-tokens: defaults(
   $navbar-dark-tokens
 );
 // scss-docs-end navbar-dark-css-vars
+// The expanded rules are read from inside the navbar's own query container, so
+// they can only style its descendants — an element is never its own container.
+// The two properties that used to sit on `.navbar-expand-*` itself move onto the
+// inner container, which is where they take effect anyway.
+@mixin navbar-expanded-container {
+  > .container,
+  > .container-fluid {
+    @content;
+  }
+
+  @each $breakpoint, $container-max-width in $container-max-widths {
+    > .container#{breakpoint-infix($breakpoint, $container-max-widths)} {
+      @content;
+    }
+  }
+}
+
 @layer components {
   // Navbar
   //
@@ -144,6 +161,9 @@ $navbar-dark-tokens: defaults(
     justify-content: space-between; // space out brand from logo
     padding: var(--#{$prefix}navbar-padding-y) var(--#{$prefix}navbar-padding-x);
     @include gradient-bg();
+    // The navbar answers to the width it is given, not to the window's: a navbar
+    // in a narrow column collapses there while a full-width one stays expanded.
+    @include set-container();
 
     // Because flex properties aren't inherited, we need to redeclare these first
     // few properties so that content nested within behave properly.
@@ -299,9 +319,11 @@ $navbar-dark-tokens: defaults(
 
       // stylelint-disable-next-line scss/selector-no-union-class-name
       &#{$infix} {
-        @include media-breakpoint-up($next) {
-          flex-wrap: nowrap;
-          justify-content: flex-start;
+        @include container-breakpoint-up($next) {
+          @include navbar-expanded-container() {
+            flex-wrap: nowrap;
+            justify-content: flex-start;
+          }
 
           .navbar-nav {
             flex-direction: row;

--- a/scss/content/_tables.scss
+++ b/scss/content/_tables.scss
@@ -2,6 +2,7 @@
 @use "sass:math";
 @use "../functions/color" as *;
 @use "../layout/breakpoints" as *;
+@use "../mixins/visually-hidden" as *;
 @use "../theme" as *;
 @use "../config" as *;
 
@@ -230,16 +231,66 @@ $table-variants: map.keys($theme-colors) !default;
 
   // Responsive tables
   //
-  // Generate series of `.table-responsive-*` classes for configuring the screen
-  // size of where your table will overflow.
+  // Generate series of `.table-responsive-*` classes that act as query containers
+  // and turn on horizontal scrolling below their breakpoint.
 
   @each $breakpoint in map.keys($grid-breakpoints) {
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
-    @include media-breakpoint-down($breakpoint) {
-      .table-responsive#{$infix} {
+    .table-responsive#{$infix} {
+      @include set-container();
+
+      @include media-breakpoint-down($breakpoint) {
         overflow-x: auto;
         -webkit-overflow-scrolling: touch;
+      }
+    }
+  }
+
+  // Stacked tables
+  //
+  // Generate `.table-stacked-*` classes that turn rows into stacked blocks when
+  // the table's container is narrower than the breakpoint. Needs a
+  // `.table-responsive*` ancestor to query, and `data-cell` on every `<td>` past
+  // the first to label the value the way the hidden header would.
+
+  @each $breakpoint in map.keys($grid-breakpoints) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+    @include container-breakpoint-down($breakpoint) {
+      .table-stacked#{$infix} {
+        > thead {
+          @include visually-hidden();
+        }
+
+        > tbody > tr {
+          display: block;
+          padding-block: var(--#{$prefix}table-cell-padding-y);
+
+          + tr {
+            border-block-start: var(--#{$prefix}table-border-width) solid var(--#{$prefix}table-border-color);
+          }
+
+          > td {
+            display: block;
+            padding: calc(var(--#{$prefix}table-cell-padding-y) * .25) calc(var(--#{$prefix}table-cell-padding-x) * 2); // stylelint-disable-line function-disallowed-list
+            border: 0;
+
+            &:first-child {
+              font-weight: $font-weight-bold;
+            }
+
+            &[data-cell]:not(:first-child)::before {
+              display: block;
+              font-weight: $font-weight-semibold;
+              content: attr(data-cell);
+            }
+          }
+
+          > td:not(:first-child) + td::before {
+            margin-block-start: .25rem;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Group A from the container-query survey: the two components whose responsive rules style **descendants**, so the component itself can be the query container and existing markup keeps working untouched. Two commits, reviewable apart.

## Navbar — `6deb19df9`

`.navbar-expand-*` asked the viewport how wide it was, which is the wrong question. A navbar in a sidebar or a narrow dashboard column stayed expanded because the *browser window* was wide. `.navbar` is a query container now, so it collapses when **it** is narrower than the breakpoint. For a navbar spanning the page — most of them — nothing changes, because its width is the viewport's.

**One thing had to move.** Our expand block opened with two declarations on the navbar itself:

```scss
.navbar-expand-lg {
  @include media-breakpoint-up(lg) {
    flex-wrap: nowrap;          // ← on the navbar
    justify-content: flex-start; // ← on the navbar
    .navbar-nav { … }            // ← descendants
```

A container query styles descendants of the container, never the container itself, so those two would have silently stopped applying. They move onto the inner `.container*` — where they took effect anyway, since the navbar's children carry `flex-wrap: inherit`. Upstream made exactly this move; I checked their compiled CSS to confirm every declaration in their navbar `@container` block targets a descendant. **A navbar written without an inner `.container`, `.container-fluid` or `.container-{breakpoint}` loses them** — migration guide says so.

## Tables — `b8c6e417c`

`.table-responsive*` becomes a query container (it still scrolls below its breakpoint), and that unlocks the new **`.table-stacked{-sm|-md|-lg|-xl|-xxl}`**: below the breakpoint each row becomes a block, the header is hidden visually and kept in the accessibility tree (through our `visually-hidden()` mixin rather than upstream's inline copy), and every cell past the first prints its `data-cell` label above the value. A table that scrolls sideways is still a table; on a narrow screen one record at a time reads better.

Because the width comes from the wrapper, the same markup stacks inside a narrow column and stays a table in the main content area.

If you would rather not take `.table-stacked` in this PR, drop the second commit — the first one stands alone.

## Not in here

Group B — `.list-group-horizontal-*`, `.card-group`, `.hstack`/`.vstack` — where the responsive rule styles the element itself and therefore needs an author-supplied wrapper. Porting those the way upstream did makes existing markup fail **silently**, so it needs your call first. Stepper is a separate question: we have no responsive stepper to rewire.

## Size and verification

+732 B gzip for both features; `coreui.css` 52.75 → 53.5 kB and `coreui.min.css` 44.5 → 45 kB.

stylelint, `fusv`, the class-API check, 62 Sass specs, bundlewatch, the JS suite and `docs-build` (140 pages, no broken links). Docs: a callout on the navbar page explaining that the breakpoint is now the navbar's own width, a "Stacked tables" section with a runnable example, and four migration entries.