### PR TITLE
feat(Avatar): colour the avatar from the theme slots and add .avatar-subtle

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "59.25kB"
+      "maxSize": "59.5kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "49.25kB"
+      "maxSize": "49.5kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/components/avatar.mdx
+++ b/docs/src/content/docs/components/avatar.mdx
@@ -8,6 +8,8 @@ css:
   - "https://cdn.jsdelivr.net/npm/@coreui/icons@3.1.0/css/brand.min.css"
 ---
 
+import { getData } from '@coreui/astro-docs/data'
+
 ## Image avatars
 
 Showcase avatars using images. These avatars are typically circular and can display user profile pictures.
@@ -26,25 +28,36 @@ Showcase avatars using images. These avatars are typically circular and can disp
 
 Use letters inside avatars to represent users or objects when images are not available. This can be useful for displaying initials.
 
-<Example code={`<div class="avatar bg-primary text-white">CUI</div>
-  <div class="avatar bg-secondary">CUI</div>
-  <div class="avatar bg-warning text-white">CUI</div>`} />
+An avatar without a `.theme-*` class stays neutral; with one, the background takes the theme color and the letters take the color that reads on it.
+
+<Example code={`<div class="avatar">CUI</div>
+  <div class="avatar theme-primary">CUI</div>
+  <div class="avatar theme-secondary">CUI</div>
+  <div class="avatar theme-warning">CUI</div>`} />
+
+## Subtle avatars
+
+<AddedIn version="6.0.0" />
+
+Add `.avatar-subtle` for a tinted avatar that keeps the theme color in the text rather than the background.
+
+<Example code={getData('theme-colors').map((c) => `<div class="avatar avatar-subtle theme-${c.name}">CUI</div>`)} />
 
 ## Icons avatars
 
 Incorporate icons within avatars, allowing for a visual representation using scalable vector graphics (SVG).
 
