### PR TITLE
feat(forms): give checkbox, radio and switch their own runtime tokens

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "54kB"
+      "maxSize": "54.5kB"
     },
     {
       "path": "./dist/css/coreui.min.css",

--- a/docs/src/content/docs/forms/checkbox.mdx
+++ b/docs/src/content/docs/forms/checkbox.mdx
@@ -155,4 +155,16 @@ Visually, these checkbox toggle buttons are identical to the [button plugin togg
 
 ### SASS variables
 
+<ScssDocs file="scss/forms/_checkbox.scss" capture="checkbox-variables" />
+
+### CSS variables
+
+Checkboxs read their own custom properties, so restyling one control does not touch the other two. Set them on the control itself — an ancestor cannot override a token the element declares for itself.
+
+<ScssDocs file="scss/forms/_checkbox.scss" capture="checkbox-css-vars" />
+
+### Shared variables
+
+The wrapper and the shared control surface:
+
 <ScssDocs file="scss/forms/_check.scss" capture="form-check-variables" />

--- a/docs/src/content/docs/forms/radio.mdx
+++ b/docs/src/content/docs/forms/radio.mdx
@@ -152,4 +152,16 @@ Create button-like radios by putting `.btn` styles on the `<label>` instead of `
 
 ### SASS variables
 
+<ScssDocs file="scss/forms/_radio.scss" capture="radio-variables" />
+
+### CSS variables
+
+Radios read their own custom properties, so restyling one control does not touch the other two. Set them on the control itself — an ancestor cannot override a token the element declares for itself.
+
+<ScssDocs file="scss/forms/_radio.scss" capture="radio-css-vars" />
+
+### Shared variables
+
+The wrapper and the shared control surface:
+
 <ScssDocs file="scss/forms/_check.scss" capture="form-check-variables" />

--- a/docs/src/content/docs/forms/switch.mdx
+++ b/docs/src/content/docs/forms/switch.mdx
@@ -76,4 +76,16 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
 
 ### SASS variables
 
-<ScssDocs file="scss/forms/_check.scss" capture="form-switch-variables" />
+<ScssDocs file="scss/forms/_switch.scss" capture="switch-variables" />
+
+### CSS variables
+
+Switchs read their own custom properties, so restyling one control does not touch the other two. Set them on the control itself — an ancestor cannot override a token the element declares for itself.
+
+<ScssDocs file="scss/forms/_switch.scss" capture="switch-css-vars" />
+
+### Shared variables
+
+The wrapper and the shared control surface:
+
+<ScssDocs file="scss/forms/_check.scss" capture="form-check-variables" />

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -616,6 +616,25 @@ adornment in the library — so the button needs no icon markup at all:
 
 #### Checkbox, radio and switch: one page became four
 
+- **Each control now owns its custom properties.** `--#{$prefix}checkbox-*`,
+  `--#{$prefix}radio-*` and `--#{$prefix}switch-*` feed the shared implementation
+  at runtime, so restyling checkboxes no longer drags radios along and no longer
+  needs a Sass rebuild. Set them **on the control** — a token an element declares
+  for itself cannot be overridden from an ancestor. The old
+  `--#{$prefix}form-check-*` properties still exist and still work; they are the
+  shared layer underneath.
+- **The control stays on the text baseline when you resize it.** Its `margin-top`
+  used to be Sass arithmetic over `$form-check-input-width`, so changing the width
+  token at runtime moved the box off the line. It is a `calc()` over the size
+  token now.
+- **Sized switches are token overrides.** `.form-switch-lg` / `-xl` set
+  `--#{$prefix}switch-width` and `--#{$prefix}switch-height` instead of writing
+  their own geometry, so a size the map does not name is two custom properties
+  rather than a Sass recompile.
+- The Sass variables behind all of this moved into `scss/forms/_checkbox.scss`,
+  `_radio.scss` and `_switch.scss`. `$form-check-*` and `$form-switch-*` keep
+  working — the new per-control variables default to them.
+
 - **The docs split.** `/forms/checks-radios/` is now
   [Checkbox](/forms/checkbox/), [Radio](/forms/radio/) and
   [Switch](/forms/switch/) — one page per control, each self-contained down to its

--- a/scss/forms/_check.scss
+++ b/scss/forms/_check.scss
@@ -161,7 +161,10 @@ $form-check-input-tokens: defaults(
     flex-shrink: 0;
     width: var(--#{$prefix}form-check-input-width);
     height: var(--#{$prefix}form-check-input-width);
-    margin-top: ($line-height-base - $form-check-input-width) * .5; // line-height minus check height
+    // Half the difference between the line box and the control, computed at
+    // runtime so the box stays on the text baseline when the size token changes.
+    // stylelint-disable-next-line function-disallowed-list
+    margin-top: calc((#{$line-height-base * 1em} - var(--#{$prefix}form-check-input-width)) * .5);
     vertical-align: top;
     appearance: none;
     background-color: var(--#{$prefix}form-check-bg);
@@ -197,17 +200,17 @@ $form-check-input-tokens: defaults(
 
       &[type="checkbox"] {
         @if $enable-gradients {
-          --#{$prefix}form-check-bg-image: #{escape-svg($form-check-input-checked-bg-image)}, var(--#{$prefix}gradient);
+          --#{$prefix}form-check-bg-image: var(--#{$prefix}checkbox-checked-icon), var(--#{$prefix}gradient);
         } @else {
-          --#{$prefix}form-check-bg-image: #{escape-svg($form-check-input-checked-bg-image)};
+          --#{$prefix}form-check-bg-image: var(--#{$prefix}checkbox-checked-icon);
         }
       }
 
       &[type="radio"] {
         @if $enable-gradients {
-          --#{$prefix}form-check-bg-image: #{escape-svg($form-check-radio-checked-bg-image)}, var(--#{$prefix}gradient);
+          --#{$prefix}form-check-bg-image: var(--#{$prefix}radio-checked-icon), var(--#{$prefix}gradient);
         } @else {
-          --#{$prefix}form-check-bg-image: #{escape-svg($form-check-radio-checked-bg-image)};
+          --#{$prefix}form-check-bg-image: var(--#{$prefix}radio-checked-icon);
         }
       }
     }
@@ -217,9 +220,9 @@ $form-check-input-tokens: defaults(
       border-color: var(--#{$prefix}form-check-input-indeterminate-border-color);
 
       @if $enable-gradients {
-        --#{$prefix}form-check-bg-image: #{escape-svg($form-check-input-indeterminate-bg-image)}, var(--#{$prefix}gradient);
+        --#{$prefix}form-check-bg-image: var(--#{$prefix}checkbox-indeterminate-icon), var(--#{$prefix}gradient);
       } @else {
-        --#{$prefix}form-check-bg-image: #{escape-svg($form-check-input-indeterminate-bg-image)};
+        --#{$prefix}form-check-bg-image: var(--#{$prefix}checkbox-indeterminate-icon);
       }
     }
 
@@ -253,7 +256,13 @@ $form-check-input-tokens: defaults(
     padding-inline-start: var(--#{$prefix}form-switch-padding-start);
 
     .form-check-input {
+      // `.form-check-input` declares `--#{$prefix}form-switch-width` itself, so an
+      // inherited value from the wrapper would lose to it. Restate it here, where
+      // the selector is specific enough to win.
+      --#{$prefix}form-switch-width: var(--#{$prefix}switch-width);
+
       width: var(--#{$prefix}form-switch-width);
+      height: var(--#{$prefix}switch-height);
       // stylelint-disable-next-line function-disallowed-list
       margin-inline-start: calc(var(--#{$prefix}form-switch-padding-start) * -1);
       background-image: var(--#{$prefix}form-switch-bg);
@@ -262,16 +271,16 @@ $form-check-input-tokens: defaults(
       @include transition(var(--#{$prefix}form-switch-transition));
 
       &:focus {
-        --#{$prefix}form-switch-bg: #{escape-svg($form-switch-focus-bg-image)};
+        --#{$prefix}form-switch-bg: var(--#{$prefix}switch-knob-focus);
       }
 
       &:checked {
         background-position: var(--#{$prefix}form-switch-checked-bg-position);
 
         @if $enable-gradients {
-          --#{$prefix}form-switch-bg: #{escape-svg($form-switch-checked-bg-image)}, var(--#{$prefix}gradient);
+          --#{$prefix}form-switch-bg: var(--#{$prefix}switch-knob-checked), var(--#{$prefix}gradient);
         } @else {
-          --#{$prefix}form-switch-bg: #{escape-svg($form-switch-checked-bg-image)};
+          --#{$prefix}form-switch-bg: var(--#{$prefix}switch-knob-checked);
         }
       }
     }
@@ -286,26 +295,6 @@ $form-check-input-tokens: defaults(
     }
   }
 
-  @each $size, $map in $form-switch-widths {
-    $width: map.get($map, "width");
-    $height: map.get($map, "height");
-
-    .form-switch-#{$size} {
-      min-height: $height;
-      padding-inline-start: $width + .5em;
-
-      .form-check-input {
-        width: $width;
-        height: $height;
-        margin-inline-start: ($width + .5em) * -1;
-      }
-
-      .form-check-label {
-        // stylelint-disable-next-line function-disallowed-list
-        padding-top: calc((#{$height} - #{$font-size-base}) / 2);
-      }
-    }
-  }
 
   .form-check-inline {
     display: inline-block;
@@ -330,7 +319,7 @@ $form-check-input-tokens: defaults(
   @if $enable-dark-mode {
     @include color-mode(dark) {
       .form-switch .form-check-input:not(:checked):not(:focus) {
-        --#{$prefix}form-switch-bg: #{escape-svg($form-switch-bg-image-dark)};
+        --#{$prefix}form-switch-bg: var(--#{$prefix}switch-knob-dark);
       }
     }
   }

--- a/scss/forms/_checkbox.scss
+++ b/scss/forms/_checkbox.scss
@@ -1,0 +1,55 @@
+@use "../functions/defaults" as *;
+@use "../functions/escape-svg" as *;
+@use "check" as *;
+@use "../mixins/tokens" as *;
+@use "../config" as *;
+
+// The checkbox's own theming surface. `.form-check-input` carries one shared
+// implementation for all three controls; these tokens are what a consumer sets
+// to restyle checkboxes alone, and they feed that implementation at runtime —
+// no Sass, and radios and switches are left where they are.
+
+// scss-docs-start checkbox-variables
+$checkbox-size:                 $form-check-input-width !default;
+$checkbox-bg:                   $form-check-input-bg !default;
+$checkbox-border:               $form-check-input-border !default;
+$checkbox-border-radius:        $form-check-input-border-radius !default;
+$checkbox-checked-icon:         $form-check-input-checked-bg-image !default;
+$checkbox-indeterminate-icon:   $form-check-input-indeterminate-bg-image !default;
+// scss-docs-end checkbox-variables
+
+$checkbox-tokens: () !default;
+
+// scss-docs-start checkbox-css-vars
+// stylelint-disable-next-line scss/dollar-variable-default
+$checkbox-tokens: defaults(
+  (
+    --#{$prefix}checkbox-size: #{$checkbox-size},
+    --#{$prefix}checkbox-bg: #{$checkbox-bg},
+    --#{$prefix}checkbox-border: #{$checkbox-border},
+    --#{$prefix}checkbox-border-radius: #{$checkbox-border-radius},
+    --#{$prefix}checkbox-checked-bg: var(--#{$prefix}control-checked-bg),
+    --#{$prefix}checkbox-checked-border-color: var(--#{$prefix}control-checked-border-color),
+    --#{$prefix}checkbox-checked-icon: #{escape-svg($checkbox-checked-icon)},
+    --#{$prefix}checkbox-indeterminate-bg: var(--#{$prefix}control-indeterminate-bg),
+    --#{$prefix}checkbox-indeterminate-border-color: var(--#{$prefix}control-indeterminate-border-color),
+    --#{$prefix}checkbox-indeterminate-icon: #{escape-svg($checkbox-indeterminate-icon)},
+  ),
+  $checkbox-tokens
+);
+// scss-docs-end checkbox-css-vars
+
+@layer forms {
+  .form-check-input[type="checkbox"] {
+    @include tokens($checkbox-tokens);
+
+    --#{$prefix}form-check-input-width: var(--#{$prefix}checkbox-size);
+    --#{$prefix}form-check-bg: var(--#{$prefix}checkbox-bg);
+    --#{$prefix}form-check-input-border: var(--#{$prefix}checkbox-border);
+    --#{$prefix}form-check-input-border-radius: var(--#{$prefix}checkbox-border-radius);
+    --#{$prefix}form-check-input-checked-bg-color: var(--#{$prefix}checkbox-checked-bg);
+    --#{$prefix}form-check-input-checked-border-color: var(--#{$prefix}checkbox-checked-border-color);
+    --#{$prefix}form-check-input-indeterminate-bg-color: var(--#{$prefix}checkbox-indeterminate-bg);
+    --#{$prefix}form-check-input-indeterminate-border-color: var(--#{$prefix}checkbox-indeterminate-border-color);
+  }
+}

--- a/scss/forms/_radio.scss
+++ b/scss/forms/_radio.scss
@@ -1,0 +1,46 @@
+@use "../functions/defaults" as *;
+@use "../functions/escape-svg" as *;
+@use "check" as *;
+@use "../mixins/tokens" as *;
+@use "../config" as *;
+
+// The radio's own theming surface — see the note in `_checkbox.scss`.
+
+// scss-docs-start radio-variables
+$radio-size:              $form-check-input-width !default;
+$radio-bg:                $form-check-input-bg !default;
+$radio-border:            $form-check-input-border !default;
+$radio-border-radius:     $form-check-radio-border-radius !default;
+$radio-checked-icon:      $form-check-radio-checked-bg-image !default;
+// scss-docs-end radio-variables
+
+$radio-tokens: () !default;
+
+// scss-docs-start radio-css-vars
+// stylelint-disable-next-line scss/dollar-variable-default
+$radio-tokens: defaults(
+  (
+    --#{$prefix}radio-size: #{$radio-size},
+    --#{$prefix}radio-bg: #{$radio-bg},
+    --#{$prefix}radio-border: #{$radio-border},
+    --#{$prefix}radio-border-radius: #{$radio-border-radius},
+    --#{$prefix}radio-checked-bg: var(--#{$prefix}control-checked-bg),
+    --#{$prefix}radio-checked-border-color: var(--#{$prefix}control-checked-border-color),
+    --#{$prefix}radio-checked-icon: #{escape-svg($radio-checked-icon)},
+  ),
+  $radio-tokens
+);
+// scss-docs-end radio-css-vars
+
+@layer forms {
+  .form-check-input[type="radio"] {
+    @include tokens($radio-tokens);
+
+    --#{$prefix}form-check-input-width: var(--#{$prefix}radio-size);
+    --#{$prefix}form-check-bg: var(--#{$prefix}radio-bg);
+    --#{$prefix}form-check-input-border: var(--#{$prefix}radio-border);
+    --#{$prefix}form-check-radio-border-radius: var(--#{$prefix}radio-border-radius);
+    --#{$prefix}form-check-input-checked-bg-color: var(--#{$prefix}radio-checked-bg);
+    --#{$prefix}form-check-input-checked-border-color: var(--#{$prefix}radio-checked-border-color);
+  }
+}

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -1,0 +1,77 @@
+@use "sass:map";
+@use "../functions/defaults" as *;
+@use "../functions/escape-svg" as *;
+@use "check" as *;
+@use "../mixins/tokens" as *;
+@use "../config" as *;
+
+// The switch's own theming surface — see the note in `_checkbox.scss`. The size
+// modifiers set tokens rather than declarations, so a size the map does not name
+// is two custom properties rather than a Sass recompile.
+
+// scss-docs-start switch-variables
+$switch-width:                $form-switch-width !default;
+$switch-height:               $form-check-input-width !default;
+$switch-border-radius:        $form-switch-border-radius !default;
+$switch-transition:           $form-switch-transition !default;
+$switch-knob:                 $form-switch-bg-image !default;
+$switch-knob-focus:           $form-switch-focus-bg-image !default;
+$switch-knob-checked:         $form-switch-checked-bg-image !default;
+$switch-knob-dark:            $form-switch-bg-image-dark !default;
+$switch-checked-knob-position: $form-switch-checked-bg-position !default;
+// scss-docs-end switch-variables
+
+$switch-tokens: () !default;
+
+// scss-docs-start switch-css-vars
+// stylelint-disable custom-property-no-missing-var-function
+// stylelint-disable-next-line scss/dollar-variable-default
+$switch-tokens: defaults(
+  (
+    --#{$prefix}switch-width: #{$switch-width},
+    --#{$prefix}switch-height: #{$switch-height},
+    --#{$prefix}switch-border-radius: #{$switch-border-radius},
+    --#{$prefix}switch-transition: #{$switch-transition},
+    --#{$prefix}switch-knob: #{escape-svg($switch-knob)},
+    --#{$prefix}switch-knob-focus: #{escape-svg($switch-knob-focus)},
+    --#{$prefix}switch-knob-checked: #{escape-svg($switch-knob-checked)},
+    --#{$prefix}switch-knob-dark: #{escape-svg($switch-knob-dark)},
+    --#{$prefix}switch-checked-knob-position: #{$switch-checked-knob-position},
+  ),
+  $switch-tokens
+);
+// stylelint-enable custom-property-no-missing-var-function
+// scss-docs-end switch-css-vars
+
+@layer forms {
+  .form-switch {
+    @include tokens($switch-tokens);
+
+    // stylelint-disable-next-line function-disallowed-list
+    --#{$prefix}form-switch-padding-start: calc(var(--#{$prefix}switch-width) + .5em);
+    --#{$prefix}form-switch-width: var(--#{$prefix}switch-width);
+    --#{$prefix}form-switch-border-radius: var(--#{$prefix}switch-border-radius);
+    --#{$prefix}form-switch-transition: var(--#{$prefix}switch-transition);
+    --#{$prefix}form-switch-bg: var(--#{$prefix}switch-knob);
+    --#{$prefix}form-switch-checked-bg-position: var(--#{$prefix}switch-checked-knob-position);
+  }
+
+  // The named sizes are token overrides now: width and height, and the rest —
+  // padding, the label's optical centring — follows from them.
+  @each $size, $map in $form-switch-widths {
+    .form-switch-#{$size} {
+      --#{$prefix}switch-width: #{map.get($map, "width")};
+      --#{$prefix}switch-height: #{map.get($map, "height")};
+
+      // A sized switch is taller than the text line it sits on, so it sets the
+      // row height itself and re-centres the label; the default one keeps
+      // `.form-check`'s.
+      min-height: var(--#{$prefix}switch-height);
+
+      .form-check-label {
+        // stylelint-disable-next-line function-disallowed-list
+        padding-top: calc((var(--#{$prefix}switch-height) - #{$font-size-base}) * .5);
+      }
+    }
+  }
+}

--- a/scss/forms/index.scss
+++ b/scss/forms/index.scss
@@ -7,6 +7,9 @@
 @forward "form-select";
 @forward "number-input";
 @forward "form-check";
+@forward "checkbox";
+@forward "radio";
+@forward "switch";
 @forward "form-multi-select";
 @forward "form-range";
 @forward "floating-labels";


### PR DESCRIPTION
> **Stacked on #718** — it edits the three docs pages that PR creates. Merge #718 first and I will retarget.

Etap 1a of the forms plan. The three controls shared one namespace — `--cui-form-check-*` plus `--cui-form-switch-*` on the same element, told apart only by `[type]` selectors — so restyling checkboxes dragged radios along, and half of what matters was not reachable at runtime at all. **That, not the class names, is what blocked splitting the stylesheet.**

Each control now owns its tokens in its own partial (`_checkbox.scss`, `_radio.scss`, `_switch.scss`), feeding the shared implementation:

```html
<input class="form-check-input" type="checkbox"
       style="--cui-checkbox-size: 2em; --cui-checkbox-checked-bg: rebeccapurple">
```
→ 32 px box, custom checked colour, **radios and switches untouched**, no Sass rebuild.

The old `--cui-form-check-*` properties and every `$form-check-*` / `$form-switch-*` Sass variable are untouched and still work — the new per-control variables default to them. **No classes changed, no markup moves.**

## Two compile-time things become runtime

- **`margin-top` was a real bug, not just an inconvenience.** It was `($line-height-base - $form-check-input-width) * .5` — Sass arithmetic. Override the width token at runtime and the box grew but its alignment stayed computed for `1em`, so it sat off the text baseline. It is a `calc()` over the size token now. Proven: at `--cui-checkbox-size: 2em` the margin resolves to `-4px`, which is what keeps a 32 px box centred on a 24 px line.
- **`.form-switch-lg` / `-xl` are token overrides**, not their own geometry. A size the map does not name is two custom properties instead of a Sass recompile.

## Verification

Not a text diff of the CSS — computed styles in Chromium. Eleven markup variants (checkbox, radio, switch, checked/disabled/indeterminate, lg/xl, inline, reverse) × light and dark × nineteen properties, before and after: **zero differences**.

That harness earned its keep — it caught two regressions while this was being written:

1. The base `.form-switch` claimed `min-height: var(--cui-switch-height)` (1em) and so beat `.form-check`'s `1.5rem`, shrinking every default switch row. `min-height` belongs on the sized variants only, which is what shipped before.
2. Sized switches lost their width: `--cui-form-switch-width` is declared **on the input** by the shared token block, so the wrapper's inherited value lost to it. The switch rule restates it where the selector is specific enough to win.

Plus stylelint, `fusv`, class-API, Sass specs, the JS suite and `docs-build` (143 pages, no broken links). `coreui.css` +0.07 kB → budget 54 → 54.5 kB.

## Known limitation, worth a decision

A token an element declares for itself **cannot be overridden from an ancestor** — `:root { --cui-checkbox-size: 2em }` does nothing, you have to set it on the control. That is how every component token in this codebase behaves (`--cui-btn-*` included), because `tokens()` emits plain declarations. Making component tokens settable from `:root` would mean inlining defaults as `var(--x, default)` fallbacks at each use instead — a repo-wide change to the token architecture, and a good question for `plans/scss-token-architecture.md` rather than something to do only for checkboxes.

## Next

**1b**: draw the marks with `mask-image` instead of a background SVG, which makes the mark colour a token and deletes the duplicate dark-mode switch knob. Kept separate because it is the step that can actually shift pixels — and checkboxes are not in the visual suite yet, so that suite should grow first.