### PR TITLE
fix(range-slider): stop painting the slider from JavaScript

### DIFF
--- a/docs/src/content/docs/forms/range-slider.mdx
+++ b/docs/src/content/docs/forms/range-slider.mdx
@@ -221,6 +221,8 @@ The Range Slider component is built with accessibility in mind. Each slider hand
 - `aria-valuenow`: Current value
 - `aria-orientation`: horizontal or vertical
 
+Tooltips are hidden from assistive technology (`aria-hidden="true"`): they repeat the value the handle already announces through `aria-valuenow`, so exposing them would have screen readers read every change twice.
+
 Additionally, ensure that labels and tooltips are clear and descriptive to provide the best experience for all users.
 
 ## Customizing

--- a/js/src/range-slider.ts
+++ b/js/src/range-slider.ts
@@ -535,30 +535,11 @@ class RangeSlider extends BaseComponent {
     }
 
     const [min, max] = [Math.min(...this._currentValue), Math.max(...this._currentValue)]
-    const from = ((min - this._config.min) / (this._config.max - this._config.min)) * 100
-    const to = ((max - this._config.min) / (this._config.max - this._config.min)) * 100
-    const direction = this._config.vertical ? 'to top' : (isRTL() ? 'to left' : 'to right')
+    const span = this._config.max - this._config.min
+    const edge = (value: number): string => `${((value - this._config.min) / span) * 100}%`
 
