### PR TITLE
feat(Alert): lay the alert out in a row and let the close button ride along

### DIFF
--- a/docs/src/content/docs/components/alerts.mdx
+++ b/docs/src/content/docs/components/alerts.mdx
@@ -73,21 +73,23 @@ Utilize the `.alert-link` utility class to instantly create matching colored lin
 
 ### Additional content
 
-Bootstrap alerts can also include additional HTML elements such as headings, paragraphs, and dividers.
+Bootstrap alerts can also include additional HTML elements such as headings, paragraphs, and dividers. The alert lays its children out in a row, so wrap them in a [`.vstack`](/helpers/stacks/) to keep them stacked.
 
 <Example code={`<div class="alert alert-success" role="alert">
-    <h4 class="alert-heading">Great job! </h4>
-    <p>Awesome! You've successfully read this crucial alert message. This example text will be slightly longer to demonstrate how spacing in an alert interacts with this type of content.</p>
-    <hr>
-    <p class="mb-0">Whenever necessary, make sure to use margin utilities to keep everything organized and neat.</p>
+    <div class="vstack">
+      <h4 class="alert-heading">Great job! </h4>
+      <p>Awesome! You've successfully read this crucial alert message. This example text will be slightly longer to demonstrate how spacing in an alert interacts with this type of content.</p>
+      <hr>
+      <p class="mb-0">Whenever necessary, make sure to use margin utilities to keep everything organized and neat.</p>
+    </div>
   </div>`} />
 
 ### Icons
 
