### PR TITLE
feat(Sass): add .hover-lift helper

### DIFF
--- a/docs/src/content/docs/helpers/hover-lift.mdx
+++ b/docs/src/content/docs/helpers/hover-lift.mdx
@@ -1,0 +1,24 @@
+---
+title: "Bootstrap 5 Hover Lift"
+name: "Hover lift"
+description: "Lift an element and add a shadow on hover or focus for a subtle sense of depth."
+---
+
+Add `.hover-lift` to any element to translate it upward and add a `box-shadow` on `:hover` and `:focus-visible`. Respects `prefers-reduced-motion`.
+
+<Example code={`<div class="card hover-lift" style="width: 18rem;">
+    <div class="card-body">
+      <h5 class="card-title">Card with hover lift</h5>
+      <p class="card-text">Hover or focus this card to see it lift with a shadow.</p>
+    </div>
+  </div>`} />
+
+## CSS variables
+
+CoreUI for Bootstrap's hover lift uses local CSS variables on `.hover-lift` for enhanced real-time customization.
+
+<ScssDocs file="scss/helpers/_hover-lift.scss" capture="hover-lift-css-vars" />
+
+## Sass variables
+
+<ScssDocs file="scss/helpers/_hover-lift.scss" capture="hover-lift-variables" />

--- a/docs/src/data/sidebar.yml
+++ b/docs/src/data/sidebar.yml
@@ -314,6 +314,8 @@
       to: /helpers/colored-links/
     - title: Focus ring
       to: /helpers/focus-ring/
+    - title: Hover lift
+      to: /helpers/hover-lift/
     - title: Icon link
       to: /helpers/icon-link/
     - title: Position

--- a/scss/helpers/_hover-lift.scss
+++ b/scss/helpers/_hover-lift.scss
@@ -1,0 +1,47 @@
+@use "../functions/defaults" as *;
+@use "../mixins/box-shadow" as *;
+@use "../mixins/tokens" as *;
+@use "../mixins/transition" as *;
+@use "../config" as *;
+
+// scss-docs-start hover-lift-variables
+$hover-lift-transition-duration: .2s !default;
+$hover-lift-transition-timing:   ease !default;
+$hover-lift-transform:           translateY(-.25rem) !default;
+$hover-lift-box-shadow:          var(--#{$prefix}box-shadow-lg) !default;
+// scss-docs-end hover-lift-variables
+
+$hover-lift-tokens: () !default;
+
+// scss-docs-start hover-lift-css-vars
+// stylelint-disable-next-line scss/dollar-variable-default
+$hover-lift-tokens: defaults(
+  (
+    --#{$prefix}hover-lift-transition-duration: #{$hover-lift-transition-duration},
+    --#{$prefix}hover-lift-transition-timing: #{$hover-lift-transition-timing},
+    --#{$prefix}hover-lift-transform: #{$hover-lift-transform},
+    --#{$prefix}hover-lift-box-shadow: #{$hover-lift-box-shadow},
+  ),
+  $hover-lift-tokens
+);
+// scss-docs-end hover-lift-css-vars
+
+@layer helpers {
+  //
+  // Hover lift
+  //
+
+  .hover-lift {
+    @include tokens($hover-lift-tokens);
+    @include transition(
+      transform var(--#{$prefix}hover-lift-transition-duration) var(--#{$prefix}hover-lift-transition-timing),
+      box-shadow var(--#{$prefix}hover-lift-transition-duration) var(--#{$prefix}hover-lift-transition-timing)
+    );
+
+    &:hover,
+    &:focus-visible {
+      transform: var(--#{$prefix}hover-lift-transform);
+      @include box-shadow(var(--#{$prefix}hover-lift-box-shadow));
+    }
+  }
+}

--- a/scss/helpers/index.scss
+++ b/scss/helpers/index.scss
@@ -2,6 +2,7 @@
 @forward "color-bg";
 @forward "colored-links";
 @forward "focus-ring";
+@forward "hover-lift";
 @forward "icon-link";
 @forward "ratio";
 @forward "position";


### PR DESCRIPTION
## Summary

Ports Bootstrap v6-dev's `.hover-lift` helper (twbs#42716): translate an element upward and add a `box-shadow` on `:hover`/`:focus-visible`, for a subtle sense of depth.

- New `scss/helpers/_hover-lift.scss`, tokenized (`--cui-hover-lift-*`) following the same `defaults()` + `tokens()` pattern as the rest of the library, gated behind `$enable-transitions`/`$enable-reduced-motion` like every other transition in the codebase.
- Registered in `scss/helpers/index.scss` (same position as upstream: right after `focus-ring`, before `icon-link`).
- Docs page at `/helpers/hover-lift/`, added to the sidebar between Focus ring and Icon link.

Purely additive — no existing classes, tokens, or markup touched. See `workspace/audits/bootstrap-v6-parity-audit-2026-08.md` for the fuller comparison this came out of; the rest of upstream's motion-utilities package (`--*-transition-property/-duration/-timing` split on button/accordion/nav/form-control) was left out since it replaces the single `--cui-<component>-transition` token every component exposes today with three — a breaking token-shape change, not something to smuggle in alongside this.

## Test plan

- [x] `sass` compile of `scss/coreui.scss` — clean, `.hover-lift` emits expected CSS incl. the `prefers-reduced-motion` media query
- [x] `stylelint` on the new file — clean
- [x] `fusv` (unused Sass vars check) — clean
- [x] `astro build --root docs` — clean, `/helpers/hover-lift/` built, no broken links, `ScssDocs` captures render correctly
- [x] Local pre-push CI gate (lint, typecheck, class-api check, bundlewatch, full JS test suite) — all green