### PR TITLE
feat(Breadcrumb): give a step its own link class, so one can open a menu

### DIFF
--- a/docs/src/content/docs/components/breadcrumb.mdx
+++ b/docs/src/content/docs/components/breadcrumb.mdx
@@ -102,6 +102,49 @@ You can also remove the divider setting `--cui-breadcrumb-divider: '';` (empty s
 $breadcrumb-divider: none;
 ```
 
+## Interactive links
+
+<AddedIn version="6.0.0" />
+
+Add `.breadcrumb-link` to give each step a padded, hoverable target instead of a bare text link. It works on an `<a>`, and on a `<button>` it looks exactly the same — which is what lets a step open a menu.
+
+<Example code={`<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a class="breadcrumb-link" href="#">Home</a></li>
+      <li class="breadcrumb-item"><a class="breadcrumb-link" href="#">Library</a></li>
+      <li class="breadcrumb-item active" aria-current="page"><span class="breadcrumb-link">Data</span></li>
+    </ol>
+  </nav>`} />
+
+## Collapsed items
+
+<AddedIn version="6.0.0" />
+
+A long trail can keep its middle steps behind one item. Make that item a `.breadcrumb-link` button that toggles a [menu](/components/menu/) of the hidden steps — no new component, the two compose as they are.
+
+Give the button an accessible name: `…` on its own tells a screen reader nothing.
+
+<Example code={`<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a class="breadcrumb-link" href="#">Home</a></li>
+      <li class="breadcrumb-item">
+        <button class="breadcrumb-link" type="button" data-coreui-toggle="menu" aria-expanded="false" aria-label="Show 3 hidden breadcrumb items">…</button>
+        <ul class="menu">
+          <li><a class="menu-item" href="#">Library</a></li>
+          <li><a class="menu-item" href="#">Reports</a></li>
+          <li><a class="menu-item" href="#">2026</a></li>
+        </ul>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page"><span class="breadcrumb-link">Data</span></li>
+    </ol>
+  </nav>`} />
+
+<Callout color="info">
+##### Keep it a disclosure, not a menu
+
+The hidden steps are navigation links, so leave them as links inside a plain list. Do not add `role="menu"` and `role="menuitem"`: those describe an application menu of commands, and applying them makes a screen reader announce a menu, expect arrow-key navigation, and stop presenting the steps as links. Our menu deliberately adds no `role` of its own, so the markup above is already a disclosure — the button carries `aria-expanded`, and that is what a user needs to hear.
+</Callout>
+
 ## Accessibility
 
 Since breadcrumbs provide navigation, it's useful to add a significant label such as `aria-label="breadcrumb"` to explain the type of navigation implemented in the `<nav>` element. You should also add an `aria-current="page"` to the last item of the set to show that it represents the current page.

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -247,6 +247,11 @@ finished, not whether the state changed.
 
 #### Breadcrumb
 
+- **New: `.breadcrumb-link`, an opt-in class that gives a step a padded,
+  hoverable target.** Bare links keep rendering as they always did. On a
+  `<button>` it looks identical to a link, which is what lets one step toggle a
+  menu of collapsed items — the composition is documented under Collapsed
+  items, together with the reason not to reach for `role="menu"` there.
 - **New: `.breadcrumb-divider`, a separator you can put in the markup.** The
   automatic `::before` divider stays exactly as it was and existing markup is
   untouched, but a `<li class="breadcrumb-divider">` placed between two items

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -15,6 +15,12 @@ $breadcrumb-margin-bottom:          1rem !default;
 $breadcrumb-bg:                     null !default;
 $breadcrumb-divider-color:          var(--#{$prefix}secondary-color) !default;
 $breadcrumb-active-color:           var(--#{$prefix}secondary-color) !default;
+$breadcrumb-link-padding-y:         .25rem !default;
+$breadcrumb-link-padding-x:         .5rem !default;
+$breadcrumb-link-color:             var(--#{$prefix}secondary-color) !default;
+$breadcrumb-link-hover-color:       var(--#{$prefix}body-color) !default;
+$breadcrumb-link-hover-bg:          var(--#{$prefix}tertiary-bg) !default;
+$breadcrumb-link-border-radius:     var(--#{$prefix}border-radius) !default;
 $breadcrumb-divider:                string.quote("/") !default;
 $breadcrumb-divider-flipped:        $breadcrumb-divider !default;
 $breadcrumb-border-radius:          null !default;
@@ -35,6 +41,12 @@ $breadcrumb-tokens: defaults(
     --#{$prefix}breadcrumb-divider-color: #{$breadcrumb-divider-color},
     --#{$prefix}breadcrumb-item-padding-x: #{$breadcrumb-item-padding-x},
     --#{$prefix}breadcrumb-item-active-color: #{$breadcrumb-active-color},
+    --#{$prefix}breadcrumb-link-padding-x: #{$breadcrumb-link-padding-x},
+    --#{$prefix}breadcrumb-link-padding-y: #{$breadcrumb-link-padding-y},
+    --#{$prefix}breadcrumb-link-color: #{$breadcrumb-link-color},
+    --#{$prefix}breadcrumb-link-hover-color: #{$breadcrumb-link-hover-color},
+    --#{$prefix}breadcrumb-link-hover-bg: #{$breadcrumb-link-hover-bg},
+    --#{$prefix}breadcrumb-link-border-radius: #{$breadcrumb-link-border-radius},
     --#{$prefix}breadcrumb-font-size: $breadcrumb-font-size,
   ),
   $breadcrumb-tokens
@@ -76,6 +88,23 @@ $breadcrumb-tokens: defaults(
 
     &.active {
       color: var(--#{$prefix}breadcrumb-item-active-color);
+    }
+  }
+
+  .breadcrumb-link {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--#{$prefix}breadcrumb-link-padding-y) var(--#{$prefix}breadcrumb-link-padding-x);
+    color: var(--#{$prefix}breadcrumb-link-color);
+    text-decoration: none;
+    background-color: transparent;
+    border: 0;
+    @include border-radius(var(--#{$prefix}breadcrumb-link-border-radius));
+
+    &:hover,
+    &:focus-visible {
+      color: var(--#{$prefix}breadcrumb-link-hover-color);
+      background-color: var(--#{$prefix}breadcrumb-link-hover-bg);
     }
   }
 


### PR DESCRIPTION
Answers mrholek's question — can a breadcrumb step be a menu toggler, and is that ARIA-clean? Yes to both, and it needs no new component: what was missing was somewhere for the trigger to live.

Breadcrumb links were bare text with no target beyond the glyphs, so a step that had to toggle something meant borrowing from another component: `btn btn-link p-0`, plus a utility to undo the button's own frame.

`.breadcrumb-link` gives a step a padded, hoverable target and renders a `<button>` identically to an `<a>`. The collapsed-items pattern then falls out as a composition: the step is a `.breadcrumb-link` button with `data-coreui-toggle="menu"`, and the hidden steps stay links inside a plain list.

**On the ARIA question.** The right pattern here is a disclosure, not a menu. `role="menu"` / `role="menuitem"` describe an application menu of commands; applied to navigation links they make a screen reader announce a menu, expect arrow-key navigation, and stop presenting the steps as links. Our Menu deliberately adds no `role` of its own — it is documented as generic for exactly this reason — so the markup is already a disclosure, with `aria-expanded` on the trigger. The docs say this next to the example, and give the trigger an `aria-label`, since `…` names nothing.

Opt-in throughout: markup without the class renders as before. Measured against the page background with alpha composited: 5.12 at rest, 11.05 for text on the hover tint. Six new tokens (`--cui-breadcrumb-link-*`) drive it.