### PR TITLE
feat(stacks): responsive variants, read from the container

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -22,15 +22,15 @@
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",
-      "maxSize": "13.10 kB"
+      "maxSize": "13.5 kB"
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "53.5kB"
+      "maxSize": "54kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "45kB"
+      "maxSize": "45.5kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/helpers/stacks.mdx
+++ b/docs/src/content/docs/helpers/stacks.mdx
@@ -47,6 +47,32 @@ And with [vertical rules](/helpers/vertical-rule/):
     <div class="p-2">Third item</div>
   </div>`} />
 
+## Responsive
+
+`.hstack{-sm|-md|-lg|-xl|-xxl}` and `.vstack{-sm|-md|-lg|-xl|-xxl}` switch direction at a breakpoint — a stack that reads as a row on a wide layout and as a column on a narrow one, without writing the flex utilities twice.
+
+The breakpoint is measured on the **container**, not the viewport, so mark an ancestor with `.stack-container` (or the [`.contains-inline`](/utilities/container-queries/) utility) for the query to have something to read. Without it the direction never switches.
+
+<Example class="docs-example-flex" code={`<div class="stack-container">
+    <div class="hstack-md vstack gap-3">
+      <div class="p-2">First item</div>
+      <div class="p-2">Second item</div>
+      <div class="p-2">Third item</div>
+    </div>
+  </div>`} />
+
+```html
+<div class="stack-container">
+  <div class="hstack-md vstack gap-3">
+    <div class="p-2">First item</div>
+    <div class="p-2">Second item</div>
+    <div class="p-2">Third item</div>
+  </div>
+</div>
+```
+
+Because the width comes from the container, the same markup can be a column in a sidebar and a row in the main content area of the same page.
+
 ## Examples
 
 Use `.vstack` to stack buttons and other elements:

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -614,6 +614,15 @@ adornment in the library — so the button needs no icon markup at all:
   `.container`, `.container-fluid` or `.container-{breakpoint}` no longer gets
   them — wrap its content, the way every example in these docs does.
 
+#### Stacks
+
+- **New: `.hstack{-sm|-md|-lg|-xl|-xxl}` and `.vstack{-sm|-md|-lg|-xl|-xxl}`** switch
+  direction at a breakpoint. The breakpoint is the width of the nearest query
+  container, so mark an ancestor with the new `.stack-container` (or the
+  [`.contains-inline`](/utilities/container-queries/) utility) — without one the
+  direction never switches. Plain `.hstack` and `.vstack` are unchanged, including
+  `.hstack`'s vertical centring and its shrink-to-content width.
+
 #### Tables
 
 - **`.table-responsive*` is a query container.** It still scrolls horizontally

--- a/scss/helpers/_stacks.scss
+++ b/scss/helpers/_stacks.scss
@@ -1,17 +1,49 @@
+@use "sass:list";
+@use "sass:map";
+@use "sass:string";
+@use "../layout/breakpoints" as *;
+@use "../config" as *;
+
+// Every stack class, so the shared flex base is written once.
+// stylelint-disable-next-line scss/dollar-variable-default
+$stack-selectors: ();
+@each $breakpoint in map.keys($grid-breakpoints) {
+  $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+  $stack-selectors: list.append($stack-selectors, string.unquote(".hstack#{$infix}"), comma);
+  $stack-selectors: list.append($stack-selectors, string.unquote(".vstack#{$infix}"), comma);
+}
+
 @layer helpers {
   // scss-docs-start stacks
-  .hstack {
+  .stack-container {
+    @include set-container();
+  }
+
+  #{$stack-selectors} {
     display: flex;
-    flex-direction: row;
-    align-items: center;
     align-self: stretch;
   }
 
-  .vstack {
-    display: flex;
-    flex: 1 1 auto;
-    flex-direction: column;
-    align-self: stretch;
+  // The responsive variants read the width of the nearest query container — put
+  // `.stack-container` (or the `.contains-inline` utility) on an ancestor, or the
+  // query has nothing to measure and the direction never switches.
+  @each $breakpoint in map.keys($grid-breakpoints) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+    .hstack#{$infix} {
+      @include container-breakpoint-up($breakpoint) {
+        flex-direction: row;
+        align-items: center;
+      }
+    }
+
+    .vstack#{$infix} {
+      @include container-breakpoint-up($breakpoint) {
+        flex: 1 1 auto;
+        flex-direction: column;
+        align-items: stretch;
+      }
+    }
   }
   // scss-docs-end stacks
 }


### PR DESCRIPTION
The one piece of group B that breaks nothing: we have no responsive stack variants today, so adding them cannot silently change existing markup. `.list-group-horizontal-*` and `.card-group` stay on media queries — parked for a decision, written up in the workspace plan.

`.hstack-{breakpoint}` / `.vstack-{breakpoint}` switch direction at a breakpoint, and `.stack-container` marks the ancestor they measure. The width comes from that container rather than the viewport, so the same markup can be a column in a sidebar and a row in the main content area of one page.

```html
<div class="stack-container">
  <div class="hstack-md vstack gap-3">…</div>
</div>
```

## Where I did not follow upstream

Their stacks run on `--stack-*` tokens over a shared `[class*="stack"]` base:

```scss
[class*="hstack"], [class*="vstack"] {
  flex: var(--stack-flex, 1 1 auto);
  align-items: var(--stack-align-items, center);
}
.hstack { --stack-align-items: flex-start; }   // ← changes today's centring
```

Copied verbatim that would hand `.hstack` `flex: 1 1 auto` (it has none today, and our docs promise it "only takes up its necessary width") and change its `align-items` from `center` to `flex-start` — **two silent visual changes to markup that already exists**, for no gain we need. Ours keeps both; only the shared `display: flex` / `align-self: stretch` moves into a generated base selector, and the responsive variants set their properties directly.

The `[class*=…]` attribute selector also went: it would match anyone's `.my-hstack-thing`. The base selector is generated from `$grid-breakpoints`, so it lists exactly our twelve classes.

## Size

`coreui-utilities.min.css` 13.1 → 13.5 kB and `coreui.css` 52.75 → 53.5 kB. The second bump is the same value PR #713 sets, so the two branches make an identical edit to that line and merge without conflict whichever lands first.

## Verification

stylelint, `fusv`, class-API check, 62 Sass specs, bundlewatch, the JS suite, `docs-build` (140 pages, no broken links). Docs get a "Responsive" section on the Stacks page with a runnable example and the container requirement spelled out, plus a migration entry.