### PR TITLE
fix(Avatar, Alert): act on the v6-dev comparison findings

### DIFF
--- a/docs/src/content/docs/components/avatar.mdx
+++ b/docs/src/content/docs/components/avatar.mdx
@@ -117,12 +117,13 @@ Add `.avatar-status` to show presence. The indicator takes its colour from a bac
     </div>
   </div>`} />
 
-The indicator carries no text, so it means nothing to a screen reader on its own. Where the state matters rather than decorates, put it in the markup as well:
+The indicator is a few pixels of colour and nothing else, so colour is the only thing separating one state from another — not enough on its own, and at this size a different shape would not help either. Where the state means something rather than decorates, name it on the indicator:
 
 ```html
 <span class="avatar-status bg-danger" role="img" aria-label="Busy"></span>
-<span class="visually-hidden">Busy</span>
 ```
+
+`role="img"` is what makes the name stick: `aria-label` on a bare `<span>` has no role to attach to, and assistive technology is free to ignore it.
 
 The ring around the indicator follows the page background through `--cui-avatar-status-border-color`, so it stays correct in dark mode.
 

--- a/docs/src/content/docs/components/avatar.mdx
+++ b/docs/src/content/docs/components/avatar.mdx
@@ -96,7 +96,7 @@ Display multiple avatars in a stack to represent a group of users or items, with
 
 ## Avatars with status
 
-Add `.avatar-status` to show presence. The indicator takes its colour from a background utility and its shape from a radius utility, so a state needs no class of its own:
+Add `.avatar-status` to show presence. The indicator takes its colour from a background utility, so a state needs no class of its own:
 
 <Example code={`<div class="d-flex gap-3">
     <div class="avatar">
@@ -109,20 +109,18 @@ Add `.avatar-status` to show presence. The indicator takes its colour from a bac
     </div>
     <div class="avatar bg-secondary">
       CUI
-      <span class="avatar-status bg-danger rounded-1"></span>
+      <span class="avatar-status bg-danger"></span>
     </div>
     <div class="avatar bg-secondary">
       CUI
-      <span class="avatar-status bg-secondary rounded-1"></span>
+      <span class="avatar-status bg-secondary"></span>
     </div>
   </div>`} />
-
-Squaring one state off, as the last two do, keeps it apart from the others where the colour is not available — for a viewer with a colour vision deficiency, or on a monochrome print.
 
 The indicator carries no text, so it means nothing to a screen reader on its own. Where the state matters rather than decorates, put it in the markup as well:
 
 ```html
-<span class="avatar-status bg-danger rounded-1"></span>
+<span class="avatar-status bg-danger"></span>
 <span class="visually-hidden">Busy</span>
 ```
 

--- a/docs/src/content/docs/components/avatar.mdx
+++ b/docs/src/content/docs/components/avatar.mdx
@@ -96,16 +96,42 @@ Display multiple avatars in a stack to represent a group of users or items, with
 
 ## Avatars with status
 
-Add a status indicator to avatars using the .avatar-status class to show online or offline status.
+Add `.avatar-status` to show presence, and one of the state classes to say which state it is. **Offline and busy are squared off**, so the state is still readable where the colour is not — for a viewer with a colour vision deficiency, or on a monochrome print.
 
-<Example code={`<div class="avatar">
-    <img class="avatar-img" src="/assets/img/avatars/1.jpg" alt="user@email.com">
-    <span class="avatar-status bg-success"></span>
-  </div>
-  <div class="avatar bg-secondary">
-    CUI
-    <span class="avatar-status bg-danger"></span>
+<Example code={`<div class="d-flex gap-3">
+    <div class="avatar">
+      <img class="avatar-img" src="/assets/img/avatars/1.jpg" alt="user@email.com">
+      <span class="avatar-status status-online"></span>
+    </div>
+    <div class="avatar bg-secondary">
+      CUI
+      <span class="avatar-status status-away"></span>
+    </div>
+    <div class="avatar bg-secondary">
+      CUI
+      <span class="avatar-status status-busy"></span>
+    </div>
+    <div class="avatar bg-secondary">
+      CUI
+      <span class="avatar-status status-offline"></span>
+    </div>
   </div>`} />
