### PR TITLE
chore(docs): bump @coreui/astro-docs to 0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@astrojs/mdx": "^7.0.3",
-        "@coreui/astro-docs": "0.1.3",
+        "@coreui/astro-docs": "0.1.4",
         "@eslint/markdown": "^7.5.1",
         "@floating-ui/dom": "^1.8.0",
         "@rollup/plugin-replace": "^6.0.3",
@@ -894,9 +894,9 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.3.tgz",
-      "integrity": "sha512-mM2NVAUlfIWSAntKFoMuyVBoEnTAu4sZeK1EIJmAk6Bn4Lp//S/vMClzfh1vEz2iXDqdk/Dht7KVM4ntSSDyPQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.4.tgz",
+      "integrity": "sha512-/RXs1YMaxl5NXuo6zAGFxwYjxgPF6GD/SXP53v/b1HmlUKKJunM+V+2W/xv2n8or1XNseCSkFVOJH9VPOsAHeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "devDependencies": {
     "@astrojs/mdx": "^7.0.3",
-    "@coreui/astro-docs": "0.1.3",
+    "@coreui/astro-docs": "0.1.4",
     "@eslint/markdown": "^7.5.1",
     "@floating-ui/dom": "^1.8.0",
     "@rollup/plugin-replace": "^6.0.3",


### PR DESCRIPTION
Picks up the two engine fixes for the v6 cascade ([astro-docs#62](https://github.com/coreui/astro-docs/pull/62)):

- the table-of-contents toggle stays hidden at desktop widths — it set `display: flex` in the stylesheet while the markup carried `.d-lg-none`, and in v6 an unlayered rule outranks the layered utility
- the example preview no longer relies on `m-0 border-0` in the template to cancel the border and margin `.docs-example` gives it standalone; the stylesheet says it once

Lock touches only this package (`0.1.3 → 0.1.4`, 8 lines). Docs build green, 144 pages.