### PR TITLE
fix(Alert): drop .alert-outline and put the version badge under its heading

### DIFF
--- a/docs/src/content/docs/components/alerts.mdx
+++ b/docs/src/content/docs/components/alerts.mdx
@@ -143,18 +143,12 @@ Different kinds of alert usually call for different icons. Put the matching SVG 
 
 ### Solid
 
-Add `.alert-solid` for a high-contrast alert. The background takes the theme color and the text takes the color that reads on it, so a yellow alert gets dark text and a dark one gets light text without you picking either. <AddedIn version="6.0.0" />
+<AddedIn version="6.0.0" />
+
+Add `.alert-solid` for a high-contrast alert. The background takes the theme color and the text takes the color that reads on it, so a yellow alert gets dark text and a dark one gets light text without you picking either.
 
 <Example code={getData('theme-colors').map((c) => `<div class="alert alert-solid alert-${c.name}" role="alert">
     Here's a straightforward example of solid ${c.name} alert—take a look!
-  </div>`)} />
-
-### Outline
-
-Add `.alert-outline` for an alert that carries a border and no fill. <AddedIn version="6.0.0" />
-
-<Example code={getData('theme-colors').map((c) => `<div class="alert alert-outline alert-${c.name}" role="alert">
-    Here's a straightforward example of outline ${c.name} alert—take a look!
   </div>`)} />
 
 ### Dismissing
@@ -162,10 +156,10 @@ Add `.alert-outline` for an alert that carries a border and no fill. <AddedIn ve
 Using the JavaScript plugin, you can remove any alert.
 
 - Ensure that you've loaded the Bootstrap alert plugin or the compiled CoreUI JavaScript.
-- Add a [close button](/components/close-button//) as a child of the alert. It is pushed to the end of the alert on its own — the `.alert-dismissible` class is no longer required. <AddedIn version="6.0.0" />
+- Add a [close button](/components/close-button//) as a child of the alert. It is pushed to the end of the alert on its own — the `.alert-dismissible` class is no longer required.
 - `.alert-dismissible` no longer carries any styling. Markup that still has it renders the same, so there is nothing to remove, but the close button has to be a direct child of the alert to be pushed to its end — a button nested in a wrapper is laid out by that wrapper.
 - On the close button, include the `data-coreui-dismiss="alert"` attribute, which triggers the JavaScript functionality. You must use the `<button>` element with it for proper behavior across all devices.
-- Add the `.fade` and `.show` classes to animate the alert. It fades out when dismissed, and an alert added to the page while carrying them fades in on its own. <AddedIn version="6.0.0" />
+- Add the `.fade` and `.show` classes to animate the alert. It fades out when dismissed, and an alert added to the page while carrying them fades in on its own.
 
 You can observe this in action with a live demonstration:
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -305,9 +305,8 @@ finished, not whether the state changed.
   danger, 2.94 on info, 1.85 on warning and 1.10 on light, where white text on a
   near-white background is invisible. `.alert-solid` reads the theme's own
   contrast token, so every colour lands between 4.56 and 18.03 — including a
-  theme colour you define yourself. `.alert-outline` joins it for an alert with
-  a border and no fill. Markup using the old recipe still renders; it is the
-  contrast that was never right.
+  theme colour you define yourself. Markup using the old recipe still renders;
+  it is the contrast that was never right.
 
 - **An alert marked `.fade show` fades in when it is added to the page.** The
   classes used to animate the alert in one direction only, because an element

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -46,11 +46,6 @@ $alert-variants: (
     "color": "contrast",
     "bg": "base",
     "border-color": "base"
-  ),
-  "outline": (
-    "color": "fg",
-    "bg": "transparent",
-    "border-color": "border"
   )
 ) !default;
 // scss-docs-end alert-variants


### PR DESCRIPTION
Two corrections to #760, both raised by mrholek.

**`.alert-outline` comes out.** It came along for the ride when the variants map landed and does not earn a place: the default alert is already the quiet one — subtle background, themed border — so an outline variant differs from it only by losing the fill. Badge can carry solid, subtle and outline because *its* default is the loud one; on the alert it would be a fourth barely distinguishable option to document, test, wrap in four frameworks and keep forever. The map keeps `solid`, which is the one that fixes a real problem.

**`<AddedIn>` goes under the heading.** Every other page puts it on its own line between the heading and the prose; the alert page had it trailing a sentence. Two more sat inside list items, where the badge appears nowhere else in the docs — those are dropped, since the migration guide already covers both behaviours.

Never released, so nothing to declare in the class API.