-    if (this._currentValue.length === 1) {
-      this._sliderTrack.style.backgroundImage = `linear-gradient(
-        ${direction},
-        var(--cui-range-slider-track-in-range-bg) 0%,
-        var(--cui-range-slider-track-in-range-bg) ${to}%,
-        transparent ${to}%,
-        transparent 100%
-      )`
-      return
-    }
-
-    this._sliderTrack.style.backgroundImage = `linear-gradient(
-      ${direction},
-      transparent 0%,
-      transparent ${from}%,
-      var(--cui-range-slider-track-in-range-bg) ${from}%,
-      var(--cui-range-slider-track-in-range-bg) ${to}%,
-      transparent ${to}%,
-      transparent 100%
-    )`
+    this._sliderTrack.style.setProperty('--cui-range-slider-track-from', this._currentValue.length === 1 ? '0%' : edge(min))
+    this._sliderTrack.style.setProperty('--cui-range-slider-track-to', edge(max))
   }
 
   _updateNearestValue(value: number): void {

--- a/js/src/range-slider.ts
+++ b/js/src/range-slider.ts
@@ -122,7 +122,6 @@ class RangeSlider extends BaseComponent {
   protected declare _inputs: HTMLInputElement[]
   protected declare _isDragging: boolean
   protected declare _sliderTrack: any
-  protected declare _thumbSize: any
   protected declare _tooltips: HTMLElement[]
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
@@ -135,7 +134,6 @@ class RangeSlider extends BaseComponent {
     this._inputs = []
     this._isDragging = false
     this._sliderTrack = null
-    this._thumbSize = null
     this._tooltips = []
 
     this._initializeRangeSlider()
@@ -410,12 +408,13 @@ class RangeSlider extends BaseComponent {
     }
 
     const inputs = SelectorEngine.find(SELECTOR_RANGE_SLIDER_INPUT, this._element as ParentNode) as HTMLInputElement[]
-    this._thumbSize = this._getThumbSize()
 
     for (const input of inputs) {
-      const tooltipElement = this._createElement('div', CLASS_NAME_RANGE_SLIDER_TOOLTIP)
-      const tooltipInnerElement = this._createElement('div', CLASS_NAME_RANGE_SLIDER_TOOLTIP_INNER)
-      const tooltipArrowElement = this._createElement('div', CLASS_NAME_RANGE_SLIDER_TOOLTIP_ARROW)
+      // `<output>` is a live region; the input already announces the value.
+      const tooltipElement = this._createElement('output', CLASS_NAME_RANGE_SLIDER_TOOLTIP)
+      tooltipElement.setAttribute('aria-hidden', 'true')
+      const tooltipInnerElement = this._createElement('span', CLASS_NAME_RANGE_SLIDER_TOOLTIP_INNER)
+      const tooltipArrowElement = this._createElement('span', CLASS_NAME_RANGE_SLIDER_TOOLTIP_ARROW)
 
       tooltipInnerElement.innerHTML = this._config.tooltipsFormat ?
         (this._config.sanitize ? sanitizeHtml(this._config.tooltipsFormat(input.value), this._config.allowList, this._config.sanitizeFn) : this._config.tooltipsFormat(input.value)) :
@@ -428,43 +427,10 @@ class RangeSlider extends BaseComponent {
     }
   }
 
-  _getThumbSize(): any {
-    const value = window
-    .getComputedStyle(this._element, null)
-    .getPropertyValue(
-      this._config.vertical ? '--cui-range-slider-thumb-height' : '--cui-range-slider-thumb-width'
-    )
-
-    const regex = /^(\d+\.?\d*)([%a-z]*)$/i
-    const match = value.match(regex)
-
-    if (match) {
-      return {
-        value: Number.parseFloat(match[1]),
-        unit: match[2] || null
-      }
-    }
-
-    return '1rem'
-  }
-
   _positionTooltip(tooltip: HTMLElement, input: HTMLInputElement): void {
-    const thumbSize = this._thumbSize
-    const percent = ((input.value as any) - this._config.min) / (this._config.max - this._config.min)
-    const margin = percent > 0.5 ?
-      `-${(percent - 0.5) * thumbSize.value}${thumbSize.unit}` :
-      `${(0.5 - percent) * thumbSize.value}${thumbSize.unit}`
+    const percent = (Number(input.value) - this._config.min) / (this._config.max - this._config.min)
 
-    if (this._config.vertical) {
-      Object.assign(tooltip.style, {
-        bottom: `${percent * 100}%`,
-        marginBottom: margin
-      })
-
-      return
-    }
-
-    Object.assign(tooltip.style, { insetInlineStart: `${percent * 100}%`, marginInlineStart: margin })
+    tooltip.style.setProperty('--cui-range-slider-tooltip-position', `${percent}`)
   }
 
   _updateTooltip(index: number, value: number): void {

--- a/js/tests/unit/range-slider.spec.js
+++ b/js/tests/unit/range-slider.spec.js
@@ -722,61 +722,53 @@ describe('RangeSlider', () => {
   })
 
   describe('Track / Gradient', () => {
-    it('should set background gradient when track is fill', () => {
+    const edges = track => [
+      track.style.getPropertyValue('--cui-range-slider-track-from'),
+      track.style.getPropertyValue('--cui-range-slider-track-to')
+    ]
+
+    it('should mark the filled band when track is fill', () => {
       fixtureEl.innerHTML = '<div id="slider"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, { track: 'fill', value: 50 })
 
-      const track = element.querySelector('.range-slider-track')
-      expect(track.style.backgroundImage).not.toBe('')
+      expect(edges(element.querySelector('.range-slider-track'))).toEqual(['0%', '50%'])
     })
 
-    it('should not set background gradient when track is false', () => {
+    it('should leave the band unset when track is false', () => {
       fixtureEl.innerHTML = '<div id="slider"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, { track: false, value: 50 })
 
-      const track = element.querySelector('.range-slider-track')
-      expect(track.style.backgroundImage).toBe('')
+      // Unset rather than zero-width: the stylesheet has no fallback for these,
+      // so the whole `background-image` falls back to `none`.
+      expect(edges(element.querySelector('.range-slider-track'))).toEqual(['', ''])
     })
 
-    it('should create a single-value gradient for one thumb', () => {
+    it('should start a single-thumb band at zero', () => {
       fixtureEl.innerHTML = '<div id="slider"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, { track: 'fill', value: [50] })
 
-      const track = element.querySelector('.range-slider-track')
-      expect(track.style.backgroundImage).toContain('linear-gradient')
-      expect(track.style.backgroundImage).toContain('50%')
+      expect(edges(element.querySelector('.range-slider-track'))).toEqual(['0%', '50%'])
     })
 
-    it('should create a multi-value gradient for multiple thumbs', () => {
+    it('should span a multi-thumb band between the outermost handles', () => {
       fixtureEl.innerHTML = '<div id="slider"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, { track: 'fill', value: [25, 75] })
 
-      const track = element.querySelector('.range-slider-track')
-      expect(track.style.backgroundImage).toContain('linear-gradient')
-      expect(track.style.backgroundImage).toContain('25%')
-      expect(track.style.backgroundImage).toContain('75%')
+      expect(edges(element.querySelector('.range-slider-track'))).toEqual(['25%', '75%'])
     })
 
-    it('should use "to top" direction for vertical', () => {
+    it('should write the same band whatever the orientation', () => {
       fixtureEl.innerHTML = '<div id="slider"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, { track: 'fill', value: [50], vertical: true })
 
-      const track = element.querySelector('.range-slider-track')
-      expect(track.style.backgroundImage).toContain('to top')
-    })
-
-    it('should use "to right" direction for horizontal LTR', () => {
-      fixtureEl.innerHTML = '<div id="slider"></div>'
-      const element = fixtureEl.querySelector('#slider')
-      const rangeSlider = new RangeSlider(element, { track: 'fill', value: [50], vertical: false })
-
-      const track = element.querySelector('.range-slider-track')
-      expect(track.style.backgroundImage).toContain('to right')
+      // Direction is the stylesheet's business now.
+      expect(edges(element.querySelector('.range-slider-track'))).toEqual(['0%', '50%'])
+      expect(element.querySelector('.range-slider-track').style.backgroundImage).toBe('')
     })
   })
 

--- a/js/tests/unit/range-slider.spec.js
+++ b/js/tests/unit/range-slider.spec.js
@@ -62,6 +62,36 @@ describe('RangeSlider', () => {
       expect(tooltip).not.toBeNull()
     })
 
+    it('should render the tooltip as a hidden <output> of phrasing content', () => {
+      fixtureEl.innerHTML = '<div data-coreui-toggle="range-slider"></div>'
+
+      const element = fixtureEl.querySelector('[data-coreui-toggle="range-slider"]')
+      const rangeSlider = new RangeSlider(element)
+      const tooltip = element.querySelector('.range-slider-tooltip')
+
+      expect(tooltip.tagName).toBe('OUTPUT')
+      expect(tooltip.getAttribute('aria-hidden')).toBe('true')
+
+      expect([...tooltip.children].map(child => child.tagName)).toEqual(['SPAN', 'SPAN'])
+    })
+
+    it('should position the tooltip through a custom property, not inline offsets', () => {
+      fixtureEl.innerHTML = '<div data-coreui-toggle="range-slider" data-coreui-min="0" data-coreui-max="200" data-coreui-value="50"></div>'
+
+      const element = fixtureEl.querySelector('[data-coreui-toggle="range-slider"]')
+      const rangeSlider = new RangeSlider(element)
+      const tooltip = element.querySelector('.range-slider-tooltip')
+
+      expect(tooltip.style.getPropertyValue('--cui-range-slider-tooltip-position')).toBe('0.25')
+      expect(tooltip.style.insetInlineStart).toBe('')
+      expect(tooltip.style.marginInlineStart).toBe('')
+
+      // `update()` rebuilds the subtree, so the tooltip has to be read again.
+      rangeSlider.update({ value: 150 })
+
+      expect(element.querySelector('.range-slider-tooltip').style.getPropertyValue('--cui-range-slider-tooltip-position')).toBe('0.75')
+    })
+
     it('should initialize with custom configuration via data attributes', () => {
       fixtureEl.innerHTML = `
         <div
@@ -1476,21 +1506,7 @@ describe('RangeSlider', () => {
   })
 
   describe('_positionTooltip', () => {
-    it('should position tooltip for vertical mode', () => {
-      fixtureEl.innerHTML = '<div id="slider" style="--cui-range-slider-thumb-height: 16px;"></div>'
-      const element = fixtureEl.querySelector('#slider')
-      const rangeSlider = new RangeSlider(element, {
-        value: [75],
-        vertical: true,
-        tooltips: true
-      })
-
-      const tooltip = element.querySelector('.range-slider-tooltip')
-      // In vertical mode, tooltip gets bottom style
-      expect(tooltip.style.bottom).not.toBe('')
-    })
-
-    it('should position tooltip for horizontal mode', () => {
+    it('should write the ratio for horizontal mode', () => {
       fixtureEl.innerHTML = '<div id="slider" style="--cui-range-slider-thumb-width: 16px;"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, {
@@ -1500,38 +1516,60 @@ describe('RangeSlider', () => {
       })
 
       const tooltip = element.querySelector('.range-slider-tooltip')
-      // In horizontal mode, tooltip gets insetInlineStart style
-      expect(tooltip.style.insetInlineStart).not.toBe('')
+      expect(tooltip.style.getPropertyValue('--cui-range-slider-tooltip-position')).toBe('0.75')
     })
 
-    it('should compute negative margin when percent > 0.5', () => {
-      fixtureEl.innerHTML = '<div id="slider" style="--cui-range-slider-thumb-width: 20px;"></div>'
+    it('should write the same ratio for vertical mode', () => {
+      fixtureEl.innerHTML = '<div id="slider" style="--cui-range-slider-thumb-height: 16px;"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, {
-        value: [80], // 80% > 50%
-        vertical: false,
+        value: [75],
+        vertical: true,
         tooltips: true
       })
 
       const tooltip = element.querySelector('.range-slider-tooltip')
-      // margin should be negative (starts with -)
-      expect(tooltip.style.marginInlineStart).toContain('-')
+      expect(tooltip.style.getPropertyValue('--cui-range-slider-tooltip-position')).toBe('0.75')
     })
 
-    it('should compute positive margin when percent < 0.5', () => {
-      fixtureEl.innerHTML = '<div id="slider" style="--cui-range-slider-thumb-width: 20px;"></div>'
+    it('should write a property name the stylesheet cannot rename', () => {
+      // The name is outside `$prefix` on both sides: a build with a different
+      // prefix must still read what the plugin writes.
+      fixtureEl.innerHTML = '<div id="slider"></div>'
+      const element = fixtureEl.querySelector('#slider')
+      const rangeSlider = new RangeSlider(element, { value: [50], tooltips: true })
+      const tooltip = element.querySelector('.range-slider-tooltip')
+
+      expect([...tooltip.style].filter(property => property.startsWith('--')))
+        .toEqual(['--cui-range-slider-tooltip-position'])
+    })
+
+    it('should give every thumb its own ratio', () => {
+      fixtureEl.innerHTML = '<div id="slider"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, {
-        value: [20], // 20% < 50%
-        vertical: false,
+        value: [20, 80],
+        tooltips: true
+      })
+
+      const positions = [...element.querySelectorAll('.range-slider-tooltip')]
+        .map(tooltip => tooltip.style.getPropertyValue('--cui-range-slider-tooltip-position'))
+
+      expect(positions).toEqual(['0.2', '0.8'])
+    })
+
+    it('should not fall back to a thumb size read from the stylesheet', () => {
+      // The old parser only matched a bare number and unit.
+      fixtureEl.innerHTML = '<div id="slider" style="--cui-range-slider-thumb-width: calc(1rem + 2px);"></div>'
+      const element = fixtureEl.querySelector('#slider')
+      const rangeSlider = new RangeSlider(element, {
+        value: [100],
         tooltips: true
       })
 
       const tooltip = element.querySelector('.range-slider-tooltip')
-      // margin should NOT start with - (positive or 0)
-      if (tooltip.style.marginInlineStart) {
-        expect(tooltip.style.marginInlineStart.startsWith('-')).toBeFalse()
-      }
+      expect(tooltip.style.getPropertyValue('--cui-range-slider-tooltip-position')).toBe('1')
+      expect(tooltip.style.marginInlineStart).toBe('')
     })
   })
 

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -148,6 +148,21 @@ $range-slider-vertical-tokens: defaults(
     height: var(--#{$prefix}range-slider-track-height);
     cursor: var(--#{$prefix}range-slider-track-cursor);
     background-color: var(--#{$prefix}range-slider-track-bg);
+    // The filled band, between the lowest and the highest handle. The edges are
+    // deliberately given no fallback: with `track: false` the plugin never
+    // writes them, the substitution fails and the whole declaration falls back
+    // to `none`, so nothing is painted. Their names sit outside `$prefix` for
+    // the same reason as the tooltip's position — the plugin writes them.
+    background-image:
+      linear-gradient(
+        var(--cui-range-slider-track-direction, to right),
+        transparent 0%,
+        transparent var(--cui-range-slider-track-from),
+        var(--#{$prefix}range-slider-track-in-range-bg) var(--cui-range-slider-track-from),
+        var(--#{$prefix}range-slider-track-in-range-bg) var(--cui-range-slider-track-to),
+        transparent var(--cui-range-slider-track-to),
+        transparent 100%
+      );
     border-color: transparent;
     @include border-radius(var(--#{$prefix}range-slider-track-border-radius));
     @include box-shadow(var(--#{$prefix}range-slider-track-box-shadow));
@@ -288,6 +303,13 @@ $range-slider-vertical-tokens: defaults(
   }
 
   .range-slider:not(.range-slider-vertical) {
+    // Gradients take no logical direction, so the horizontal one is mirrored
+    // here. Scoped away from the vertical slider so neither rule depends on
+    // source order.
+    @include rtl() {
+      --cui-range-slider-track-direction: to left;
+    }
+
 
     .range-slider-inputs-container {
       width: 100%;
@@ -314,6 +336,8 @@ $range-slider-vertical-tokens: defaults(
 
   .range-slider-vertical {
     @include tokens($range-slider-vertical-tokens);
+
+    --cui-range-slider-track-direction: to top;
 
     flex-direction: row;
     height: var(--#{$prefix}range-slider-vertical-track-height);

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -249,7 +249,12 @@ $range-slider-vertical-tokens: defaults(
   }
 
   .range-slider-tooltip {
+    // The thumb's centre: half a thumb in, then the track minus a thumb.
+    // Deliberately outside `$prefix`: the plugin writes this name, so a
+    // configurable one would let the two sides disagree.
     position: absolute;
+    // stylelint-disable-next-line function-disallowed-list
+    inset-inline-start: calc(var(--#{$prefix}range-slider-thumb-width) * .5 + var(--cui-range-slider-tooltip-position, 0) * (100% - var(--#{$prefix}range-slider-thumb-width)));
     z-index: var(--#{$prefix}range-slider-tooltip-zindex);
     display: flex;
     flex-direction: column;
@@ -331,7 +336,10 @@ $range-slider-vertical-tokens: defaults(
     }
 
     .range-slider-tooltip {
+      inset-inline-start: auto;
       inset-inline-end: calc(var(--#{$prefix}range-slider-tooltip-margin-end) + var(--#{$prefix}range-slider-thumb-width)); // stylelint-disable-line function-disallowed-list
+      // stylelint-disable-next-line function-disallowed-list
+      bottom: calc(var(--#{$prefix}range-slider-thumb-height) * .5 + var(--cui-range-slider-tooltip-position, 0) * (100% - var(--#{$prefix}range-slider-thumb-height)));
       flex-direction: row;
       transform: translateY(50%);
     }


### PR DESCRIPTION
Came out of reading Bootstrap v6-dev's new JS-driven `.form-range`. Their value bubble is placed entirely in CSS from one ratio; ours was placed by JavaScript on every value change. Same arithmetic, so the calculation moves to the stylesheet.

### Positioning

`percent·W + (0.5 − percent)·T` reduces to `T/2 + percent·(W − T)` — the handle's centre. The stylesheet computes it from `--cui-range-slider-tooltip-position` (0–1), which the plugin keeps in sync. The vertical orientation becomes a second declaration rather than a second code path.

That deletes `_getThumbSize()` and two defects it carried:

- its fallback returned the string `'1rem'` where callers read `.value` / `.unit`, so a handle width the regex could not parse (`calc()`, `var()`) produced `NaNundefined` and silently dropped the compensation — the tooltip then sat half a handle off at both ends
- the ternary in `_positionTooltip()` computed the same expression in both branches

**16 lines in, 39 out**, and no `getComputedStyle` in the update path.

### `<output>`

The tooltip is an `<output>` with `<span>` children. `<output>` takes phrasing content, so Bootstrap's own `<div>`s inside one are invalid HTML — we need no workaround, because our tooltip is a flex container and the spans are blockified anyway.

`aria-hidden="true"` is load-bearing. Measured through CDP:

| markup | accessibility tree |
| --- | --- |
| `<div>` (before) | static text, no role |
| `<output>` alone | `role="status"`, `live="polite"` |
| `<output aria-hidden>` | absent |

The handle is already a `role="slider"` with `aria-valuenow`, so an unhidden `<output>` would announce every drag twice.

### Verified

- tooltip position identical across **60 combinations** — LTR/RTL × horizontal/vertical × three handle sizes × five values — comparing the inline styles the old code wrote against the new custom property
- `<output>`/`<span>` renders **pixel-identical** to the old `<div>`s, 19 measured properties
- unit suite green (131); the three specs that asserted the inline offsets are rewritten against the ratio, plus a regression test for the `calc()` handle width that used to break the old parser