-In a similar vein, you can utilize [flexbox utilities](/utilities/flex/) and [CoreUI Icons](https://coreui.io/icons/) for crafting alerts that include icons. Based on your choice of icons and the content involved, you might consider incorporating additional utilities or custom styling.
+Put an icon straight into the alert — it lays its children out in a row and spaces them with `--cui-alert-gap`, so no flexbox utilities are needed. Use [CoreUI Icons](https://coreui.io/icons/) or any inline SVG.
 
-<Example code={`<div class="alert alert-primary d-flex align-items-center" role="alert">
-    <svg class="me-2" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 512 512">
+<Example code={`<div class="alert alert-primary" role="alert">
+    <svg class="flex-shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 512 512">
       <rect width="32" height="176" x="240" y="176" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
       <rect width="32" height="32" x="240" y="384" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
       <path fill="var(--ci-primary-color, currentColor)" d="M274.014,16H237.986L16,445.174V496H496V445.174ZM464,464H48V452.959L256,50.826,464,452.959Z" class="ci-primary"/>
@@ -116,26 +118,26 @@ If you require multiple icons for your alerts, think about utilizing additional 
     </symbol>
   </svg>
 
-  <div class="alert alert-primary d-flex align-items-center" role="alert">
-    <svg class="flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Info:"><use xlink:href="#icon-info"/></svg>
+  <div class="alert alert-primary" role="alert">
+    <svg class="flex-shrink-0" width="24" height="24" role="img" aria-label="Info:"><use xlink:href="#icon-info"/></svg>
     <div>
       A straightforward alert with an icon
     </div>
   </div>
-  <div class="alert alert-success d-flex align-items-center" role="alert">
-    <svg class="flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Success:"><use xlink:href="#icon-check"/></svg>
+  <div class="alert alert-success" role="alert">
+    <svg class="flex-shrink-0" width="24" height="24" role="img" aria-label="Success:"><use xlink:href="#icon-check"/></svg>
     <div>
       A straightforward success alert with an icon
     </div>
   </div>
-  <div class="alert alert-warning d-flex align-items-center" role="alert">
-    <svg class="flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Warning:"><use xlink:href="#icon-warning"/></svg>
+  <div class="alert alert-warning" role="alert">
+    <svg class="flex-shrink-0" width="24" height="24" role="img" aria-label="Warning:"><use xlink:href="#icon-warning"/></svg>
     <div>
       A straightforward warning alert with an icon
     </div>
   </div>
-  <div class="alert alert-danger d-flex align-items-center" role="alert">
-    <svg class="flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Danger:"><use xlink:href="#icon-warning"/></svg>
+  <div class="alert alert-danger" role="alert">
+    <svg class="flex-shrink-0" width="24" height="24" role="img" aria-label="Danger:"><use xlink:href="#icon-warning"/></svg>
     <div>
       A straightforward danger alert with an icon
     </div>
@@ -156,7 +158,7 @@ To create a solid alert, remove the `alert-*` contextual class (like alert-prima
 Using the JavaScript plugin, you can remove any alert.
 
 - Ensure that you've loaded the Bootstrap alert plugin or the compiled CoreUI JavaScript.
-- Add a [close button](/components/close-button//) as a child of the alert. The alert makes room for it and positions it on its own — the `.alert-dismissible` class is no longer required. <AddedIn version="6.0.0" />
+- Add a [close button](/components/close-button//) as a child of the alert. It is pushed to the end of the alert on its own — the `.alert-dismissible` class is no longer required. <AddedIn version="6.0.0" />
 - Keep `.alert-dismissible` if the close button is added later by your own code, or if it sits inside a wrapper element rather than directly in the alert. The class keeps working and does exactly what it always did.
 - On the close button, include the `data-coreui-dismiss="alert"` attribute, which triggers the JavaScript functionality. You must use the `<button>` element with it for proper behavior across all devices.
 - To animate alerts during dismissal, you need to add the `.fade` and `.show` classes.

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -280,6 +280,30 @@ finished, not whether the state changed.
 
 #### Alert
 
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The alert lays its children out in a row.** It is `display: flex` with
+  `align-items: start` and `--cui-alert-gap` between children, so an icon next
+  to a label needs no `d-flex` and no spacing utility. Text mixed with inline
+  elements is a single anonymous item and is unaffected, but an alert built
+  from **several block elements** — a heading, paragraphs, an `<hr>` — now sits
+  side by side. Wrap that content in a `.vstack`:
+
+  ```html
+  <div class="alert alert-success" role="alert">
+    <div class="vstack">
+      <h4 class="alert-heading">Great job!</h4>
+      <p>…</p>
+    </div>
+  </div>
+  ```
+
+- **The close button is a flex item, not an absolutely positioned one.** It is
+  pushed to the end with `margin-inline-start: auto`, so it no longer overlaps
+  the text and the alert no longer reserves three paddings of room for it.
+  Markup does not change: a `.btn-close` inside the alert still lands where it
+  did, with or without `.alert-dismissible`. `--cui-alert-close-*` and the
+  `$alert-dismissible-padding-r` machinery are gone with the positioning.
+
 - **An `<hr>` inside an alert takes the variant's border colour.** The alert
   redeclares `--cui-hr-border-color`, so a separator in a `.alert-success` is
   green rather than the page's neutral grey.

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -8,6 +8,7 @@
 // scss-docs-start alert-variables
 $alert-padding-y:               $spacer !default;
 $alert-padding-x:               $spacer !default;
+$alert-gap:                     $spacer * .5 !default;
 $alert-margin-bottom:           1rem !default;
 $alert-border-radius:           var(--#{$prefix}border-radius) !default;
 $alert-link-font-weight:        $font-weight-bold !default;
@@ -24,12 +25,13 @@ $alert-tokens: defaults(
     --#{$prefix}alert-bg: var(--#{$prefix}theme-bg-subtle, transparent),
     --#{$prefix}alert-padding-x: #{$alert-padding-x},
     --#{$prefix}alert-padding-y: #{$alert-padding-y},
+    --#{$prefix}alert-gap: #{$alert-gap},
     --#{$prefix}alert-margin-bottom: #{$alert-margin-bottom},
     --#{$prefix}alert-color: var(--#{$prefix}theme-fg, inherit),
     --#{$prefix}alert-border-color: var(--#{$prefix}theme-border, transparent),
     --#{$prefix}alert-border: #{$alert-border-width} solid var(--#{$prefix}alert-border-color),
     --#{$prefix}alert-border-radius: #{$alert-border-radius},
-    --#{$prefix}alert-link-color: var(--#{$prefix}theme-fg, inherit),
+    --#{$prefix}alert-link-color: inherit,
     --#{$prefix}hr-border-color: var(--#{$prefix}theme-border, var(--#{$prefix}border-color)),
   ),
   $alert-tokens
@@ -42,13 +44,19 @@ $alert-tokens: defaults(
   .alert {
     @include tokens($alert-tokens);
 
-    position: relative;
+    display: flex;
+    gap: var(--#{$prefix}alert-gap);
+    align-items: start;
     padding: var(--#{$prefix}alert-padding-y) var(--#{$prefix}alert-padding-x);
     margin-bottom: var(--#{$prefix}alert-margin-bottom);
     color: var(--#{$prefix}alert-color);
     background-color: var(--#{$prefix}alert-bg);
     border: var(--#{$prefix}alert-border);
     @include border-radius(var(--#{$prefix}alert-border-radius));
+  }
+
+  .alert > p {
+    margin-bottom: 0;
   }
 
   .alert-heading {
@@ -61,17 +69,9 @@ $alert-tokens: defaults(
   }
 
 
-  .alert:has(> .btn-close),
-  .alert-dismissible {
-    padding-inline-end: calc(var(--#{$prefix}alert-padding-x) * 3); // stylelint-disable-line function-disallowed-list
-
-    .btn-close {
-      position: absolute;
-      inset-inline-end: 0;
-      top: 0;
-      z-index: $stretched-link-z-index + 1;
-      padding: calc(var(--#{$prefix}alert-padding-y) * 1.25) var(--#{$prefix}alert-padding-x); // stylelint-disable-line function-disallowed-list
-    }
+  .alert:has(> .btn-close) > .btn-close,
+  .alert-dismissible > .btn-close {
+    margin-inline-start: auto;
   }
 
 


### PR DESCRIPTION
An icon beside a label needed `d-flex` and a spacing utility in the markup, and the close button was held in place by a stack of compensations: absolute positioning, `z-index`, three paddings of reserved room on the alert, and its own padding kept in step with the alert's.

The alert is a flex row now (`align-items: start`, spaced by the new `--cui-alert-gap`), and the close button is an ordinary flex item pushed to the end with `margin-inline-start: auto`. Every compensation goes away with it — including the two `calc()` lint pragmas.

`--cui-alert-link-color` drops to plain `inherit`; it resolved to the same colour the long way round.

**Compatibility, checked in a browser**

- A plain alert, an alert with a link, and a solid alert render as before.
- A `.btn-close` inside the alert still lands at the trailing edge, with or without `.alert-dismissible` and without adding `ms-auto` — the `:has()` rule we already had now pushes it instead of reserving padding for it. Upstream needs `ms-auto` in the markup for the same result.
- **The one regression:** an alert built from several block elements (heading, paragraphs, `<hr>`) now sits side by side and has to wrap that content in a `.vstack`. Documented in the migration guide and fixed in the Additional content example.

`.vstack` rather than a bare wrapper on purpose: it grows to the alert's width (`flex: 1 1 auto`), so an `<hr>` still reaches the edge. A plain `<div>` shrink-wraps and leaves it short — which is what upstream's own example does, since their `<vstack>` matches no selector in their CSS (`[class*="vstack"]`) and is a one-off in their docs.

Icons examples lose `d-flex align-items-center` and `me-2`; the gap handles the spacing now.