### PR TITLE
fix(Sass): make $utilities configurable from the entrypoint

### DIFF
--- a/scss/coreui-utilities.scss
+++ b/scss/coreui-utilities.scss
@@ -4,6 +4,7 @@
 
 // Configuration
 @forward "config";
+@forward "utilities";
 
 // Layout & components
 @forward "root";

--- a/scss/coreui.scss
+++ b/scss/coreui.scss
@@ -3,6 +3,7 @@
 // scss-docs-start import-stack
 // Configuration
 @forward "config";
+@forward "utilities";
 @forward "functions";
 @forward "mixins";
 @forward "theme";


### PR DESCRIPTION
## Summary

`@use "coreui" with ($utilities: (...))` currently fails with:

> This variable was not declared with `!default` in the `@used` module.

`scss/coreui.scss` forwards `utilities/api`, which internally does `@use "../utilities" as *` — loading the module that declares `$utilities` **unconfigured**. By the time a consumer's `with (...)` configuration would apply, the module has already loaded, so Sass refuses it. Same root cause in `coreui-utilities.scss` (the utilities-only build).

Fix: forward the `utilities` module directly from both entrypoints, right after `config`, so it's reachable for configuration before anything loads it unconfigured. Two lines, one per entrypoint.

This mirrors how Bootstrap v6-dev just fixed the identical bug for their own `$utilities` (twbs#42801) — worth noting their `bootstrap-utilities.scss` already had this forward; only their full `bootstrap.scss` was missing it. Same shape here: our utilities-only build (`coreui-utilities.scss`) had the same gap as the full build.

Purely additive — no existing forwards removed or reordered beyond inserting these two lines, and compiled CSS is byte-identical for every entry point when no configuration is passed (verified below).

## Test plan

- [x] Compiled `coreui.scss`, `coreui-grid.scss`, `coreui-reboot.scss`, `coreui-utilities.scss`, `themes/bootstrap/bootstrap.scss` — no new errors/warnings
- [x] Diffed compiled `coreui.css` / `coreui-utilities.css` before vs. after (unconfigured) — byte-identical aside from the source-map comment
- [x] Scratch `@use ".../coreui" with ($utilities: (...))` and `@use ".../coreui-utilities" with ($utilities: (...))` — both now compile and emit the custom utility; both failed with the reported error before this fix
- [x] `stylelint` on the two changed files — clean
- [x] Local pre-push CI gate (lint, typecheck, class-api check, bundlewatch, full JS test suite) — all green

## Follow-up (not in this PR)

While digging into this, found that `docs/src/content/docs/utilities/api.mdx` ("Using the API" section) still teaches the pre-v6 `@import "@coreui/coreui/scss/variables"` + `map-merge()`/`map-get()` syntax, which predates the `@use`/`@forward` module migration and no longer matches the current file layout (`_variables.scss` is now a deprecated shim forwarding `_config.scss`). Worth a dedicated docs PR rewriting those examples around `@use ... with (...)` / the two-file `map.merge()` pattern this fix enables — flagged in `workspace/audits/bootstrap-v6-parity-audit-2026-08.md` for follow-up.