### PR TITLE
docs: point the version badges at v6, and mark the deprecated flag

### DIFF
--- a/docs/src/content/docs/components/menu.mdx
+++ b/docs/src/content/docs/components/menu.mdx
@@ -6,6 +6,8 @@ description: "The Menu component toggles contextual overlays with submenus, cont
 
 ## Overview
 
+<AddedIn version="6.0.0" />
+
 Toggle menus with buttons whenever possible. Here’s an example using a CoreUI button:
 
 <Example code={`<button class="btn btn-primary" type="button" data-coreui-toggle="menu" aria-expanded="false">

--- a/docs/src/content/docs/customize/options.mdx
+++ b/docs/src/content/docs/customize/options.mdx
@@ -22,9 +22,9 @@ You can find and customize these variables for key global options in CoreUI for 
 | `$enable-button-pointers`      | `true` (default) or `false`        | Add "hand" cursor to non-disabled button elements. |
 | `$enable-validation-icons`     | `true` (default) or `false`        | Enables `background-image` icons within textual inputs and some custom forms for validation states. |
 | `$enable-negative-margins`     | `true` or `false` (default)        | Enables the generation of [negative margin utilities](/utilities/spacing/#negative-margin). |
-| `$enable-deprecation-messages` | `true` (default) or `false`        | Set to `false` to hide warnings when using any of the deprecated mixins and functions that are planned to be removed in `v6`. |
+| `$enable-deprecation-messages` | `true` (default) or `false`        | Set to `false` to hide warnings when using any of the deprecated variables, mixins and functions that are planned to be removed in the next major. |
 | `$enable-important-utilities`  | `true` (default) or `false`        | Enables the `!important` suffix in utility classes. |
 | `$enable-smooth-scroll`        | `true` (default) or `false`        | Applies `scroll-behavior: smooth` globally, except for users asking for reduced motion through [`prefers-reduced-motion` media query](/getting-started/accessibility/#reduced-motion) |
-| `$enable-container-queries`    | `true` or `false` (default)        | Enables container query support. (New in v5.2.0) |
+| `$enable-container-queries`    | `true` or `false` (default)        | <span class="badge text-danger-emphasis bg-danger-subtle">Deprecated in v6</span> No effect. The `cq-*` grid it used to gate is gone and every `.grid` is a [query container](/utilities/container-queries/) of its own. Kept so a build that still configures it keeps compiling; removed in v7. |
 | `$enable-ltr`                  | `false` or `false` (default)       | Enables Left-to-Right |
 | `$enable-rtl`                  | `true` (default) or `false`        | Enables Right-to-Left |

--- a/docs/src/content/docs/forms/date-input.mdx
+++ b/docs/src/content/docs/forms/date-input.mdx
@@ -19,7 +19,7 @@ import dateInputDisabledDates2 from './snippets/date-input-disabled-dates2.js?ra
 
 ## Example
 
-<AddedIn version="5.27.0" />
+<AddedIn version="6.0.0" />
 
 Use an empty container with `data-coreui-date-input` to create a masked date field. The mask is split into day, month, and year sections — click or focus a section and type, use arrow keys to adjust values, and the caret moves to the next section automatically.
 

--- a/docs/src/content/docs/forms/date-time-input.mdx
+++ b/docs/src/content/docs/forms/date-time-input.mdx
@@ -15,7 +15,7 @@ import dateTimeInputCustomFormats1 from './snippets/date-time-input-custom-forma
 
 ## Example
 
-<AddedIn version="5.27.0" />
+<AddedIn version="6.0.0" />
 
 Use an empty container with `data-coreui-date-time-input` to create a masked date and time field. Both the date layout and the hour cycle follow the locale, and every section supports typing, arrow keys, and automatic caret advancement.
 

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -16,6 +16,8 @@ description: "The v6 date time picker: a masked date-time field composed with a 
 
 ## Example
 
+<AddedIn version="6.0.0" />
+
 The popup shows the calendar and the time selection side by side. The two halves
 own different parts of one value — picking a day keeps the time, picking a time
 keeps the day — so the popup does not auto-close.

--- a/docs/src/content/docs/forms/form-control-group.mdx
+++ b/docs/src/content/docs/forms/form-control-group.mdx
@@ -6,6 +6,8 @@ description: "Assemble an input, icons and action buttons into one control that 
 
 ## Example
 
+<AddedIn version="6.0.0" />
+
 A control is often more than an input: it carries an icon, a clear button, a
 toggle. `.form-control-group` draws **one** frame around all of it, so the
 result reads as a single field rather than a row of parts.

--- a/docs/src/content/docs/forms/number-input.mdx
+++ b/docs/src/content/docs/forms/number-input.mdx
@@ -14,6 +14,8 @@ the component replaces it with two buttons sized like every other adornment in a
 
 ## Example
 
+<AddedIn version="6.0.0" />
+
 Add `data-coreui-toggle="number-input"` to an `<input type="number">`. The
 component wraps it in a [`form-control-group`](/forms/form-control-group/) and
 adds the buttons — you write neither the frame, the buttons nor their icons.

--- a/docs/src/content/docs/forms/time-input.mdx
+++ b/docs/src/content/docs/forms/time-input.mdx
@@ -15,7 +15,7 @@ import timeInputCustomFormats1 from './snippets/time-input-custom-formats1.js?ra
 
 ## Example
 
-<AddedIn version="5.27.0" />
+<AddedIn version="6.0.0" />
 
 Use an empty container with `data-coreui-time-input` to create a masked time field. The mask is split into hour, minute, and — depending on the locale — AM/PM sections. Click or focus a section and type, use arrow keys to adjust values, and the caret moves to the next section automatically.
 


### PR DESCRIPTION
Two small things, both cases of docs saying something that stopped being true.

## `<AddedIn>` pointed at v5

Date Input, Time Input and Date Time Input carried `<AddedIn version="5.27.0" />` — the package version that happened to be current on the branch when they were written. **None of the three exists in v5**: no docs page, no module in `js/src`. Verified against `repos/coreui-pro` before changing anything. They are v6 components and say `6.0.0` now.

Menu, Number Input, Date Time Picker and Form control group are v6-only too and carried no badge at all; they get one.

The Multi Select badges are **left alone** — `hideSelectAllOnSearchNoResults` really did ship in 5.27.0 (the identical badge sits in the v5 docs), and so did the 5.6.0 / 5.26.0 features above it.

## A deprecation nobody could see

`$enable-container-queries` was still documented as *"Enables container query support. (New in v5.2.0)"*. Since #711 it does nothing — it is kept only so a build that still configures it keeps compiling, and the shared docs engine is one of those builds. The options table now says that, with a `Deprecated in v6` badge in the same style the migration guide already uses for `Breaking`.

`$enable-deprecation-messages` said the warnings cover things "planned to be removed in `v6`", which reads oddly inside the v6 docs; it now says the next major.

## The pattern this establishes

You asked whether docs can show new and old usage side by side with the old marked deprecated. This is the cheap half of that — a badge built from existing primitives, no engine change. For the markup case (stage 2 of the forms plan, where `.form-check-input` becomes the deprecated spelling of `.check`), the same badge goes above the old example with a link to the migration guide.

Worth considering separately: the engine already ships `<AddedIn version>`, and its API tables already render a `Deprecated {version}` badge for props. A symmetric `<Deprecated version>` shortcode would be the tidier form — but it is shared infra, so it needs an engine release, a pin bump and downstream builds before any docs page can use it.