### PR TITLE
chore: keep lint pragmas out of the documented Sass snippets

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -21,8 +21,9 @@ $alert-dismissible-padding-r:   $alert-padding-x * 3 !default; // 3x covers widt
 
 $alert-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start alert-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $alert-tokens: defaults(
   (
     --#{$prefix}alert-bg: var(--#{$prefix}theme-bg-subtle, transparent),
@@ -41,6 +42,8 @@ $alert-tokens: defaults(
   $alert-tokens
 );
 // scss-docs-end alert-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 
 @layer components {
   .alert {

--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -31,8 +31,9 @@ $avatar-sizes: (
 
 $avatar-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start avatar-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $avatar-tokens: defaults(
   (
     --#{$prefix}avatar-size: #{$avatar-size},
@@ -45,6 +46,8 @@ $avatar-tokens: defaults(
   $avatar-tokens
 );
 // scss-docs-end avatar-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .avatar {
     @include tokens($avatar-tokens);

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -22,8 +22,9 @@ $breadcrumb-border-radius:          null !default;
 
 $breadcrumb-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start breadcrumb-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $breadcrumb-tokens: defaults(
   (
     --#{$prefix}breadcrumb-padding-x: #{$breadcrumb-padding-x},
@@ -39,6 +40,8 @@ $breadcrumb-tokens: defaults(
   $breadcrumb-tokens
 );
 // scss-docs-end breadcrumb-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .breadcrumb {
     @include tokens($breadcrumb-tokens);

--- a/scss/_calendar.scss
+++ b/scss/_calendar.scss
@@ -63,8 +63,9 @@ $calendar-cell-week-number-color:            var(--#{$prefix}secondary-color) !d
 
 $calendar-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start calendar-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $calendar-tokens: defaults(
   (
     --#{$prefix}calendar-table-margin: #{$calendar-table-margin},
@@ -108,6 +109,8 @@ $calendar-tokens: defaults(
   $calendar-tokens
 );
 // scss-docs-end calendar-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .calendar {
     @include tokens($calendar-tokens);

--- a/scss/_callout.scss
+++ b/scss/_callout.scss
@@ -28,8 +28,9 @@ $callout-variants: (
 
 $callout-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start callout-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $callout-tokens: defaults(
   (
     --#{$prefix}callout-padding-x: #{$callout-padding-x},
@@ -44,6 +45,8 @@ $callout-tokens: defaults(
   $callout-tokens
 );
 // scss-docs-end callout-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .callout {
     @include tokens($callout-tokens);

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -30,8 +30,9 @@ $card-group-margin:                 $grid-gutter-width * .5 !default;
 
 $card-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start card-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $card-tokens: defaults(
   (
     --#{$prefix}card-spacer-y: #{$card-spacer-y},
@@ -57,6 +58,8 @@ $card-tokens: defaults(
   $card-tokens
 );
 // scss-docs-end card-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   //
   // Base styles

--- a/scss/_chip-set.scss
+++ b/scss/_chip-set.scss
@@ -8,8 +8,9 @@ $chip-set-gap: .25rem !default;
 
 $chip-set-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start chip-set-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $chip-set-tokens: defaults(
   (
     --#{$prefix}chip-set-gap: #{$chip-set-gap},
@@ -17,6 +18,8 @@ $chip-set-tokens: defaults(
   $chip-set-tokens
 );
 // scss-docs-end chip-set-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .chip-set {
     @include tokens($chip-set-tokens);

--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -56,8 +56,9 @@ $chip-remove-size-lg:        1.25rem !default;
 
 $chip-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start chip-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $chip-tokens: defaults(
   (
     --#{$prefix}chip-height: #{$chip-height},
@@ -88,10 +89,13 @@ $chip-tokens: defaults(
 );
 // scss-docs-end chip-css-vars
 
+// stylelint-enable scss/dollar-variable-default
+
 $chip-outline-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start chip-outline-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $chip-outline-tokens: defaults(
   (
     --#{$prefix}chip-color: var(--#{$prefix}color, var(--#{$prefix}body-color)),
@@ -106,6 +110,8 @@ $chip-outline-tokens: defaults(
   $chip-outline-tokens
 );
 // scss-docs-end chip-outline-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .chip {
     @include tokens($chip-tokens);

--- a/scss/_combobox.scss
+++ b/scss/_combobox.scss
@@ -66,9 +66,10 @@ $combobox-option-indicator-width:         var(--#{$prefix}check-size, 1em) !defa
 
 $combobox-tokens: () !default;
 
-// scss-docs-start combobox-css-vars
 // stylelint-disable custom-property-no-missing-var-function
-// stylelint-disable-next-line scss/dollar-variable-default
+// stylelint-disable scss/dollar-variable-default
+
+// scss-docs-start combobox-css-vars
 $combobox-tokens: defaults(
   (
     --#{$prefix}combobox-popup-min-width: #{$combobox-popup-min-width},
@@ -114,8 +115,10 @@ $combobox-tokens: defaults(
   ),
   $combobox-tokens
 );
-// stylelint-enable custom-property-no-missing-var-function
 // scss-docs-end combobox-css-vars
+
+// stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function
 
 @layer components {
   // The chrome comes from the `.popup` primitive the panel carries; the

--- a/scss/_date-picker.scss
+++ b/scss/_date-picker.scss
@@ -14,8 +14,9 @@ $date-picker-footer-border-color:      var(--#{$prefix}border-color) !default;
 
 $date-picker-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start date-picker-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $date-picker-tokens: defaults(
   (
     --#{$prefix}date-picker-footer-padding: #{$date-picker-footer-padding},
@@ -25,6 +26,8 @@ $date-picker-tokens: defaults(
   $date-picker-tokens
 );
 // scss-docs-end date-picker-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   // Lean pickers-v2 shell styling (workspace: architecture/pickers-v2.md, "Styling
   // budget"). Compiled AFTER _date-picker.scss and replaces it once the v1 shell

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -41,9 +41,10 @@ $dialog-footer-border-width:        var(--#{$prefix}border-width) !default;
 $dialog-footer-gap:                 .5rem !default;
 // scss-docs-end dialog-variables
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start dialog-sizes
 $dialog-sizes: () !default;
-// stylelint-disable-next-line scss/dollar-variable-default
 $dialog-sizes: defaults(
   (
     sm: 280px,
@@ -54,10 +55,13 @@ $dialog-sizes: defaults(
 );
 // scss-docs-end dialog-sizes
 
+// stylelint-enable scss/dollar-variable-default
+
 $dialog-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start dialog-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $dialog-tokens: defaults(
   (
     --#{$prefix}dialog-zindex: #{$zindex-modal},
@@ -86,6 +90,8 @@ $dialog-tokens: defaults(
   $dialog-tokens
 );
 // scss-docs-end dialog-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 
 @layer components {
   .dialog {

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -39,8 +39,9 @@ $drawer-sheet-width:                760px !default;
 
 $drawer-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start drawer-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $drawer-tokens: defaults(
   (
     --#{$prefix}drawer-inset: #{$drawer-inset},
@@ -64,6 +65,8 @@ $drawer-tokens: defaults(
   $drawer-tokens
 );
 // scss-docs-end drawer-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   %drawer-css-vars {
     @include tokens($drawer-tokens);

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -58,8 +58,9 @@ $dropdown-dark-header-color:        $gray-500 !default;
 
 $dropdown-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start dropdown-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $dropdown-tokens: defaults(
   (
     --#{$prefix}dropdown-zindex: #{$zindex-dropdown},
@@ -93,10 +94,13 @@ $dropdown-tokens: defaults(
 );
 // scss-docs-end dropdown-css-vars
 
+// stylelint-enable scss/dollar-variable-default
+
 $dropdown-dark-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start dropdown-dark-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $dropdown-dark-tokens: defaults(
   (
     --#{$prefix}dropdown-color: #{$dropdown-dark-color},
@@ -115,6 +119,8 @@ $dropdown-dark-tokens: defaults(
   $dropdown-dark-tokens
 );
 // scss-docs-end dropdown-dark-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   // The dropdown wrapper (`<div>`)
   .dropup,

--- a/scss/_footer.scss
+++ b/scss/_footer.scss
@@ -15,8 +15,9 @@ $footer-border-color:  var(--#{$prefix}border-color) !default;
 
 $footer-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start footer-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $footer-tokens: defaults(
   (
     --#{$prefix}footer-min-height: #{$footer-min-height},
@@ -30,6 +31,8 @@ $footer-tokens: defaults(
   $footer-tokens
 );
 // scss-docs-end footer-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .footer {
     @include tokens($footer-tokens);

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -52,8 +52,9 @@ $header-divider-border-color:   var(--#{$prefix}border-color) !default;
 
 $header-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start header-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $header-tokens: defaults(
   (
     --#{$prefix}header-padding-x: #{$header-padding-x},
@@ -85,6 +86,8 @@ $header-tokens: defaults(
   $header-tokens
 );
 // scss-docs-end header-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .header {
     @include tokens($header-tokens);

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -35,8 +35,9 @@ $list-group-action-active-bg:       var(--#{$prefix}secondary-bg) !default;
 
 $list-group-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start list-group-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $list-group-tokens: defaults(
   (
     --#{$prefix}list-group-color: #{$list-group-color},
@@ -60,6 +61,8 @@ $list-group-tokens: defaults(
   $list-group-tokens
 );
 // scss-docs-end list-group-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   // Base class
   //

--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -49,9 +49,10 @@ $menu-transition-timing:        cubic-bezier(.22, 1, .36, 1) !default;
 
 $menu-tokens: () !default;
 
-// scss-docs-start menu-css-vars
 // stylelint-disable custom-property-no-missing-var-function
-// stylelint-disable-next-line scss/dollar-variable-default
+// stylelint-disable scss/dollar-variable-default
+
+// scss-docs-start menu-css-vars
 $menu-tokens: defaults(
   (
     --#{$prefix}menu-zindex: #{$menu-zindex},
@@ -88,8 +89,10 @@ $menu-tokens: defaults(
   ),
   $menu-tokens
 );
-// stylelint-enable custom-property-no-missing-var-function
 // scss-docs-end menu-css-vars
+
+// stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function
 
 @layer components {
   .menu {

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -60,8 +60,9 @@ $modal-transition-timing:           ease-out !default;
 
 $modal-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start modal-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $modal-tokens: defaults(
   (
     --#{$prefix}modal-zindex: #{$zindex-modal},
@@ -93,6 +94,8 @@ $modal-tokens: defaults(
   $modal-tokens
 );
 // scss-docs-end modal-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 
 @layer components {
   // Scroll lock while any modal <dialog> (Modal or Offcanvas) is open. Both

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -59,8 +59,9 @@ $nav-enclosed-link-disabled-color:       var(--#{$prefix}secondary-color) !defau
 
 $nav-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start nav-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $nav-tokens: defaults(
   (
     --#{$prefix}nav-link-padding-x: #{$nav-link-padding-x},
@@ -75,10 +76,13 @@ $nav-tokens: defaults(
 );
 // scss-docs-end nav-css-vars
 
+// stylelint-enable scss/dollar-variable-default
+
 $nav-tabs-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start nav-tabs-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $nav-tabs-tokens: defaults(
   (
     --#{$prefix}nav-tabs-border-width: #{$nav-tabs-border-width},
@@ -93,10 +97,13 @@ $nav-tabs-tokens: defaults(
 );
 // scss-docs-end nav-tabs-css-vars
 
+// stylelint-enable scss/dollar-variable-default
+
 $nav-pills-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start nav-pills-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $nav-pills-tokens: defaults(
   (
     --#{$prefix}nav-pills-border-radius: #{$nav-pills-border-radius},
@@ -107,10 +114,13 @@ $nav-pills-tokens: defaults(
 );
 // scss-docs-end nav-pills-css-vars
 
+// stylelint-enable scss/dollar-variable-default
+
 $nav-underline-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start nav-underline-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $nav-underline-tokens: defaults(
   (
     --#{$prefix}nav-underline-gap: #{$nav-underline-gap},
@@ -121,10 +131,13 @@ $nav-underline-tokens: defaults(
 );
 // scss-docs-end nav-underline-css-vars
 
+// stylelint-enable scss/dollar-variable-default
+
 $nav-underline-border-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start nav-underline-border-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $nav-underline-border-tokens: defaults(
   (
     --#{$prefix}nav-underline-border-gap: #{$nav-underline-border-gap},
@@ -139,6 +152,8 @@ $nav-underline-border-tokens: defaults(
   $nav-underline-border-tokens
 );
 // scss-docs-end nav-underline-border-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   // Base class
   //

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -61,9 +61,10 @@ $navbar-dark-brand-hover-color:     $navbar-dark-active-color !default;
 
 $navbar-tokens: () !default;
 
-// scss-docs-start navbar-css-vars
 // stylelint-disable scss/at-function-named-arguments
-// stylelint-disable-next-line scss/dollar-variable-default
+// stylelint-disable scss/dollar-variable-default
+
+// scss-docs-start navbar-css-vars
 $navbar-tokens: defaults(
   (
     --#{$prefix}navbar-padding-x: #{if(sass($navbar-padding-x == null): 0; else: $navbar-padding-x)},
@@ -89,13 +90,16 @@ $navbar-tokens: defaults(
   ),
   $navbar-tokens
 );
-// stylelint-enable scss/at-function-named-arguments
 // scss-docs-end navbar-css-vars
+
+// stylelint-enable scss/dollar-variable-default
+// stylelint-enable scss/at-function-named-arguments
 
 $navbar-nav-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start navbar-nav-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $navbar-nav-tokens: defaults(
   (
     --#{$prefix}nav-link-padding-x: 0,
@@ -110,10 +114,13 @@ $navbar-nav-tokens: defaults(
 );
 // scss-docs-end navbar-nav-css-vars
 
+// stylelint-enable scss/dollar-variable-default
+
 $navbar-dark-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start navbar-dark-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $navbar-dark-tokens: defaults(
   (
     --#{$prefix}navbar-color: #{$navbar-dark-color},
@@ -128,6 +135,8 @@ $navbar-dark-tokens: defaults(
   $navbar-dark-tokens
 );
 // scss-docs-end navbar-dark-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 // The expanded rules are read from inside the navbar's own query container, so
 // they can only style its descendants — an element is never its own container.
 // The two properties that used to sit on `.navbar-expand-*` itself move onto the

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -34,8 +34,9 @@ $offcanvas-backdrop-opacity:        $modal-backdrop-opacity !default;
 
 $offcanvas-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start offcanvas-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $offcanvas-tokens: defaults(
   (
     --#{$prefix}offcanvas-zindex: #{$zindex-offcanvas},
@@ -57,6 +58,8 @@ $offcanvas-tokens: defaults(
   $offcanvas-tokens
 );
 // scss-docs-end offcanvas-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   %offcanvas-css-vars {
     @include tokens($offcanvas-tokens);

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -48,8 +48,9 @@ $pagination-border-radius-lg:       var(--#{$prefix}border-radius-lg) !default;
 
 $pagination-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start pagination-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $pagination-tokens: defaults(
   (
     --#{$prefix}pagination-padding-x: #{$pagination-padding-x},
@@ -76,6 +77,8 @@ $pagination-tokens: defaults(
   $pagination-tokens
 );
 // scss-docs-end pagination-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .pagination {
     @include tokens($pagination-tokens);

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -37,8 +37,9 @@ $popover-arrow-outer-color:         var(--#{$prefix}border-color-translucent) !d
 
 $popover-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start popover-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $popover-tokens: defaults(
   (
     --#{$prefix}popover-zindex: #{$zindex-popover},
@@ -65,6 +66,8 @@ $popover-tokens: defaults(
   $popover-tokens
 );
 // scss-docs-end popover-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .popover {
     @include tokens($popover-tokens);

--- a/scss/_popup.scss
+++ b/scss/_popup.scss
@@ -16,9 +16,10 @@ $popup-transition-duration: .15s !default;
 $popup-transition-timing:   cubic-bezier(.22, 1, .36, 1) !default;
 // scss-docs-end popup-variables
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start popup-tokens
 $popup-tokens: () !default;
-// stylelint-disable-next-line scss/dollar-variable-default
 $popup-tokens: defaults(
   (
     --#{$prefix}popup-zindex: #{$popup-zindex},
@@ -33,6 +34,8 @@ $popup-tokens: defaults(
   $popup-tokens
 );
 // scss-docs-end popup-tokens
+
+// stylelint-enable scss/dollar-variable-default
 
 @layer components {
   // The floating surface of the field components — one chrome for the pickers'

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -24,8 +24,9 @@ $progress-group-header-margin-bottom:  $spacer * .25 !default;
 
 $progress-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start progress-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $progress-tokens: defaults(
   (
     --#{$prefix}progress-height: #{$progress-height},
@@ -40,6 +41,8 @@ $progress-tokens: defaults(
   $progress-tokens
 );
 // scss-docs-end progress-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   // Disable animation if transitions are disabled
 

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -61,8 +61,9 @@ $range-slider-vertical-track-height:       10rem !default;
 
 $range-slider-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start range-slider-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $range-slider-tokens: defaults(
   (
     --#{$prefix}range-slider-track-width: #{$range-slider-track-width},
@@ -106,10 +107,13 @@ $range-slider-tokens: defaults(
 );
 // scss-docs-end range-slider-css-vars
 
+// stylelint-enable scss/dollar-variable-default
+
 $range-slider-vertical-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start range-slider-vertical-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $range-slider-vertical-tokens: defaults(
   (
     --#{$prefix}range-slider-vertical-track-width: #{$range-slider-vertical-track-width},
@@ -118,6 +122,8 @@ $range-slider-vertical-tokens: defaults(
   $range-slider-vertical-tokens
 );
 // scss-docs-end range-slider-vertical-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .range-slider {
     @include tokens($range-slider-tokens);

--- a/scss/_rating.scss
+++ b/scss/_rating.scss
@@ -21,8 +21,9 @@ $rating-item-icon:             url("data:image/svg+xml,%3Csvg xmlns='http://www.
 
 $rating-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start rating-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $rating-tokens: defaults(
   (
     --#{$prefix}rating-gap: #{$rating-gap},
@@ -36,6 +37,8 @@ $rating-tokens: defaults(
   $rating-tokens
 );
 // scss-docs-end rating-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .rating {
     @include tokens($rating-tokens);

--- a/scss/_spinner.scss
+++ b/scss/_spinner.scss
@@ -18,8 +18,9 @@ $spinner-border-width-sm: .2em !default;
 
 $spinner-border-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start spinner-border-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $spinner-border-tokens: defaults(
   (
     --#{$prefix}spinner-width: #{$spinner-width},
@@ -33,10 +34,13 @@ $spinner-border-tokens: defaults(
 );
 // scss-docs-end spinner-border-css-vars
 
+// stylelint-enable scss/dollar-variable-default
+
 $spinner-border-sm-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start spinner-border-sm-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $spinner-border-sm-tokens: defaults(
   (
     --#{$prefix}spinner-width: #{$spinner-width-sm},
@@ -47,10 +51,13 @@ $spinner-border-sm-tokens: defaults(
 );
 // scss-docs-end spinner-border-sm-css-vars
 
+// stylelint-enable scss/dollar-variable-default
+
 $spinner-grow-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start spinner-grow-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $spinner-grow-tokens: defaults(
   (
     --#{$prefix}spinner-width: #{$spinner-width},
@@ -62,6 +69,8 @@ $spinner-grow-tokens: defaults(
   $spinner-grow-tokens
 );
 // scss-docs-end spinner-grow-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   //
   // Rotating border

--- a/scss/_stepper.scss
+++ b/scss/_stepper.scss
@@ -47,8 +47,9 @@ $stepper-step-content-transition:               height .3s ease-in-out !default;
 
 $stepper-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start stepper-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $stepper-tokens: defaults(
   (
     --#{$prefix}stepper-steps-gap: #{$stepper-steps-gap},
@@ -88,6 +89,8 @@ $stepper-tokens: defaults(
   $stepper-tokens
 );
 // scss-docs-end stepper-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .stepper {
     @include tokens($stepper-tokens);

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -7,8 +7,9 @@
 // Time Picker
 $time-picker-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start time-picker-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $time-picker-tokens: defaults(
   (
     --#{$prefix}time-picker-body-padding: #{$time-picker-body-padding},
@@ -34,6 +35,8 @@ $time-picker-tokens: defaults(
   $time-picker-tokens
 );
 // scss-docs-end time-picker-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .time-picker {
     position: relative;

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -28,8 +28,9 @@ $toast-header-border-color:         $toast-border-color !default;
 
 $toast-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start toast-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $toast-tokens: defaults(
   (
     --#{$prefix}toast-zindex: #{$zindex-toast},
@@ -53,6 +54,8 @@ $toast-tokens: defaults(
   $toast-tokens
 );
 // scss-docs-end toast-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .toast {
     @include tokens($toast-tokens);

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -22,8 +22,9 @@ $tooltip-arrow-height:              .4rem !default;
 
 $tooltip-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start tooltip-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $tooltip-tokens: defaults(
   (
     --#{$prefix}tooltip-zindex: #{$zindex-tooltip},
@@ -42,6 +43,8 @@ $tooltip-tokens: defaults(
   $tooltip-tokens
 );
 // scss-docs-end tooltip-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   // Base class
   .tooltip {

--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -6,8 +6,9 @@
 $fade-tokens: () !default;
 $collapse-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start fade-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $fade-tokens: defaults(
   (
     --#{$prefix}transition-fade-duration: #{$transition-fade-duration},
@@ -17,8 +18,11 @@ $fade-tokens: defaults(
 );
 // scss-docs-end fade-css-vars
 
+// stylelint-enable scss/dollar-variable-default
+
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start collapse-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $collapse-tokens: defaults(
   (
     --#{$prefix}transition-collapse-duration: #{$transition-collapse-duration},
@@ -27,6 +31,8 @@ $collapse-tokens: defaults(
   $collapse-tokens
 );
 // scss-docs-end collapse-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 
 @layer components {
   .fade {

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -86,12 +86,13 @@ $btn-lightness-overrides: (
   "dark": ("hover": 1.48, "active": 1.62)
 ) !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start btn-variants
 // Each variant maps a button token to a --#{$prefix}theme-* token, so one set of
 // rules serves every theme color. Hover and active are derived in CSS from the
 // same token, which is what lets a custom theme color work without Sass.
 $button-variants: () !default;
-// stylelint-disable-next-line scss/dollar-variable-default
 $button-variants: defaults(
   (
     "solid": (
@@ -113,6 +114,8 @@ $button-variants: defaults(
   $button-variants
 );
 // scss-docs-end btn-variants
+
+// stylelint-enable scss/dollar-variable-default
 
 // scss-docs-start btn-variant-mixin
 @mixin button-variant($variant, $hover-lightness: $btn-hover-lightness, $active-lightness: $btn-active-lightness) {

--- a/scss/buttons/_close.scss
+++ b/scss/buttons/_close.scss
@@ -24,8 +24,9 @@ $btn-close-filter-dark:      invert(1) grayscale(100%) brightness(200%) !default
 
 $close-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start close-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $close-tokens: defaults(
   (
     --#{$prefix}btn-close-color: #{$btn-close-color},
@@ -39,6 +40,8 @@ $close-tokens: defaults(
   $close-tokens
 );
 // scss-docs-end close-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   // Transparent background and border properties included for button version.
   // iOS requires the button element instead of an anchor tag.

--- a/scss/buttons/_search-button.scss
+++ b/scss/buttons/_search-button.scss
@@ -40,8 +40,9 @@ $search-button-placeholder-margin-inline:  .55rem 2rem !default;
 
 $search-button-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start search-button-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $search-button-tokens: defaults(
   (
     --#{$prefix}search-button-height: #{$search-button-height},
@@ -74,6 +75,8 @@ $search-button-tokens: defaults(
   $search-button-tokens
 );
 // scss-docs-end search-button-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
   .search-button {
     @include tokens($search-button-tokens);

--- a/scss/forms/_check.scss
+++ b/scss/forms/_check.scss
@@ -32,9 +32,10 @@ $check-sizes: (
 
 $check-tokens: () !default;
 
-// scss-docs-start check-css-vars
 // stylelint-disable custom-property-no-missing-var-function, function-disallowed-list
-// stylelint-disable-next-line scss/dollar-variable-default
+// stylelint-disable scss/dollar-variable-default
+
+// scss-docs-start check-css-vars
 $check-tokens: defaults(
   (
     --#{$prefix}check-size: #{$check-size},
@@ -57,8 +58,10 @@ $check-tokens: defaults(
   ),
   $check-tokens
 );
-// stylelint-enable custom-property-no-missing-var-function, function-disallowed-list
 // scss-docs-end check-css-vars
+
+// stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function, function-disallowed-list
 
 // The v5 spelling is an alias of this control rather than a second
 // implementation, so it is part of its selector list;

--- a/scss/forms/_chip-input.scss
+++ b/scss/forms/_chip-input.scss
@@ -31,13 +31,14 @@ $chip-input-border-radius-lg:  var(--#{$prefix}border-radius-lg) !default;
 $chip-input-gap-lg:            .5rem !default;
 // scss-docs-end chip-input-variables
 
+// stylelint-disable custom-property-no-missing-var-function
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start chip-input-css-vars
 // The frame — padding, typography, colors, border, transition — is the shared
 // text-control appearance, so it goes in the --#{$prefix}control-* namespace;
 // min-height and gap are the only chip-input-specific knobs.
 $chip-input-tokens: () !default;
-// stylelint-disable custom-property-no-missing-var-function
-// stylelint-disable-next-line scss/dollar-variable-default
 $chip-input-tokens: defaults(
   (
     --#{$prefix}chip-input-min-height: #{$chip-input-min-height},
@@ -54,8 +55,10 @@ $chip-input-tokens: defaults(
   ),
   $chip-input-tokens
 );
-// stylelint-enable custom-property-no-missing-var-function
 // scss-docs-end chip-input-css-vars
+
+// stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function
 
 @layer forms {
   // The frame, the focus and the disabled treatment come from

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -21,9 +21,10 @@ $form-floating-label-disabled-color:    $gray-600 !default;
 $form-floating-transition:              opacity .1s ease-in-out, transform .1s ease-in-out !default;
 // scss-docs-end form-floating-variables
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start form-floating-tokens
 $form-floating-tokens: () !default;
-// stylelint-disable-next-line scss/dollar-variable-default
 $form-floating-tokens: defaults(
   (
     --#{$prefix}form-floating-height: #{$form-floating-height},
@@ -41,6 +42,8 @@ $form-floating-tokens: defaults(
   $form-floating-tokens
 );
 // scss-docs-end form-floating-tokens
+
+// stylelint-enable scss/dollar-variable-default
 
 @layer forms {
   .form-floating {

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -74,10 +74,11 @@ $form-switch-color-dark:            rgba($white, .25) !default;
 $form-switch-bg-image-dark:         url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color-dark}'/></svg>") !default;
 // scss-docs-end form-switch-dark-variables
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start form-check-tokens
 // Tokens the wrapper owns; the input reads them by inheritance.
 $form-check-tokens: () !default;
-// stylelint-disable-next-line scss/dollar-variable-default
 $form-check-tokens: defaults(
   (
     --#{$prefix}form-check-min-height: #{$form-check-min-height},
@@ -91,12 +92,15 @@ $form-check-tokens: defaults(
 );
 // scss-docs-end form-check-tokens
 
+// stylelint-enable scss/dollar-variable-default
+
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start form-check-input-tokens
 // Tokens the input owns, so it still styles itself when used outside .form-check
 // — an input group, for instance. Keeping them off the wrapper means a wrapper
 // or :root override is not shadowed by the input's own declaration.
 $form-check-input-tokens: () !default;
-// stylelint-disable-next-line scss/dollar-variable-default
 $form-check-input-tokens: defaults(
   (
     --#{$prefix}form-check-input-width: #{$form-check-input-width},
@@ -121,6 +125,8 @@ $form-check-input-tokens: defaults(
   $form-check-input-tokens
 );
 // scss-docs-end form-check-input-tokens
+
+// stylelint-enable scss/dollar-variable-default
 
 @layer forms {
   @if $enable-deprecated-form-check {

--- a/scss/forms/_form-control-group.scss
+++ b/scss/forms/_form-control-group.scss
@@ -20,12 +20,13 @@ $form-control-group-action-bg:        transparent !default;
 $form-control-group-action-hover-bg:  var(--#{$prefix}tertiary-bg) !default;
 // scss-docs-end form-control-group-variables
 
+// stylelint-disable custom-property-no-missing-var-function
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start form-control-group-tokens
 // The frame itself runs on the shared --#{$prefix}control-* namespace, so only
 // the parts the group owns get their own properties.
 $form-control-group-tokens: () !default;
-// stylelint-disable custom-property-no-missing-var-function
-// stylelint-disable-next-line scss/dollar-variable-default
 $form-control-group-tokens: defaults(
   (
     --#{$prefix}control-group-gap: #{$form-control-group-gap},
@@ -41,8 +42,10 @@ $form-control-group-tokens: defaults(
   ),
   $form-control-group-tokens
 );
-// stylelint-enable custom-property-no-missing-var-function
 // scss-docs-end form-control-group-tokens
+
+// stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function
 
 // scss-docs-start form-control-group-active-mixin
 // "This control is the one being operated" — colour, fill and border, with no

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -16,12 +16,13 @@ $form-file-button-bg:             var(--#{$prefix}tertiary-bg) !default;
 $form-file-button-hover-bg:       var(--#{$prefix}secondary-bg) !default;
 // scss-docs-end form-file-variables
 
+// stylelint-disable custom-property-no-missing-var-function
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start form-control-tokens
 // The --#{$prefix}control-* namespace is shared by every form control, so a
 // control never has to read another component's Sass variables to line up.
 $form-control-tokens: () !default;
-// stylelint-disable custom-property-no-missing-var-function
-// stylelint-disable-next-line scss/dollar-variable-default
 $form-control-tokens: defaults(
   (
     --#{$prefix}control-padding-y: var(--#{$prefix}btn-input-padding-y),
@@ -52,8 +53,10 @@ $form-control-tokens: defaults(
   ),
   $form-control-tokens
 );
-// stylelint-enable custom-property-no-missing-var-function
 // scss-docs-end form-control-tokens
+
+// stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function
 
 // scss-docs-start form-control-frame-mixin
 // The visual frame of a control, without the layout. `.form-control` is one
@@ -99,9 +102,10 @@ $form-control-select-indicator-dark:       url("data:image/svg+xml,<svg xmlns='h
 // scss-docs-end form-control-select-dark-variables
 
 $form-control-select-tokens: () !default;
-// scss-docs-start form-control-select-tokens
 // stylelint-disable custom-property-no-missing-var-function
-// stylelint-disable-next-line scss/dollar-variable-default
+// stylelint-disable scss/dollar-variable-default
+
+// scss-docs-start form-control-select-tokens
 $form-control-select-tokens: defaults(
   (
     --#{$prefix}control-select-bg-img: #{escape-svg($form-control-select-indicator)},
@@ -112,8 +116,10 @@ $form-control-select-tokens: defaults(
   ),
   $form-control-select-tokens
 );
-// stylelint-enable custom-property-no-missing-var-function
 // scss-docs-end form-control-select-tokens
+
+// stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function
 
 @layer forms {
   //

--- a/scss/forms/_form-date-time.scss
+++ b/scss/forms/_form-date-time.scss
@@ -10,13 +10,14 @@ $form-date-time-section-border-radius:   .25rem !default;
 $form-date-time-section-focus-bg:        color-mix(in srgb, var(--#{$prefix}primary) 25%, transparent) !default;
 // scss-docs-end form-date-time-variables
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start form-date-time-tokens
 // Only the section-level knobs live here. The frame is `.form-control` on the
 // same element, so its --#{$prefix}control-* tokens are already in scope and
 // must not be redeclared — that would shadow `.form-control` and validation
 // state overrides.
 $form-date-time-tokens: () !default;
-// stylelint-disable-next-line scss/dollar-variable-default
 $form-date-time-tokens: defaults(
   (
     --#{$prefix}form-date-time-placeholder-color: #{$form-date-time-placeholder-color},
@@ -26,6 +27,8 @@ $form-date-time-tokens: defaults(
   $form-date-time-tokens
 );
 // scss-docs-end form-date-time-tokens
+
+// stylelint-enable scss/dollar-variable-default
 
 @layer forms {
   // A cleaner next to a section field only means something once the field holds

--- a/scss/forms/_form-field.scss
+++ b/scss/forms/_form-field.scss
@@ -9,8 +9,9 @@ $form-field-column-gap:     .5rem !default;
 
 $form-field-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start form-field-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $form-field-tokens: defaults(
   (
     --#{$prefix}form-field-gap: #{$form-field-gap},
@@ -19,6 +20,8 @@ $form-field-tokens: defaults(
   $form-field-tokens
 );
 // scss-docs-end form-field-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 
 // The v5 spelling is an alias of this control rather than a second
 // implementation, so it is part of its selector list;

--- a/scss/forms/_form-multi-select.scss
+++ b/scss/forms/_form-multi-select.scss
@@ -12,8 +12,9 @@ $form-multi-select-selection-tags-padding-y:  .25rem !default;
 
 $form-multi-select-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start form-multi-select-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $form-multi-select-tokens: defaults(
   (
     --#{$prefix}form-multi-select-selection-tags-gap: #{$form-multi-select-selection-tags-gap},
@@ -22,6 +23,8 @@ $form-multi-select-tokens: defaults(
   $form-multi-select-tokens
 );
 // scss-docs-end form-multi-select-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 
 @layer forms {
   .form-multi-select {

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -14,13 +14,14 @@ $input-group-addon-bg:                  var(--#{$prefix}tertiary-bg) !default;
 $input-group-addon-border-color:        $input-border-color !default;
 // scss-docs-end input-group-variables
 
+// stylelint-disable custom-property-no-missing-var-function
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start input-group-tokens
 // The addon matches the text controls it sits next to, so its sizing lives in
 // the shared --#{$prefix}control-* namespace; only the addon-specific looks
 // keep the --#{$prefix}input-group-addon-* names.
 $input-group-tokens: () !default;
-// stylelint-disable custom-property-no-missing-var-function
-// stylelint-disable-next-line scss/dollar-variable-default
 $input-group-tokens: defaults(
   (
     --#{$prefix}control-padding-y: #{$input-group-addon-padding-y},
@@ -36,8 +37,10 @@ $input-group-tokens: defaults(
   ),
   $input-group-tokens
 );
-// stylelint-enable custom-property-no-missing-var-function
 // scss-docs-end input-group-tokens
+
+// stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function
 
 @layer forms {
   //

--- a/scss/forms/_otp-input.scss
+++ b/scss/forms/_otp-input.scss
@@ -40,9 +40,10 @@ $form-otp-control-font-size-lg:        $input-font-size-lg !default;
 $form-otp-control-border-radius-lg:    $input-border-radius-lg !default;
 // scss-docs-end form-otp-variables
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start form-otp-tokens
 $form-otp-tokens: () !default;
-// stylelint-disable-next-line scss/dollar-variable-default
 $form-otp-tokens: defaults(
   (
     --#{$prefix}form-otp-gap: #{$form-otp-gap},
@@ -51,12 +52,15 @@ $form-otp-tokens: defaults(
 );
 // scss-docs-end form-otp-tokens
 
+// stylelint-enable scss/dollar-variable-default
+
+// stylelint-disable custom-property-no-missing-var-function
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start form-otp-control-tokens
 // .form-otp-control is the input itself, so it carries the shared control
 // tokens rather than inheriting them from the .form-otp wrapper.
 $form-otp-control-tokens: () !default;
-// stylelint-disable custom-property-no-missing-var-function
-// stylelint-disable-next-line scss/dollar-variable-default
 $form-otp-control-tokens: defaults(
   (
     --#{$prefix}control-padding-y: #{$form-otp-control-padding-y},
@@ -80,8 +84,10 @@ $form-otp-control-tokens: defaults(
   ),
   $form-otp-control-tokens
 );
-// stylelint-enable custom-property-no-missing-var-function
 // scss-docs-end form-otp-control-tokens
+
+// stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function
 
 @layer forms {
   .form-otp {

--- a/scss/forms/_radio.scss
+++ b/scss/forms/_radio.scss
@@ -20,9 +20,10 @@ $radio-mark:              url("data:image/svg+xml,<svg xmlns='http://www.w3.org/
 
 $radio-tokens: () !default;
 
-// scss-docs-start radio-css-vars
 // stylelint-disable custom-property-no-missing-var-function, function-disallowed-list
-// stylelint-disable-next-line scss/dollar-variable-default
+// stylelint-disable scss/dollar-variable-default
+
+// scss-docs-start radio-css-vars
 $radio-tokens: defaults(
   (
     --#{$prefix}radio-size: #{$radio-size},
@@ -42,8 +43,10 @@ $radio-tokens: defaults(
   ),
   $radio-tokens
 );
-// stylelint-enable custom-property-no-missing-var-function, function-disallowed-list
 // scss-docs-end radio-css-vars
+
+// stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function, function-disallowed-list
 
 // The v5 spelling is an alias of this control rather than a second
 // implementation, so it is part of its selector list;

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -46,9 +46,10 @@ $switch-sizes: (
 
 $switch-tokens: () !default;
 
-// scss-docs-start switch-css-vars
 // stylelint-disable custom-property-no-missing-var-function, function-disallowed-list
-// stylelint-disable-next-line scss/dollar-variable-default
+// stylelint-disable scss/dollar-variable-default
+
+// scss-docs-start switch-css-vars
 $switch-tokens: defaults(
   (
     --#{$prefix}switch-width: calc(var(--#{$prefix}switch-height) * #{$switch-aspect-ratio}),
@@ -78,8 +79,10 @@ $switch-tokens: defaults(
   ),
   $switch-tokens
 );
-// stylelint-enable custom-property-no-missing-var-function, function-disallowed-list
 // scss-docs-end switch-css-vars
+
+// stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function, function-disallowed-list
 
 // The v5 spelling is an alias of this control rather than a second
 // implementation, so it is part of its selector list;

--- a/scss/helpers/_hover-lift.scss
+++ b/scss/helpers/_hover-lift.scss
@@ -13,8 +13,9 @@ $hover-lift-box-shadow:          var(--#{$prefix}box-shadow-lg) !default;
 
 $hover-lift-tokens: () !default;
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start hover-lift-css-vars
-// stylelint-disable-next-line scss/dollar-variable-default
 $hover-lift-tokens: defaults(
   (
     --#{$prefix}hover-lift-transition-duration: #{$hover-lift-transition-duration},
@@ -25,6 +26,8 @@ $hover-lift-tokens: defaults(
   $hover-lift-tokens
 );
 // scss-docs-end hover-lift-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 
 @layer helpers {
   //

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -23,11 +23,12 @@ $form-feedback-tooltip-opacity:       .9 !default;
 $form-feedback-tooltip-border-radius: var(--#{$prefix}border-radius) !default;
 // scss-docs-end tooltip-feedback-variables
 
+// stylelint-disable scss/dollar-variable-default
+
 // scss-docs-start form-feedback-tokens
 // Geometry of the feedback and tooltip elements. They are siblings of the
 // control rather than descendants, so they carry their own tokens.
 $form-feedback-tokens: () !default;
-// stylelint-disable-next-line scss/dollar-variable-default
 $form-feedback-tokens: defaults(
   (
     --#{$prefix}form-feedback-margin-top: #{$form-feedback-margin-top},
@@ -42,6 +43,10 @@ $form-feedback-tokens: defaults(
   $form-feedback-tokens
 );
 // scss-docs-end form-feedback-tokens
+
+// stylelint-enable scss/dollar-variable-default
+
+// stylelint-disable scss/at-function-named-arguments
 
 // scss-docs-start form-validation-mixins
 @mixin form-validation-state-selector($state) {
@@ -70,7 +75,6 @@ $form-feedback-tokens: defaults(
 
 // The v5 spelling is an alias of the controls rather than a second
 // implementation; `$enable-deprecated-form-check: false` compiles it out.
-// stylelint-disable-next-line scss/at-function-named-arguments
 $validated-controls: if(sass($enable-deprecated-form-check): ".check, .radio, .switch, .form-check-input"; else: ".check, .radio, .switch") !default;
 
 @mixin form-validation-state(
@@ -270,3 +274,5 @@ $validated-controls: if(sass($enable-deprecated-form-check): ".check, .radio, .s
   }
 }
 // scss-docs-end form-validation-mixins
+
+// stylelint-enable scss/at-function-named-arguments


### PR DESCRIPTION
Every component's CSS variables table is captured between the `scss-docs` markers, so a `stylelint-disable` sitting under the start marker was rendered as the first line of that table on the docs page. Same defect we fixed by hand in Badge and Accordion — it turned out to be everywhere.

The pragmas move above the start marker as `disable` / `enable` pairs around the block, so the snippet starts at the declaration. 80 pragmas across 51 files, all of the token-map shape.

**Verification**

- Compiled CSS is byte-identical for all five bundles (`coreui`, `coreui-grid`, `coreui-reboot`, `coreui-utilities`, `themes/bootstrap`), compared against a `v6-dev` worktree build.
- `stylelint` clean over the whole tree, with `reportNeedlessDisables` on, so no pair covers a range where its rule never fires.
- `css-lint-vars`, `check-class-api`, the SCSS suite (62 specs) and `docs-build` (146 pages) all pass.
- `scss/dollar-variable-default` and `custom-property-no-missing-var-function` no longer appear on any built page.

**Deliberately left alone**, because hoisting them would silence a rule for far more than the line it was written for: pragmas attached to a documented line of code (`// stylelint-disable-line …`, 24 + 12 occurrences), pragmas inside rule bodies and mixins (navbar, modal, dialog, buttons, `mixins/_forms.scss`), and the `value-keyword-case` pair in `_config.scss`, which wraps two font-family declarations inside a much larger documented block.