### PR TITLE
docs(Breadcrumb): lead with the recommended markup, keep the old one as a fallback

### DIFF
--- a/docs/src/content/docs/components/breadcrumb.mdx
+++ b/docs/src/content/docs/components/breadcrumb.mdx
@@ -8,22 +8,36 @@ otherFrameworks:
 
 ## Example
 
-The breadcrumb navigation provides links back to each previous page the user navigated through and shows the current location in a website or an application. You don't have to add separators, because they automatically added in CSS through [`::before`](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) and [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content).
+The breadcrumb navigation provides links back to each previous page the user navigated through and shows the current location in a website or an application. Separators are added for you, so the markup is a list of steps and nothing else.
+
+Give each step a `.breadcrumb-link` for a padded, hoverable target. It works on an `<a>`, and on a `<button>` it looks exactly the same — which is what lets a step [open a menu](#collapsed-items).
 
 <Example code={`<nav aria-label="breadcrumb">
     <ol class="breadcrumb">
-      <li class="breadcrumb-item active" aria-current="page">Home</li>
+      <li class="breadcrumb-item active" aria-current="page"><span class="breadcrumb-link">Home</span></li>
     </ol>
   </nav>
 
   <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
-      <li class="breadcrumb-item"><a href="#">Home</a></li>
-      <li class="breadcrumb-item active" aria-current="page">Library</li>
+      <li class="breadcrumb-item"><a class="breadcrumb-link" href="#">Home</a></li>
+      <li class="breadcrumb-item active" aria-current="page"><span class="breadcrumb-link">Library</span></li>
     </ol>
   </nav>
 
   <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a class="breadcrumb-link" href="#">Home</a></li>
+      <li class="breadcrumb-item"><a class="breadcrumb-link" href="#">Library</a></li>
+      <li class="breadcrumb-item active" aria-current="page"><span class="breadcrumb-link">Data</span></li>
+    </ol>
+  </nav>`} />
+
+### Plain links
+
+A step without `.breadcrumb-link` renders as a plain text link. Markup written before v6 keeps working, and so does mixing the two.
+
+<Example code={`<nav aria-label="breadcrumb">
     <ol class="breadcrumb">
       <li class="breadcrumb-item"><a href="#">Home</a></li>
       <li class="breadcrumb-item"><a href="#">Library</a></li>
@@ -33,20 +47,7 @@ The breadcrumb navigation provides links back to each previous page the user nav
 
 ## Dividers
 
-Dividers are automatically added in CSS through [`::before`](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) and [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content). They can be changed by modifying a local CSS custom property `--cui-breadcrumb-divider`, or through the `$breadcrumb-divider` Sass variable — and `$breadcrumb-divider-flipped` for its RTL counterpart, if needed. We default to our Sass variable, which is set as a fallback to the custom property. This way, you get a global divider that you can override without recompiling CSS at any time.
-
-<Example code={`<nav style="--cui-breadcrumb-divider: '>';" aria-label="breadcrumb">
-    <ol class="breadcrumb">
-      <li class="breadcrumb-item"><a href="#">Home</a></li>
-      <li class="breadcrumb-item active" aria-current="page">Library</li>
-    </ol>
-  </nav>`} />
-
-When modifying via Sass, the [quote](https://sass-lang.com/documentation/modules/string#quote) function is required to generate the quotes around a string. For example, using `>` as the divider, you can use this:
-
-```scss
-$breadcrumb-divider: quote(">");
-```
+A breadcrumb writes its separators for you. Put one in the markup when a single divider needs its own content, or change them all at once with a variable.
 
 ### Divider element
 
@@ -68,12 +69,29 @@ Mark it `aria-hidden="true"`: it is a list item like any other, and without it a
     </ol>
   </nav>`} />
 
+### CSS variable
+
+Dividers are automatically added in CSS through [`::before`](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) and [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content). They can be changed by modifying a local CSS custom property `--cui-breadcrumb-divider`, or through the `$breadcrumb-divider` Sass variable — and `$breadcrumb-divider-flipped` for its RTL counterpart, if needed. We default to our Sass variable, which is set as a fallback to the custom property. This way, you get a global divider that you can override without recompiling CSS at any time.
+
+<Example code={`<nav style="--cui-breadcrumb-divider: '>';" aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="#">Home</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Library</li>
+    </ol>
+  </nav>`} />
+
+When modifying via Sass, the [quote](https://sass-lang.com/documentation/modules/string#quote) function is required to generate the quotes around a string. For example, using `>` as the divider, you can use this:
+
+```scss
+$breadcrumb-divider: quote(">");
+```
+
 ### Embedded SVG
 
 It's also possible to use an **embedded SVG icon**. Apply it via our CSS custom property, or use the Sass variable.
 
 <Callout color="info">
-### Using embedded SVG
+##### Using embedded SVG
 
 Inlining SVG as data URI requires to URL escape a few characters, most notably `<`, `>` and `#`. That's why the `$breadcrumb-divider` variable is passed through our [`escape-svg()` Sass function](/customize/sass/#escape-svg). When using the CSS custom property, you need to URL escape your SVG on your own. Read [Kevin Weber's explanations on CodePen](https://codepen.io/kevinweber/pen/dXWoRw ) for detailed information on what to escape.
 </Callout>
@@ -101,20 +119,6 @@ You can also remove the divider setting `--cui-breadcrumb-divider: '';` (empty s
 ```scss
 $breadcrumb-divider: none;
 ```
-
-## Interactive links
-
-<AddedIn version="6.0.0" />
-
-Add `.breadcrumb-link` to give each step a padded, hoverable target instead of a bare text link. It works on an `<a>`, and on a `<button>` it looks exactly the same — which is what lets a step open a menu.
-
-<Example code={`<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-      <li class="breadcrumb-item"><a class="breadcrumb-link" href="#">Home</a></li>
-      <li class="breadcrumb-item"><a class="breadcrumb-link" href="#">Library</a></li>
-      <li class="breadcrumb-item active" aria-current="page"><span class="breadcrumb-link">Data</span></li>
-    </ol>
-  </nav>`} />
 
 ## Collapsed items
 


### PR DESCRIPTION
mrholek's point: the page should open with the version we recommend, and show the current one after it as still working.

It opened on bare links and only reached `.breadcrumb-link` two thirds of the way down, in its own section — so a reader following the page from the top built the older markup and never learned there was another one.

- **Example** now shows `.breadcrumb-link` across all three trails, and a **Plain links** subsection right after it shows a step without the class, saying plainly that markup written before v6 keeps working and that the two mix.
- **Dividers** reads the same way round: the element you can put in the markup first, then the variable that changes them all at once, then the embedded-SVG route with its escaping rules.
- The standalone Interactive links section is gone, folded into Example.

Also: a callout heading was an `<h3>` and put itself in the table of contents next to real sections; it is an `<h5>` now, like the other callout on the page.