### PR TITLE
docs: make the date picker keyboard table self-contained

### DIFF
--- a/docs/src/content/docs/components/calendar.mdx
+++ b/docs/src/content/docs/components/calendar.mdx
@@ -277,7 +277,7 @@ This example demonstrates advanced usage of custom cell rendering to display pri
 
 ## Accessibility
 
-Keyboard navigation in the grid follows the [date picker dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/). Selected cells carry `aria-selected`, today carries `aria-current="date"`, and every cell announces its full localized date.
+Keyboard navigation in the grid follows the [date picker dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/). Selected cells carry `aria-selected`, today carries `aria-current="date"`, and every cell announces its full localized date. The months, quarters, and years views answer to the same keys, with arrows moving by cell and row, and no jump ever lands outside `minDate` / `maxDate` — focus stops on the closest date still selectable.
 
 ### Keyboard support
 
@@ -286,11 +286,9 @@ Keyboard navigation in the grid follows the [date picker dialog pattern](https:/
 | <kbd>Arrow Right</kbd> / <kbd>Arrow Left</kbd> | Move focus to the next / previous day; crossing the edge of the grid moves to the adjacent month |
 | <kbd>Arrow Down</kbd> / <kbd>Arrow Up</kbd> | Move focus to the same day of the next / previous week |
 | <kbd>Home</kbd> / <kbd>End</kbd> | Move focus to the first / last selectable day of the current week |
-| <kbd>Page Down</kbd> / <kbd>Page Up</kbd> | Move focus to the same day of the next / previous month, keeping the day number when the target month is long enough |
+| <kbd>Page Down</kbd> / <kbd>Page Up</kbd> | Move focus to the same day of the next / previous month, keeping the day number when the target month is long enough; in the months and quarters views move by year, in the years view by decade |
 | <kbd>Shift</kbd> + <kbd>Page Down</kbd> / <kbd>Shift</kbd> + <kbd>Page Up</kbd> | Move focus to the same day of the next / previous year |
 | <kbd>Enter</kbd> / <kbd>Space</kbd> | Select the focused date |
-
-The months, quarters, and years views answer to the same keys, with arrows moving by cell and row, and <kbd>Page Down</kbd> / <kbd>Page Up</kbd> moving by year (by decade in the years view). A jump never lands outside `minDate` / `maxDate` — focus stops on the closest date still selectable.
 
 ## Usage
 

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -309,9 +309,12 @@ The field is a [date input](/forms/date-input/#accessibility) — a group of spi
 | <kbd>Alt</kbd> + <kbd>Arrow Down</kbd> / <kbd>F4</kbd> | Open the calendar popup and move focus into the grid |
 | <kbd>Escape</kbd> | Close the popup and return focus to the field |
 | <kbd>Tab</kbd> / <kbd>Shift</kbd> + <kbd>Tab</kbd> | Cycle between the field, its buttons, and the open popup |
+| <kbd>Arrow Right</kbd> / <kbd>Arrow Left</kbd> | Move focus to the next / previous day; crossing the edge of the grid moves to the adjacent month |
+| <kbd>Arrow Down</kbd> / <kbd>Arrow Up</kbd> | Move focus to the same day of the next / previous week |
+| <kbd>Home</kbd> / <kbd>End</kbd> | Move focus to the first / last selectable day of the current week |
+| <kbd>Page Down</kbd> / <kbd>Page Up</kbd> | Move focus to the same day of the next / previous month, keeping the day number when the target month is long enough |
+| <kbd>Shift</kbd> + <kbd>Page Down</kbd> / <kbd>Shift</kbd> + <kbd>Page Up</kbd> | Move focus to the same day of the next / previous year |
 | <kbd>Enter</kbd> / <kbd>Space</kbd> | Select the focused date and close the popup |
-
-Inside the grid, navigation follows the [calendar keyboard model](/components/calendar/#keyboard-support): arrows move by day and week, <kbd>Home</kbd> / <kbd>End</kbd> jump within the week, and <kbd>Page Down</kbd> / <kbd>Page Up</kbd> (with <kbd>Shift</kbd> for years) move between months and years.
 
 ## Usage
 

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -240,7 +240,7 @@ format. Set it with `data-coreui-format`, forwarded to both fields.
 
 ## Accessibility
 
-The fields and the popup share the [date picker keyboard model](/forms/date-picker/#keyboard-support): <kbd>Alt</kbd> + <kbd>Arrow Down</kbd> or <kbd>F4</kbd> opens the calendars, <kbd>Escape</kbd> closes them and returns focus, and grid navigation — including <kbd>Home</kbd> / <kbd>End</kbd> and <kbd>Page Down</kbd> / <kbd>Page Up</kbd> (with <kbd>Shift</kbd> for years) — follows the [calendar keyboard support](/components/calendar/#keyboard-support).
+The fields and the popup answer to the [same keys as the date picker](/forms/date-picker/#keyboard-support): <kbd>Alt</kbd> + <kbd>Arrow Down</kbd> or <kbd>F4</kbd> opens the calendars, <kbd>Escape</kbd> closes them and returns focus, and arrows, <kbd>Home</kbd> / <kbd>End</kbd>, and <kbd>Page Down</kbd> / <kbd>Page Up</kbd> (with <kbd>Shift</kbd> for years) move the focused date.
 
 ## Usage
 

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -110,7 +110,7 @@ keeps the day — so the popup does not auto-close.
 
 ## Accessibility
 
-The field and the popup share the [date picker keyboard model](/forms/date-picker/#keyboard-support): <kbd>Alt</kbd> + <kbd>Arrow Down</kbd> or <kbd>F4</kbd> opens the panel, <kbd>Escape</kbd> closes it and returns focus, and calendar grid navigation — including <kbd>Home</kbd> / <kbd>End</kbd> and <kbd>Page Down</kbd> / <kbd>Page Up</kbd> (with <kbd>Shift</kbd> for years) — follows the [calendar keyboard support](/components/calendar/#keyboard-support).
+The field and the popup answer to the [same keys as the date picker](/forms/date-picker/#keyboard-support): <kbd>Alt</kbd> + <kbd>Arrow Down</kbd> or <kbd>F4</kbd> opens the panel, <kbd>Escape</kbd> closes it and returns focus, and arrows, <kbd>Home</kbd> / <kbd>End</kbd>, and <kbd>Page Down</kbd> / <kbd>Page Up</kbd> (with <kbd>Shift</kbd> for years) move the focused date.
 
 ## Usage
 


### PR DESCRIPTION
Follow-up to #735.

The picker page listed only the keys the composite adds and sent the reader to the calendar page for grid navigation — but a docs reader has no reason to know the popup is the Calendar component. Changes:

- The date picker's keyboard table now carries the full key set (open/close, Tab, grid navigation, selection) — self-contained.
- The trailing paragraphs under both keyboard tables are gone: on the calendar page the view variants moved into the PageUp/PageDown row and the min/max clamp into the intro, so the table closes the section.
- The date range picker and date time picker pages point at the date picker's table instead of at the calendar internals.