### PR TITLE
fix(Breadcrumb): sit the automatic divider on the text baseline

### DIFF
--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -69,12 +69,14 @@ $breadcrumb-tokens: defaults(
   }
 
   .breadcrumb-item {
+    display: flex;
+    align-items: center;
+
     // The separator between breadcrumbs (by default, a forward-slash: "/")
     + .breadcrumb-item {
       padding-inline-start: var(--#{$prefix}breadcrumb-item-padding-x);
 
       &::before {
-        float: inline-start; // Suppress inline spacings and underlining of the separator
         padding-inline-end: var(--#{$prefix}breadcrumb-item-padding-x);
         color: var(--#{$prefix}breadcrumb-divider-color);
         @include ltr-rtl(


### PR DESCRIPTION
Spotted by mrholek on the docs page: the `/` hangs above the words either side of it.

The separator was `float: inline-start`, a carry-over from v5. A float is out of flow, so it pinned itself to the top of the item's content box. That was invisible while items had no padding — but `.breadcrumb-link` (#764) gives them `.25rem` top and bottom, which pushes the text down and leaves the slash floating above it.

The item is a flex container now, so the separator is an ordinary flex item centred against the link beside it.

**Checked both ways round.** Rendered the same markup against a `v6-dev` build and this one at 3× and compared: with `.breadcrumb-link` the slash moves down onto the line; **without it — plain links, a divider set through `--cui-breadcrumb-divider`, and RTL — the screenshots hash identically**, so nothing written before this changes. Without item padding the floated and the centred separator land in the same place, which is why this went unnoticed until the link class existed.