### PR TITLE
chore: drop the fusv-disable pairs that wrap nothing

### DIFF
--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -585,8 +585,6 @@ $border-radius-xl:            1rem !default;
 $border-radius-xxl:           2rem !default;
 $border-radius-pill:          50rem !default;
 // scss-docs-end border-radius-variables
-// fusv-disable
-// fusv-enable
 
 // scss-docs-start box-shadow-variables
 $box-shadow:                  0 .5rem 1rem rgba($black, .15) !default;
@@ -735,9 +733,6 @@ $small-font-size:               .875em !default;
 
 $sub-sup-font-size:             .75em !default;
 
-// fusv-disable
-// fusv-enable
-
 $initialism-font-size:        $small-font-size !default;
 
 $blockquote-margin-y:         $spacer !default;
@@ -747,9 +742,6 @@ $blockquote-footer-font-size: $small-font-size !default;
 
 $hr-margin-y:                 $spacer !default;
 $hr-color:                    inherit !default;
-
-// fusv-disable
-// fusv-enable
 
 $hr-border-color:             null !default; // Allows for inherited colors
 $hr-border-width:             var(--#{$prefix}border-width) !default;
@@ -973,9 +965,6 @@ $placeholder-opacity-min:           .2 !default;
 // Tooltips
 
 // Alerts
-
-// fusv-disable
-// fusv-enable
 
 // Image thumbnails
 

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -39,8 +39,6 @@ $dropdown-item-padding-x:           $spacer !default;
 $dropdown-header-color:             $gray-600 !default;
 $dropdown-header-padding-x:         $dropdown-item-padding-x !default;
 $dropdown-header-padding-y:         $dropdown-padding-y !default;
-// fusv-disable
-// fusv-enable
 // scss-docs-end dropdown-variables
 
 // scss-docs-start dropdown-dark-variables

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -17,8 +17,6 @@ $list-group-border-radius:          var(--#{$prefix}border-radius) !default;
 
 $list-group-item-padding-y:         $spacer * .5 !default;
 $list-group-item-padding-x:         $spacer !default;
-// fusv-disable
-// fusv-enable
 
 $list-group-hover-bg:               var(--#{$prefix}tertiary-bg) !default;
 $list-group-active-color:           $component-active-color !default;

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -18,8 +18,6 @@ $tooltip-margin:                    null !default; // TODO: remove this in v6
 
 $tooltip-arrow-width:               .8rem !default;
 $tooltip-arrow-height:              .4rem !default;
-// fusv-disable
-// fusv-enable
 // scss-docs-end tooltip-variables
 
 $tooltip-tokens: () !default;


### PR DESCRIPTION
Seven `fusv-disable` / `fusv-enable` pairs sat back to back with no variable between them, left behind by variables that were removed: `_list-group.scss`, `_tooltip.scss`, `_dropdown.scss` and four times in `_config.scss`. A reader hitting one of them is told that something below is deliberately unused, which is no longer true anywhere they stand.

The pairs that still wrap variables (`_popover.scss`, `buttons/_button.scss`, two in `_config.scss`) are untouched, `npm run css-lint-vars` still reports no unused variables, and the compiled CSS is byte-identical (verified against a `v6-dev` worktree build).