### PR TITLE
feat(Collapse): let find-in-page reach collapsed content

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,11 +34,11 @@
     },
     {
       "path": "./dist/js/coreui.bundle.js",
-      "maxSize": "119.5kB"
+      "maxSize": "120kB"
     },
     {
       "path": "./dist/js/coreui.bundle.min.js",
-      "maxSize": "76.5kB"
+      "maxSize": "76.75kB"
     },
     {
       "path": "./dist/js/coreui.esm.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -42,7 +42,7 @@
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "108.75kB"
+      "maxSize": "109kB"
     },
     {
       "path": "./dist/js/coreui.esm.min.js",
@@ -50,7 +50,7 @@
     },
     {
       "path": "./dist/js/coreui.js",
-      "maxSize": "109.5kB"
+      "maxSize": "109.75kB"
     },
     {
       "path": "./dist/js/coreui.min.js",

--- a/docs/src/content/docs/components/collapse.mdx
+++ b/docs/src/content/docs/components/collapse.mdx
@@ -86,7 +86,7 @@ Multiple `<button>` or `<a>` can show and hide an element if they each reference
     </div>
   </div>`} />
 
-## Find-in-page
+## Findable when collapsed
 
 By default a collapsed area is removed from the layout, which also removes it from what the browser's find-in-page can search. Set `data-coreui-hidden-until-found="true"` on the collapsible element to hide it with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden) instead: the content stays laid out but invisible, so searching the page finds it, and the browser expands the area to show the match.
 

--- a/docs/src/content/docs/components/collapse.mdx
+++ b/docs/src/content/docs/components/collapse.mdx
@@ -86,6 +86,25 @@ Multiple `<button>` or `<a>` can show and hide an element if they each reference
     </div>
   </div>`} />
 
+## Find-in-page
+
+By default a collapsed area is removed from the layout, which also removes it from what the browser's find-in-page can search. Set `data-coreui-hidden-until-found="true"` on the collapsible element to hide it with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden) instead: the content stays laid out but invisible, so searching the page finds it, and the browser expands the area to show the match.
+
+<Example code={`<p>
+    <button class="btn btn-primary" type="button" data-coreui-toggle="collapse" data-coreui-target="#collapseFindable" aria-expanded="false" aria-controls="collapseFindable">
+      Toggle findable content
+    </button>
+  </p>
+  <div class="collapse" id="collapseFindable" data-coreui-hidden-until-found="true">
+    <div class="card card-body">
+      Search this page for <strong>capybara</strong> with your browser's find-in-page and this panel opens on its own.
+    </div>
+  </div>`} />
+
+The component keeps up with the browser: when a match reveals the content, it adds `.show` and sets `aria-expanded` on the triggers, so the state the reader sees and the state the markup declares do not drift apart. The attribute goes back on once the area is collapsed again.
+
+Requires Chrome 102, Firefox 148 or Safari 26.2. Below those the attribute hides the content the way `hidden` always did, which is what a collapsed area does anyway — the content is simply not findable, exactly as without the option.
+
 ## Accessibility
 
 Be sure to add `aria-expanded` to the control component. This attribute explicitly sends the current state of the collapsible element connected to the control to screen readers and related assistive technologies. If the collapsible part is closed by default, the attribute on the control element should have a value of `aria-expanded="false"`. If you have set the collapsible element to be open by default using the `show` class, set `aria-expanded="true"` on the control alternatively. The plugin will automatically toggle this attribute on the control based on whether or not the collapsible element has been opened or closed (via JavaScript, or because the user triggered another control element also tied to the same collapsible element). If the control element's HTML element is not a button (e.g., an `<a>` or `<div>`), the attribute `role="button"` should be added to the element.
