### PR TITLE
feat(buttons): move .btn-check onto the label, with the input nested inside

### DIFF
--- a/docs/src/content/docs/components/button-group.mdx
+++ b/docs/src/content/docs/components/button-group.mdx
@@ -53,25 +53,37 @@ These classes can also be added to groups of links, as an alternative to the [`.
 Combine button-like [checkbox](/forms/checkbox/#toggle-buttons) and [radio](/forms/radio/#toggle-buttons) toggle buttons into a seamless looking button group.
 
 <Example code={`<div class="btn-group" role="group" aria-label="Basic checkbox toggle button group">
-    <input type="checkbox" class="btn-check" id="btncheck1" autocomplete="off">
-    <label class="btn btn-outline-primary" for="btncheck1">Checkbox 1</label>
+    <label class="btn btn-outline-primary btn-check">
+      <input type="checkbox" autocomplete="off">
+      Checkbox 1
+    </label>
 
-    <input type="checkbox" class="btn-check" id="btncheck2" autocomplete="off">
-    <label class="btn btn-outline-primary" for="btncheck2">Checkbox 2</label>
+    <label class="btn btn-outline-primary btn-check">
+      <input type="checkbox" autocomplete="off">
+      Checkbox 2
+    </label>
 
-    <input type="checkbox" class="btn-check" id="btncheck3" autocomplete="off">
-    <label class="btn btn-outline-primary" for="btncheck3">Checkbox 3</label>
+    <label class="btn btn-outline-primary btn-check">
+      <input type="checkbox" autocomplete="off">
+      Checkbox 3
+    </label>
   </div>`} />
 
 <Example code={`<div class="btn-group" role="group" aria-label="Basic radio toggle button group">
-    <input type="radio" class="btn-check" name="btnradio" id="btnradio1" autocomplete="off" checked>
-    <label class="btn btn-outline-primary" for="btnradio1">Radio 1</label>
+    <label class="btn btn-outline-primary btn-check">
+      <input type="radio" name="btnradio" checked autocomplete="off">
+      Radio 1
+    </label>
 
-    <input type="radio" class="btn-check" name="btnradio" id="btnradio2" autocomplete="off">
-    <label class="btn btn-outline-primary" for="btnradio2">Radio 2</label>
+    <label class="btn btn-outline-primary btn-check">
+      <input type="radio" name="btnradio" autocomplete="off">
+      Radio 2
+    </label>
 
-    <input type="radio" class="btn-check" name="btnradio" id="btnradio3" autocomplete="off">
-    <label class="btn btn-outline-primary" for="btnradio3">Radio 3</label>
+    <label class="btn btn-outline-primary btn-check">
+      <input type="radio" name="btnradio" autocomplete="off">
+      Radio 3
+    </label>
   </div>`} />
 
 ## Button toolbar
@@ -222,20 +234,32 @@ Create a set of buttons that appear vertically stacked rather than horizontally.
 
   <div class="docs-example">
     <div class="btn-group-vertical" role="group" aria-label="Vertical radio toggle button group">
-      <input type="radio" class="btn-check" name="vbtn-radio" id="vbtn-radio1" autocomplete="off" checked>
-      <label class="btn btn-outline-danger" for="vbtn-radio1">Radio 1</label>
-      <input type="radio" class="btn-check" name="vbtn-radio" id="vbtn-radio2" autocomplete="off">
-      <label class="btn btn-outline-danger" for="vbtn-radio2">Radio 2</label>
-      <input type="radio" class="btn-check" name="vbtn-radio" id="vbtn-radio3" autocomplete="off">
-      <label class="btn btn-outline-danger" for="vbtn-radio3">Radio 3</label>
+      <label class="btn btn-outline-danger btn-check">
+        <input type="radio" name="vbtn-radio" checked autocomplete="off">
+        Radio 1
+      </label>
+      <label class="btn btn-outline-danger btn-check">
+        <input type="radio" name="vbtn-radio" autocomplete="off">
+        Radio 2
+      </label>
+      <label class="btn btn-outline-danger btn-check">
+        <input type="radio" name="vbtn-radio" autocomplete="off">
+        Radio 3
+      </label>
     </div>
   </div>`} />
 
 <Example code={`<div class="btn-group-vertical" role="group" aria-label="Vertical radio toggle button group">
-    <input type="radio" class="btn-check" name="vbtn-radio2" id="vbtn-radio2-1" autocomplete="off" checked>
-    <label class="btn btn-outline-danger" for="vbtn-radio2-1">Radio 1</label>
-    <input type="radio" class="btn-check" name="vbtn-radio2" id="vbtn-radio2-2" autocomplete="off">
-    <label class="btn btn-outline-danger" for="vbtn-radio2-2">Radio 2</label>
-    <input type="radio" class="btn-check" name="vbtn-radio2" id="vbtn-radio2-3" autocomplete="off">
-    <label class="btn btn-outline-danger" for="vbtn-radio2-3">Radio 3</label>
+    <label class="btn btn-outline-danger btn-check">
+      <input type="radio" name="vbtn-radio2" checked autocomplete="off">
+      Radio 1
+    </label>
+    <label class="btn btn-outline-danger btn-check">
+      <input type="radio" name="vbtn-radio2" autocomplete="off">
+      Radio 2
+    </label>
+    <label class="btn btn-outline-danger btn-check">
+      <input type="radio" name="vbtn-radio2" autocomplete="off">
+      Radio 3
+    </label>
   </div>`} />

