### PR TITLE
chore(docs): bump @coreui/astro-docs to 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@astrojs/mdx": "^7.0.3",
-        "@coreui/astro-docs": "0.1.4",
+        "@coreui/astro-docs": "0.1.5",
         "@eslint/markdown": "^7.5.1",
         "@floating-ui/dom": "^1.8.0",
         "@rollup/plugin-replace": "^6.0.3",
@@ -894,9 +894,9 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.4.tgz",
-      "integrity": "sha512-/RXs1YMaxl5NXuo6zAGFxwYjxgPF6GD/SXP53v/b1HmlUKKJunM+V+2W/xv2n8or1XNseCSkFVOJH9VPOsAHeQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.5.tgz",
+      "integrity": "sha512-UG9pN0lbTxqmSWSi6c+69P+8ZhrK+nxzeg/iqurjsjzTrQed2IT+l3QtcaoYpvsRSDm9yQbwviEd/1cupLSLrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -908,7 +908,7 @@
         "@stackblitz/sdk": "^1.11.1",
         "astro-auto-import": "^0.5.2",
         "astro-broken-links-checker": "^1.1.0",
-        "js-yaml": "^5.2.2",
+        "js-yaml": "^5.2.3",
         "lz-string": "^1.5.0",
         "rehype-autolink-headings": "^7.1.0",
         "unist-util-visit": "^5.1.0",
@@ -917,7 +917,7 @@
       "peerDependencies": {
         "@astrojs/markdown-remark": "^7.2.0",
         "@astrojs/mdx": "^7.0.5",
-        "astro": "^7.1.5"
+        "astro": "^7.1.6"
       }
     },
     "node_modules/@coreui/astro-docs/node_modules/js-yaml": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "devDependencies": {
     "@astrojs/mdx": "^7.0.3",
-    "@coreui/astro-docs": "0.1.4",
+    "@coreui/astro-docs": "0.1.5",
     "@eslint/markdown": "^7.5.1",
     "@floating-ui/dom": "^1.8.0",
     "@rollup/plugin-replace": "^6.0.3",


### PR DESCRIPTION
Callouts stop being grey on v6.

The engine painted the tint with `rgba(var(--cui-<variant>-rgb), .1)`, and v6 has no `-rgb` variables at all — it rebuilds those same utility classes on `color-mix()`. The declaration was therefore invalid at computed-value time and every callout on every page fell through to the `--cui-gray-100` fallback, keeping only its coloured left border. 0.1.5 composes the colour from `bg-<color> bg-opacity-10 border-start-<color>` and leaves only the geometry in the stylesheet.

Measured on this repo's docs, before → after:

| | background | border |
| --- | --- | --- |
| info callout | `rgb(243, 244, 247)` | `rgb(51, 153, 255)` |
| after | `color(srgb 0.2 0.6 1 / 0.1)` | `rgb(51, 153, 255)` |

Callout links also go back to `$blue-600`: the engine set only `--cui-link-color-rgb`, which v6 does not read, so they were rendering in the docs' default violet.

## Verification

- Lock diff is the engine entry and nothing else — 1165 entries before and after, none added, none removed, no platform optionals pruned. `npm ci` accepts it.
- `docs:build`: **146 pages, 0 errors**, callouts emitted as `docs-callout bg-<color> bg-opacity-10 border-start-<color>` (91 info, 51 warning, 4 danger).
- The engine change was diffed against these docs at three viewport widths before release — 51,210 elements, ~21.1M computed-property comparisons — with callouts and their links as the only rendered differences.