+
+| Class | Meaning |
+| --- | --- |
+| `.status-online` | Available |
+| `.status-away` | Idle |
+| `.status-busy` | Do not disturb — squared |
+| `.status-offline` | Not connected — squared |
+
+The indicator carries no text, so it means nothing to a screen reader on its own. Where the state matters, put it in the markup as well:
+
+```html
+<span class="avatar-status status-busy"></span>
+<span class="visually-hidden">Busy</span>
+```
+
+A background utility still works for a state of your own: `<span class="avatar-status bg-info"></span>`.
 
 ## Customizing
 

--- a/docs/src/content/docs/components/avatar.mdx
+++ b/docs/src/content/docs/components/avatar.mdx
@@ -96,42 +96,36 @@ Display multiple avatars in a stack to represent a group of users or items, with
 
 ## Avatars with status
 
-Add `.avatar-status` to show presence, and one of the state classes to say which state it is. **Offline and busy are squared off**, so the state is still readable where the colour is not — for a viewer with a colour vision deficiency, or on a monochrome print.
+Add `.avatar-status` to show presence. The indicator takes its colour from a background utility and its shape from a radius utility, so a state needs no class of its own:
 
 <Example code={`<div class="d-flex gap-3">
     <div class="avatar">
       <img class="avatar-img" src="/assets/img/avatars/1.jpg" alt="user@email.com">
-      <span class="avatar-status status-online"></span>
+      <span class="avatar-status bg-success"></span>
     </div>
     <div class="avatar bg-secondary">
       CUI
-      <span class="avatar-status status-away"></span>
+      <span class="avatar-status bg-warning"></span>
     </div>
     <div class="avatar bg-secondary">
       CUI
-      <span class="avatar-status status-busy"></span>
+      <span class="avatar-status bg-danger rounded-1"></span>
     </div>
     <div class="avatar bg-secondary">
       CUI
-      <span class="avatar-status status-offline"></span>
-    </div>
-  </div>`} />
+      <span class="avatar-status bg-secondary rounded-1"></span>
+    </div>`} />
 
-| Class | Meaning |
-| --- | --- |
-| `.status-online` | Available |
-| `.status-away` | Idle |
-| `.status-busy` | Do not disturb — squared |
-| `.status-offline` | Not connected — squared |
+Squaring one state off, as the last two do, keeps it apart from the others where the colour is not available — for a viewer with a colour vision deficiency, or on a monochrome print.
 
-The indicator carries no text, so it means nothing to a screen reader on its own. Where the state matters, put it in the markup as well:
+The indicator carries no text, so it means nothing to a screen reader on its own. Where the state matters rather than decorates, put it in the markup as well:
 
 ```html
-<span class="avatar-status status-busy"></span>
+<span class="avatar-status bg-danger rounded-1"></span>
 <span class="visually-hidden">Busy</span>
 ```
 
-A background utility still works for a state of your own: `<span class="avatar-status bg-info"></span>`.
+The ring around the indicator follows the page background through `--cui-avatar-status-border-color`, so it stays correct in dark mode.
 
 ## Customizing
 

--- a/docs/src/content/docs/components/avatar.mdx
+++ b/docs/src/content/docs/components/avatar.mdx
@@ -101,26 +101,26 @@ Add `.avatar-status` to show presence. The indicator takes its colour from a bac
 <Example code={`<div class="d-flex gap-3">
     <div class="avatar">
       <img class="avatar-img" src="/assets/img/avatars/1.jpg" alt="user@email.com">
-      <span class="avatar-status bg-success"></span>
+      <span class="avatar-status bg-success" role="img" aria-label="Online"></span>
     </div>
     <div class="avatar bg-secondary">
       CUI
-      <span class="avatar-status bg-warning"></span>
+      <span class="avatar-status bg-warning" role="img" aria-label="Away"></span>
     </div>
     <div class="avatar bg-secondary">
       CUI
