### PR TITLE
fix(Breadcrumb): give the null tokens real defaults

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -247,6 +247,15 @@ finished, not whether the state changed.
 
 #### Breadcrumb
 
+- **Three breadcrumb tokens have real defaults.** `--cui-breadcrumb-bg`,
+  `--cui-breadcrumb-border-radius` and `--cui-breadcrumb-font-size` were `null`
+  in Sass, so the first two were emitted empty (`--cui-breadcrumb-bg: ;`) and
+  the third was not emitted at all. They are `transparent`,
+  `var(--cui-border-radius)` and `inherit` now. Nothing renders differently on
+  a default breadcrumb, and a font size set on an ancestor still reaches it —
+  the one visible change is that a breadcrumb **given a background** now has
+  rounded corners like every other surface. Set
+  `--cui-breadcrumb-border-radius: 0` to square it off.
 - **New: `.breadcrumb-link`, an opt-in class that gives a step a padded,
   hoverable target.** Bare links keep rendering as they always did. On a
   `<button>` it looks identical to a link, which is what lets one step toggle a

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -7,12 +7,12 @@
 @use "config" as *;
 
 // scss-docs-start breadcrumb-variables
-$breadcrumb-font-size:              null !default;
+$breadcrumb-font-size:              inherit !default;
 $breadcrumb-padding-y:              0 !default;
 $breadcrumb-padding-x:              0 !default;
 $breadcrumb-item-padding-x:         .5rem !default;
 $breadcrumb-margin-bottom:          1rem !default;
-$breadcrumb-bg:                     null !default;
+$breadcrumb-bg:                     transparent !default;
 $breadcrumb-divider-color:          var(--#{$prefix}secondary-color) !default;
 $breadcrumb-active-color:           var(--#{$prefix}secondary-color) !default;
 $breadcrumb-link-padding-y:         .25rem !default;
@@ -23,7 +23,7 @@ $breadcrumb-link-hover-bg:          var(--#{$prefix}tertiary-bg) !default;
 $breadcrumb-link-border-radius:     var(--#{$prefix}border-radius) !default;
 $breadcrumb-divider:                string.quote("/") !default;
 $breadcrumb-divider-flipped:        $breadcrumb-divider !default;
-$breadcrumb-border-radius:          null !default;
+$breadcrumb-border-radius:          var(--#{$prefix}border-radius) !default;
 // scss-docs-end breadcrumb-variables
 
 $breadcrumb-tokens: () !default;
@@ -47,7 +47,7 @@ $breadcrumb-tokens: defaults(
     --#{$prefix}breadcrumb-link-hover-color: #{$breadcrumb-link-hover-color},
     --#{$prefix}breadcrumb-link-hover-bg: #{$breadcrumb-link-hover-bg},
     --#{$prefix}breadcrumb-link-border-radius: #{$breadcrumb-link-border-radius},
-    --#{$prefix}breadcrumb-font-size: $breadcrumb-font-size,
+    --#{$prefix}breadcrumb-font-size: #{$breadcrumb-font-size},
   ),
   $breadcrumb-tokens
 );


### PR DESCRIPTION
`$breadcrumb-bg`, `$breadcrumb-border-radius` and `$breadcrumb-font-size` were `null`, which put two empty declarations in the stylesheet (`--cui-breadcrumb-bg: ;`, `--cui-breadcrumb-border-radius: ;`) and left the third unemitted while `.breadcrumb` read it — the CSS variables table documented values that were not there. The font-size entry also lacked its `#{}` interpolation.

They are `transparent`, `var(--cui-border-radius)` and `inherit` now.

Compared before and after in a browser across four cases — plain, with a background and padding, with a font size on the breadcrumb, and with a font size on an ancestor:

- background, font size and margin come out identical in all four, **including the inherited font size** (32px before and after), which the `inherit` keyword preserves for a custom property;
- the one change is `border-radius`, 0 → 6px. Invisible on a default breadcrumb, since the background is transparent; visible on a breadcrumb that is **given** a background, which now has rounded corners like every other surface. Migration guide says to set `--cui-breadcrumb-border-radius: 0` to square it off.