### PR TITLE
feat(Calendar): complete the APG grid keyboard model

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -42,19 +42,19 @@
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "107kB"
-    },
-    {
-      "path": "./dist/js/coreui.esm.min.js",
-      "maxSize": "76.5kB"
-    },
-    {
-      "path": "./dist/js/coreui.js",
       "maxSize": "107.5kB"
     },
     {
+      "path": "./dist/js/coreui.esm.min.js",
+      "maxSize": "77kB"
+    },
+    {
+      "path": "./dist/js/coreui.js",
+      "maxSize": "108.25kB"
+    },
+    {
       "path": "./dist/js/coreui.min.js",
-      "maxSize": "69kB"
+      "maxSize": "69.75kB"
     }
   ],
   "ci": {

--- a/docs/src/content/docs/components/calendar.mdx
+++ b/docs/src/content/docs/components/calendar.mdx
@@ -275,6 +275,23 @@ This example demonstrates advanced usage of custom cell rendering to display pri
 
 <Code code={calendarCustomizeCells} lang="js" />
 
+## Accessibility
+
+Keyboard navigation in the grid follows the [date picker dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/). Selected cells carry `aria-selected`, today carries `aria-current="date"`, and every cell announces its full localized date.
+
+### Keyboard support
+
+| Key | Action |
+| --- | --- |
+| <kbd>Arrow Right</kbd> / <kbd>Arrow Left</kbd> | Move focus to the next / previous day; crossing the edge of the grid moves to the adjacent month |
+| <kbd>Arrow Down</kbd> / <kbd>Arrow Up</kbd> | Move focus to the same day of the next / previous week |
+| <kbd>Home</kbd> / <kbd>End</kbd> | Move focus to the first / last selectable day of the current week |
+| <kbd>Page Down</kbd> / <kbd>Page Up</kbd> | Move focus to the same day of the next / previous month, keeping the day number when the target month is long enough |
+| <kbd>Shift</kbd> + <kbd>Page Down</kbd> / <kbd>Shift</kbd> + <kbd>Page Up</kbd> | Move focus to the same day of the next / previous year |
+| <kbd>Enter</kbd> / <kbd>Space</kbd> | Select the focused date |
+
+The months, quarters, and years views answer to the same keys, with arrows moving by cell and row, and <kbd>Page Down</kbd> / <kbd>Page Up</kbd> moving by year (by decade in the years view). A jump never lands outside `minDate` / `maxDate` — focus stops on the closest date still selectable.
+
 ## Usage
 
 ### Via data attributes

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -298,6 +298,21 @@ the first day of the month.
     </div>
   </div>`} sandboxJs={datePickerFormats} />
 
+## Accessibility
+
+The field is a [date input](/forms/date-input/#accessibility) — a group of spinbutton sections — so its own arrow keys belong to the value, and the popup opens on the native control's dropdown keys. Focus enters the calendar on the selected date, on today when nothing is selected, or on the last selectable date when today is out of range.
+
+### Keyboard support
+
+| Key | Action |
+| --- | --- |
+| <kbd>Alt</kbd> + <kbd>Arrow Down</kbd> / <kbd>F4</kbd> | Open the calendar popup and move focus into the grid |
+| <kbd>Escape</kbd> | Close the popup and return focus to the field |
+| <kbd>Tab</kbd> / <kbd>Shift</kbd> + <kbd>Tab</kbd> | Cycle between the field, its buttons, and the open popup |
+| <kbd>Enter</kbd> / <kbd>Space</kbd> | Select the focused date and close the popup |
+
+Inside the grid, navigation follows the [calendar keyboard model](/components/calendar/#keyboard-support): arrows move by day and week, <kbd>Home</kbd> / <kbd>End</kbd> jump within the week, and <kbd>Page Down</kbd> / <kbd>Page Up</kbd> (with <kbd>Shift</kbd> for years) move between months and years.
+
 ## Usage
 
 ### Via data attributes

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -238,6 +238,10 @@ format. Set it with `data-coreui-format`, forwarded to both fields.
     </div>
   </div>`} />
 