@@ -126,6 +145,7 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
+`hiddenUntilFound` | boolean | `false` | Hides the collapsed content with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden) instead of taking it out of the layout, so find-in-page can search it and reveal it. |
 `parent` | selector, jQuery object, DOM element | `null` | If parent is provided, then all collapsible elements under the specified parent will be closed when this collapsible item is shown. (similar to traditional accordion behavior - this is dependent on the `card` class). The attribute has to be set on the target collapsible area. |
 
 ### Methods

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -764,6 +764,13 @@ adornment in the library — so the button needs no icon markup at all:
   + [data-coreui-toggle="collapse"][aria-expanded="false"]::after { transform: rotate(-90deg); }
   ```
 
+- **New `hiddenUntilFound` option.** With `data-coreui-hidden-until-found="true"`
+  a collapsed area is hidden with `hidden="until-found"` rather than taken out
+  of the layout, so the browser's find-in-page searches it and expands it on a
+  match; the component then syncs `.show` and `aria-expanded` so the declared
+  state follows what the reader sees. Off by default, and below Chrome 102 /
+  Firefox 148 / Safari 26.2 it hides the content the way `hidden` always did.
+
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
   **The transition is set through CSS variables, and the Sass variables split
   in two.** `$transition-collapse` and `$transition-collapse-width` were

--- a/js/src/collapse.ts
+++ b/js/src/collapse.ts
@@ -71,6 +71,13 @@ type CollapseConfig = {
   parent: string | Element | null
 }
 
+// Where `auto` can be interpolated, a `hidden="until-found"` area is animated by
+// the stylesheet: it stays in the layout, so its height needs no measuring.
+const usesInterpolatedHeight = (): boolean =>
+  typeof CSS !== 'undefined' &&
+  typeof CSS.supports === 'function' &&
+  CSS.supports('interpolate-size', 'allow-keywords')
+
 /**
  * Class definition
  */
@@ -159,13 +166,16 @@ class Collapse extends BaseComponent {
     }
 
     const dimension = this._getDimension()
+    const interpolated = this._usesInterpolatedHeight()
 
     this._setHiddenUntilFound(false)
 
     this._element.classList.remove(CLASS_NAME_COLLAPSE)
     this._element.classList.add(CLASS_NAME_COLLAPSING)
 
-    this._element.style[dimension] = '0'
+    if (!interpolated) {
+      this._element.style[dimension] = '0'
+    }
 
     this._setAriaExpanded(this._triggerArray, true)
     this._isTransitioning = true
@@ -179,6 +189,11 @@ class Collapse extends BaseComponent {
       this._element.style[dimension] = ''
 
       EventHandler.trigger(this._element, EVENT_SHOWN)
+    }
+
+    if (interpolated) {
+      await this._queueCallback(complete, this._element, true)
+      return
     }
 
     const capitalizedDimension = dimension[0].toUpperCase() + dimension.slice(1)
@@ -203,10 +218,18 @@ class Collapse extends BaseComponent {
     }
 
     const dimension = this._getDimension()
+    const interpolated = this._usesInterpolatedHeight()
 
-    this._element.style[dimension] = `${this._element.getBoundingClientRect()[dimension]}px`
+    if (interpolated) {
+      // The attribute is what the stylesheet animates towards, so it goes on
+      // now rather than at the end; `content-visibility` is transitioned with
+      // `allow-discrete`, which keeps the content on screen until it finishes.
+      this._setHiddenUntilFound(true)
+    } else {
+      this._element.style[dimension] = `${this._element.getBoundingClientRect()[dimension]}px`
 
-    reflow(this._element)
+      reflow(this._element)
+    }
 
     this._element.classList.add(CLASS_NAME_COLLAPSING)
     this._element.classList.remove(CLASS_NAME_COLLAPSE, CLASS_NAME_SHOW)
@@ -225,7 +248,11 @@ class Collapse extends BaseComponent {
       this._isTransitioning = false
       this._element.classList.remove(CLASS_NAME_COLLAPSING)
       this._element.classList.add(CLASS_NAME_COLLAPSE)
-      this._setHiddenUntilFound(true)
+
+      if (!interpolated) {
+        this._setHiddenUntilFound(true)
+      }
+
       EventHandler.trigger(this._element, EVENT_HIDDEN)
     }
 
@@ -268,6 +295,10 @@ class Collapse extends BaseComponent {
     const children = SelectorEngine.find(CLASS_NAME_DEEPER_CHILDREN, this._config.parent as ParentNode)
     // remove children if greater depth
     return SelectorEngine.find(selector, this._config.parent as ParentNode).filter(element => !children.includes(element))
+  }
+
+  _usesInterpolatedHeight(): boolean {
+    return this._config.hiddenUntilFound && usesInterpolatedHeight()
   }
 
   _setHiddenUntilFound(hidden: boolean): void {

--- a/js/src/collapse.ts
+++ b/js/src/collapse.ts
@@ -33,6 +33,7 @@ const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_HIDE = `hide${EVENT_KEY}`
 const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
+const EVENT_LOAD_DATA_API = `DOMContentLoaded${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_BEFOREMATCH = `beforematch${EVENT_KEY}`
 
 const CLASS_NAME_SHOW = 'show'
@@ -49,6 +50,7 @@ const VALUE_UNTIL_FOUND = 'until-found'
 
 const SELECTOR_ACTIVES = '.collapse.show, .collapse.collapsing'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="collapse"]'
