### PR TITLE
feat(Sass): add dynamic viewport width/height utilities

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -18,7 +18,7 @@
     },
     {
       "path": "./dist/css/coreui-utilities.css",
-      "maxSize": "14.25 kB"
+      "maxSize": "14.3 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",

--- a/docs/src/content/docs/utilities/sizing.mdx
+++ b/docs/src/content/docs/utilities/sizing.mdx
@@ -41,6 +41,15 @@ You can also use utilities to set the width and height relative to the viewport.
 <div class="vh-100">Height 100vh</div>
 ```
 
+A mobile browser resizes the viewport as it shows or hides its URL bar, so `vh-100` can end up taller than the visible area. The `dvh`/`dvw` units track that change instead of the largest possible viewport, so use `dvh-100`/`min-dvh-100` for full-screen mobile layouts.
+
+```html
+<div class="min-dvw-100">Min-width 100dvw</div>
+<div class="min-dvh-100">Min-height 100dvh</div>
+<div class="dvw-100">Width 100dvw</div>
+<div class="dvh-100">Height 100dvh</div>
+```
+
 ## Sass
 
 ### Utilities API

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -286,6 +286,16 @@ $utilities: map.merge(
       class: min-vw,
       values: (100: 100vw)
     ),
+    "dynamic-viewport-width": (
+      property: width,
+      class: dvw,
+      values: (100: 100dvw)
+    ),
+    "min-dynamic-viewport-width": (
+      property: min-width,
+      class: min-dvw,
+      values: (100: 100dvw)
+    ),
     "height": (
       property: height,
       class: h,
@@ -311,6 +321,16 @@ $utilities: map.merge(
       property: min-height,
       class: min-vh,
       values: (100: 100vh)
+    ),
+    "dynamic-viewport-height": (
+      property: height,
+      class: dvh,
+      values: (100: 100dvh)
+    ),
+    "min-dynamic-viewport-height": (
+      property: min-height,
+      class: min-dvh,
+      values: (100: 100dvh)
     ),
     // scss-docs-end utils-sizing
     // Flex utilities


### PR DESCRIPTION
## Summary

Ports Bootstrap v6-dev's dynamic viewport utilities (twbs#42800): `.dvh-100`, `.min-dvh-100`, `.dvw-100`, `.min-dvw-100`.

A mobile browser resizes the viewport as it shows or hides its URL bar; the `vh`/`vw` units always measure with the browser UI hidden, so a `.vh-100` section can end up taller than what's actually visible. The `dvh`/`dvw` units track the *current* viewport instead, so `.dvh-100` fills the visible area on every device.

- Four new entries in the existing `utils-sizing` block of `scss/_utilities.scss`, right after `min-viewport-width`/`min-viewport-height` — purely additive, existing `vh`/`vw` utilities untouched.
- Docs: added a short "dynamic viewport" note + examples to `/utilities/sizing/`, next to the existing viewport-relative section.
- `+20 B` gzip on `coreui-utilities.css`; bumped its bundlewatch budget by 50 B (`14.25 -> 14.3 kB`) to keep headroom — the same shape of bump Bootstrap made on their own PR.

Browser support verified against `caniuse-lite` in this repo's tree: `dvh`/`dvw` are supported on every browser at our floor (Chrome 123, Firefox 120, Safari/iOS 17.5).

Part of the ongoing Bootstrap v6-dev parity sweep — see `workspace/audits/bootstrap-v6-parity-audit-2026-08.md`.

## Test plan

- [x] `sass` compile — clean, four new classes emit expected `dvh`/`dvw` declarations
- [x] `stylelint` on the changed file — clean
- [x] `fusv` (unused Sass vars check) — clean
- [x] `bundlewatch` — all budgets pass with the bump
- [x] `astro build --root docs` — clean, no broken links
- [x] Local pre-push CI gate (lint, typecheck, class-api check, bundlewatch, full JS test suite) — all green