+## Accessibility
+
+The fields and the popup share the [date picker keyboard model](/forms/date-picker/#keyboard-support): <kbd>Alt</kbd> + <kbd>Arrow Down</kbd> or <kbd>F4</kbd> opens the calendars, <kbd>Escape</kbd> closes them and returns focus, and grid navigation — including <kbd>Home</kbd> / <kbd>End</kbd> and <kbd>Page Down</kbd> / <kbd>Page Up</kbd> (with <kbd>Shift</kbd> for years) — follows the [calendar keyboard support](/components/calendar/#keyboard-support).
+
 ## Usage
 
 ### Via data attributes

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -108,6 +108,10 @@ keeps the day — so the popup does not auto-close.
     </div>
   </div>`} />
 
+## Accessibility
+
+The field and the popup share the [date picker keyboard model](/forms/date-picker/#keyboard-support): <kbd>Alt</kbd> + <kbd>Arrow Down</kbd> or <kbd>F4</kbd> opens the panel, <kbd>Escape</kbd> closes it and returns focus, and calendar grid navigation — including <kbd>Home</kbd> / <kbd>End</kbd> and <kbd>Page Down</kbd> / <kbd>Page Up</kbd> (with <kbd>Shift</kbd> for years) — follows the [calendar keyboard support](/components/calendar/#keyboard-support).
+
 ## Usage
 
 ### Via data attributes

--- a/js/src/calendar.ts
+++ b/js/src/calendar.ts
@@ -57,6 +57,10 @@ const ARROW_DOWN_KEY = 'ArrowDown'
 const ARROW_LEFT_KEY = 'ArrowLeft'
 const ENTER_KEY = 'Enter'
 const SPACE_KEY = 'Space'
+const HOME_KEY = 'Home'
+const END_KEY = 'End'
+const PAGE_UP_KEY = 'PageUp'
+const PAGE_DOWN_KEY = 'PageDown'
 
 const EVENT_BLUR = `blur${EVENT_KEY}`
 const EVENT_CALENDAR_DATE_CHANGE = `calendarDateChange${EVENT_KEY}`
@@ -280,6 +284,29 @@ class Calendar extends BaseComponent {
     }
   }
 
+  // Closest by date, not exact match: the requested date may sit on a cell
+  // disabled by disabledDates or clamped away by min/max
+  _focusOnDate(date: Date): void {
+    const focusables = (SelectorEngine.find(
+      this._config.selectionType === 'week' ? SELECTOR_CALENDAR_ROW_CLICKABLE : SELECTOR_CALENDAR_CELL_CLICKABLE,
+      this._element as ParentNode
+    ) as HTMLElement[]).filter(element => !element.classList.contains('previous') && !element.classList.contains('next'))
+
+    let closest = null
+    let closestGap = Number.POSITIVE_INFINITY
+
+    for (const element of focusables) {
+      const gap = Math.abs(this._getDate(element).getTime() - date.getTime())
+
+      if (gap < closestGap) {
+        closest = element
+        closestGap = gap
+      }
+    }
+
+    closest?.focus()
+  }
+
   _getDate(target: HTMLElement): Date {
     if (this._config.selectionType === 'week') {
       const firstCell = SelectorEngine.findOne(SELECTOR_CALENDAR_CELL, target.closest(SELECTOR_CALENDAR_ROW) as ParentNode)
@@ -329,6 +356,55 @@ class Calendar extends BaseComponent {
     if (event.code === SPACE_KEY || event.key === ENTER_KEY) {
       event.preventDefault()
       this._handleCalendarClick(event)
+    }
+
+    if (event.key === HOME_KEY || event.key === END_KEY) {
+      event.preventDefault()
+
+      const cells = SelectorEngine.find(SELECTOR_CALENDAR_CELL_CLICKABLE, event.target.closest('tr') as ParentNode)
+      const cell = event.key === HOME_KEY ? cells[0] : cells[cells.length - 1]
+      cell?.focus()
+      return
+    }
+
+    if (event.key === PAGE_UP_KEY || event.key === PAGE_DOWN_KEY) {
+      event.preventDefault()
+
+      const direction = event.key === PAGE_DOWN_KEY ? 1 : -1
+      const target = new Date(date)
+
+      if (this._view === 'days') {
+        // Land on day 1 before shifting so a 31st cannot overflow past the
+        // target month, then restore the day clamped to that month's length
+        const day = target.getDate()
+        target.setDate(1)
+
+        if (event.shiftKey) {
+          target.setFullYear(target.getFullYear() + direction)
+        } else {
+          target.setMonth(target.getMonth() + direction)
+        }
+
+        target.setDate(Math.min(day, new Date(target.getFullYear(), target.getMonth() + 1, 0).getDate()))
+      } else {
+        target.setFullYear(target.getFullYear() + ((this._view === 'years' ? 10 : 1) * direction))
+      }
+
+      if (this._maxDate && target > this._maxDate) {
+        target.setTime(this._maxDate.getTime())
+      }
+
+      if (this._minDate && target < this._minDate) {
+        target.setTime(this._minDate.getTime())
+      }
+
+      if (target.getTime() === date.getTime()) {
+        return
+      }
+
+      const monthsDelta = ((target.getFullYear() - date.getFullYear()) * 12) + (target.getMonth() - date.getMonth())
+      this._modifyCalendarDate(0, monthsDelta, () => this._focusOnDate(target))
+      return
     }
 
     if (

--- a/js/tests/unit/calendar.spec.js
+++ b/js/tests/unit/calendar.spec.js
@@ -977,6 +977,190 @@ describe('Calendar', () => {
       })
     })
 
+    const findDayCell = (div, year, month, day) =>
+      [...div.querySelectorAll('.calendar-cell[tabindex="0"]')].find(cell => {
+        const date = new Date(cell.dataset.coreuiDate)
+        return date.getFullYear() === year && date.getMonth() === month && date.getDate() === day
+      })
+
+    const pressKey = (cell, key, shiftKey = false) => {
+      const keydownEvent = createEvent('keydown')
+      keydownEvent.key = key
+      keydownEvent.shiftKey = shiftKey
+      cell.dispatchEvent(keydownEvent)
+    }
+
+    const activeDate = () => new Date(document.activeElement.dataset.coreuiDate)
+
+    it('should move focus to the first day of the week on Home', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div></div>'
+        const div = fixtureEl.querySelector('div')
+        new Calendar(div, { calendarDate: new Date(2023, 5, 1), locale: 'en-US' }) // eslint-disable-line no-new
+
+        setTimeout(() => {
+          const cell = findDayCell(div, 2023, 5, 15)
+          cell.focus()
+          pressKey(cell, 'Home')
+
+          expect(activeDate().getDate()).toEqual(12)
+          resolve()
+        }, 10)
+      })
+    })
+
+    it('should move focus to the last day of the week on End', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div></div>'
+        const div = fixtureEl.querySelector('div')
+        new Calendar(div, { calendarDate: new Date(2023, 5, 1), locale: 'en-US' }) // eslint-disable-line no-new
+
+        setTimeout(() => {
+          const cell = findDayCell(div, 2023, 5, 15)
+          cell.focus()
+          pressKey(cell, 'End')
+
+          expect(activeDate().getDate()).toEqual(18)
+          resolve()
+        }, 10)
+      })
+    })
+
+    it('should move focus to the same day of the previous month on PageUp', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div></div>'
+        const div = fixtureEl.querySelector('div')
+        new Calendar(div, { calendarDate: new Date(2023, 5, 1), locale: 'en-US' }) // eslint-disable-line no-new
+
+        setTimeout(() => {
+          const cell = findDayCell(div, 2023, 5, 15)
+          cell.focus()
+          pressKey(cell, 'PageUp')
+
+          setTimeout(() => {
+            expect(activeDate()).toEqual(new Date(2023, 4, 15))
+            resolve()
+          }, 20)
+        }, 10)
+      })
+    })
+
+    it('should move focus to the same day of the next month on PageDown', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div></div>'
+        const div = fixtureEl.querySelector('div')
+        new Calendar(div, { calendarDate: new Date(2023, 5, 1), locale: 'en-US' }) // eslint-disable-line no-new
+
+        setTimeout(() => {
+          const cell = findDayCell(div, 2023, 5, 15)
+          cell.focus()
+          pressKey(cell, 'PageDown')
+
+          setTimeout(() => {
+            expect(activeDate()).toEqual(new Date(2023, 6, 15))
+            resolve()
+          }, 20)
+        }, 10)
+      })
+    })
+
+    it('should move focus to the same day of the previous year on Shift+PageUp', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div></div>'
+        const div = fixtureEl.querySelector('div')
+        new Calendar(div, { calendarDate: new Date(2023, 5, 1), locale: 'en-US' }) // eslint-disable-line no-new
+
+        setTimeout(() => {
+          const cell = findDayCell(div, 2023, 5, 15)
+          cell.focus()
+          pressKey(cell, 'PageUp', true)
+
+          setTimeout(() => {
+            expect(activeDate()).toEqual(new Date(2022, 5, 15))
+            resolve()
+          }, 20)
+        }, 10)
+      })
+    })
+
+    it('should move focus to the same day of the next year on Shift+PageDown', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div></div>'
+        const div = fixtureEl.querySelector('div')
+        new Calendar(div, { calendarDate: new Date(2023, 5, 1), locale: 'en-US' }) // eslint-disable-line no-new
+
+        setTimeout(() => {
+          const cell = findDayCell(div, 2023, 5, 15)
+          cell.focus()
+          pressKey(cell, 'PageDown', true)
+
+          setTimeout(() => {
+            expect(activeDate()).toEqual(new Date(2024, 5, 15))
+            resolve()
+          }, 20)
+        }, 10)
+      })
+    })
+
+    it('should clamp the day to the target month length on PageDown', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div></div>'
+        const div = fixtureEl.querySelector('div')
+        new Calendar(div, { calendarDate: new Date(2023, 0, 1), locale: 'en-US' }) // eslint-disable-line no-new
+
+        setTimeout(() => {
+          const cell = findDayCell(div, 2023, 0, 31)
+          cell.focus()
+          pressKey(cell, 'PageDown')
+
+          setTimeout(() => {
+            expect(activeDate()).toEqual(new Date(2023, 1, 28))
+            resolve()
+          }, 20)
+        }, 10)
+      })
+    })
+
+    it('should not move focus past maxDate on PageDown', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div></div>'
+        const div = fixtureEl.querySelector('div')
+        // eslint-disable-next-line no-new
+        new Calendar(div, { calendarDate: new Date(2023, 5, 1), locale: 'en-US', maxDate: new Date(2023, 6, 5) })
+
+        setTimeout(() => {
+          const cell = findDayCell(div, 2023, 5, 15)
+          cell.focus()
+          pressKey(cell, 'PageDown')
+
+          setTimeout(() => {
+            expect(activeDate()).toEqual(new Date(2023, 6, 5))
+            resolve()
+          }, 20)
+        }, 10)
+      })
+    })
+
+    it('should move focus to the same month of the next year on PageDown in months view', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div></div>'
+        const div = fixtureEl.querySelector('div')
+        // eslint-disable-next-line no-new
+        new Calendar(div, { calendarDate: new Date(2023, 5, 1), locale: 'en-US', selectionType: 'month' })
+
+        setTimeout(() => {
+          const cell = findDayCell(div, 2023, 5, 1)
+          cell.focus()
+          pressKey(cell, 'PageDown')
+
+          setTimeout(() => {
+            expect(activeDate()).toEqual(new Date(2024, 5, 1))
+            resolve()
+          }, 20)
+        }, 10)
+      })
+    })
+
     it('should not navigate past maxDate with ArrowRight', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<div></div>'


### PR DESCRIPTION
## What

The calendar grid handled arrow keys only. This adds the remaining keys from the [APG date picker grid model](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-datepicker/):

| Key | Action |
| --- | --- |
| Home / End | first / last selectable day of the current week row |
| PageUp / PageDown | same day of the previous / next month, day number clamped to the target month's length (months/quarters views: year; years view: decade) |
| Shift + PageUp / PageDown | same day of the previous / next year |

## How

- A jump is clamped to `minDate`/`maxDate`; when the requested date is disabled, focus lands on the closest selectable cell (`_focusOnDate` picks by date distance instead of exact match).
- Week selection keeps its row-based focus: PageUp/PageDown move the row, Home/End are a no-op (the row is the whole week).
- The deliberate divergences from the APG example stay as they are — Alt+ArrowDown/F4 to open (bare arrows belong to the section input) and select-closes-the-popup — both follow the native `<input type="date">` model.

## Docs

New `## Accessibility` + `### Keyboard support` section on the calendar page; the date picker page documents the field/popup keys and links to it; the date range picker and date time picker pages link to both.

## Testing

9 new unit specs asserting where focus actually lands (`document.activeElement` + `data-coreui-date`): Home/End, PageUp/PageDown, Shift variants, day clamping (Jan 31 → Feb 28), maxDate clamping, and the months view. Calendar suite 186/186 green.

JS bundle budgets raised by the ~0.3 kB gzip this adds (headroom was already consumed).