### PR TITLE
fix(Alert): size the close button's space from the alert's padding tokens

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -283,6 +283,17 @@ finished, not whether the state changed.
 - **An `<hr>` inside an alert takes the variant's border colour.** The alert
   redeclares `--cui-hr-border-color`, so a separator in a `.alert-success` is
   green rather than the page's neutral grey.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`$alert-dismissible-padding-r` is gone; the space for the close button
+  follows `--cui-alert-padding-x`.** The variable was multiplied out in Sass
+  when the stylesheet was built, so raising `--cui-alert-padding-x` widened
+  three sides of a dismissible alert and left the fourth on the default: at
+  `2rem` the alert had 32px of padding and 48px of room for the button, which
+  also kept its own 16px padding. Both are subtracted from the tokens now —
+  `calc(var(--cui-alert-padding-x) * 3)` and
+  `calc(var(--cui-alert-padding-y) * 1.25) var(--cui-alert-padding-x)` — so one
+  token resizes the whole alert. Defaults render as before; drop any override
+  of the removed variable.
 
 #### Badge
 

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -12,12 +12,7 @@ $alert-margin-bottom:           1rem !default;
 $alert-border-radius:           var(--#{$prefix}border-radius) !default;
 $alert-link-font-weight:        $font-weight-bold !default;
 $alert-border-width:            var(--#{$prefix}border-width) !default;
-$alert-dismissible-padding-r:   $alert-padding-x * 3 !default; // 3x covers width of x plus default padding on either side
 // scss-docs-end alert-variables
-
-//
-// Base styles
-//
 
 $alert-tokens: () !default;
 
@@ -35,8 +30,6 @@ $alert-tokens: defaults(
     --#{$prefix}alert-border: #{$alert-border-width} solid var(--#{$prefix}alert-border-color),
     --#{$prefix}alert-border-radius: #{$alert-border-radius},
     --#{$prefix}alert-link-color: var(--#{$prefix}theme-fg, inherit),
-    // Redeclared inside the alert so an <hr> in its body takes the variant's
-    // border instead of staying the page's neutral grey.
     --#{$prefix}hr-border-color: var(--#{$prefix}theme-border, var(--#{$prefix}border-color)),
   ),
   $alert-tokens
@@ -58,44 +51,31 @@ $alert-tokens: defaults(
     @include border-radius(var(--#{$prefix}alert-border-radius));
   }
 
-  // Headings for larger alerts
   .alert-heading {
-    // Specified to prevent conflicts of changing $headings-color
     color: inherit;
   }
 
-  // Provide class for links that match alerts
   .alert-link {
     font-weight: $alert-link-font-weight;
     color: var(--#{$prefix}alert-link-color);
   }
 
 
-  // Dismissible alerts
-  //
-  // Expand the inline-end padding and account for the close button's
-  // positioning. An alert that contains a close button gets this on its own —
-  // `.alert-dismissible` stays supported for markup that already carries it,
-  // and for the case where the button is rendered later.
-
   .alert:has(> .btn-close),
   .alert-dismissible {
-    padding-inline-end: $alert-dismissible-padding-r;
+    padding-inline-end: calc(var(--#{$prefix}alert-padding-x) * 3); // stylelint-disable-line function-disallowed-list
 
-    // Adjust close link position (descendant, as before: the button may sit
-    // inside a wrapper in existing `.alert-dismissible` markup)
     .btn-close {
       position: absolute;
       inset-inline-end: 0;
       top: 0;
       z-index: $stretched-link-z-index + 1;
-      padding: $alert-padding-y * 1.25 $alert-padding-x;
+      padding: calc(var(--#{$prefix}alert-padding-y) * 1.25) var(--#{$prefix}alert-padding-x); // stylelint-disable-line function-disallowed-list
     }
   }
 
 
   // scss-docs-start alert-modifiers
-  // Generate contextual modifier classes for colorizing the alert.
   @each $state in map.keys($theme-colors) {
     .alert-#{$state} {
       @include theme-tokens($state);


### PR DESCRIPTION
`$alert-dismissible-padding-r` (`$alert-padding-x * 3`) and the close button's own padding (`$alert-padding-y * 1.25 $alert-padding-x`) were multiplied out in Sass when the stylesheet was built, so they could not follow `--cui-alert-padding-*`. Measured in a browser with `--cui-alert-padding-x: 2rem; --cui-alert-padding-y: 2rem`: the alert had 32px of padding on three sides, 48px of room for the button on the fourth, and a button still padded to 16px.

Both are subtracted from the tokens now — the same shape the Accordion moved to in #748. With the same override the alert reads 32/32, 96px of room, and a 40/32 button; defaults are untouched at 16/16, 48px and 20/16.

The Sass variable is removed, so `npm run css-lint-vars` stays clean; migration guide entry included.

Also drops the prose from the file: the stranded `// Base styles` header that sat above a variable declaration, the note inside the token map that the docs rendered into the CSS variables table, and the paragraph explaining `.alert-dismissible` — that reasoning is in this commit instead.

**Not** taking upstream's flex layout in this PR. It only works with their markup contract (text wrapped in `<p>`, multi-content in a `<vstack>`, the close button as a flex item with `ms-auto` rather than positioned), so the CSS alone would turn every existing alert with several children into a row. Recorded as a decision in the audit.