### PR TITLE
feat(Badge): three variants on the theme slots, and a badge that stands on its own

### DIFF
--- a/docs/src/content/docs/components/badge.mdx
+++ b/docs/src/content/docs/components/badge.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bootstrap 5 Badges"
 name: "Badges"
-description: "Bootstrap badge is small count and labeling components."
+description: "Small components for indicating status and counts, or labelling items."
 otherFrameworks:
   - badge
 ---
@@ -10,23 +10,32 @@ import { getData } from '@coreui/astro-docs/data'
 
 ## Examples
 
-Bootstrap badge scale to suit the size of the parent element by using relative font sizing and `em` units.
+Badges are tiny, static display components used for adding context to other elements. They can be used as part of navigation, buttons, and more to provide a counter or label. Badges scale to match the size of the immediate parent element by using relative font sizing and `em` units.
+
+Badges come in three variants: solid (default), subtle, and outline. A badge without a `.theme-*` class stays neutral.
+
+<Example code={`<span class="badge">New</span>
+  <span class="badge theme-primary">New</span>
+  <span class="badge badge-subtle theme-primary">New</span>
+  <span class="badge badge-outline theme-primary">New</span>`} />
 
 ### Headings
 
-<Example code={`<h1>Example heading <span class="badge text-bg-secondary">New</span></h1>
-  <h2>Example heading <span class="badge text-bg-secondary">New</span></h2>
-  <h3>Example heading <span class="badge text-bg-secondary">New</span></h3>
-  <h4>Example heading <span class="badge text-bg-secondary">New</span></h4>
-  <h5>Example heading <span class="badge text-bg-secondary">New</span></h5>
-  <h6>Example heading <span class="badge text-bg-secondary">New</span></h6>`} />
+Badges adapt to the `font-size` of the parent element, down to a floor that keeps them legible.
+
+<Example code={`<h1>Example heading <span class="badge">New</span></h1>
+  <h2>Example heading <span class="badge">New</span></h2>
+  <h3>Example heading <span class="badge">New</span></h3>
+  <h4>Example heading <span class="badge">New</span></h4>
+  <h5>Example heading <span class="badge">New</span></h5>
+  <h6>Example heading <span class="badge">New</span></h6>`} />
 
 ### Buttons
 
 Badges can be used as part of links or buttons to provide a counter.
 
 <Example code={`<button type="button" class="btn btn-primary">
-    Notifications <span class="badge text-bg-secondary">4</span>
+    Notifications <span class="badge theme-danger">4</span>
   </button>`} />
 
 Remark that depending on how you use them, badges may be complicated for users of screen readers and related assistive technologies.
@@ -39,7 +48,7 @@ Use utilities to modify a `.badge` and position it in the corner of a link or bu
 
 <Example code={`<button type="button" class="btn btn-primary position-relative">
     Inbox
-    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">
+    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill theme-danger">
       99+
       <span class="visually-hidden">unread messages</span>
     </span>
@@ -54,11 +63,21 @@ You can also replace the `.badge` class with a few more utilities without a coun
     </span>
   </button>`} />
 
-## Contextual variations
+### Sizes
 
-Add any of the below-mentioned classes to modify the presentation of a badge. Please note that when using CoreUI for Bootstrap's default `.bg-light`, you'll likely need a text color utility like `.text-dark` for proper styling. This is because background utilities do not set anything but `background-color`.
+Add `.badge-sm` or `.badge-lg` to change the padding and the minimum height.
 
-<Example code={getData('theme-colors').map((c) => `<span class="badge text-bg-${c.name}">${c.title}</span>`)} />
+<Example code={`<span class="badge badge-sm theme-primary">Small</span>
+  <span class="badge theme-primary">Default</span>
+  <span class="badge badge-lg theme-primary">Large</span>`} />
+
+## Variants
+
+Use the contextual `.theme-{color}` classes to apply a semantic theme color to badges. Combine them with `.badge-subtle` or `.badge-outline` for the other two variants.
+
+<Example code={getData('theme-colors').map((c) => `<span class="badge theme-${c.name}">${c.title}</span>`)} />
+<Example code={getData('theme-colors').map((c) => `<span class="badge badge-subtle theme-${c.name}">${c.title}</span>`)} />
+<Example code={getData('theme-colors').map((c) => `<span class="badge badge-outline theme-${c.name}">${c.title}</span>`)} />
 
 <Callout color="info">
 ##### Conveying meaning to assistive technologies
@@ -70,7 +89,7 @@ Relying on color to convey meaning creates a visual cue that assistive technolog
 
 Apply the `.rounded-pill` modifier class to make badges rounded.
 
-<Example code={getData('theme-colors').map((c) => `<span class="badge rounded-pill text-bg-${c.name}">${c.title}</span>`)} />
+<Example code={getData('theme-colors').map((c) => `<span class="badge rounded-pill theme-${c.name}">${c.title}</span>`)} />
 
 ## Customizing
 
