### PR TITLE
feat(Accordion): size the whole control from one padding and font-size token, and add .accordion-sm

### DIFF
--- a/docs/src/content/docs/components/accordion.mdx
+++ b/docs/src/content/docs/components/accordion.mdx
@@ -64,6 +64,34 @@ Add a contextual `.theme-{color}` class to the `.accordion` to tint its **open**
     </details>
   </div>`} />
 
+## Sizes
+
+Add `.accordion-sm` for a more compact accordion: tighter padding, a smaller font size, radius, and icon.
+
+<Example code={`<div class="accordion accordion-sm">
+    <details class="accordion-item" name="accordionSm" open>
+      <summary class="accordion-header">Accordion Item #1</summary>
+      <div class="accordion-body">Placeholder content for the first item of a small accordion.</div>
+    </details>
+    <details class="accordion-item" name="accordionSm">
+      <summary class="accordion-header">Accordion Item #2</summary>
+      <div class="accordion-body">Placeholder content for the second item of a small accordion.</div>
+    </details>
+  </div>`} />
+
+Padding and font size are single tokens shared by the header and the body, so one declaration resizes the whole control:
+
+<Example code={`<div class="accordion" style="--cui-accordion-padding-x: 2rem; --cui-accordion-font-size: 1.125rem">
+    <details class="accordion-item" name="accordionTokens" open>
+      <summary class="accordion-header">Accordion Item #1</summary>
+      <div class="accordion-body">Set <code>--cui-accordion-padding-x</code> once and both the header and the body follow.</div>
+    </details>
+    <details class="accordion-item" name="accordionTokens">
+      <summary class="accordion-header">Accordion Item #2</summary>
+      <div class="accordion-body">Override <code>--cui-accordion-btn-padding-x</code> or <code>--cui-accordion-body-padding-x</code> to give one part its own value.</div>
+    </details>
+  </div>`} />
+
 ## Nested
 
 Put a whole `.accordion` inside an `.accordion-body` to nest one. Give each level its own `name`, so the outer and inner groups open and close independently — `name` groups the `<details>` elements across the whole document, not per container.
@@ -248,6 +276,10 @@ summary.addEventListener('click', event => {
 Accordions use local CSS variables on .accordion for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
 
 <ScssDocs file="scss/_accordion.scss" capture="accordion-css-vars" />
+
+`.accordion-sm` sets these:
+
+<ScssDocs file="scss/_accordion.scss" capture="accordion-sm-css-vars" />
 
 ### SASS variables
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -237,6 +237,15 @@ finished, not whether the state changed.
   — so one token now shapes the whole item. Defaults render as before; drop any
   override of the removed variable.
 
+- **One padding token and one font size for the whole control, plus
+  `.accordion-sm`.** `--cui-accordion-padding-x` / `-y` and
+  `--cui-accordion-font-size` are read by the header and the body alike, so
+  resizing an accordion is one declaration instead of four.
+  `--cui-accordion-btn-padding-*` and `--cui-accordion-body-padding-*` are no
+  longer declared by default, but they still override their part where they are
+  set, so existing overrides keep working. `.accordion-sm` builds on the same
+  tokens for a compact accordion.
+
 #### Avatar
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -11,17 +11,13 @@
 // scss-docs-start accordion-variables
 $accordion-padding-y:                     1rem !default;
 $accordion-padding-x:                     1.25rem !default;
+$accordion-font-size:                     var(--#{$prefix}body-font-size) !default;
 $accordion-color:                         var(--#{$prefix}body-color) !default;
 $accordion-bg:                            var(--#{$prefix}body-bg) !default;
 $accordion-border-width:                  var(--#{$prefix}border-width) !default;
 $accordion-border-color:                  var(--#{$prefix}border-color) !default;
 $accordion-border-radius:                 var(--#{$prefix}border-radius) !default;
 
-$accordion-body-padding-y:                $accordion-padding-y !default;
-$accordion-body-padding-x:                $accordion-padding-x !default;
-
-$accordion-button-padding-y:              $accordion-padding-y !default;
-$accordion-button-padding-x:              $accordion-padding-x !default;
 $accordion-button-color:                  var(--#{$prefix}body-color) !default;
 $accordion-button-bg:                     var(--#{$prefix}accordion-bg) !default;
 $accordion-transition:                    $btn-transition, border-radius .15s ease !default;
@@ -30,6 +26,12 @@ $accordion-button-active-color:           var(--#{$prefix}primary-text-emphasis)
 $accordion-active-border-color:           $accordion-border-color !default;
 
 $accordion-button-focus-ring:             var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
+
+$accordion-padding-y-sm:                  .625rem !default;
+$accordion-padding-x-sm:                  .875rem !default;
+$accordion-font-size-sm:                  $font-size-sm !default;
+$accordion-border-radius-sm:              var(--#{$prefix}border-radius-sm) !default;
+$accordion-icon-width-sm:                 1rem !default;
 
 $accordion-content-duration:              .35s !default;
 $accordion-content-easing:                ease !default;
@@ -41,25 +43,24 @@ $accordion-icon-transition:               transform .2s ease-in-out !default;
 $accordion-icon-transform:                rotate(-180deg) !default;
 
 $accordion-button-icon:         url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-linecap='round' stroke-linejoin='round'><path d='m2 5 6 6 6-6'/></svg>") !default;
-// Painted through the mask by --#{$prefix}accordion-btn-icon-color, so the
-// stroke colour above is irrelevant — only the shape's alpha is used.
 // scss-docs-end accordion-variables
 
 $accordion-tokens: () !default;
 
-// stylelint-disable scss/dollar-variable-default
+// stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
 
 // scss-docs-start accordion-css-vars
 $accordion-tokens: defaults(
   (
+    --#{$prefix}accordion-padding-x: #{$accordion-padding-x},
+    --#{$prefix}accordion-padding-y: #{$accordion-padding-y},
+    --#{$prefix}accordion-font-size: #{$accordion-font-size},
     --#{$prefix}accordion-color: #{$accordion-color},
     --#{$prefix}accordion-bg: #{$accordion-bg},
     --#{$prefix}accordion-transition: #{$accordion-transition},
     --#{$prefix}accordion-border-color: #{$accordion-border-color},
     --#{$prefix}accordion-border-width: #{$accordion-border-width},
     --#{$prefix}accordion-border-radius: #{$accordion-border-radius},
-    --#{$prefix}accordion-btn-padding-x: #{$accordion-button-padding-x},
-    --#{$prefix}accordion-btn-padding-y: #{$accordion-button-padding-y},
     --#{$prefix}accordion-btn-color: #{$accordion-button-color},
     --#{$prefix}accordion-btn-bg: #{$accordion-button-bg},
     --#{$prefix}accordion-btn-icon: #{escape-svg($accordion-button-icon)},
@@ -69,8 +70,6 @@ $accordion-tokens: defaults(
     --#{$prefix}accordion-btn-icon-transform: #{$accordion-icon-transform},
     --#{$prefix}accordion-btn-icon-transition: #{$accordion-icon-transition},
     --#{$prefix}accordion-btn-focus-ring: #{$accordion-button-focus-ring},
-    --#{$prefix}accordion-body-padding-x: #{$accordion-body-padding-x},
-    --#{$prefix}accordion-body-padding-y: #{$accordion-body-padding-y},
     --#{$prefix}accordion-active-color: var(--#{$prefix}theme-fg, #{$accordion-button-active-color}),
     --#{$prefix}accordion-active-bg: var(--#{$prefix}theme-bg-subtle, #{$accordion-button-active-bg}),
     --#{$prefix}accordion-active-border-color: var(--#{$prefix}theme-border, #{$accordion-active-border-color}),
@@ -81,13 +80,9 @@ $accordion-tokens: defaults(
 );
 // scss-docs-end accordion-css-vars
 
-// stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function, scss/dollar-variable-default
 
 @layer components {
-  //
-  // Base styles
-  //
-
   .accordion {
     @include tokens($accordion-tokens);
   }
@@ -103,11 +98,6 @@ $accordion-tokens: defaults(
       overflow-y: clip;
     }
 
-    // Only where `auto` can be interpolated does the panel animate itself.
-    // Elsewhere accordion.js animates the item, and a transition left on the
-    // panel would still hold it short while the component measures how tall the
-    // item has to become — the open animation would then run to the wrong size
-    // and the panel would jump at the end.
     @supports (interpolate-size: allow-keywords) {
       @media (prefers-reduced-motion: no-preference) {
         interpolate-size: allow-keywords;
@@ -121,9 +111,6 @@ $accordion-tokens: defaults(
       }
     }
 
-    // accordion.js animates the item's own block-size where the panel cannot be
-    // animated by ::details-content. It sets the two sizes and leaves the timing
-    // here, so both paths are driven by the same tokens.
     &[data-coreui-accordion-animating] {
       overflow: clip;
       @include transition(
@@ -139,13 +126,10 @@ $accordion-tokens: defaults(
       }
     }
 
-    // Keep the border and pull the item up over it: an item without a
-    // block-start border has nothing to recolour when it opens.
     &:not(:first-of-type) {
       margin-block-start: calc(-1 * var(--#{$prefix}accordion-border-width)); // stylelint-disable-line function-disallowed-list
     }
 
-    // Only set a border-radius on the last item if the accordion is collapsed
     &:last-of-type {
       @include border-bottom-radius(var(--#{$prefix}accordion-border-radius));
 
@@ -187,8 +171,8 @@ $accordion-tokens: defaults(
     display: flex;
     align-items: center;
     width: 100%;
-    padding: var(--#{$prefix}accordion-btn-padding-y) var(--#{$prefix}accordion-btn-padding-x);
-    font-size: $font-size-base;
+    padding: var(--#{$prefix}accordion-btn-padding-y, var(--#{$prefix}accordion-padding-y)) var(--#{$prefix}accordion-btn-padding-x, var(--#{$prefix}accordion-padding-x));
+    font-size: var(--#{$prefix}accordion-font-size);
     color: var(--#{$prefix}accordion-btn-color);
     text-align: start;
     list-style: none;
@@ -200,7 +184,6 @@ $accordion-tokens: defaults(
       display: none;
     }
 
-    // Accordion icon
     &::after {
       flex-shrink: 0;
       width: var(--#{$prefix}accordion-btn-icon-width);
@@ -212,8 +195,6 @@ $accordion-tokens: defaults(
       @include transition(var(--#{$prefix}accordion-btn-icon-transition));
     }
 
-    // A heading inside `<summary>` keeps the section reachable by heading
-    // navigation, which a bare `<summary>` does not offer.
     > :is(h1, h2, h3, h4, h5, h6) {
       margin-bottom: 0;
       font-size: inherit;
@@ -234,13 +215,21 @@ $accordion-tokens: defaults(
   }
 
   .accordion-body {
-    padding: var(--#{$prefix}accordion-body-padding-y) var(--#{$prefix}accordion-body-padding-x);
+    padding: var(--#{$prefix}accordion-body-padding-y, var(--#{$prefix}accordion-padding-y)) var(--#{$prefix}accordion-body-padding-x, var(--#{$prefix}accordion-padding-x));
+    font-size: var(--#{$prefix}accordion-font-size);
   }
 
 
-  // Flush accordion items
-  //
-  // Remove borders and border-radius to keep accordion items edge-to-edge.
+  .accordion-sm {
+    // scss-docs-start accordion-sm-css-vars
+    --#{$prefix}accordion-padding-x: #{$accordion-padding-x-sm};
+    --#{$prefix}accordion-padding-y: #{$accordion-padding-y-sm};
+    --#{$prefix}accordion-font-size: #{$accordion-font-size-sm};
+    --#{$prefix}accordion-border-radius: #{$accordion-border-radius-sm};
+    --#{$prefix}accordion-btn-icon-width: #{$accordion-icon-width-sm};
+    // scss-docs-end accordion-sm-css-vars
+  }
+
 
   .accordion-flush {
     > .accordion-item {


### PR DESCRIPTION
Padding lived in four tokens that the header and the body read separately, and the header's font size was hard-coded to `$font-size-base` while the body had none. Resizing an accordion therefore took four declarations, and anything set on the header left the body behind.

- `--cui-accordion-padding-x` / `-y` and `--cui-accordion-font-size` are read by the header and the body alike, so one declaration resizes the control.
- `--cui-accordion-btn-padding-*` and `--cui-accordion-body-padding-*` are no longer declared by default but still override their own part where they are set — existing overrides keep working (verified in a browser).
- `.accordion-sm` builds on those tokens: tighter padding, smaller font size, smaller radius and icon.

Defaults render exactly as before: 16px/20px padding and a 16px font on both parts, 6px radius.

Also drops the prose comments from the file, per our "comments are a last resort" rule — the reasoning behind the two animation paths and the markup choices lives in the PRs that introduced them.

Docs get a Sizes section and the `.accordion-sm` variables table; migration guide entry included.