### PR TITLE
docs(Alert): put the icons straight into the examples

### DIFF
--- a/docs/src/content/docs/components/alerts.mdx
+++ b/docs/src/content/docs/components/alerts.mdx
@@ -99,45 +99,43 @@ Put an icon straight into the alert — it lays its children out in a row and sp
     </div>
   </div>`} />
 
-If you require multiple icons for your alerts, think about utilizing additional CoreUI Icons and creating a local SVG sprite. This method allows for easy and repeated reference to the same icons.
+Different kinds of alert usually call for different icons. Put the matching SVG straight into each one. To reuse a single icon many times across a page, define it once as a symbol — see [Icons](/icons/).
 
-<Example code={`<svg xmlns="http://www.w3.org/2000/svg" class="d-none">
-    <symbol id="icon-warning" viewBox="0 0 512 512">
-      <rect width="32" height="176" x="240" y="176" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
-      <rect width="32" height="32" x="240" y="384" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
-      <path fill="var(--ci-primary-color, currentColor)" d="M274.014,16H237.986L16,445.174V496H496V445.174ZM464,464H48V452.959L256,50.826,464,452.959Z" class="ci-primary"/>
-    </symbol>
-    <symbol id="icon-check" viewBox="0 0 512 512">
-      <path fill="var(--ci-primary-color, currentColor)" d="M426.072,86.928A238.75,238.75,0,0,0,88.428,424.572,238.75,238.75,0,0,0,426.072,86.928ZM257.25,462.5c-114,0-206.75-92.748-206.75-206.75S143.248,49,257.25,49,464,141.748,464,255.75,371.252,462.5,257.25,462.5Z" class="ci-primary"/>
-      <polygon fill="var(--ci-primary-color, currentColor)" points="221.27 305.808 147.857 232.396 125.23 255.023 221.27 351.063 388.77 183.564 366.142 160.937 221.27 305.808" class="ci-primary"/>
-    </symbol>
-    <symbol id="icon-info" viewBox="0 0 512 512">
+<Example code={`<div class="alert alert-primary" role="alert">
+    <svg class="flex-shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 512 512" role="img" aria-label="Info:">
       <rect width="34.924" height="34.924" x="256" y="95.998" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
       <path fill="var(--ci-primary-color, currentColor)" d="M16,496H496V16H16ZM48,48H464V464H48Z" class="ci-primary"/>
       <path fill="var(--ci-primary-color, currentColor)" d="M285.313,359.032a18.123,18.123,0,0,1-15.6,8.966,18.061,18.061,0,0,1-17.327-23.157l35.67-121.277A49.577,49.577,0,0,0,194.7,190.572l-11.718,28.234,29.557,12.266,11.718-28.235a17.577,17.577,0,0,1,33.1,11.7l-35.67,121.277A50.061,50.061,0,0,0,269.709,400a50.227,50.227,0,0,0,43.25-24.853l15.1-25.913-27.646-16.115Z" class="ci-primary"/>
-    </symbol>
-  </svg>
-
-  <div class="alert alert-primary" role="alert">
-    <svg class="flex-shrink-0" width="24" height="24" role="img" aria-label="Info:"><use xlink:href="#icon-info"/></svg>
+    </svg>
     <div>
       A straightforward alert with an icon
     </div>
   </div>
   <div class="alert alert-success" role="alert">
-    <svg class="flex-shrink-0" width="24" height="24" role="img" aria-label="Success:"><use xlink:href="#icon-check"/></svg>
+    <svg class="flex-shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 512 512" role="img" aria-label="Success:">
+      <path fill="var(--ci-primary-color, currentColor)" d="M426.072,86.928A238.75,238.75,0,0,0,88.428,424.572,238.75,238.75,0,0,0,426.072,86.928ZM257.25,462.5c-114,0-206.75-92.748-206.75-206.75S143.248,49,257.25,49,464,141.748,464,255.75,371.252,462.5,257.25,462.5Z" class="ci-primary"/>
+      <polygon fill="var(--ci-primary-color, currentColor)" points="221.27 305.808 147.857 232.396 125.23 255.023 221.27 351.063 388.77 183.564 366.142 160.937 221.27 305.808" class="ci-primary"/>
+    </svg>
     <div>
       A straightforward success alert with an icon
     </div>
   </div>
   <div class="alert alert-warning" role="alert">
-    <svg class="flex-shrink-0" width="24" height="24" role="img" aria-label="Warning:"><use xlink:href="#icon-warning"/></svg>
+    <svg class="flex-shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 512 512" role="img" aria-label="Warning:">
+      <rect width="32" height="176" x="240" y="176" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
+      <rect width="32" height="32" x="240" y="384" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
+      <path fill="var(--ci-primary-color, currentColor)" d="M274.014,16H237.986L16,445.174V496H496V445.174ZM464,464H48V452.959L256,50.826,464,452.959Z" class="ci-primary"/>
+    </svg>
     <div>
       A straightforward warning alert with an icon
     </div>
   </div>
   <div class="alert alert-danger" role="alert">
-    <svg class="flex-shrink-0" width="24" height="24" role="img" aria-label="Danger:"><use xlink:href="#icon-warning"/></svg>
+    <svg class="flex-shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 512 512" role="img" aria-label="Danger:">
+      <rect width="32" height="176" x="240" y="176" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
+      <rect width="32" height="32" x="240" y="384" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
+      <path fill="var(--ci-primary-color, currentColor)" d="M274.014,16H237.986L16,445.174V496H496V445.174ZM464,464H48V452.959L256,50.826,464,452.959Z" class="ci-primary"/>
+    </svg>
     <div>
       A straightforward danger alert with an icon
     </div>

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -59,8 +59,6 @@ $alert-tokens: defaults(
     margin-bottom: 0;
   }
 
-  // An alert inserted with `.show` already on it has no earlier state to
-  // transition from, so the fade-in needs one declared here.
   @starting-style {
     .alert.fade.show {
       opacity: 0;
@@ -75,7 +73,6 @@ $alert-tokens: defaults(
     font-weight: $alert-link-font-weight;
     color: var(--#{$prefix}alert-link-color);
   }
-
 
   .alert > .btn-close {
     margin-inline-start: auto;


### PR DESCRIPTION
The icon examples defined three `<symbol>` elements in a hidden sprite and referenced them with `<use>`, which taught SVG sprites on a page about alerts. That technique already has its own sections on the Icons page (SVG Sprites, SVG Symbols), and upstream's alert docs carry nothing like it.

Each alert now carries its own inline SVG, so the example shows the thing it is about — an alert with an icon — and the reader is pointed at Icons for reuse across a page.

Also drops the comment above `@starting-style` in the stylesheet (mrholek's edit).