@@ -83,3 +102,7 @@ Badges use local CSS variables on `.badge` for enhanced real-time customization.
 ### SASS variables
 
 <ScssDocs file="scss/_badge.scss" capture="badge-variables" />
+
+Each entry in the variants map names the theme role every token reads, so adding a variant takes a map entry rather than a new rule.
+
+<ScssDocs file="scss/_badge.scss" capture="badge-variants" />

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -267,6 +267,38 @@ finished, not whether the state changed.
   redeclares `--cui-hr-border-color`, so a separator in a `.alert-success` is
   green rather than the page's neutral grey.
 
+#### Badge
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **Colour comes from `.theme-*`, and `.badge-*` now names the variant.** A bare
+  `.badge` used to be white text with no background of its own, so it was
+  invisible until a `.text-bg-*` utility supplied both. It renders neutral on
+  its own now — `--cui-badge-color` is `inherit` and `--cui-badge-bg` is
+  `--cui-secondary-bg` — and a `.theme-*` class colours it:
+  `<span class="badge theme-danger">`. The `.badge-*` namespace carries the
+  three variants instead: solid (default), `.badge-subtle` and
+  `.badge-outline`, each mapping the same theme roles.
+
+  `.text-bg-*` still works and still sets both properties, so existing markup
+  keeps rendering. Markup that paired `.badge` with a background utility alone
+  (`<span class="badge bg-danger">`) now shows the inherited text colour on
+  that background instead of white — swap it for `.theme-danger` or add a text
+  colour utility.
+
+- **The badge lays itself out.** `display` is `inline-flex` with
+  `--cui-badge-gap` between children and `--cui-badge-min-height` as the floor,
+  so an icon next to a label needs no spacing utility and badges keep one
+  height across a table or a list.
+
+- **The font size has a legibility floor.** `--cui-badge-font-size` is
+  `clamp(12px, .75em, .75em)`, so a badge inside small text stops shrinking at
+  12px while still scaling up with a larger parent.
+
+- **New: `--cui-badge-border-width` / `--cui-badge-border-color` (transparent),
+  `.badge-lg`, and a link reset.** The border tokens are what `.badge-outline`
+  switches, `.badge-lg` joins `.badge-sm` on the size scale, and `a.badge` no
+  longer inherits the underline from the reboot.
+
 #### Autocomplete and Multi Select share one options menu
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -3,57 +3,92 @@
 @use "mixins/tokens" as *;
 @use "config" as *;
 
-// stylelint-disable custom-property-no-missing-var-function
-
 // scss-docs-start badge-variables
+$badge-gap:                         .375em !default;
+$badge-min-height:                  1.375rem !default;
+$badge-padding-y:                   .25em !default;
+$badge-padding-x:                   .625em !default;
 $badge-font-size:                   .75em !default;
