### PR TITLE
fix(Reboot): stop hiding until-found content outright

### DIFF
--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -626,9 +626,13 @@ $th-font-weight:       null !default;
 
   // Hidden attribute
   //
-  // Always hide an element with the `hidden` HTML attribute.
+  // Always hide an element with the `hidden` HTML attribute. The user agent
+  // already does, but from its own origin, which any author rule setting
+  // `display` outruns — a `hidden` element carrying `.d-flex` would show.
+  // `until-found` is excluded the way the user agent stylesheet excludes it:
+  // that content stays laid out so find-in-page can reach and reveal it.
 
-  [hidden] {
+  [hidden]:not([hidden="until-found"]) {
     display: none !important;
   }
 }


### PR DESCRIPTION
Reboot restates the user agent's `[hidden]` rule, and in doing so drops the exclusion the user agent carries, which silently disables `hidden="until-found"` for every project built on CoreUI.

## Why the rule exists at all

Not as a duplicate of the user agent. Author styles beat the UA origin whatever the specificity, so the UA's `[hidden]` rule loses to any author rule that sets `display` — including our own utilities and component classes. Measured on a bare page with no framework CSS:

| | `display` | rendered |
| --- | --- | --- |
| `hidden` | `none` | no |
| `hidden` + `.d-flex` | `flex` | **yes** |
| `hidden` + `.card` | `flex` | **yes** |

So the rule is there to fix a collision the framework itself creates. That reasoning is now a comment in the file, because it is not obvious from the declaration and it is the sort of thing that gets "cleaned up" later.

## What was wrong

The UA hides `[hidden]:not([hidden=until-found])`. The exclusion is deliberate: `until-found` content stays laid out with `content-visibility: hidden`, which is exactly what lets find-in-page reach it, reveal it and fire `beforematch`.

Our restatement matched every `[hidden]`, with `!important`. So on any CoreUI page `hidden="until-found"` collapsed to `display: none`: no error, no warning, the feature simply did nothing — and the `!important` left authors no way back short of raising specificity against the framework.

## After

Excluded the same way the user agent excludes it. Verified against the built stylesheet, not a hand-written one:

| | `display` | `content-visibility` | rendered |
| --- | --- | --- | --- |
| `hidden` | `none` | — | no |
| `hidden` + `.d-flex` | `none` | — | no |
| `hidden` + `.card` | `none` | — | no |
| `hidden="until-found"` | `block` | `hidden` | no |

Plain `hidden` still outruns the utilities, which is the whole point of the rule, and `until-found` behaves as the platform intends.

Nothing else changes: for a `hidden` attribute without a value the two selectors are equivalent.

`hidden="until-found"` is interoperable as of Firefox 148 and Safari 26.2, Chrome having shipped it in 102. Below those it degrades to plain `hidden`, which is what the markup meant anyway.

Upstream Bootstrap carries the same line and the same defect.
