### PR TITLE
fix(scss): keep the CSS-to-JS signals out of $prefix

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -183,7 +183,9 @@ $dropdown-dark-tokens: defaults(
       $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
       .dropdown-menu#{$infix}-start {
-        --#{$prefix}position: start;
+        // Read by the plugin, so the name cannot follow `$prefix` — the two
+        // sides would disagree in a build that changes it.
+        --cui-position: start;
 
         &[data#{$data-infix}popper] {
           inset-inline-start: 0;
@@ -192,7 +194,7 @@ $dropdown-dark-tokens: defaults(
       }
 
       .dropdown-menu#{$infix}-end {
-        --#{$prefix}position: end;
+        --cui-position: end;
 
         &[data#{$data-infix}popper] {
           inset-inline-start: auto;

--- a/scss/sidebar/_sidebar.scss
+++ b/scss/sidebar/_sidebar.scss
@@ -86,8 +86,10 @@ $sidebar-narrow-unfoldable-box-shadow:     var(--#{$prefix}box-shadow) !default;
     }
 
     @include media-breakpoint-down($mobile-breakpoint) {
-      // Some of our components use this property to detect if the sidebar has mobile behavior.
-      --#{$prefix}is-mobile: true;
+      // Read by the plugin to detect the sidebar's mobile behavior, so the name
+      // cannot follow `$prefix` — the two sides would disagree in a build that
+      // changes it.
+      --cui-is-mobile: true;
 
       position: fixed;
       top: 0;


### PR DESCRIPTION
Follow-up to #724, closing the same class of defect in the last two places it exists.

Two custom properties are not design tokens but **signals from the stylesheet to a plugin**:

| property | written by | read by |
| --- | --- | --- |
| `--cui-position` | `.dropdown-menu-end` / `-start` | `dropdown.ts` — is the menu end-aligned |
| `--cui-is-mobile` | `.sidebar` inside a media query | `sidebar.ts` — is the sidebar in mobile behavior |

Both were emitted through `$prefix`, while both are read from JavaScript by a name spelled out in full. Change the prefix and the two sides stop talking. Measured in Chromium against a `$prefix: bs-` build:

```
$prefix: cui-  --cui-position: end      ✓   --cui-is-mobile: true  ✓
$prefix: bs-   --cui-position: (empty)  ✗   --cui-is-mobile: false ✗
```

The dropdown silently stops seeing its own alignment; the sidebar silently stops seeing that it is mobile. Neither throws, both just take the default branch. After the change both read correctly under either prefix.

### Why hardcoding is the right call here

Neither property is documented, neither is meant to be set by hand, and both are read by a name the plugin cannot compute. A configurable name is precisely what allows the desync — the same reasoning applied to `--cui-range-slider-track-from` in #724. Design tokens keep `$prefix`; wiring does not.

### Safety

**The compiled stylesheet is byte-identical at the default prefix** — `--#{$prefix}position` with `cui-` already produced `--cui-position`. Verified by diffing the full build before and after: 0 changed lines. This only affects builds that reconfigure the prefix, which are the ones it fixes.

Dropdown and sidebar suites green (147).