--- a/docs/src/content/docs/forms/checkbox.mdx
+++ b/docs/src/content/docs/forms/checkbox.mdx
@@ -122,22 +122,32 @@ A checkbox with no label text is the input on its own. Give it an accessible nam
 
 ## Toggle buttons
 
-Create button-like checkboxes by putting `.btn` styles on the `<label>` instead of `.form-check-label`, and `.btn-check` on the input. They can be grouped in a [button group](/components/button-group/).
+Create button-like checkboxes by putting `.btn-check` on a `<label>` with the button classes, and nesting the input inside it. The label is the button, so there is no `id`/`for` pair to keep in sync. They can be grouped in a [button group](/components/button-group/).
 
-<Example code={`<input type="checkbox" class="btn-check" id="btn-check" autocomplete="off">
-  <label class="btn btn-primary" for="btn-check">Single toggle</label>
+<Example code={`<label class="btn btn-primary btn-check">
+    <input type="checkbox" autocomplete="off">
+    Single toggle
+  </label>
 
-  <input type="checkbox" class="btn-check" id="btn-check-2" checked autocomplete="off">
-  <label class="btn btn-primary" for="btn-check-2">Checked</label>
+  <label class="btn btn-primary btn-check">
+    <input type="checkbox" checked autocomplete="off">
+    Checked
+  </label>
 
-  <input type="checkbox" class="btn-check" id="btn-check-3" autocomplete="off" disabled>
-  <label class="btn btn-primary" for="btn-check-3">Disabled</label>`} />
+  <label class="btn btn-primary btn-check">
+    <input type="checkbox" disabled autocomplete="off">
+    Disabled
+  </label>`} />
 
