### PR TITLE
feat(Alert): add .alert-solid and .alert-outline

### DIFF
--- a/docs/src/content/docs/components/alerts.mdx
+++ b/docs/src/content/docs/components/alerts.mdx
@@ -143,12 +143,18 @@ Different kinds of alert usually call for different icons. Put the matching SVG 
 
 ### Solid
 
-Use solid alerts to create high-contrast notifications by applying background utility classes. This variant removes the default alert styling and relies on the utility classes for full-color backgrounds and text.
+Add `.alert-solid` for a high-contrast alert. The background takes the theme color and the text takes the color that reads on it, so a yellow alert gets dark text and a dark one gets light text without you picking either. <AddedIn version="6.0.0" />
 
-To create a solid alert, remove the `alert-*` contextual class (like alert-primary) and apply any of the `bg-*` utility classes (e.g. `bg-primary`, `bg-danger`, `bg-success`, etc.). Make sure to also add the appropriate `text-*` class to ensure good contrast and accessibility.
-
-<Example code={getData('theme-colors').map((c) => `<div class="alert bg-${c.name} text-white" role="alert">
+<Example code={getData('theme-colors').map((c) => `<div class="alert alert-solid alert-${c.name}" role="alert">
     Here's a straightforward example of solid ${c.name} alert—take a look!
+  </div>`)} />
+
+### Outline
+
+Add `.alert-outline` for an alert that carries a border and no fill. <AddedIn version="6.0.0" />
+
+<Example code={getData('theme-colors').map((c) => `<div class="alert alert-outline alert-${c.name}" role="alert">
+    Here's a straightforward example of outline ${c.name} alert—take a look!
   </div>`)} />
 
 ### Dismissing
@@ -253,8 +259,12 @@ Our Bootstrap alerts utilize local CSS variables on `.alert` for improved real-t
 
 <ScssDocs file="scss/_alert.scss" capture="alert-variables" />
 
+Each entry in the variants map names the theme role every token reads, so adding a variant takes a map entry rather than a new rule.
+
+<ScssDocs file="scss/_alert.scss" capture="alert-variants" />
+
 ### SASS loop
 
-Loop that creates the modifier classes, pointing each alert's tokens at the matching theme color.
+Loops that create the modifier classes: one points each alert's tokens at the matching theme color, the other at the roles a variant reads.
 
 <ScssDocs file="scss/_alert.scss" capture="alert-modifiers" />

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -297,6 +297,18 @@ finished, not whether the state changed.
   </div>
   ```
 
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **A solid alert is `.alert-solid`, not a pile of utilities.** The docs used to
+  say to drop the contextual class and reach for `bg-{color}` plus a `text-*`
+  class picked by hand — and the examples hard-coded `text-white`, which fails
+  WCAG AA on five of the eight theme colours: measured 3.50 on success, 3.69 on
+  danger, 2.94 on info, 1.85 on warning and 1.10 on light, where white text on a
+  near-white background is invisible. `.alert-solid` reads the theme's own
+  contrast token, so every colour lands between 4.56 and 18.03 — including a
+  theme colour you define yourself. `.alert-outline` joins it for an alert with
+  a border and no fill. Markup using the old recipe still renders; it is the
+  contrast that was never right.
+
 - **An alert marked `.fade show` fades in when it is added to the page.** The
   classes used to animate the alert in one direction only, because an element
   inserted with `.show` already on it has no earlier state to transition from;

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -40,6 +40,21 @@ $alert-tokens: defaults(
 
 // stylelint-enable scss/dollar-variable-default
 
+// scss-docs-start alert-variants
+$alert-variants: (
+  "solid": (
+    "color": "contrast",
+    "bg": "base",
+    "border-color": "base"
+  ),
+  "outline": (
+    "color": "fg",
+    "bg": "transparent",
+    "border-color": "border"
+  )
+) !default;
+// scss-docs-end alert-variants
+
 @layer components {
   .alert {
     @include tokens($alert-tokens);
@@ -83,6 +98,18 @@ $alert-tokens: defaults(
   @each $state in map.keys($theme-colors) {
     .alert-#{$state} {
       @include theme-tokens($state);
+    }
+  }
+
+  @each $variant, $properties in $alert-variants {
+    .alert-#{$variant} {
+      @each $property, $value in $properties {
+        @if $value == "transparent" {
+          --#{$prefix}alert-#{$property}: transparent;
+        } @else {
+          --#{$prefix}alert-#{$property}: var(--#{$prefix}theme-#{$value});
+        }
+      }
     }
   }
   // scss-docs-end alert-modifiers


### PR DESCRIPTION
Spotted by mrholek: Badge builds its variants from a map of theme roles, while a "solid" alert was a recipe — drop the contextual class, add `bg-{color}`, then pick a text colour by hand.

That recipe was also wrong. The docs generated every example with `text-white`, and measured in a browser it fails WCAG AA on five of the eight theme colours:

| | `bg-* text-white` | `.alert-solid` |
| --- | --- | --- |
| success | 3.50 ✗ | 5.67 |
| danger | 3.69 ✗ | 5.38 |
| info | 2.94 ✗ | 6.74 |
| warning | 1.85 ✗ | 10.70 |
| light | 1.10 ✗ | 18.03 |
| primary / secondary / dark | 5.65 / 4.56 / 15.15 | unchanged |

`.alert-solid` reads the theme's own contrast token, so the text colour follows the background instead of being guessed — a yellow alert gets dark text, a dark one gets light text, and a theme colour you define yourself is covered too. `.alert-outline` joins it for an alert with a border and no fill.

The variants come from an `$alert-variants` map with the same shape as `$badge-variants`, so a new variant is a map entry rather than a new rule, and the two components now describe variants the same way.

Markup using the old utility recipe still renders exactly as it did — it is the contrast that was never right. Docs get a Solid and an Outline section plus the map in Customizing; migration guide entry included.

Note the namespace still carries both axes here (`.alert-solid` beside the legacy `.alert-danger`); moving colour onto `.theme-*` with legacy aliases is the etap 2½ item in plans/theme-slots-and-tokens.md.