### PR TITLE
docs(Breadcrumb): give each way of setting a divider its own section

### DIFF
--- a/docs/src/content/docs/components/breadcrumb.mdx
+++ b/docs/src/content/docs/components/breadcrumb.mdx
@@ -47,31 +47,55 @@ A step without `.breadcrumb-link` renders as a plain text link. Markup written b
 
 ## Dividers
 
-A breadcrumb writes its separators for you. Put one in the markup when a single divider needs its own content, or change them all at once with a variable.
+A breadcrumb writes its separators for you. Put a `.breadcrumb-divider` in the markup when one separator needs its own content, or change them all at once with a variable.
 
-### Divider element
+Mark every divider element `aria-hidden="true"`: it is a list item like any other, and without it a screen reader counts the separators as steps in the trail.
+
+### Default divider
 
 <AddedIn version="6.0.0" />
 
-Put a `.breadcrumb-divider` between two items to give that one divider its own content — an inline SVG, an icon, any character — without escaping anything or touching a variable. The automatic divider steps aside wherever you place one, so the two never double up, and an empty `.breadcrumb-divider` renders the default.
-
-Mark it `aria-hidden="true"`: it is a list item like any other, and without it a screen reader counts the separators as steps in the trail.
+Leave the `.breadcrumb-divider` empty to render the default separator. The automatic divider steps aside wherever you place an element, so the two never double up, and the spacing is the same either way.
 
 <Example code={`<nav aria-label="breadcrumb">
     <ol class="breadcrumb">
-      <li class="breadcrumb-item"><a href="#">Home</a></li>
-      <li class="breadcrumb-divider" aria-hidden="true">
-        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="12" viewBox="0 0 8 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 2l4 6-4 6"/></svg>
-      </li>
-      <li class="breadcrumb-item"><a href="#">Library</a></li>
-      <li class="breadcrumb-divider" aria-hidden="true">→</li>
-      <li class="breadcrumb-item active" aria-current="page">Data</li>
+      <li class="breadcrumb-item"><a class="breadcrumb-link" href="#">Home</a></li>
+      <li class="breadcrumb-divider" aria-hidden="true"></li>
+      <li class="breadcrumb-item active" aria-current="page"><span class="breadcrumb-link">Library</span></li>
     </ol>
   </nav>`} />
 
-### CSS variable
+### Text dividers
 
-Dividers are automatically added in CSS through [`::before`](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) and [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content). They can be changed by modifying a local CSS custom property `--cui-breadcrumb-divider`, or through the `$breadcrumb-divider` Sass variable — and `$breadcrumb-divider-flipped` for its RTL counterpart, if needed. We default to our Sass variable, which is set as a fallback to the custom property. This way, you get a global divider that you can override without recompiling CSS at any time.
+Put the character straight into the element — no quoting, no variable.
+
+<Example code={`<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a class="breadcrumb-link" href="#">Home</a></li>
+      <li class="breadcrumb-divider" aria-hidden="true">›</li>
+      <li class="breadcrumb-item"><a class="breadcrumb-link" href="#">Library</a></li>
+      <li class="breadcrumb-divider" aria-hidden="true">→</li>
+      <li class="breadcrumb-item active" aria-current="page"><span class="breadcrumb-link">Data</span></li>
+    </ol>
+  </nav>`} />
+
+### SVG dividers
+
+Put an inline SVG inside the element. Nothing has to be URL escaped, and `currentColor` makes it follow the divider color, dark mode included.
+
+<Example code={`<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a class="breadcrumb-link" href="#">Home</a></li>
+      <li class="breadcrumb-divider" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="12" viewBox="0 0 8 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 2l4 6-4 6"/></svg>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page"><span class="breadcrumb-link">Library</span></li>
+    </ol>
+  </nav>`} />
+
+### Changing every divider
+
+The separators a breadcrumb writes for itself come from [`::before`](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) and [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content). Change them all at once with the `--cui-breadcrumb-divider` custom property, or with the `$breadcrumb-divider` Sass variable — and `$breadcrumb-divider-flipped` for its RTL counterpart. The Sass variable is the fallback of the custom property, so a global divider can be overridden per breadcrumb without recompiling.
 
 <Example code={`<nav style="--cui-breadcrumb-divider: '>';" aria-label="breadcrumb">
     <ol class="breadcrumb">


### PR DESCRIPTION
Taken from upstream's page, which is the one thing it does better than ours: it splits dividers into named sections, so a reader looking for "how do I use a text character" finds a heading that says exactly that.

Ours had one Divider element section with an SVG and a character in the same example, leaving the reader to take it apart.

- **Default divider** — an empty `.breadcrumb-divider`
- **Text dividers** — the character straight in the element
- **SVG dividers** — inline SVG, `currentColor`, nothing to escape
- **Changing every divider** — the custom property and the Sass variable, followed by the existing embedded-SVG route

The `aria-hidden` guidance moves up to the Dividers intro, where it covers all three element sections rather than one. A paragraph that repeated what the section above it had just said is gone, and the examples use `.breadcrumb-link` like the rest of the page now.

Not taken: their claim that divider elements are hidden from assistive technology by CSS. Measured on their exact markup — an empty `<li>` with `content: ""` and a mask — the divider still comes back as a bare `listitem`, so the trail counts three steps instead of two. That is why the note tells you to add `aria-hidden` yourself.