-<Example code={`<input type="checkbox" class="btn-check" id="btn-check-outlined" autocomplete="off">
-  <label class="btn btn-outline-primary" for="btn-check-outlined">Single toggle</label>
+<Example code={`<label class="btn btn-outline-primary btn-check">
+    <input type="checkbox" autocomplete="off">
+    Single toggle
+  </label>
 
-  <input type="checkbox" class="btn-check" id="btn-check-2-outlined" checked autocomplete="off">
-  <label class="btn btn-outline-secondary" for="btn-check-2-outlined">Checked</label>`} />
+  <label class="btn btn-outline-secondary btn-check">
+    <input type="checkbox" checked autocomplete="off">
+    Checked
+  </label>`} />
 
 <Callout color="info">
 Visually, these checkbox toggle buttons are identical to the [button plugin toggle buttons](/components/buttons/#button-plugin). However, they are conveyed differently by assistive technologies: the checkbox toggles will be announced by screen readers as "checked"/"not checked" (since, despite their appearance, they are fundamentally still checkboxes), whereas the button plugin toggle buttons will be announced as "button"/"button pressed". The choice between these two approaches will depend on the type of toggle you are creating, and whether or not the toggle will make sense to users when announced as a checkbox or as an actual button.
@@ -168,6 +178,8 @@ The v5 spelling — `.form-check` wrapping a `.form-check-input` and a `.form-ch
 +   <label for="c">Label</label>
 + </div>
 ```
+
+The v5 toggle button — `.btn-check` on the input, with a sibling `.btn` label tied to it by `id`/`for` — also still works and renders identically.
 
 See the [v6 migration guide](/migration/v6/) for the full picture.
 

--- a/docs/src/content/docs/forms/radio.mdx
+++ b/docs/src/content/docs/forms/radio.mdx
@@ -125,22 +125,32 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
 
 ## Toggle buttons
 
-Create button-like radios by putting `.btn` styles on the `<label>` instead of `.form-check-label`, and `.btn-check` on the input. They can be grouped in a [button group](/components/button-group/).
+Create button-like radios by putting `.btn-check` on a `<label>` with the button classes, and nesting the input inside it. The label is the button, so there is no `id`/`for` pair to keep in sync. They can be grouped in a [button group](/components/button-group/).
 
-<Example code={`<input type="radio" class="btn-check" name="options" id="option1" autocomplete="off" checked>
-  <label class="btn btn-secondary" for="option1">Checked</label>
+<Example code={`<label class="btn btn-secondary btn-check">
+    <input type="radio" name="options" checked autocomplete="off">
+    Checked
+  </label>
 
-  <input type="radio" class="btn-check" name="options" id="option2" autocomplete="off">
-  <label class="btn btn-secondary" for="option2">Radio</label>
+  <label class="btn btn-secondary btn-check">
+    <input type="radio" name="options" autocomplete="off">
+    Radio
+  </label>
 
-  <input type="radio" class="btn-check" name="options" id="option3" autocomplete="off" disabled>
-  <label class="btn btn-secondary" for="option3">Disabled</label>`} />
+  <label class="btn btn-secondary btn-check">
+    <input type="radio" name="options" disabled autocomplete="off">
+    Disabled
+  </label>`} />
 
-<Example code={`<input type="radio" class="btn-check" name="options-outlined" id="success-outlined" autocomplete="off" checked>
-  <label class="btn btn-outline-success" for="success-outlined">Checked success radio</label>
+<Example code={`<label class="btn btn-outline-success btn-check">
+    <input type="radio" name="options-outlined" checked autocomplete="off">
+    Checked success radio
+  </label>
 
-  <input type="radio" class="btn-check" name="options-outlined" id="danger-outlined" autocomplete="off">
-  <label class="btn btn-outline-danger" for="danger-outlined">Danger radio</label>`} />
+  <label class="btn btn-outline-danger btn-check">
+    <input type="radio" name="options-outlined" autocomplete="off">
+    Danger radio
+  </label>`} />
 
 ## Deprecated markup
 
@@ -158,6 +168,8 @@ The v5 spelling — `.form-check` wrapping a `.form-check-input` and a `.form-ch
 +   <label for="r1">Label</label>
 + </div>
 ```
+
+The v5 toggle button — `.btn-check` on the input, with a sibling `.btn` label tied to it by `id`/`for` — also still works and renders identically.
 
 See the [v6 migration guide](/migration/v6/) for the full picture.
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1085,6 +1085,26 @@ Upstream v6 does the same, with a `mask-icon()` mixin.
 - **The dark-mode button block is gone** (~160 lines of CSS) — variants follow
   the root color tokens, which already switch in dark mode.
 - `.btn-primary`, `.btn-outline-*`, `.btn-ghost-*` class APIs are unchanged.
+- **Toggle buttons: `.btn-check` moves onto the `<label>`, with the input nested
+  inside.** A toggle button was two elements held together by an `id`/`for`
+  pair; it is one element now, so nothing can fall out of sync:
+
+  ```diff
+  - <input type="checkbox" class="btn-check" id="t" autocomplete="off">
+  - <label class="btn btn-primary" for="t">Toggle</label>
+  + <label class="btn btn-primary btn-check">
+  +   <input type="checkbox" autocomplete="off">
+  +   Toggle
+  + </label>
+  ```
+
+  The states read the nested input with `:has()` instead of sibling selectors,
+  and a `.btn-group` stops having to reason about a hidden child that is not a
+  button. **The old spelling keeps working** — the label carries `.btn` in the
+  new one, so the two select themselves apart — and renders identically; it is
+  deprecated in v6 and removed in v7. One behavior is deliberately carried over:
+  a disabled toggle is dimmed rather than repainted, so a disabled checked
+  toggle still reads as checked.
 
 #### Utilities API: one `property` map replaces `css-var`, `css-variable-name` and `local-vars`
 

--- a/scss/buttons/_button-group.scss
+++ b/scss/buttons/_button-group.scss
@@ -18,8 +18,10 @@
 
     // Bring the hover, focused, and "active" buttons to the front to overlay
     // the borders properly
-    > .btn-check:checked + .btn,
-    > .btn-check:focus + .btn,
+    > #{$btn-check-deprecated}:checked + .btn,
+    > #{$btn-check-deprecated}:focus + .btn,
+    > .btn-check:has(input:checked),
+    > .btn-check:has(input:focus),
     > .btn:hover,
     > .btn:focus,
     > .btn:active,
@@ -43,7 +45,7 @@
     @include border-radius($btn-border-radius);
 
     // Prevent double borders when buttons are next to each other
-    > :not(.btn-check:first-child) + .btn,
+    > :not(#{$btn-check-deprecated}:first-child) + .btn,
     > .btn-group:not(:first-child) {
       margin-inline-start: calc(-1 * #{$btn-border-width}); // stylelint-disable-line function-disallowed-list
     }
@@ -57,10 +59,11 @@
 
     // The left radius should be 0 if the button is:
     // - the "third or more" child
-    // - the second child and the previous element isn't `.btn-check` (making it the first child visually)
+    // - the second child and the previous element isn't a deprecated `.btn-check`
+    //   input (making it the first child visually)
     // - part of a btn-group which isn't the first child
     > .btn:nth-child(n + 3),
-    > :not(.btn-check) + .btn,
+    > :not(#{$btn-check-deprecated}) + .btn,
     > .btn-group:not(:first-child) > .btn {
       @include border-start-radius(0);
     }
@@ -143,10 +146,11 @@
 
     // The top radius should be 0 if the button is:
     // - the "third or more" child
-    // - the second child and the previous element isn't `.btn-check` (making it the first child visually)
+    // - the second child and the previous element isn't a deprecated `.btn-check`
+    //   input (making it the first child visually)
     // - part of a btn-group which isn't the first child
     > .btn:nth-child(n + 3),
-    > :not(.btn-check) + .btn,
+    > :not(#{$btn-check-deprecated}) + .btn,
     > .btn-group:not(:first-child) > .btn {
       @include border-top-radius(0);
     }

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -53,6 +53,11 @@ $btn-transition:              $input-btn-transition !default;
 
 // scss-docs-end btn-variables
 
+// The two toggle-button spellings each select themselves: the v6 one puts
+// `.btn-check` on the `<label>` alongside the button classes, so the deprecated
+// one — the class on the input — is the `.btn-check` that is not a `.btn`.
+$btn-check-deprecated: ".btn-check:not(.btn)" !default;
+
 // scss-docs-start btn-outline-variables
 $btn-outline-color: var(--#{$prefix}secondary-color) !default;
 $btn-outline-border-color: var(--#{$prefix}border-color) !default;
@@ -208,7 +213,8 @@ $btn-ghost-focus-shadow: var(--#{$prefix}tertiary-bg) !default;
       border-color: var(--#{$prefix}btn-hover-border-color);
     }
 
-    .btn-check + &:hover {
+    #{$btn-check-deprecated} + &:hover,
+    &.btn-check:hover {
       // override for the checkbox/radio buttons
       color: var(--#{$prefix}btn-color);
       background-color: var(--#{$prefix}btn-bg);
@@ -223,14 +229,16 @@ $btn-ghost-focus-shadow: var(--#{$prefix}tertiary-bg) !default;
       outline: var(--#{$prefix}btn-focus-ring);
     }
 
-    .btn-check:focus-visible + & {
+    #{$btn-check-deprecated}:focus-visible + &,
+    &.btn-check:has(input:focus-visible) {
       border-color: var(--#{$prefix}btn-hover-border-color);
       // Avoid using mixin so we can pass custom focus shadow properly
       outline: var(--#{$prefix}btn-focus-ring);
     }
 
-    .btn-check:checked + &,
-    :not(.btn-check) + &:active,
+    #{$btn-check-deprecated}:checked + &,
+    &.btn-check:has(input:checked),
+    :not(#{$btn-check-deprecated}) + &:active,
     &:first-child:active,
     &.active,
     &.show {
@@ -248,7 +256,8 @@ $btn-ghost-focus-shadow: var(--#{$prefix}tertiary-bg) !default;
       }
     }
 
-    .btn-check:checked:focus-visible + & {
+    #{$btn-check-deprecated}:checked:focus-visible + &,
+    &.btn-check:has(input:checked:focus-visible) {
       // Avoid using mixin so we can pass custom focus shadow properly
       outline: var(--#{$prefix}btn-focus-ring);
     }
@@ -271,11 +280,31 @@ $btn-ghost-focus-shadow: var(--#{$prefix}tertiary-bg) !default;
   //
   // Toggle buttons (.btn-check)
   //
-  // A checkbox or radio that looks like a button: the input carries
-  // `.btn-check` and is hidden, the `<label>` next to it carries `.btn`. The
-  // states are the `.btn-check:checked + .btn` rules in the base block above.
+  // A checkbox or radio that looks like a button. The class goes on the
+  // `<label>` with the button classes, and the input nests inside it, so the
+  // button is one element and needs no `id`/`for` pair to hold it together:
+  //
+  //   <label class="btn btn-primary btn-check"><input type="checkbox">Toggle</label>
+  //
+  // Its states are the `&.btn-check:has(input:…)` rules in the base block above.
 
-  .btn-check {
+  .btn-check > input {
+    position: absolute;
+    clip: rect(0, 0, 0, 0);
+    pointer-events: none;
+  }
+
+  // Dimmed rather than repainted, so a disabled toggle that is checked still
+  // reads as checked — the behavior of the deprecated spelling, where the
+  // `:disabled` input never matched the label's own disabled rules.
+  .btn-check:has(input:disabled) {
+    pointer-events: none;
+    filter: none;
+    opacity: var(--#{$prefix}btn-disabled-opacity);
+  }
+
+  // Deprecated in v6: the class on the input, with a sibling `.btn` label.
+  #{$btn-check-deprecated} {
     position: absolute;
     clip: rect(0, 0, 0, 0);
     pointer-events: none;


### PR DESCRIPTION
Follows Bootstrap v6-dev: a toggle button stops being two elements held together by an `id`/`for` pair.

```diff
- <input type="checkbox" class="btn-check" id="t" autocomplete="off">
- <label class="btn btn-primary" for="t">Toggle</label>
+ <label class="btn btn-primary btn-check">
+   <input type="checkbox" autocomplete="off">
+   Toggle
+ </label>
```

The states move from sibling selectors to `:has()` on the label, and `.btn-group` stops having to reason about a hidden child that is not a button — the `:not(.btn-check)` rules that keep the input from counting as the visually-first child no longer apply to the new spelling.

**Backward compatible.** The v6 label carries `.btn`, so the deprecated spelling is simply the `.btn-check` that is not a `.btn` (`$btn-check-deprecated`). Both render identically.

One deliberate difference from upstream: a disabled toggle is **dimmed, not repainted**, so a disabled checked toggle still reads as checked. That is v5's behavior here, where a `:disabled` input never matched the label's own `.btn:disabled` rules.

### Verified in Chromium

- deprecated spelling renders byte-identical to before — four states, `.btn-group` and `.btn-group-vertical` at two and three buttons, and a group mixing a toggle with a plain button
- new spelling matches the old one on every measured property in the same cases
- the nested input is clipped out of view, clicking the label toggles it, and the checked state repaints the button

Stacked on #722 — retarget to `v6-dev` when that merges.