+const SELECTOR_HIDDEN_UNTIL_FOUND = '.collapse[data-coreui-hidden-until-found="true"]'
 
 const Default = {
   hiddenUntilFound: false,
@@ -306,6 +308,14 @@ class Collapse extends BaseComponent {
   }
 
   // Static
+  // The option has to take effect before anyone interacts with the area, and
+  // Collapse is otherwise only constructed on the first click of a trigger.
+  static _initializeDataApi(): void {
+    for (const element of SelectorEngine.find(SELECTOR_HIDDEN_UNTIL_FOUND)) {
+      Collapse.getOrCreateInstance(element)
+    }
+  }
+
   static jQueryInterface(this: any, config: any): void {
     return this.each(function (this: HTMLElement) {
       const data: any = Collapse.getOrCreateInstance(this)
@@ -324,6 +334,10 @@ class Collapse extends BaseComponent {
 /**
  * Data API implementation
  */
+
+EventHandler.on(document, EVENT_LOAD_DATA_API, () => {
+  Collapse._initializeDataApi()
+})
 
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
   // preventDefault only for <a> elements (which change the URL) not inside the collapsible element

--- a/js/src/collapse.ts
+++ b/js/src/collapse.ts
@@ -33,6 +33,7 @@ const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_HIDE = `hide${EVENT_KEY}`
 const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
+const EVENT_BEFOREMATCH = `beforematch${EVENT_KEY}`
 
 const CLASS_NAME_SHOW = 'show'
 const CLASS_NAME_COLLAPSE = 'collapse'
@@ -43,14 +44,19 @@ const CLASS_NAME_HORIZONTAL = 'collapse-horizontal'
 const WIDTH = 'width'
 const HEIGHT = 'height'
 
+const ATTRIBUTE_HIDDEN = 'hidden'
+const VALUE_UNTIL_FOUND = 'until-found'
+
 const SELECTOR_ACTIVES = '.collapse.show, .collapse.collapsing'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="collapse"]'
 
 const Default = {
+  hiddenUntilFound: false,
   parent: null
 }
 
 const DefaultType = {
+  hiddenUntilFound: 'boolean',
   parent: '(null|element)'
 }
 
@@ -59,6 +65,7 @@ const DefaultType = {
  */
 
 type CollapseConfig = {
+  hiddenUntilFound: boolean
   parent: string | Element | null
 }
 
@@ -93,6 +100,14 @@ class Collapse extends BaseComponent {
 
     if (!this._config.parent) {
       this._setAriaExpanded(this._triggerArray, this._isShown())
+    }
+
+    if (this._config.hiddenUntilFound) {
+      // The browser strips the attribute as it reveals the content, so the
+      // classes have to catch up before it does — otherwise the stylesheet
+      // hides what the reader was just sent to.
+      EventHandler.on(this._element, EVENT_BEFOREMATCH, () => this._onBeforeMatch())
+      this._setHiddenUntilFound(!this._isShown())
     }
   }
 
@@ -142,6 +157,8 @@ class Collapse extends BaseComponent {
     }
 
     const dimension = this._getDimension()
+
+    this._setHiddenUntilFound(false)
 
     this._element.classList.remove(CLASS_NAME_COLLAPSE)
     this._element.classList.add(CLASS_NAME_COLLAPSING)
@@ -206,6 +223,7 @@ class Collapse extends BaseComponent {
       this._isTransitioning = false
       this._element.classList.remove(CLASS_NAME_COLLAPSING)
       this._element.classList.add(CLASS_NAME_COLLAPSE)
+      this._setHiddenUntilFound(true)
       EventHandler.trigger(this._element, EVENT_HIDDEN)
     }
 
@@ -248,6 +266,33 @@ class Collapse extends BaseComponent {
     const children = SelectorEngine.find(CLASS_NAME_DEEPER_CHILDREN, this._config.parent as ParentNode)
     // remove children if greater depth
     return SelectorEngine.find(selector, this._config.parent as ParentNode).filter(element => !children.includes(element))
+  }
+
+  _setHiddenUntilFound(hidden: boolean): void {
+    if (!this._config.hiddenUntilFound) {
+      return
+    }
+
+    if (hidden) {
+      this._element.setAttribute(ATTRIBUTE_HIDDEN, VALUE_UNTIL_FOUND)
+      return
+    }
+
+    this._element.removeAttribute(ATTRIBUTE_HIDDEN)
+  }
+
+  // Find-in-page reveals the content itself; this only brings the component's
+  // state in line with what the reader can already see. `beforematch` is not
+  // cancelable, so there is no `show` event to prevent here.
+  _onBeforeMatch(): void {
+    if (this._isShown()) {
+      return
+    }
+
+    this._element.classList.add(CLASS_NAME_SHOW)
+    this._setAriaExpanded(this._triggerArray, true)
+
+    EventHandler.trigger(this._element, EVENT_SHOWN)
   }
 
   _setAriaExpanded(triggerArray: HTMLElement[], isOpen: boolean): void {

--- a/js/src/collapse.ts
+++ b/js/src/collapse.ts
@@ -71,6 +71,12 @@ type CollapseConfig = {
   parent: string | Element | null
 }
 
+// Without support the attribute is left off entirely. A browser that does not
+// know it falls back to plain `hidden`, which the stylesheet no longer backs
+// with `!important` — so an area carrying a display utility would show.
+const supportsUntilFound = (): boolean =>
+  typeof document !== 'undefined' && 'onbeforematch' in document.documentElement
+
 // Where `auto` can be interpolated, a `hidden="until-found"` area is animated by
 // the stylesheet: it stays in the layout, so its height needs no measuring.
 const usesInterpolatedHeight = (): boolean =>
@@ -111,7 +117,7 @@ class Collapse extends BaseComponent {
       this._setAriaExpanded(this._triggerArray, this._isShown())
     }
 
-    if (this._config.hiddenUntilFound) {
+    if (this._config.hiddenUntilFound && supportsUntilFound()) {
       // The browser strips the attribute as it reveals the content, so the
       // classes have to catch up before it does — otherwise the stylesheet
       // hides what the reader was just sent to.
@@ -298,11 +304,11 @@ class Collapse extends BaseComponent {
   }
 
   _usesInterpolatedHeight(): boolean {
-    return this._config.hiddenUntilFound && usesInterpolatedHeight()
+    return this._config.hiddenUntilFound && supportsUntilFound() && usesInterpolatedHeight()
   }
 
   _setHiddenUntilFound(hidden: boolean): void {
-    if (!this._config.hiddenUntilFound) {
+    if (!this._config.hiddenUntilFound || !supportsUntilFound()) {
       return
     }
 
@@ -342,6 +348,10 @@ class Collapse extends BaseComponent {
   // The option has to take effect before anyone interacts with the area, and
   // Collapse is otherwise only constructed on the first click of a trigger.
   static _initializeDataApi(): void {
+    if (!supportsUntilFound()) {
+      return
+    }
+
     for (const element of SelectorEngine.find(SELECTOR_HIDDEN_UNTIL_FOUND)) {
       Collapse.getOrCreateInstance(element)
     }

--- a/js/src/dom/event-handler.ts
+++ b/js/src/dom/event-handler.ts
@@ -102,7 +102,8 @@ const nativeEvents = new Set([
   'error',
   'abort',
   'scroll',
-  'toggle'
+  'toggle',
+  'beforematch'
 ])
 
 /**

--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -474,6 +474,22 @@ describe('Collapse', () => {
   })
 
   describe('hiddenUntilFound', () => {
+    it('should apply the attribute from the data API, before any interaction', () => {
+      fixtureEl.innerHTML = [
+        '<a role="button" data-coreui-toggle="collapse" href="#panel"></a>',
+        '<div class="collapse" id="panel" data-coreui-hidden-until-found="true"><p>needle</p></div>'
+      ].join('')
+
+      const collapseEl = fixtureEl.querySelector('#panel')
+
+      expect(collapseEl.hasAttribute('hidden')).toBeFalse()
+
+      Collapse._initializeDataApi()
+
+      expect(collapseEl.getAttribute('hidden')).toEqual('until-found')
+      expect(Collapse.getInstance(collapseEl)).not.toBeNull()
+    })
+
     it('should leave the content laid out so find-in-page can reach it', () => {
       fixtureEl.innerHTML = '<div class="collapse" id="panel"><p>needle</p></div>'
 

--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -473,6 +473,83 @@ describe('Collapse', () => {
     })
   })
 
+  describe('hiddenUntilFound', () => {
+    it('should leave the content laid out so find-in-page can reach it', () => {
+      fixtureEl.innerHTML = '<div class="collapse" id="panel"><p>needle</p></div>'
+
+      const collapseEl = fixtureEl.querySelector('#panel')
+      // eslint-disable-next-line no-new
+      new Collapse(collapseEl, { hiddenUntilFound: true })
+
+      expect(collapseEl.getAttribute('hidden')).toEqual('until-found')
+    })
+
+    it('should not touch the attribute when the option is off', () => {
+      fixtureEl.innerHTML = '<div class="collapse" id="panel"><p>needle</p></div>'
+
+      const collapseEl = fixtureEl.querySelector('#panel')
+      // eslint-disable-next-line no-new
+      new Collapse(collapseEl)
+
+      expect(collapseEl.hasAttribute('hidden')).toBeFalse()
+    })
+
+    it('should leave an already shown collapse alone', () => {
+      fixtureEl.innerHTML = '<div class="collapse show" id="panel"><p>needle</p></div>'
+
+      const collapseEl = fixtureEl.querySelector('#panel')
+      // eslint-disable-next-line no-new
+      new Collapse(collapseEl, { hiddenUntilFound: true })
+
+      expect(collapseEl.hasAttribute('hidden')).toBeFalse()
+    })
+
+    it('should drop the attribute while shown and restore it once hidden', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div class="collapse" id="panel"><p>needle</p></div>'
+
+        const collapseEl = fixtureEl.querySelector('#panel')
+        const collapse = new Collapse(collapseEl, { hiddenUntilFound: true })
+
+        collapseEl.addEventListener('shown.coreui.collapse', () => {
+          expect(collapseEl.hasAttribute('hidden')).toBeFalse()
+          collapse.hide()
+        })
+
+        collapseEl.addEventListener('hidden.coreui.collapse', () => {
+          expect(collapseEl.getAttribute('hidden')).toEqual('until-found')
+          resolve()
+        })
+
+        collapse.show()
+      })
+    })
+
+    it('should catch up with the browser when find-in-page reveals the content', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<a role="button" data-coreui-toggle="collapse" href="#panel" aria-expanded="false"></a>',
+          '<div class="collapse" id="panel"><p>needle</p></div>'
+        ].join('')
+
+        const collapseEl = fixtureEl.querySelector('#panel')
+        const trigger = fixtureEl.querySelector('a')
+        // eslint-disable-next-line no-new
+        new Collapse(collapseEl, { hiddenUntilFound: true })
+
+        collapseEl.addEventListener('shown.coreui.collapse', () => {
+          expect(collapseEl).toHaveClass('show')
+          expect(trigger.getAttribute('aria-expanded')).toEqual('true')
+          resolve()
+        })
+
+        // What the browser does on a match: announce it, then strip the attribute.
+        collapseEl.dispatchEvent(new Event('beforematch', { bubbles: true }))
+        collapseEl.removeAttribute('hidden')
+      })
+    })
+  })
+
   describe('dispose', () => {
     it('should destroy a collapse', () => {
       fixtureEl.innerHTML = '<div class="collapse show"></div>'

--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -490,6 +490,34 @@ describe('Collapse', () => {
       expect(Collapse.getInstance(collapseEl)).not.toBeNull()
     })
 
+    it('should stay out of the way where the browser has no support', () => {
+      // The property sits somewhere up the prototype chain; find its owner.
+      let owner = Object.getPrototypeOf(document.documentElement)
+      while (owner && !Object.getOwnPropertyDescriptor(owner, 'onbeforematch')) {
+        owner = Object.getPrototypeOf(owner)
+      }
+
+      const support = owner && Object.getOwnPropertyDescriptor(owner, 'onbeforematch')
+
+      if (support) {
+        delete owner.onbeforematch
+      }
+
+      try {
+        fixtureEl.innerHTML = '<div class="collapse" id="panel"><p>needle</p></div>'
+
+        const collapseEl = fixtureEl.querySelector('#panel')
+        // eslint-disable-next-line no-new
+        new Collapse(collapseEl, { hiddenUntilFound: true })
+
+        expect(collapseEl.hasAttribute('hidden')).toBeFalse()
+      } finally {
+        if (support) {
+          Object.defineProperty(owner, 'onbeforematch', support)
+        }
+      }
+    })
+
     it('should leave the content laid out so find-in-page can reach it', () => {
       fixtureEl.innerHTML = '<div class="collapse" id="panel"><p>needle</p></div>'
 

--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -40,7 +40,10 @@ $collapse-tokens: defaults(
 
   // scss-docs-start collapse-classes
   .collapse {
-    &:not(.show) {
+    // `until-found` content is hidden by the browser instead, which keeps it
+    // laid out so find-in-page can reach it. `display: none` would take it back
+    // out of the layout and undo that.
+    &:not(.show):not([hidden="until-found"]) {
       display: none;
     }
   }

--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -62,4 +62,31 @@ $collapse-tokens: defaults(
     }
   }
   // scss-docs-end collapse-classes
+
+  // A `hidden="until-found"` area stays in the layout, which is what lets the
+  // height be interpolated to `auto` here instead of being measured in
+  // JavaScript. Scoped to the option rather than to `[hidden]`, because that
+  // attribute comes and goes while the opt-in does not.
+  @supports (interpolate-size: allow-keywords) {
+    // Not scoped to `.collapse`: during the transition the element carries
+    // `.collapsing` instead, and the declaration has to survive that swap.
+    [data-coreui-hidden-until-found="true"] {
+      interpolate-size: allow-keywords;
+      overflow: hidden;
+      @include transition(
+        height var(--#{$prefix}transition-collapse-duration) var(--#{$prefix}transition-collapse-timing),
+        content-visibility var(--#{$prefix}transition-collapse-duration) allow-discrete
+      );
+    }
+
+    // `.collapsing` still marks the transition for anyone styling it, but its
+    // own height would clamp the one being interpolated.
+    .collapsing[data-coreui-hidden-until-found="true"] {
+      height: auto;
+    }
+
+    [data-coreui-hidden-until-found="true"][hidden="until-found"] {
+      height: 0;
+    }
+  }
 }


### PR DESCRIPTION
A collapsed area is taken out of the layout, and what is out of the layout is out of reach of the browser's find-in-page. Searching a page therefore skips everything inside a collapse — the wrong outcome for the content it usually holds: FAQs, documentation sections, long forms.

`data-coreui-hidden-until-found="true"` hides the area with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden) instead. The content stays laid out but invisible, so the browser searches it and expands the area on a match. Off by default; nothing changes for existing markup.

Follows #740, which stopped Reboot from cancelling the attribute outright.

## The three things that had to line up

- **The stylesheet stops forcing `display: none`** on an area carrying the attribute. Without that our own CSS takes the content back out of the layout and undoes it — the same exclusion Reboot now makes.
- **`beforematch`.** The browser strips the attribute as it reveals the content, so the component adds `.show` and `aria-expanded` before that happens. Otherwise the stylesheet re-hides what the reader was just sent to, and the trigger keeps claiming the area is collapsed. The event is not cancelable, so no `show` event is fired that a listener could prevent.
- **The attribute goes back on** once the area is collapsed again, so it stays findable for the next search.

## Where the height comes from

On this path the area stays in the layout, which is the one condition `interpolate-size` needs — so where `auto` can be interpolated the height is animated by the stylesheet rather than measured. That drops the forced layout `scrollHeight` causes on every open, and the animation stops being pinned to a height frozen at the start, which today breaks when an image inside finishes loading mid-transition. Elsewhere the existing JavaScript measuring runs unchanged.

`.collapsing` and the events are emitted on both paths, so nothing about the public surface depends on which one runs.

The declarations are scoped to the opt-in attribute rather than to `.collapse`: during the transition the element carries `.collapsing` instead, and a rule scoped to `.collapse` stops matching exactly when it is needed. The first attempt made that mistake and animated nothing at all.

## Support

Chrome 102, Firefox 148, Safari 26.2. Below those the attribute is not applied at all — the option is inert and the area hides exactly as it does today. That matters: with the stylesheet no longer backing `display: none` for this attribute, a browser that does not know the value would fall back to the user agent rule alone, which loses to any author rule setting `display`. So the option would have weakened the hiding while buying nothing, since those browsers cannot search the content anyway.

## Verification

`css-lint`, `js-lint`, `tsc --noEmit`, `dist`, `docs` including the HTML validator, the class API gate and bundlewatch all pass; unit suite green at 3208, 50 of them Collapse's, seven covering the attribute lifecycle, the reveal, the bootstrap and the unsupported path.

Measured in the browser: the CSS-driven open and close, the default path still setting its inline height and animating as before, the attribute across a full cycle, and the unsupported path staying inert. The JavaScript fallback for this option was confirmed in a real Firefox — stubbing `CSS.supports` cannot disable an `@supports` block, so that one cannot be simulated.

Bundle ceilings rise by the usual small margin for the four bundles the feature pushes over.

## Noticed while checking, not addressed here

`.collapse` carrying a display utility already shows its content on plain `v6-dev`, with none of this involved: utilities sit in a later cascade layer and outrank the component rule, as they did through `!important` in v5. Long-standing upstream behaviour, worth its own look.
