### PR TITLE
feat(Alert): fade an alert in when it is added to the page

### DIFF
--- a/docs/src/content/docs/components/alerts.mdx
+++ b/docs/src/content/docs/components/alerts.mdx
@@ -161,7 +161,7 @@ Using the JavaScript plugin, you can remove any alert.
 - Add a [close button](/components/close-button//) as a child of the alert. It is pushed to the end of the alert on its own — the `.alert-dismissible` class is no longer required. <AddedIn version="6.0.0" />
 - Keep `.alert-dismissible` if the close button is added later by your own code, or if it sits inside a wrapper element rather than directly in the alert. The class keeps working and does exactly what it always did.
 - On the close button, include the `data-coreui-dismiss="alert"` attribute, which triggers the JavaScript functionality. You must use the `<button>` element with it for proper behavior across all devices.
-- To animate alerts during dismissal, you need to add the `.fade` and `.show` classes.
+- Add the `.fade` and `.show` classes to animate the alert. It fades out when dismissed, and an alert added to the page while carrying them fades in on its own. <AddedIn version="6.0.0" />
 
 You can observe this in action with a live demonstration:
 

--- a/docs/src/content/docs/components/snippets/alert-live.js
+++ b/docs/src/content/docs/components/snippets/alert-live.js
@@ -2,7 +2,7 @@ const alertPlaceholder = document.getElementById('liveAlertPlaceholder')
 const appendAlert = (message, type) => {
   const wrapper = document.createElement('div')
   wrapper.innerHTML = [
-    `<div class="alert alert-${type} alert-dismissible" role="alert">`,
+    `<div class="alert alert-${type} fade show" role="alert">`,
     `   <div>${message}</div>`,
     '   <button type="button" class="btn-close" data-coreui-dismiss="alert" aria-label="Close"></button>',
     '</div>'

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -297,6 +297,13 @@ finished, not whether the state changed.
   </div>
   ```
 
+- **An alert marked `.fade show` fades in when it is added to the page.** The
+  classes used to animate the alert in one direction only, because an element
+  inserted with `.show` already on it has no earlier state to transition from;
+  `@starting-style` supplies one. Nothing to change in your code — an alert you
+  append at runtime animates without the class juggling that used to be needed,
+  and an alert already in the markup is unaffected.
+
 - **The close button is a flex item, not an absolutely positioned one.** It is
   pushed to the end with `margin-inline-start: auto`, so it no longer overlaps
   the text and the alert no longer reserves three paddings of room for it.

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -59,6 +59,14 @@ $alert-tokens: defaults(
     margin-bottom: 0;
   }
 
+  // An alert inserted with `.show` already on it has no earlier state to
+  // transition from, so the fade-in needs one declared here.
+  @starting-style {
+    .alert.fade.show {
+      opacity: 0;
+    }
+  }
+
   .alert-heading {
     color: inherit;
   }


### PR DESCRIPTION
`.fade` and `.show` animated the alert in one direction only. An element inserted with `.show` already on it has no earlier state to transition from, so it appeared at full opacity and only faded on the way out. `@starting-style` supplies that state.

Measured in a browser: an alert appended at runtime now ramps 0.17 → 0.33 → 0.50 → 0.67 → 0.83 → 1 over ~150ms, matching `--cui-transition-fade-duration`. Dismissal is unchanged (1 → 0 → removed at ~164ms).

Scoped to `.fade` so it stays opt-in: an alert already in the markup without the class is untouched, and no `@supports` guard is needed — our floor (Chrome 123, Edge 123, Firefox 129, Safari/iOS 17.5) is at or above `@starting-style` support everywhere.

The live example in the docs built its alert as `alert alert-{type} alert-dismissible`, without `.fade .show`, so it neither faded in nor out — that is the one place on the page where the animation was visibly missing. It carries them now.