### PR TITLE
chore(Accordion): align $accordion-button-icon with the rest of the variables

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -42,7 +42,7 @@ $accordion-icon-active-color:             var(--#{$prefix}primary-text-emphasis)
 $accordion-icon-transition:               transform .2s ease-in-out !default;
 $accordion-icon-transform:                rotate(-180deg) !default;
 
-$accordion-button-icon:         url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-linecap='round' stroke-linejoin='round'><path d='m2 5 6 6 6-6'/></svg>") !default;
+$accordion-button-icon:                   url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-linecap='round' stroke-linejoin='round'><path d='m2 5 6 6 6-6'/></svg>") !default;
 // scss-docs-end accordion-variables
 
 $accordion-tokens: () !default;


### PR DESCRIPTION
The icon variable sat at a different column than every other variable in the block.