### PR TITLE
chore(Accordion): drop .accordion-sm

### DIFF
--- a/docs/src/content/docs/components/accordion.mdx
+++ b/docs/src/content/docs/components/accordion.mdx
@@ -66,19 +66,6 @@ Add a contextual `.theme-{color}` class to the `.accordion` to tint its **open**
 
 ## Sizes
 
-Add `.accordion-sm` for a more compact accordion: tighter padding, a smaller font size, radius, and icon.
-
-<Example code={`<div class="accordion accordion-sm">
-    <details class="accordion-item" name="accordionSm" open>
-      <summary class="accordion-header">Accordion Item #1</summary>
-      <div class="accordion-body">Placeholder content for the first item of a small accordion.</div>
-    </details>
-    <details class="accordion-item" name="accordionSm">
-      <summary class="accordion-header">Accordion Item #2</summary>
-      <div class="accordion-body">Placeholder content for the second item of a small accordion.</div>
-    </details>
-  </div>`} />
-
 Padding and font size are single tokens shared by the header and the body, so one declaration resizes the whole control:
 
 <Example code={`<div class="accordion" style="--cui-accordion-padding-x: 2rem; --cui-accordion-font-size: 1.125rem">
@@ -276,10 +263,6 @@ summary.addEventListener('click', event => {
 Accordions use local CSS variables on .accordion for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
 
 <ScssDocs file="scss/_accordion.scss" capture="accordion-css-vars" />
-
-`.accordion-sm` sets these:
-
-<ScssDocs file="scss/_accordion.scss" capture="accordion-sm-css-vars" />
 
 ### SASS variables
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -237,14 +237,13 @@ finished, not whether the state changed.
   — so one token now shapes the whole item. Defaults render as before; drop any
   override of the removed variable.
 
-- **One padding token and one font size for the whole control, plus
-  `.accordion-sm`.** `--cui-accordion-padding-x` / `-y` and
-  `--cui-accordion-font-size` are read by the header and the body alike, so
-  resizing an accordion is one declaration instead of four.
-  `--cui-accordion-btn-padding-*` and `--cui-accordion-body-padding-*` are no
-  longer declared by default, but they still override their part where they are
-  set, so existing overrides keep working. `.accordion-sm` builds on the same
-  tokens for a compact accordion.
+- **One padding token and one font size for the whole control.**
+  `--cui-accordion-padding-x` / `-y` and `--cui-accordion-font-size` are read by
+  the header and the body alike, so resizing an accordion is one declaration
+  instead of four. `--cui-accordion-btn-padding-*` and
+  `--cui-accordion-body-padding-*` are no longer declared by default, but they
+  still override their part where they are set, so existing overrides keep
+  working.
 
 #### Avatar
 

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -27,12 +27,6 @@ $accordion-active-border-color:           $accordion-border-color !default;
 
 $accordion-button-focus-ring:             var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 
-$accordion-padding-y-sm:                  .625rem !default;
-$accordion-padding-x-sm:                  .875rem !default;
-$accordion-font-size-sm:                  $font-size-sm !default;
-$accordion-border-radius-sm:              var(--#{$prefix}border-radius-sm) !default;
-$accordion-icon-width-sm:                 1rem !default;
-
 $accordion-content-duration:              .35s !default;
 $accordion-content-easing:                ease !default;
 
@@ -47,7 +41,7 @@ $accordion-button-icon:                   url("data:image/svg+xml,<svg xmlns='ht
 
 $accordion-tokens: () !default;
 
-// stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
+// stylelint-disable scss/dollar-variable-default
 
 // scss-docs-start accordion-css-vars
 $accordion-tokens: defaults(
@@ -80,7 +74,7 @@ $accordion-tokens: defaults(
 );
 // scss-docs-end accordion-css-vars
 
-// stylelint-enable custom-property-no-missing-var-function, scss/dollar-variable-default
+// stylelint-enable scss/dollar-variable-default
 
 @layer components {
   .accordion {
@@ -217,17 +211,6 @@ $accordion-tokens: defaults(
   .accordion-body {
     padding: var(--#{$prefix}accordion-body-padding-y, var(--#{$prefix}accordion-padding-y)) var(--#{$prefix}accordion-body-padding-x, var(--#{$prefix}accordion-padding-x));
     font-size: var(--#{$prefix}accordion-font-size);
-  }
-
-
-  .accordion-sm {
-    // scss-docs-start accordion-sm-css-vars
-    --#{$prefix}accordion-padding-x: #{$accordion-padding-x-sm};
-    --#{$prefix}accordion-padding-y: #{$accordion-padding-y-sm};
-    --#{$prefix}accordion-font-size: #{$accordion-font-size-sm};
-    --#{$prefix}accordion-border-radius: #{$accordion-border-radius-sm};
-    --#{$prefix}accordion-btn-icon-width: #{$accordion-icon-width-sm};
-    // scss-docs-end accordion-sm-css-vars
   }
 
 


### PR DESCRIPTION
The size variant is on hold as a concept, so it comes out before it reaches a release.

What it was built on stays: `--cui-accordion-padding-x` / `-y` and `--cui-accordion-font-size` still resize the header and the body together, and the docs Sizes section now shows that token route on its own. The `$accordion-*-sm` Sass variables and the `accordion-sm-css-vars` snippet are gone with the class.

Narrowing the stylelint pair back to `scss/dollar-variable-default` came along with it: `custom-property-no-missing-var-function` only fired because of the `.accordion-sm` block, and `reportNeedlessDisables` flags it once the block is gone.