-<Example code={`<div class="avatar bg-info text-white">
+<Example code={`<div class="avatar theme-info">
     <svg class="icon" viewBox="0 0 32 32">
       <path d="M27.912 7.289l-10.324-5.961c-0.455-0.268-1.002-0.425-1.588-0.425s-1.133 0.158-1.604 0.433l0.015-0.008-10.324 5.961c-0.955 0.561-1.586 1.582-1.588 2.75v11.922c0.002 1.168 0.635 2.189 1.574 2.742l0.016 0.008 10.322 5.961c0.455 0.267 1.004 0.425 1.59 0.425 0.584 0 1.131-0.158 1.602-0.433l-0.014 0.008 10.322-5.961c0.955-0.561 1.586-1.582 1.588-2.75v-11.922c-0.002-1.168-0.633-2.189-1.573-2.742zM27.383 21.961c0 0.389-0.211 0.73-0.526 0.914l-0.004 0.002-10.324 5.961c-0.152 0.088-0.334 0.142-0.53 0.142s-0.377-0.053-0.535-0.145l0.005 0.002-10.324-5.961c-0.319-0.186-0.529-0.527-0.529-0.916v-11.922c0-0.389 0.211-0.73 0.526-0.914l0.004-0.002 10.324-5.961c0.152-0.090 0.334-0.143 0.53-0.143s0.377 0.053 0.535 0.144l-0.006-0.002 10.324 5.961c0.319 0.185 0.529 0.527 0.529 0.916z"></path><path d="M22.094 19.451h-0.758c-0.188 0-0.363 0.049-0.515 0.135l0.006-0.004-4.574 2.512-5.282-3.049v-6.082l5.282-3.051 4.576 2.504c0.146 0.082 0.323 0.131 0.508 0.131h0.758c0.293 0 0.529-0.239 0.529-0.531v-0.716c0-0.2-0.11-0.373-0.271-0.463l-0.004-0.002-5.078-2.777c-0.293-0.164-0.645-0.26-1.015-0.26-0.39 0-0.756 0.106-1.070 0.289l0.010-0.006-5.281 3.049c-0.636 0.375-1.056 1.055-1.059 1.834v6.082c0 0.779 0.422 1.461 1.049 1.828l0.009 0.006 5.281 3.049c0.305 0.178 0.67 0.284 1.061 0.284 0.373 0 0.723-0.098 1.027-0.265l-0.012 0.006 5.080-2.787c0.166-0.091 0.276-0.265 0.276-0.465v-0.716c0-0.293-0.238-0.529-0.529-0.529z"></path>
     </svg>
   </div>
-  <div class="avatar bg-success text-white">
+  <div class="avatar theme-success">
     <svg class="icon" viewBox="0 0 32 32">
       <path d="M27.912 7.289l-10.324-5.961c-0.455-0.268-1.002-0.425-1.588-0.425s-1.133 0.158-1.604 0.433l0.015-0.008-10.324 5.961c-0.955 0.561-1.586 1.582-1.588 2.75v11.922c0.002 1.168 0.635 2.189 1.574 2.742l0.016 0.008 10.322 5.961c0.455 0.267 1.004 0.425 1.59 0.425 0.584 0 1.131-0.158 1.602-0.433l-0.014 0.008 10.322-5.961c0.955-0.561 1.586-1.582 1.588-2.75v-11.922c-0.002-1.168-0.633-2.189-1.573-2.742zM27.383 21.961c0 0.389-0.211 0.73-0.526 0.914l-0.004 0.002-10.324 5.961c-0.152 0.088-0.334 0.142-0.53 0.142s-0.377-0.053-0.535-0.145l0.005 0.002-10.324-5.961c-0.319-0.186-0.529-0.527-0.529-0.916v-11.922c0-0.389 0.211-0.73 0.526-0.914l0.004-0.002 10.324-5.961c0.152-0.090 0.334-0.143 0.53-0.143s0.377 0.053 0.535 0.144l-0.006-0.002 10.324 5.961c0.319 0.185 0.529 0.527 0.529 0.916z"></path><path d="M22.094 19.451h-0.758c-0.188 0-0.363 0.049-0.515 0.135l0.006-0.004-4.574 2.512-5.282-3.049v-6.082l5.282-3.051 4.576 2.504c0.146 0.082 0.323 0.131 0.508 0.131h0.758c0.293 0 0.529-0.239 0.529-0.531v-0.716c0-0.2-0.11-0.373-0.271-0.463l-0.004-0.002-5.078-2.777c-0.293-0.164-0.645-0.26-1.015-0.26-0.39 0-0.756 0.106-1.070 0.289l0.010-0.006-5.281 3.049c-0.636 0.375-1.056 1.055-1.059 1.834v6.082c0 0.779 0.422 1.461 1.049 1.828l0.009 0.006 5.281 3.049c0.305 0.178 0.67 0.284 1.061 0.284 0.373 0 0.723-0.098 1.027-0.265l-0.012 0.006 5.080-2.787c0.166-0.091 0.276-0.265 0.276-0.465v-0.716c0-0.293-0.238-0.529-0.529-0.529z"></path>
     </svg>
   </div>
-  <div class="avatar bg-danger text-white">
+  <div class="avatar theme-danger">
     <svg class="icon" viewBox="0 0 32 32">
       <path d="M27.912 7.289l-10.324-5.961c-0.455-0.268-1.002-0.425-1.588-0.425s-1.133 0.158-1.604 0.433l0.015-0.008-10.324 5.961c-0.955 0.561-1.586 1.582-1.588 2.75v11.922c0.002 1.168 0.635 2.189 1.574 2.742l0.016 0.008 10.322 5.961c0.455 0.267 1.004 0.425 1.59 0.425 0.584 0 1.131-0.158 1.602-0.433l-0.014 0.008 10.322-5.961c0.955-0.561 1.586-1.582 1.588-2.75v-11.922c-0.002-1.168-0.633-2.189-1.573-2.742zM27.383 21.961c0 0.389-0.211 0.73-0.526 0.914l-0.004 0.002-10.324 5.961c-0.152 0.088-0.334 0.142-0.53 0.142s-0.377-0.053-0.535-0.145l0.005 0.002-10.324-5.961c-0.319-0.186-0.529-0.527-0.529-0.916v-11.922c0-0.389 0.211-0.73 0.526-0.914l0.004-0.002 10.324-5.961c0.152-0.090 0.334-0.143 0.53-0.143s0.377 0.053 0.535 0.144l-0.006-0.002 10.324 5.961c0.319 0.185 0.529 0.527 0.529 0.916z"></path><path d="M22.094 19.451h-0.758c-0.188 0-0.363 0.049-0.515 0.135l0.006-0.004-4.574 2.512-5.282-3.049v-6.082l5.282-3.051 4.576 2.504c0.146 0.082 0.323 0.131 0.508 0.131h0.758c0.293 0 0.529-0.239 0.529-0.531v-0.716c0-0.2-0.11-0.373-0.271-0.463l-0.004-0.002-5.078-2.777c-0.293-0.164-0.645-0.26-1.015-0.26-0.39 0-0.756 0.106-1.070 0.289l0.010-0.006-5.281 3.049c-0.636 0.375-1.056 1.055-1.059 1.834v6.082c0 0.779 0.422 1.461 1.049 1.828l0.009 0.006 5.281 3.049c0.305 0.178 0.67 0.284 1.061 0.284 0.373 0 0.723-0.098 1.027-0.265l-0.012 0.006 5.080-2.787c0.166-0.091 0.276-0.265 0.276-0.465v-0.716c0-0.293-0.238-0.529-0.529-0.529z"></path>
     </svg>
@@ -54,26 +67,26 @@ Incorporate icons within avatars, allowing for a visual representation using sca
 
 Create avatars with rounded corners by adding the `.rounded` class. This gives a softer, less angular appearance.
 
-<Example code={`<div class="avatar rounded bg-primary text-white">CUI</div>
-  <div class="avatar rounded bg-secondary">CUI</div>
-  <div class="avatar rounded bg-warning text-white">CUI</div>`} />
+<Example code={`<div class="avatar rounded theme-primary">CUI</div>
+  <div class="avatar rounded theme-secondary">CUI</div>
+  <div class="avatar rounded theme-warning">CUI</div>`} />
 
 ## Square avatars
 
 Make avatars square by using the `.rounded-0` class, removing any rounded edges for a sharper look.
 
-<Example code={`<div class="avatar rounded-0 bg-primary text-white">CUI</div>
-  <div class="avatar rounded-0 bg-secondary">CUI</div>
-  <div class="avatar rounded-0 bg-warning text-white">CUI</div>`} />
+<Example code={`<div class="avatar rounded-0 theme-primary">CUI</div>
+  <div class="avatar rounded-0 theme-secondary">CUI</div>
+  <div class="avatar rounded-0 theme-warning">CUI</div>`} />
 
 ## Sizes
 
 Adjust the size of avatars using the `.avatar-sm`, `.avatar-md`, `.avatar-lg`, and `.avatar-xl` classes for larger or smaller versions.
-<Example code={`<div class="avatar avatar-xl bg-secondary">CUI</div>
-  <div class="avatar avatar-lg bg-secondary">CUI</div>
-  <div class="avatar avatar-md bg-secondary">CUI</div>
-  <div class="avatar bg-secondary">CUI</div>
-  <div class="avatar avatar-sm bg-secondary">CUI</div>`} />
+<Example code={`<div class="avatar avatar-xl">CUI</div>
+  <div class="avatar avatar-lg">CUI</div>
+  <div class="avatar avatar-md">CUI</div>
+  <div class="avatar">CUI</div>
+  <div class="avatar avatar-sm">CUI</div>`} />
 
 ## Stacked avatars
 
@@ -89,7 +102,7 @@ Display multiple avatars in a stack to represent a group of users or items, with
     <div class="avatar">
       <img class="avatar-img" src="/assets/img/avatars/3.jpg" alt="user@email.com">
     </div>
-    <div class="avatar bg-secondary">
+    <div class="avatar">
       +2
     </div>
   </div>`} />
@@ -103,15 +116,15 @@ Add `.avatar-status` to show presence. The indicator takes its colour from a bac
       <img class="avatar-img" src="/assets/img/avatars/1.jpg" alt="user@email.com">
       <span class="avatar-status bg-success" role="img" aria-label="Online"></span>
     </div>
-    <div class="avatar bg-secondary">
+    <div class="avatar">
       CUI
       <span class="avatar-status bg-warning" role="img" aria-label="Away"></span>
     </div>
-    <div class="avatar bg-secondary">
+    <div class="avatar">
       CUI
       <span class="avatar-status bg-danger" role="img" aria-label="Busy"></span>
     </div>
-    <div class="avatar bg-secondary">
+    <div class="avatar">
       CUI
       <span class="avatar-status bg-secondary" role="img" aria-label="Offline"></span>
     </div>

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -247,6 +247,18 @@ finished, not whether the state changed.
 
 #### Avatar
 
+- **The avatar carries its own colours, and `.theme-{color}` tints it.**
+  `--cui-avatar-bg` and `--cui-avatar-color` are new: a bare avatar is a
+  neutral circle instead of a transparent one, and a `.theme-*` class puts the
+  theme colour behind the letters and the colour that reads on it in front of
+  them. The docs used to reach for `bg-{color}` plus a hand-picked `text-*`,
+  which fails WCAG AA on five of the six examples they shipped — measured 1.85
+  on `bg-warning text-white`, 2.94 on info, 3.50 on success, 3.69 on danger,
+  and 3.12 on `bg-secondary`, which carried no text colour at all. Every theme
+  colour now lands between 4.56 and 18.03. Background utilities keep working on
+  an avatar; they just no longer have to.
+- **New: `.avatar-subtle`**, a tinted avatar that keeps the theme colour in the
+  letters rather than behind them.
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
   **One size token replaces the width/height pair.** `--cui-avatar-width` and
   `--cui-avatar-height` always carried the same value, in the base and in all

--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -12,6 +12,8 @@
 $avatar-size:                  2rem !default;
 // The label scales with the frame, so a size only has to be given once.
 $avatar-font-size-ratio:       .4 !default;
+$avatar-color:                 inherit !default;
+$avatar-bg:                    var(--#{$prefix}secondary-bg) !default;
 $avatar-border-radius:         50em !default;
 $avatar-status-size:           .5rem !default;
 $avatar-status-border-radius:  50em !default;
@@ -37,6 +39,8 @@ $avatar-tokens: () !default;
 $avatar-tokens: defaults(
   (
     --#{$prefix}avatar-size: #{$avatar-size},
+    --#{$prefix}avatar-color: var(--#{$prefix}theme-contrast, #{$avatar-color}),
+    --#{$prefix}avatar-bg: var(--#{$prefix}theme-base, #{$avatar-bg}),
     --#{$prefix}avatar-border-radius: #{$avatar-border-radius},
     --#{$prefix}avatar-status-size: #{$avatar-status-size},
     --#{$prefix}avatar-status-border-radius: #{$avatar-status-border-radius},
@@ -48,6 +52,15 @@ $avatar-tokens: defaults(
 // scss-docs-end avatar-css-vars
 
 // stylelint-enable scss/dollar-variable-default
+
+// scss-docs-start avatar-variants
+$avatar-variants: (
+  "subtle": (
+    "color": "fg",
+    "bg": "bg-subtle"
+  )
+) !default;
+// scss-docs-end avatar-variants
 @layer components {
   .avatar {
     @include tokens($avatar-tokens);
@@ -61,10 +74,22 @@ $avatar-tokens: defaults(
     // Declared as a fallback rather than a token, so the derived size is the
     // default and an explicit one still wins.
     font-size: var(--#{$prefix}avatar-font-size, calc(var(--#{$prefix}avatar-size) * #{$avatar-font-size-ratio})); // stylelint-disable-line function-disallowed-list
+    color: var(--#{$prefix}avatar-color);
     vertical-align: middle;
+    background-color: var(--#{$prefix}avatar-bg);
     @include border-radius(var(--#{$prefix}avatar-border-radius));
     @include transition($avatar-transition);
   }
+
+  // scss-docs-start avatar-modifiers
+  @each $variant, $properties in $avatar-variants {
+    .avatar-#{$variant} {
+      @each $property, $value in $properties {
+        --#{$prefix}avatar-#{$property}: var(--#{$prefix}theme-#{$value});
+      }
+    }
+  }
+  // scss-docs-end avatar-modifiers
 
   .avatar-img {
     width: 100%;


### PR DESCRIPTION
The avatar had no colour of its own, so the docs painted it with `bg-{color}` plus a text colour picked by hand — and that recipe is broken. Measured in a browser, five of the six examples the page shipped fail WCAG AA:

| example | before | after |
| --- | --- | --- |
| `bg-warning text-white` | 1.85 ✗ | 10.70 |
| `bg-info text-white` | 2.94 ✗ | 6.74 |
| `bg-secondary` (no text class at all) | 3.12 ✗ | 4.56 |
| `bg-success text-white` | 3.50 ✗ | 5.67 |
| `bg-danger text-white` | 3.69 ✗ | 5.38 |
| `bg-primary text-white` | 5.65 | 5.65 |

`--cui-avatar-bg` and `--cui-avatar-color` read the theme slots, so `.theme-{color}` puts the theme colour behind the letters and the colour that reads on it in front of them — all eight land between 4.56 and 18.03, a theme colour you define yourself included. A bare avatar is a neutral circle rather than a transparent one, which is also what lets the Sizes and Stacked examples drop their `bg-secondary`.

`.avatar-subtle` joins it — the tinted variant upstream has — keeping the theme colour in the letters instead of behind them (7.26 to 10.09 across the eight).

Background utilities still work on an avatar; they just no longer have to. The status dot keeps taking its colour from a utility, as the docs describe — it carries no text, so nothing to contrast.

Contrast was measured through a canvas readback rather than by parsing `getComputedStyle`, because the subtle tokens resolve to `lab()` and `color-mix()`; the helper checks out at exactly 21.00 for white on black.

**Note the budget bump.** `dist/css/coreui.css` came in 30 bytes over its gzip ceiling, so `coreui.css` goes 59.25 → 59.5 kB and `coreui.min.css` 49.25 → 49.5 kB. The pre-push gate caught it, which is what it is for — flagging it here rather than burying it.