### PR TITLE
docs(forms): narrow the shared variables the control pages show

### DIFF
--- a/docs/src/content/docs/forms/checkbox.mdx
+++ b/docs/src/content/docs/forms/checkbox.mdx
@@ -165,6 +165,6 @@ Checkboxs read their own custom properties, so restyling one control does not to
 
 ### Shared variables
 
-The wrapper and the shared control surface:
+`.form-check` lays out the row and all three controls share their focus, active and disabled states, so these are set once rather than per control:
 
 <ScssDocs file="scss/forms/_check.scss" capture="form-check-variables" />

--- a/docs/src/content/docs/forms/radio.mdx
+++ b/docs/src/content/docs/forms/radio.mdx
@@ -162,6 +162,6 @@ Radios read their own custom properties, so restyling one control does not touch
 
 ### Shared variables
 
-The wrapper and the shared control surface:
+`.form-check` lays out the row and all three controls share their focus, active and disabled states, so these are set once rather than per control:
 
 <ScssDocs file="scss/forms/_check.scss" capture="form-check-variables" />

--- a/docs/src/content/docs/forms/switch.mdx
+++ b/docs/src/content/docs/forms/switch.mdx
@@ -86,6 +86,6 @@ Switchs read their own custom properties, so restyling one control does not touc
 
 ### Shared variables
 
-The wrapper and the shared control surface:
+`.form-check` lays out the row and all three controls share their focus, active and disabled states, so these are set once rather than per control:
 
 <ScssDocs file="scss/forms/_check.scss" capture="form-check-variables" />

--- a/scss/forms/_check.scss
+++ b/scss/forms/_check.scss
@@ -7,23 +7,16 @@
 @use "../mixins/transition" as *;
 @use "../config" as *;
 
-// scss-docs-start form-check-variables
+// The values each control's own variables default to. A consumer sets
+// `$checkbox-*` / `$radio-*` / `$switch-*` (documented on their pages); these are
+// what those fall back to, and what still works for a v5-era override.
+// scss-docs-start form-check-defaults
 $form-check-input-width:                  1em !default;
-$form-check-min-height:                   $font-size-base * $line-height-base !default;
-$form-check-padding-start:                $form-check-input-width + .5em !default;
-$form-check-margin-bottom:                .125rem !default;
-$form-check-label-color:                  null !default;
-$form-check-label-cursor:                 null !default;
-$form-check-transition:                   null !default;
-
-$form-check-input-active-filter:          brightness(90%) !default;
 
 $form-check-input-bg:                     $input-bg !default;
 $form-check-input-border:                 var(--#{$prefix}border-width) solid var(--#{$prefix}border-color) !default;
 $form-check-input-border-radius:          .25em !default;
 $form-check-radio-border-radius:          50% !default;
-$form-check-input-focus-border:           $input-focus-border-color !default;
-$form-check-input-focus-ring:       $focus-ring !default;
 
 $form-check-input-checked-color:          $component-active-color !default;
 $form-check-input-checked-bg-image:       url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$form-check-input-checked-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/></svg>") !default;
@@ -31,12 +24,27 @@ $form-check-radio-checked-bg-image:       url("data:image/svg+xml,<svg xmlns='ht
 
 $form-check-input-indeterminate-color:          $component-active-color !default;
 $form-check-input-indeterminate-bg-image:       url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$form-check-input-indeterminate-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/></svg>") !default;
+// scss-docs-end form-check-defaults
+
+// What the wrapper owns and what all three controls share: the row, the label,
+// and the focus / active / disabled states.
+// scss-docs-start form-check-variables
+$form-check-min-height:                   $font-size-base * $line-height-base !default;
+$form-check-padding-start:                $form-check-input-width + .5em !default;
+$form-check-margin-bottom:                .125rem !default;
+$form-check-inline-margin-end:            1rem !default;
+
+$form-check-label-color:                  null !default;
+$form-check-label-cursor:                 null !default;
+$form-check-transition:                   null !default;
+
+$form-check-input-active-filter:          brightness(90%) !default;
+$form-check-input-focus-border:           $input-focus-border-color !default;
+$form-check-input-focus-ring:             $focus-ring !default;
 
 $form-check-input-disabled-opacity:        .5 !default;
 $form-check-label-disabled-opacity:        $form-check-input-disabled-opacity !default;
 $form-check-btn-check-disabled-opacity:    $input-btn-disabled-opacity !default;
-
-$form-check-inline-margin-end:    1rem !default;
 // scss-docs-end form-check-variables
 
 // scss-docs-start form-switch-variables


### PR DESCRIPTION
You asked what "Shared variables — the wrapper and the shared control surface" was doing on the Checkbox, Radio and Switch pages. Fair question: it was printing the same **21 variables three times**, and after #719 landed a third of them duplicated what the page already showed above it.

On the Checkbox page you saw `$checkbox-size` under *SASS variables*, then `$form-check-input-width` under *Shared variables* — which is simply the value the first one defaults to. On the Radio page you saw the checkbox's tick and indeterminate icons. On all three you saw `$form-check-radio-border-radius` and `$form-check-btn-check-disabled-opacity`, which belong to one control and to toggle buttons respectively.

The block is split in two:

- **`form-check-defaults`** — the values the per-control variables fall back to (`$form-check-input-width`, `-bg`, `-border`, the radii, the three icons). They still work as a v5-era override; the per-control listings already show them as the defaults, so printing them again taught nothing.
- **`form-check-variables`** — what is genuinely shared and is what the three pages now show: the row (`min-height`, `padding-start`, margins), the label, and the focus / active / disabled states.

Reordering only — dependencies are respected (`$form-check-input-width` still precedes `$form-check-padding-start`), and **the compiled CSS is byte-for-byte identical**, verified by compiling before and after and running `cmp`.

stylelint, `fusv` and `docs-build` (143 pages, no broken links) all clean.