### PR TITLE
fix(Accordion): shape the header's corners from the accordion's own radius token

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -227,6 +227,15 @@ finished, not whether the state changed.
 - **`.theme-{color}` tints the open items.** The active tokens resolve through
   `--cui-theme-fg` / `-bg-subtle` / `-border` with the old primary values as the
   fallback, so an untouched accordion renders exactly as before.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`--cui-accordion-inner-border-radius` is gone; the header's corners follow
+  `--cui-accordion-border-radius`.** The token was computed from the global
+  `--cui-border-radius` when the stylesheet was built, so setting
+  `--cui-accordion-border-radius` rounded the item while the header inside kept
+  the page's default radius. The two corners are subtracted where they are
+  used — `calc(var(--cui-accordion-border-radius) - var(--cui-accordion-border-width))`
+  — so one token now shapes the whole item. Defaults render as before; drop any
+  override of the removed variable.
 
 #### Avatar
 

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -1,7 +1,6 @@
 @use "buttons/button" as *;
 @use "functions/defaults" as *;
 @use "functions/escape-svg" as *;
-@use "functions/math" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/mask-icon" as *;
 @use "mixins/tokens" as *;
@@ -17,7 +16,6 @@ $accordion-bg:                            var(--#{$prefix}body-bg) !default;
 $accordion-border-width:                  var(--#{$prefix}border-width) !default;
 $accordion-border-color:                  var(--#{$prefix}border-color) !default;
 $accordion-border-radius:                 var(--#{$prefix}border-radius) !default;
-$accordion-inner-border-radius:           subtract($accordion-border-radius, $accordion-border-width) !default;
 
 $accordion-body-padding-y:                $accordion-padding-y !default;
 $accordion-body-padding-x:                $accordion-padding-x !default;
@@ -31,9 +29,7 @@ $accordion-button-active-bg:              var(--#{$prefix}primary-bg-subtle) !de
 $accordion-button-active-color:           var(--#{$prefix}primary-text-emphasis) !default;
 $accordion-active-border-color:           $accordion-border-color !default;
 
-// fusv-disable
-// fusv-enable
-$accordion-button-focus-ring:       var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
+$accordion-button-focus-ring:             var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 
 $accordion-content-duration:              .35s !default;
 $accordion-content-easing:                ease !default;
@@ -62,7 +58,6 @@ $accordion-tokens: defaults(
     --#{$prefix}accordion-border-color: #{$accordion-border-color},
     --#{$prefix}accordion-border-width: #{$accordion-border-width},
     --#{$prefix}accordion-border-radius: #{$accordion-border-radius},
-    --#{$prefix}accordion-inner-border-radius: #{$accordion-inner-border-radius},
     --#{$prefix}accordion-btn-padding-x: #{$accordion-button-padding-x},
     --#{$prefix}accordion-btn-padding-y: #{$accordion-button-padding-y},
     --#{$prefix}accordion-btn-color: #{$accordion-button-color},
@@ -140,7 +135,7 @@ $accordion-tokens: defaults(
       @include border-top-radius(var(--#{$prefix}accordion-border-radius));
 
       > .accordion-header {
-        @include border-top-radius(var(--#{$prefix}accordion-inner-border-radius));
+        @include border-top-radius(calc(var(--#{$prefix}accordion-border-radius) - var(--#{$prefix}accordion-border-width)));
       }
     }
 
@@ -155,7 +150,7 @@ $accordion-tokens: defaults(
       @include border-bottom-radius(var(--#{$prefix}accordion-border-radius));
 
       > .accordion-header {
-        @include border-bottom-radius(var(--#{$prefix}accordion-inner-border-radius));
+        @include border-bottom-radius(calc(var(--#{$prefix}accordion-border-radius) - var(--#{$prefix}accordion-border-width)));
       }
 
       > .accordion-body {


### PR DESCRIPTION
`--cui-accordion-inner-border-radius` was computed when the stylesheet was built, from the global `--cui-border-radius` rather than from the component's token. Setting the documented `--cui-accordion-border-radius` therefore rounded the item and left the header inside it on the page default — measured in a browser: a `2rem` accordion rendered a 32px item around a 5px header.

The subtraction moves to where it is used, against the component's own tokens (`calc(var(--cui-accordion-border-radius) - var(--cui-accordion-border-width))`, the same shape `_toasts.scss` already uses), and the variable is removed. Defaults are unchanged: 6px item / 5px header before and after; with the override the header now follows at 31px.

Also drops an empty `fusv-disable` / `fusv-enable` pair and the `functions/math` import that only `subtract()` needed.

Migration guide entry included. The other seven empty `fusv` pairs are a separate PR.