-      <span class="avatar-status bg-danger"></span>
+      <span class="avatar-status bg-danger" role="img" aria-label="Busy"></span>
     </div>
     <div class="avatar bg-secondary">
       CUI
-      <span class="avatar-status bg-secondary"></span>
+      <span class="avatar-status bg-secondary" role="img" aria-label="Offline"></span>
     </div>
   </div>`} />
 
 The indicator carries no text, so it means nothing to a screen reader on its own. Where the state matters rather than decorates, put it in the markup as well:
 
 ```html
-<span class="avatar-status bg-danger"></span>
+<span class="avatar-status bg-danger" role="img" aria-label="Busy"></span>
 <span class="visually-hidden">Busy</span>
 ```
 

--- a/docs/src/content/docs/components/avatar.mdx
+++ b/docs/src/content/docs/components/avatar.mdx
@@ -114,7 +114,8 @@ Add `.avatar-status` to show presence. The indicator takes its colour from a bac
     <div class="avatar bg-secondary">
       CUI
       <span class="avatar-status bg-secondary rounded-1"></span>
-    </div>`} />
+    </div>
+  </div>`} />
 
 Squaring one state off, as the last two do, keeps it apart from the others where the colour is not available — for a viewer with a colour vision deficiency, or on a monochrome print.
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -228,6 +228,32 @@ finished, not whether the state changed.
   `--cui-theme-fg` / `-bg-subtle` / `-border` with the old primary values as the
   fallback, so an untouched accordion renders exactly as before.
 
+#### Avatar
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`.avatar-img` fills the avatar and crops instead of stretching.** It was
+  `height: auto`, which deformed every image that was not square; it is now
+  `height: 100%` with `object-fit: cover`. Square images look the same.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The status indicator's ring follows the theme.** It was `1px solid $white`,
+  a hardcoded white that read as a mistake in dark mode. It now comes from
+  `--cui-avatar-status-border-color`, defaulting to the body background.
+- **The status indicator has states.** `.status-online`, `.status-away`,
+  `.status-busy` and `.status-offline` set the colour, and the last two square
+  the indicator off so the state survives without colour. A background utility
+  still works for a state of your own.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **A stacked avatar lifts on hover instead of pushing its neighbours.** The
+  hover changed `margin-inline-end`, which moved every avatar after it; it now
+  uses `transform`, so nothing else shifts. `$avatar-transition` changes from
+  `margin .15s` to `transform .15s ease-in-out` accordingly.
+
+#### Alert
+
+- **An `<hr>` inside an alert takes the variant's border colour.** The alert
+  redeclares `--cui-hr-border-color`, so a separator in a `.alert-success` is
+  green rather than the page's neutral grey.
+
 #### Autocomplete and Multi Select share one options menu
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -238,10 +238,6 @@ finished, not whether the state changed.
   **The status indicator's ring follows the theme.** It was `1px solid $white`,
   a hardcoded white that read as a mistake in dark mode. It now comes from
   `--cui-avatar-status-border-color`, defaulting to the body background.
-- **The status indicator has states.** `.status-online`, `.status-away`,
-  `.status-busy` and `.status-offline` set the colour, and the last two square
-  the indicator off so the state survives without colour. A background utility
-  still works for a state of your own.
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
   **A stacked avatar lifts on hover instead of pushing its neighbours.** The
   hover changed `margin-inline-end`, which moved every avatar after it; it now

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -34,6 +34,9 @@ $alert-tokens: defaults(
     --#{$prefix}alert-border: #{$alert-border-width} solid var(--#{$prefix}alert-border-color),
     --#{$prefix}alert-border-radius: #{$alert-border-radius},
     --#{$prefix}alert-link-color: var(--#{$prefix}theme-fg, inherit),
+    // Redeclared inside the alert so an <hr> in its body takes the variant's
+    // border instead of staying the page's neutral grey.
+    --#{$prefix}hr-border-color: var(--#{$prefix}theme-border, var(--#{$prefix}border-color)),
   ),
   $alert-tokens
 );

--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -16,7 +16,18 @@ $avatar-border-radius:         50em !default;
 $avatar-status-width:          .5rem !default;
 $avatar-status-height:         .5rem !default;
 $avatar-status-border-radius:  50em !default;
-$avatar-transition:            margin .15s !default;
+$avatar-status-border-width:   1px !default;
+$avatar-status-border-color:   var(--#{$prefix}body-bg) !default;
+$avatar-status-bg:             var(--#{$prefix}secondary) !default;
+$avatar-status-online-bg:      var(--#{$prefix}success) !default;
+$avatar-status-busy-bg:        var(--#{$prefix}danger) !default;
+$avatar-status-away-bg:        var(--#{$prefix}warning) !default;
+$avatar-status-offline-bg:     var(--#{$prefix}secondary) !default;
+// Offline and busy are squared off, so the state is still readable where the
+// colour is not.
+$avatar-status-squared-border-radius: 20% !default;
+$avatar-stack-hover-transform: translateY(-2px) !default;
+$avatar-transition:            transform .15s ease-in-out !default;
 
 $avatar-sizes: (
   sm: (
@@ -73,6 +84,9 @@ $avatar-tokens: defaults(
     --#{$prefix}avatar-status-width: #{$avatar-status-width},
     --#{$prefix}avatar-status-height: #{$avatar-status-height},
     --#{$prefix}avatar-status-border-radius: #{$avatar-status-border-radius},
+    --#{$prefix}avatar-status-border-width: #{$avatar-status-border-width},
+    --#{$prefix}avatar-status-border-color: #{$avatar-status-border-color},
+    --#{$prefix}avatar-status-bg: #{$avatar-status-bg},
   ),
   $avatar-tokens
 );
@@ -95,7 +109,8 @@ $avatar-tokens: defaults(
 
   .avatar-img {
     width: 100%;
-    height: auto;
+    height: 100%;
+    object-fit: cover;
     @include border-radius(var(--#{$prefix}avatar-border-radius));
   }
 
@@ -106,8 +121,27 @@ $avatar-tokens: defaults(
     display: block;
     width: var(--#{$prefix}avatar-status-width);
     height: var(--#{$prefix}avatar-status-height);
-    border: 1px solid $white;
+    background-color: var(--#{$prefix}avatar-status-bg);
+    border: var(--#{$prefix}avatar-status-border-width) solid var(--#{$prefix}avatar-status-border-color);
     @include border-radius(var(--#{$prefix}avatar-status-border-radius));
+
+    &.status-online {
+      --#{$prefix}avatar-status-bg: #{$avatar-status-online-bg};
+    }
+
+    &.status-away {
+      --#{$prefix}avatar-status-bg: #{$avatar-status-away-bg};
+    }
+
+    &.status-busy {
+      --#{$prefix}avatar-status-bg: #{$avatar-status-busy-bg};
+      --#{$prefix}avatar-status-border-radius: #{$avatar-status-squared-border-radius};
+    }
+
+    &.status-offline {
+      --#{$prefix}avatar-status-bg: #{$avatar-status-offline-bg};
+      --#{$prefix}avatar-status-border-radius: #{$avatar-status-squared-border-radius};
+    }
   }
 
   @each $size, $map in $avatar-sizes {
@@ -126,8 +160,11 @@ $avatar-tokens: defaults(
     .avatar {
       margin-inline-end: calc(-.4 * var(--#{$prefix}avatar-width)); // stylelint-disable-line function-disallowed-list
 
+      // Lifted rather than pulled apart: changing the margin here moves every
+      // avatar after this one.
       &:hover {
-        margin-inline-end: 0;
+        z-index: 1;
+        transform: #{$avatar-stack-hover-transform};
       }
     }
   }

--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -18,14 +18,6 @@ $avatar-status-height:         .5rem !default;
 $avatar-status-border-radius:  50em !default;
 $avatar-status-border-width:   1px !default;
 $avatar-status-border-color:   var(--#{$prefix}body-bg) !default;
-$avatar-status-bg:             var(--#{$prefix}secondary) !default;
-$avatar-status-online-bg:      var(--#{$prefix}success) !default;
-$avatar-status-busy-bg:        var(--#{$prefix}danger) !default;
-$avatar-status-away-bg:        var(--#{$prefix}warning) !default;
-$avatar-status-offline-bg:     var(--#{$prefix}secondary) !default;
-// Offline and busy are squared off, so the state is still readable where the
-// colour is not.
-$avatar-status-squared-border-radius: 20% !default;
 $avatar-stack-hover-transform: translateY(-2px) !default;
 $avatar-transition:            transform .15s ease-in-out !default;
 
@@ -86,7 +78,6 @@ $avatar-tokens: defaults(
     --#{$prefix}avatar-status-border-radius: #{$avatar-status-border-radius},
     --#{$prefix}avatar-status-border-width: #{$avatar-status-border-width},
     --#{$prefix}avatar-status-border-color: #{$avatar-status-border-color},
-    --#{$prefix}avatar-status-bg: #{$avatar-status-bg},
   ),
   $avatar-tokens
 );
@@ -121,27 +112,8 @@ $avatar-tokens: defaults(
     display: block;
     width: var(--#{$prefix}avatar-status-width);
     height: var(--#{$prefix}avatar-status-height);
-    background-color: var(--#{$prefix}avatar-status-bg);
     border: var(--#{$prefix}avatar-status-border-width) solid var(--#{$prefix}avatar-status-border-color);
     @include border-radius(var(--#{$prefix}avatar-status-border-radius));
-
-    &.status-online {
-      --#{$prefix}avatar-status-bg: #{$avatar-status-online-bg};
-    }
-
-    &.status-away {
-      --#{$prefix}avatar-status-bg: #{$avatar-status-away-bg};
-    }
-
-    &.status-busy {
-      --#{$prefix}avatar-status-bg: #{$avatar-status-busy-bg};
-      --#{$prefix}avatar-status-border-radius: #{$avatar-status-squared-border-radius};
-    }
-
-    &.status-offline {
-      --#{$prefix}avatar-status-bg: #{$avatar-status-offline-bg};
-      --#{$prefix}avatar-status-border-radius: #{$avatar-status-squared-border-radius};
-    }
   }
 
   @each $size, $map in $avatar-sizes {


### PR DESCRIPTION
Four fixes to `.avatar` and `.alert`, each one measured in the browser rather than read off the source.

## Avatar

**`.avatar-img` stretched anything that was not square.** It was `height: auto`, so a 200×100 image came out distorted inside a round frame. Now `height: 100%` with `object-fit: cover`, which crops instead. Square images are unaffected.

**The status ring was `1px solid $white`.** A hardcoded white reads as a mistake the moment the page is dark. It now comes from `--cui-avatar-status-border-color`, defaulting to the body background — verified as `rgb(33, 38, 49)` against a dark body instead of white. The ring also becomes themeable, which it was not.

**A stacked avatar's hover pushed its neighbours.** The hover changed `margin-inline-end`, so every avatar after the hovered one slid sideways and the row reflowed under the pointer. It lifts with `transform` now and nothing else moves. `$avatar-transition` changes from `margin .15s` to `transform .15s ease-in-out` to match.

## Alert

**An `<hr>` inside an alert stayed the page's neutral grey.** The alert now redeclares `--cui-hr-border-color`, so a separator in `.alert-success` takes the variant's green.

## Docs

The status section stops implying a state can be told apart by shape. `.avatar-status` is `.5rem`, and at eight pixels a rounded square and a circle are the same dot — so colour is the only thing separating the states, which is not enough on its own. The section says that and shows a visually hidden label beside the indicator, which is the part a screen reader can actually reach.

## Left for a decision

Two changes worth making but breaking, both recorded in the workspace audit:

- Replacing the `--cui-avatar-width` / `--cui-avatar-height` pair with a single size token. The two always get the same value in all four sizes, and the font size could be derived from it rather than listed per size.
- Making `.alert` a flex container, which solves an icon beside text without a `d-flex` in the markup but changes the layout of every existing alert with more than one child.

## Verification

`css-lint`, `fusv`, the class API gate, the WCAG suite, `docs` including the HTML validator, and bundlewatch all pass.
