### PR TITLE
docs: fix the component name in the footer intro and even out the CSS variables sentence

### DIFF
--- a/docs/src/content/docs/components/footer.mdx
+++ b/docs/src/content/docs/components/footer.mdx
@@ -29,7 +29,7 @@ Here's what you need to know before getting started with the aside menu:
 
 ### CSS variables
 
-Sidebars use local CSS variables on `.footer` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
+Footers use local CSS variables on `.footer` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
 
 <ScssDocs file="scss/_footer.scss" capture="footer-css-vars" />
 

--- a/docs/src/content/docs/components/progress.mdx
+++ b/docs/src/content/docs/components/progress.mdx
@@ -203,7 +203,7 @@ The striped gradient can also be animated. Add `.progress-bar-animated` to `.pro
 
 ### CSS variables
 
-Progress bars use local CSS variables on `.progress` for enhanced real-time customization. Values for the CSS variables are set via SASS, so Sass customization is still supported, too.
+Progress bars use local CSS variables on `.progress` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
 
 <ScssDocs file="scss/_progress.scss" capture="progress-css-vars" />
 

--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -356,7 +356,7 @@ myToastEl.addEventListener('hidden.coreui.toast', () => {
 ## Customizing
 ### CSS variables
 
-Toasts use local CSS variables on `.toast` for improved real-time customization. Values for these CSS variables are set through Sass, so Sass customization remains supported as well.
+Toasts use local CSS variables on `.toast` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
 
 <ScssDocs file="scss/_toasts.scss" capture="toast-css-vars" />
 

--- a/docs/src/content/docs/forms/select.mdx
+++ b/docs/src/content/docs/forms/select.mdx
@@ -125,7 +125,7 @@ See the [v6 migration guide](/migration/v6/) for the full picture.
 
 ### CSS variables
 
-Selects use local CSS variables on the control for real-time customization. Values are set via Sass, so Sass customization is still supported, too.
+Selects use local CSS variables on the control for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
 
 <ScssDocs file="scss/forms/_form-control.scss" capture="form-control-select-tokens" />
 


### PR DESCRIPTION
Came out of checking what upstream's `<CSSVariables>` component actually does. It renders one boilerplate paragraph — the table under it is the same `ScssDocs` snippet we use — so there is no capability to port. What it does buy them is that the sentence lives in one place.

Ours is written by hand on 29 pages, and it had drifted:

- **`footer.mdx` opened by calling itself Sidebars** — a copy-paste left over from whichever page it was cloned from.
- `progress.mdx` said `SASS` where every other page says `Sass`.
- `toasts.mdx` and `forms/select.mdx` had been reworded into variants of their own.

All 29 read the same now. Whether to factor the sentence into a component of our own is a separate question — that would be a change in `coreui-astro-docs`, which is shared by every docs edition.