### PR TITLE
docs: correct what jQuery detection does to event listening

### DIFF
--- a/docs/src/content/docs/getting-started/javascript.mdx
+++ b/docs/src/content/docs/getting-started/javascript.mdx
@@ -392,7 +392,7 @@ CoreUI for Bootstrap does not officially support third-party JavaScript librarie
 
 ### jQuery events
 
-CoreUI for Bootstrap will detect jQuery if `jQuery` is present in the `window` object and there is no `data-coreui-no-jquery` attribute set on `<body>`. If jQuery is found, CoreUI for Bootstrap will emit events thanks to jQuery's event system. So if you want to listen to CoreUI for Bootstrap's events, you'll have to use the jQuery methods (`.on`, `.one`) instead of `addEventListener`.
+CoreUI for Bootstrap will detect jQuery if `jQuery` is present in the `window` object and there is no `data-coreui-no-jquery` attribute set on `<body>`. If jQuery is found, CoreUI for Bootstrap will emit events thanks to jQuery's event system. The events are dispatched natively as well, so `addEventListener` keeps working; jQuery's methods (`.on`, `.one`) are an additional way to reach them, not a replacement. A jQuery handler that calls `stopImmediatePropagation()` is the one case that stops the native listeners from running.
 
 ```js
 $('#myTab a').on('shown.coreui.tab', () => {


### PR DESCRIPTION
The **jQuery events** section told readers that once jQuery is on the page they have to listen with `.on`/`.one` **instead of** `addEventListener`. That is not what happens.

Measured with jQuery loaded alongside the bundle, toggling a collapse:

| listener | receives the event |
| --- | --- |
| `addEventListener` | **yes** |
| `jQuery.on()` | yes |

`EventHandler.trigger()` dispatches natively as well — `nativeDispatch` is only skipped when a jQuery handler calls `stopImmediatePropagation()`. So jQuery's methods are an additional way to reach our events, not a replacement for the native one.

The sentence had a real cost either way it was read: rewrite working code that did not need rewriting, or conclude our events are unreachable without jQuery.

The two sentences before it are accurate and stay — `getjQuery()` does require `window.jQuery` and the absence of `data-coreui-no-jquery` on `<body>`.

The replacement also names the one case the original was probably reaching for, since it is real: a jQuery handler calling `stopImmediatePropagation()` does stop the native listeners.

Found while weighing whether to drop jQuery support in v6 as upstream did. It argued against dropping: the bridge is additive and harmless, so the strongest case for removing it was this documented footgun, and the footgun does not exist.
