### PR TITLE
docs(Accordion): keep the lint pragma out of the documented CSS variables snippet

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -51,8 +51,9 @@ $accordion-button-icon:         url("data:image/svg+xml,<svg xmlns='http://www.w
 
 $accordion-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start accordion-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $accordion-tokens: defaults(
   (
     --#{$prefix}accordion-color: #{$accordion-color},
@@ -84,6 +85,9 @@ $accordion-tokens: defaults(
   $accordion-tokens
 );
 // scss-docs-end accordion-css-vars
+
+// stylelint-enable scss/dollar-variable-default
+
 @layer components {
   //
   // Base styles


### PR DESCRIPTION
The `scss-docs` capture starts at the marker, so the `stylelint-disable-next-line` sitting right under `// scss-docs-start accordion-css-vars` was rendered as the first line of the CSS variables snippet on the Accordion page.

It moves above the marker and becomes a `disable` / `enable` pair around the token map, so the documented snippet starts at the declaration. No CSS output change.

The same pattern sits in ~30 other component files — those are a separate sweep.