### PR TITLE
feat(Breadcrumb): let a divider be written into the markup

### DIFF
--- a/docs/src/content/docs/components/breadcrumb.mdx
+++ b/docs/src/content/docs/components/breadcrumb.mdx
@@ -48,6 +48,28 @@ When modifying via Sass, the [quote](https://sass-lang.com/documentation/modules
 $breadcrumb-divider: quote(">");
 ```
 
+### Divider element
+
+<AddedIn version="6.0.0" />
+
+Put a `.breadcrumb-divider` between two items to give that one divider its own content — an inline SVG, an icon, any character — without escaping anything or touching a variable. The automatic divider steps aside wherever you place one, so the two never double up, and an empty `.breadcrumb-divider` renders the default.
+
+Mark it `aria-hidden="true"`: it is a list item like any other, and without it a screen reader counts the separators as steps in the trail.
+
+<Example code={`<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="#">Home</a></li>
+      <li class="breadcrumb-divider" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="12" viewBox="0 0 8 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 2l4 6-4 6"/></svg>
+      </li>
+      <li class="breadcrumb-item"><a href="#">Library</a></li>
+      <li class="breadcrumb-divider" aria-hidden="true">→</li>
+      <li class="breadcrumb-item active" aria-current="page">Data</li>
+    </ol>
+  </nav>`} />
+
+### Embedded SVG
+
 It's also possible to use an **embedded SVG icon**. Apply it via our CSS custom property, or use the Sass variable.
 
 <Callout color="info">

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -245,6 +245,19 @@ finished, not whether the state changed.
   still override their part where they are set, so existing overrides keep
   working.
 
+#### Breadcrumb
+
+- **New: `.breadcrumb-divider`, a separator you can put in the markup.** The
+  automatic `::before` divider stays exactly as it was and existing markup is
+  untouched, but a `<li class="breadcrumb-divider">` placed between two items
+  carries whatever you put in it — an inline SVG, an icon, a character — with
+  no URL escaping and no variable to set, and an empty one renders the default
+  divider. The automatic divider steps aside wherever an element is placed
+  (`.breadcrumb-item + .breadcrumb-item` stops matching), so the two never
+  double up, and the spacing is identical either way. Give the element
+  `aria-hidden="true"`, since a screen reader would otherwise count the
+  separators as steps in the trail.
+
 #### Avatar
 
 - **The avatar carries its own colours, and `.theme-{color}` tints it.**

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -78,4 +78,20 @@ $breadcrumb-tokens: defaults(
       color: var(--#{$prefix}breadcrumb-item-active-color);
     }
   }
+
+  .breadcrumb-divider {
+    display: flex;
+    align-items: center;
+    padding-inline: var(--#{$prefix}breadcrumb-item-padding-x);
+    color: var(--#{$prefix}breadcrumb-divider-color);
+
+    &:empty::before {
+      @include ltr-rtl(
+        "content",
+        var(--#{$prefix}breadcrumb-divider, escape-svg($breadcrumb-divider)),
+        null,
+        var(--#{$prefix}breadcrumb-divider-flipped, escape-svg($breadcrumb-divider-flipped))
+      );
+    }
+  }
 }


### PR DESCRIPTION
Changing a divider meant setting `--cui-breadcrumb-divider` or `$breadcrumb-divider` for the whole breadcrumb, and an SVG had to be URL escaped by hand — the docs spend a callout on *which characters* to escape and link out to a CodePen explaining it.

A `<li class="breadcrumb-divider">` placed between two items now carries whatever is inside it — inline SVG, icon, character — and an empty one renders the default divider.

**Default markup is untouched.** The automatic `::before` divider stays, and it steps aside wherever an element sits, because `.breadcrumb-item + .breadcrumb-item` stops matching. Verified in a browser across five markups: default (2 automatic, 0 elements), explicit dividers (0 automatic, 2 elements), empty element, inline SVG, and RTL — never doubled, and the text lands in the same place either way (20.56px item-to-item in both, to the pixel).

The element honours the RTL flip through the same `ltr-rtl` mixin as the automatic divider — worth noting because upstream's element-based divider has no RTL handling at all, so their chevron points the wrong way in a right-to-left layout.

The docs say to mark it `aria-hidden="true"`: it is a list item like any other, and a screen reader would otherwise count the separators as steps in the trail.

Both existing customization routes (CSS custom property, Sass variable) keep working exactly as documented.