-$badge-font-weight:                 $font-weight-bold !default;
-$badge-color:                       $white !default;
-$badge-padding-y:                   .35em !default;
-$badge-padding-x:                   .65em !default;
+$badge-font-size-floor:             12px !default;
+$badge-font-weight:                 $font-weight-semibold !default;
+$badge-color:                       inherit !default;
+$badge-bg:                          var(--#{$prefix}secondary-bg) !default;
+$badge-border-width:                var(--#{$prefix}border-width) !default;
+$badge-border-color:                transparent !default;
 $badge-border-radius:               var(--#{$prefix}border-radius) !default;
 
-$badge-font-size-sm:                .65em !default;
-$badge-padding-y-sm:                .3em !default;
+$badge-min-height-sm:               1.125rem !default;
+$badge-padding-y-sm:                .2em !default;
 $badge-padding-x-sm:                .5em !default;
+$badge-font-size-sm:                .65em !default;
+
+$badge-min-height-lg:               1.75rem !default;
+$badge-padding-y-lg:                .375em !default;
+$badge-padding-x-lg:                .875em !default;
+$badge-font-size-lg:                .875em !default;
 // scss-docs-end badge-variables
 
 $badge-tokens: () !default;
 
+// stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
+
 // scss-docs-start badge-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $badge-tokens: defaults(
   (
+    --#{$prefix}badge-gap: #{$badge-gap},
+    --#{$prefix}badge-min-height: #{$badge-min-height},
     --#{$prefix}badge-padding-x: #{$badge-padding-x},
     --#{$prefix}badge-padding-y: #{$badge-padding-y},
+    --#{$prefix}badge-font-size: clamp(#{$badge-font-size-floor}, #{$badge-font-size}, #{$badge-font-size}),
     --#{$prefix}badge-font-weight: #{$badge-font-weight},
-    --#{$prefix}badge-color: #{$badge-color},
+    --#{$prefix}badge-color: var(--#{$prefix}theme-contrast, #{$badge-color}),
+    --#{$prefix}badge-bg: var(--#{$prefix}theme-base, #{$badge-bg}),
+    --#{$prefix}badge-border-width: #{$badge-border-width},
+    --#{$prefix}badge-border-color: #{$badge-border-color},
     --#{$prefix}badge-border-radius: #{$badge-border-radius},
-    --#{$prefix}badge-font-size: $badge-font-size,
   ),
   $badge-tokens
 );
 // scss-docs-end badge-css-vars
-@layer components {
-  // Base class
-  //
-  // Requires one of the contextual, color modifier classes for `color` and
-  // `background-color`.
 
+// scss-docs-start badge-variants
+$badge-variants: (
+  "subtle": (
+    "color": "fg",
+    "bg": "bg-subtle",
+    "border-color": "transparent"
+  ),
+  "outline": (
+    "color": "fg",
+    "bg": "transparent",
+    "border-color": "border"
+  )
+) !default;
+// scss-docs-end badge-variants
+
+// stylelint-enable custom-property-no-missing-var-function, scss/dollar-variable-default
+
+@layer components {
   .badge {
     @include tokens($badge-tokens);
 
-    display: inline-block;
+    display: inline-flex;
+    gap: var(--#{$prefix}badge-gap);
+    align-items: center;
+    justify-content: center;
+    min-height: var(--#{$prefix}badge-min-height);
     padding: var(--#{$prefix}badge-padding-y) var(--#{$prefix}badge-padding-x);
     font-size: var(--#{$prefix}badge-font-size);
     font-weight: var(--#{$prefix}badge-font-weight);
     line-height: 1;
     color: var(--#{$prefix}badge-color);
     text-align: center;
+    text-decoration: none;
     white-space: nowrap;
     vertical-align: baseline;
+    border: var(--#{$prefix}badge-border-width) solid var(--#{$prefix}badge-border-color);
     border-radius: var(--#{$prefix}badge-border-radius, 0); // stylelint-disable-line property-disallowed-list
-    @include gradient-bg();
+    @include gradient-bg(var(--#{$prefix}badge-bg));
 
     // Empty badges collapse automatically
     &:empty {
@@ -67,13 +102,35 @@ $badge-tokens: defaults(
     top: -1px;
   }
 
+  // scss-docs-start badge-modifiers
+  @each $variant, $properties in $badge-variants {
+    .badge-#{$variant} {
+      @each $property, $value in $properties {
+        @if $value == "transparent" {
+          --#{$prefix}badge-#{$property}: transparent;
+        } @else {
+          --#{$prefix}badge-#{$property}: var(--#{$prefix}theme-#{$value});
+        }
+      }
+    }
+  }
+  // scss-docs-end badge-modifiers
+
   //
   // Badge Sizes
   //
 
   .badge-sm {
+    --#{$prefix}badge-min-height: #{$badge-min-height-sm};
     --#{$prefix}badge-padding-x: #{$badge-padding-x-sm};
     --#{$prefix}badge-padding-y: #{$badge-padding-y-sm};
-    font-size: $badge-font-size-sm;
+    --#{$prefix}badge-font-size: clamp(#{$badge-font-size-floor}, #{$badge-font-size-sm}, #{$badge-font-size-sm});
+  }
+
+  .badge-lg {
+    --#{$prefix}badge-min-height: #{$badge-min-height-lg};
+    --#{$prefix}badge-padding-x: #{$badge-padding-x-lg};
+    --#{$prefix}badge-padding-y: #{$badge-padding-y-lg};
+    --#{$prefix}badge-font-size: clamp(#{$badge-font-size-floor}, #{$badge-font-size-lg}, #{$badge-font-size-lg});
   }
 }


### PR DESCRIPTION
- The base badge renders neutral by itself: `--cui-badge-color` is `inherit` and `--cui-badge-bg` is `--cui-secondary-bg`, so a bare `.badge` is legible instead of white text with no background. Color comes from a `.theme-*` class.
- `.badge-*` carries the variant axis: solid (default), `.badge-subtle` and `.badge-outline`, each mapping the same theme roles through `$badge-variants`, so a new variant is a map entry rather than a rule. `.text-bg-*` keeps working.
- The badge lays itself out: `inline-flex` with `--cui-badge-gap` and `--cui-badge-min-height`, so an icon beside a label needs no spacing utility and badges keep one height across a list or table.
- `--cui-badge-font-size` gets a 12px floor, so a badge inside small text stays legible while still scaling with a larger parent.
- New border tokens (what `.badge-outline` switches), `.badge-lg` beside `.badge-sm`, and no underline when the badge is a link.
- Docs rewritten around the three variants, plus a Sizes section and a migration guide entry.