### PR TITLE
feat(Accordion): allow a custom icon element and a distinct open-state icon

### DIFF
--- a/docs/src/content/docs/components/accordion.mdx
+++ b/docs/src/content/docs/components/accordion.mdx
@@ -177,6 +177,80 @@ Both return a promise that settles once the items have finished moving.
     </details>
   </div>`} />
 
+## Custom icon
+
+<AddedIn version="6.0.0" />
+
+The chevron is drawn by the header itself, from the `--cui-accordion-btn-icon` custom property, and rotated by `--cui-accordion-btn-icon-transform` while the item is open. Point the property at your own URL-escaped SVG to change it everywhere.
+
+<Example code={`<div class="accordion" style="--cui-accordion-btn-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 3 5 5-5 5'/%3E%3C/svg%3E&quot;); --cui-accordion-btn-icon-transform: rotate(90deg);">
+    <details class="accordion-item" name="accordionIconToken" open>
+      <summary class="accordion-header">Accordion Item #1</summary>
+      <div class="accordion-body">The icon comes from the custom property, so no item carries markup for it.</div>
+    </details>
+    <details class="accordion-item" name="accordionIconToken">
+      <summary class="accordion-header">Accordion Item #2</summary>
+      <div class="accordion-body">Placeholder content for the second accordion item.</div>
+    </details>
+  </div>`} />
+
+### Icon as an element
+
+Put an `<svg class="accordion-icon">` inside the `<summary>` to hand the header a real element instead. Nothing has to be URL escaped, an icon font or an `<img>` works the same way, and the header stops drawing its own icon as soon as it finds one — so the two never double up. Sizing, placement and the open-state rotation stay with the class; `currentColor` keeps the shape on the header's text color, theme tint included.
+
+<Example code={`<div class="accordion">
+    <details class="accordion-item" name="accordionIconElement" open>
+      <summary class="accordion-header">Accordion Item #1
+        <svg class="accordion-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 6 5 5 5-5"/></svg>
+      </summary>
+      <div class="accordion-body">Placeholder content for the first accordion item.</div>
+    </details>
+    <details class="accordion-item" name="accordionIconElement">
+      <summary class="accordion-header">Accordion Item #2
+        <svg class="accordion-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 6 5 5 5-5"/></svg>
+      </summary>
+      <div class="accordion-body">Placeholder content for the second accordion item.</div>
+    </details>
+  </div>`} />
+
+### A different icon when open
+
+A plus that becomes a minus is a swap, not a rotation. Set `--cui-accordion-btn-active-icon` to the open-state shape and turn the rotation off:
+
+<Example code={`<div class="accordion" style="--cui-accordion-btn-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round'%3E%3Cpath d='M8 3v10M3 8h10'/%3E%3C/svg%3E&quot;); --cui-accordion-btn-active-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round'%3E%3Cpath d='M3 8h10'/%3E%3C/svg%3E&quot;); --cui-accordion-btn-icon-transform: none;">
+    <details class="accordion-item" name="accordionIconPair" open>
+      <summary class="accordion-header">Accordion Item #1</summary>
+      <div class="accordion-body">Placeholder content for the first accordion item.</div>
+    </details>
+    <details class="accordion-item" name="accordionIconPair">
+      <summary class="accordion-header">Accordion Item #2</summary>
+      <div class="accordion-body">Placeholder content for the second accordion item.</div>
+    </details>
+  </div>`} />
+
+The element form takes a pair too: add a second icon marked `.accordion-icon-active` and the header shows it in place of the first while the item is open. Rotation is dropped on its own here, because supplying a second shape already says the icon is not meant to turn.
+
+<Example code={`<div class="accordion">
+    <details class="accordion-item" name="accordionIconElementPair" open>
+      <summary class="accordion-header">Accordion Item #1
+        <svg class="accordion-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M8 3v10M3 8h10"/></svg>
+        <svg class="accordion-icon accordion-icon-active" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 8h10"/></svg>
+      </summary>
+      <div class="accordion-body">Placeholder content for the first accordion item.</div>
+    </details>
+    <details class="accordion-item" name="accordionIconElementPair">
+      <summary class="accordion-header">Accordion Item #2
+        <svg class="accordion-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M8 3v10M3 8h10"/></svg>
+        <svg class="accordion-icon accordion-icon-active" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 8h10"/></svg>
+      </summary>
+      <div class="accordion-body">Placeholder content for the second accordion item.</div>
+    </details>
+  </div>`} />
+
+<Callout color="info">
+The icon carries no accessible name in either form. `<summary>` already announces its expanded state, so keep the SVG out of the accessibility tree with `aria-hidden="true"` if your icon set does not do that for you.
+</Callout>
+
 ## Accessibility
 
 `<summary>` is a native disclosure control. It is focusable, it is operated with <kbd>Enter</kbd> and <kbd>Space</kbd>, and its expanded state is exposed to assistive technology by the browser — no `aria-expanded` or `aria-controls` bookkeeping is required.

--- a/docs/src/content/docs/components/accordion.mdx
+++ b/docs/src/content/docs/components/accordion.mdx
@@ -4,6 +4,8 @@ name: "Accordion"
 description: "Build vertically collapsing accordions on top of the native HTML disclosure element."
 otherFrameworks:
   - accordion
+css:
+  - "https://cdn.jsdelivr.net/npm/@coreui/icons@3.1.0/css/free.min.css"
 ---
 
 import accordionToggleAll from './snippets/accordion-toggle-all.js?raw'
@@ -181,9 +183,9 @@ Both return a promise that settles once the items have finished moving.
 
 <AddedIn version="6.0.0" />
 
-The chevron is drawn by the header itself, from the `--cui-accordion-btn-icon` custom property, and rotated by `--cui-accordion-btn-icon-transform` while the item is open. Point the property at your own URL-escaped SVG to change it everywhere.
+The chevron is drawn by the header itself, from the `--cui-accordion-btn-icon` custom property, and rotated by `--cui-accordion-btn-icon-transform` while the item is open. Point the property at your own URL-escaped SVG to change it everywhere. The example takes `cil-chevron-right` from [CoreUI Icons](https://coreui.io/icons/) and turns it a quarter clockwise when the item opens.
 
-<Example code={`<div class="accordion" style="--cui-accordion-btn-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 3 5 5-5 5'/%3E%3C/svg%3E&quot;); --cui-accordion-btn-icon-transform: rotate(90deg);">
+<Example code={`<div class="accordion" style="--cui-accordion-btn-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23000' d='m183.505 496-97.268-97.27 143.175-143.174L86.237 112.38l97.268-97.27 143.227 143.228 11.316 11.209 85.9 85.9.051.05-11.311 11.419-85.9 85.9-.055-.054Zm-52.013-97.27 52.013 52.014L326.629 307.62l.055.054 52.116-52.118-52.127-52.128-11.308-11.2-131.86-131.862-52.013 52.014 143.175 143.176Z'/%3E%3C/svg%3E&quot;); --cui-accordion-btn-icon-transform: rotate(90deg);">
     <details class="accordion-item" name="accordionIconToken" open>
       <summary class="accordion-header">Accordion Item #1</summary>
       <div class="accordion-body">The icon comes from the custom property, so no item carries markup for it.</div>
@@ -196,18 +198,37 @@ The chevron is drawn by the header itself, from the `--cui-accordion-btn-icon` c
 
 ### Icon as an element
 
-Put an `<svg class="accordion-icon">` inside the `<summary>` to hand the header a real element instead. Nothing has to be URL escaped, an icon font or an `<img>` works the same way, and the header stops drawing its own icon as soon as it finds one — so the two never double up. Sizing, placement and the open-state rotation stay with the class; `currentColor` keeps the shape on the header's text color, theme tint included.
+Put an element carrying `.accordion-icon` inside the `<summary>` to hand the header a real icon instead. The header stops drawing its own as soon as it finds one, so the two never double up. Sizing, placement and the open-state rotation stay with the class, and it fits both kinds of icon: an `<svg>` on `currentColor`, or a glyph from an icon font, which the class scales to the same box.
+
+The example uses [CoreUI Icons](https://coreui.io/icons/), so a step is one class:
 
 <Example code={`<div class="accordion">
     <details class="accordion-item" name="accordionIconElement" open>
       <summary class="accordion-header">Accordion Item #1
-        <svg class="accordion-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 6 5 5 5-5"/></svg>
+        <span class="accordion-icon cil-chevron-bottom" aria-hidden="true"></span>
       </summary>
       <div class="accordion-body">Placeholder content for the first accordion item.</div>
     </details>
     <details class="accordion-item" name="accordionIconElement">
       <summary class="accordion-header">Accordion Item #2
-        <svg class="accordion-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 6 5 5 5-5"/></svg>
+        <span class="accordion-icon cil-chevron-bottom" aria-hidden="true"></span>
+      </summary>
+      <div class="accordion-body">Placeholder content for the second accordion item.</div>
+    </details>
+  </div>`} />
+
+An inline `<svg>` goes in the same slot, and nothing about it has to be URL escaped:
+
+<Example code={`<div class="accordion">
+    <details class="accordion-item" name="accordionIconSvg" open>
+      <summary class="accordion-header">Accordion Item #1
+        <svg class="accordion-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="m256.072 424-11.421-11.313-85.808-85.809.053-.054L16 183.928l97.122-97.122 142.9 142.9 142.9-142.9 97.122 97.122-142.801 142.794-11.361 11.469Zm-.107-45.254.054.053 51.835-51.835 11.346-11.453 131.583-131.583-51.868-51.868-142.9 142.9-142.9-142.9-51.861 51.868 142.9 142.9-.053.054Z"/></svg>
+      </summary>
+      <div class="accordion-body">Placeholder content for the first accordion item.</div>
+    </details>
+    <details class="accordion-item" name="accordionIconSvg">
+      <summary class="accordion-header">Accordion Item #2
+        <svg class="accordion-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="m256.072 424-11.421-11.313-85.808-85.809.053-.054L16 183.928l97.122-97.122 142.9 142.9 142.9-142.9 97.122 97.122-142.801 142.794-11.361 11.469Zm-.107-45.254.054.053 51.835-51.835 11.346-11.453 131.583-131.583-51.868-51.868-142.9 142.9-142.9-142.9-51.861 51.868 142.9 142.9-.053.054Z"/></svg>
       </summary>
       <div class="accordion-body">Placeholder content for the second accordion item.</div>
     </details>
@@ -217,7 +238,7 @@ Put an `<svg class="accordion-icon">` inside the `<summary>` to hand the header 
 
 A plus that becomes a minus is a swap, not a rotation. Set `--cui-accordion-btn-active-icon` to the open-state shape and turn the rotation off:
 
-<Example code={`<div class="accordion" style="--cui-accordion-btn-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round'%3E%3Cpath d='M8 3v10M3 8h10'/%3E%3C/svg%3E&quot;); --cui-accordion-btn-active-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round'%3E%3Cpath d='M3 8h10'/%3E%3C/svg%3E&quot;); --cui-accordion-btn-icon-transform: none;">
+<Example code={`<div class="accordion" style="--cui-accordion-btn-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23000' d='M440 240H272V72h-32v168H72v32h168v168h32V272h168z'/%3E%3C/svg%3E&quot;); --cui-accordion-btn-active-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23000' d='M72 240h368v32H72z'/%3E%3C/svg%3E&quot;); --cui-accordion-btn-icon-transform: none;">
     <details class="accordion-item" name="accordionIconPair" open>
       <summary class="accordion-header">Accordion Item #1</summary>
       <div class="accordion-body">Placeholder content for the first accordion item.</div>
@@ -233,22 +254,22 @@ The element form takes a pair too: add a second icon marked `.accordion-icon-act
 <Example code={`<div class="accordion">
     <details class="accordion-item" name="accordionIconElementPair" open>
       <summary class="accordion-header">Accordion Item #1
-        <svg class="accordion-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M8 3v10M3 8h10"/></svg>
-        <svg class="accordion-icon accordion-icon-active" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 8h10"/></svg>
+        <span class="accordion-icon cil-plus" aria-hidden="true"></span>
+        <span class="accordion-icon accordion-icon-active cil-minus" aria-hidden="true"></span>
       </summary>
       <div class="accordion-body">Placeholder content for the first accordion item.</div>
     </details>
     <details class="accordion-item" name="accordionIconElementPair">
       <summary class="accordion-header">Accordion Item #2
-        <svg class="accordion-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M8 3v10M3 8h10"/></svg>
-        <svg class="accordion-icon accordion-icon-active" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 8h10"/></svg>
+        <span class="accordion-icon cil-plus" aria-hidden="true"></span>
+        <span class="accordion-icon accordion-icon-active cil-minus" aria-hidden="true"></span>
       </summary>
       <div class="accordion-body">Placeholder content for the second accordion item.</div>
     </details>
   </div>`} />
 
 <Callout color="info">
-The icon carries no accessible name in either form. `<summary>` already announces its expanded state, so keep the SVG out of the accessibility tree with `aria-hidden="true"` if your icon set does not do that for you.
+The icon carries no accessible name in either form. `<summary>` already announces its expanded state, so keep the icon out of the accessibility tree with `aria-hidden="true"` — a bare inline `<svg>` reaches it as an unnamed image otherwise.
 </Callout>
 
 ## Accessibility

--- a/docs/src/content/docs/components/accordion.mdx
+++ b/docs/src/content/docs/components/accordion.mdx
@@ -49,7 +49,7 @@ Click the accordions below to expand/collapse the accordion content.
 
 ## Variants
 
-Add a contextual `.theme-{color}` class to the `.accordion` to tint its **open** items. Closed items keep the neutral surface, so the theme marks what is currently expanded rather than recolouring the whole control.
+An open item is a neutral surface on its own. Add a contextual `.theme-{color}` class to the `.accordion` to tint it — closed items are untouched either way, so the theme marks what is currently expanded rather than recolouring the whole control.
 
 <Example code={`<div class="accordion theme-success">
     <details class="accordion-item" name="accordionTheme" open>

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1418,21 +1418,24 @@ the accordion swapped in a second SVG, the carousel inverted the first with a
 `background-color` as an ordinary token and follows the root colours by itself.
 Upstream v6 does the same, with a `mask-icon()` mixin.
 
-- **The accordion's two icons collapse into one.**
-  `$accordion-button-active-icon` and the `--#{$prefix}accordion-btn-active-icon`
-  custom property are **removed**; the active state changes
-  `--#{$prefix}accordion-btn-active-icon-color` instead of the whole image. New
-  tokens: `--#{$prefix}accordion-btn-icon-color` and
+- **The accordion's icon is one shape recoloured per state, not two images.**
+  `--#{$prefix}accordion-btn-active-icon` no longer has to carry a second copy
+  of the artwork: it defaults to `--#{$prefix}accordion-btn-icon`, and the open
+  state changes `--#{$prefix}accordion-btn-active-icon-color` instead. Set it
+  only when the open state is a genuinely different shape — a minus against a
+  plus. New tokens: `--#{$prefix}accordion-btn-icon-color` and
   `--#{$prefix}accordion-btn-active-icon-color`.
 - **A custom icon is now a shape, not a coloured image.** Whatever colour you put
   inside `$accordion-button-icon` or `$carousel-control-prev-icon-bg` /
   `$carousel-control-next-icon-bg` is ignored — only the alpha of the SVG is used.
   Set the colour through the token (`--#{$prefix}accordion-btn-icon-color`,
   `--#{$prefix}carousel-control-color`).
-- **`$accordion-icon-color` and `$accordion-icon-active-color` are `var()`
-  references now** (`var(--#{$prefix}body-color)`,
-  `var(--#{$prefix}primary-text-emphasis)`), not Sass colours — Sass colour
-  functions on them no longer work.
+- **`$accordion-icon-color` and `$accordion-icon-active-color` are
+  `currentcolor` now**, not Sass colours — Sass colour functions on them no
+  longer work. The icon therefore takes the header's colour in every state, so
+  anything that recolours an open header (`--#{$prefix}accordion-active-color`,
+  a `.theme-{color}` class) carries the icon with it. Both tokens stay, for the
+  case where the icon is meant to differ from the text.
 - **`$carousel-control-icon-filter` is removed**, with its
   `--#{$prefix}carousel-control-icon-filter` custom property and its two dark
   companions (`$carousel-control-icon-filter-dark`,

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -232,9 +232,15 @@ finished, not whether the state changed.
   `.accordion-icon-active` does the same in markup — that is what a plus/minus
   accordion needs, where the icon is swapped rather than rotated. The default
   chevron and its rotation are unchanged when neither is used.
-- **`.theme-{color}` tints the open items.** The active tokens resolve through
-  `--cui-theme-fg` / `-bg-subtle` / `-border` with the old primary values as the
-  fallback, so an untouched accordion renders exactly as before.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The open item is neutral, and `.theme-{color}` is what tints it.**
+  `--cui-accordion-active-bg` and `--cui-accordion-active-color` were fixed to
+  `--cui-primary-bg-subtle` / `--cui-primary-text-emphasis`, so every accordion
+  turned the brand colour on open whether or not that suited the page. They are
+  `--cui-secondary-bg` and `--cui-body-color` now, and the active tokens resolve
+  through `--cui-theme-fg` / `-bg-subtle` / `-border` first — so the colour is a
+  decision you make per accordion instead of one baked into the component. To
+  keep the old look, put `.theme-primary` on the `.accordion`.
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
   **`--cui-accordion-inner-border-radius` is gone; the header's corners follow
   `--cui-accordion-border-radius`.** The token was computed from the global

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -224,6 +224,14 @@ finished, not whether the state changed.
   colour), plus `--cui-accordion-content-duration` and
   `--cui-accordion-content-easing`, which drive the panel transition and are
   read back by `accordion.js` so both paths animate for the same length of time.
+- **The indicator can be an element instead of a background image.** Put an
+  `<svg class="accordion-icon">` in the `<summary>` and the header stops drawing
+  its own icon, so any icon set or `<img>` can be used without URL escaping an
+  SVG into a custom property. `--cui-accordion-btn-active-icon` selects the
+  shape shown while the item is open, and a second element marked
+  `.accordion-icon-active` does the same in markup — that is what a plus/minus
+  accordion needs, where the icon is swapped rather than rotated. The default
+  chevron and its rotation are unchanged when neither is used.
 - **`.theme-{color}` tints the open items.** The active tokens resolve through
   `--cui-theme-fg` / `-bg-subtle` / `-border` with the old primary values as the
   fallback, so an untouched accordion renders exactly as before.

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -212,10 +212,15 @@ $accordion-tokens: defaults(
     }
 
     .accordion-icon {
+      display: flex;
       flex-shrink: 0;
+      align-items: center;
+      justify-content: center;
       width: var(--#{$prefix}accordion-btn-icon-width);
       height: var(--#{$prefix}accordion-btn-icon-width);
       margin-inline-start: auto;
+      font-size: var(--#{$prefix}accordion-btn-icon-width);
+      line-height: 1;
       color: var(--#{$prefix}accordion-btn-icon-color);
       @include transition(var(--#{$prefix}accordion-btn-icon-transition));
     }

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -37,6 +37,7 @@ $accordion-icon-transition:               transform .2s ease-in-out !default;
 $accordion-icon-transform:                rotate(-180deg) !default;
 
 $accordion-button-icon:                   url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-linecap='round' stroke-linejoin='round'><path d='m2 5 6 6 6-6'/></svg>") !default;
+$accordion-button-active-icon:            var(--#{$prefix}accordion-btn-icon) !default;
 // scss-docs-end accordion-variables
 
 $accordion-tokens: () !default;
@@ -58,6 +59,7 @@ $accordion-tokens: defaults(
     --#{$prefix}accordion-btn-color: #{$accordion-button-color},
     --#{$prefix}accordion-btn-bg: #{$accordion-button-bg},
     --#{$prefix}accordion-btn-icon: #{escape-svg($accordion-button-icon)},
+    --#{$prefix}accordion-btn-active-icon: #{escape-svg($accordion-button-active-icon)},
     --#{$prefix}accordion-btn-icon-width: #{$accordion-icon-width},
     --#{$prefix}accordion-btn-icon-color: #{$accordion-icon-color},
     --#{$prefix}accordion-btn-active-icon-color: var(--#{$prefix}theme-fg, #{$accordion-icon-active-color}),
@@ -150,8 +152,27 @@ $accordion-tokens: defaults(
         box-shadow: inset 0 calc(-1 * var(--#{$prefix}accordion-border-width)) 0 var(--#{$prefix}accordion-active-border-color); // stylelint-disable-line function-disallowed-list
 
         &::after {
-          background-color: var(--#{$prefix}accordion-btn-active-icon-color);
+          mask-image: var(--#{$prefix}accordion-btn-active-icon);
+        }
+
+        &::after,
+        .accordion-icon {
+          color: var(--#{$prefix}accordion-btn-active-icon-color);
+        }
+
+        &:not(:has(.accordion-icon-active))::after,
+        &:not(:has(.accordion-icon-active)) .accordion-icon {
           transform: var(--#{$prefix}accordion-btn-icon-transform);
+        }
+
+        &:has(.accordion-icon-active) {
+          .accordion-icon:not(.accordion-icon-active) {
+            display: none;
+          }
+
+          .accordion-icon-active {
+            display: block;
+          }
         }
       }
 
@@ -178,15 +199,29 @@ $accordion-tokens: defaults(
       display: none;
     }
 
-    &::after {
+    &:not(:has(.accordion-icon))::after {
       flex-shrink: 0;
       width: var(--#{$prefix}accordion-btn-icon-width);
       height: var(--#{$prefix}accordion-btn-icon-width);
       margin-inline-start: auto;
+      color: var(--#{$prefix}accordion-btn-icon-color);
       content: "";
-      background-color: var(--#{$prefix}accordion-btn-icon-color);
+      background-color: currentcolor;
       @include mask-icon(var(--#{$prefix}accordion-btn-icon), var(--#{$prefix}accordion-btn-icon-width), null);
       @include transition(var(--#{$prefix}accordion-btn-icon-transition));
+    }
+
+    .accordion-icon {
+      flex-shrink: 0;
+      width: var(--#{$prefix}accordion-btn-icon-width);
+      height: var(--#{$prefix}accordion-btn-icon-width);
+      margin-inline-start: auto;
+      color: var(--#{$prefix}accordion-btn-icon-color);
+      @include transition(var(--#{$prefix}accordion-btn-icon-transition));
+    }
+
+    .accordion-icon-active {
+      display: none;
     }
 
     > :is(h1, h2, h3, h4, h5, h6) {

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -31,8 +31,8 @@ $accordion-content-duration:              .35s !default;
 $accordion-content-easing:                ease !default;
 
 $accordion-icon-width:                    1.25rem !default;
-$accordion-icon-color:                    var(--#{$prefix}body-color) !default;
-$accordion-icon-active-color:             var(--#{$prefix}primary-text-emphasis) !default;
+$accordion-icon-color:                    currentcolor !default;
+$accordion-icon-active-color:             currentcolor !default;
 $accordion-icon-transition:               transform .2s ease-in-out !default;
 $accordion-icon-transform:                rotate(-180deg) !default;
 
@@ -62,7 +62,7 @@ $accordion-tokens: defaults(
     --#{$prefix}accordion-btn-active-icon: #{escape-svg($accordion-button-active-icon)},
     --#{$prefix}accordion-btn-icon-width: #{$accordion-icon-width},
     --#{$prefix}accordion-btn-icon-color: #{$accordion-icon-color},
-    --#{$prefix}accordion-btn-active-icon-color: var(--#{$prefix}theme-fg, #{$accordion-icon-active-color}),
+    --#{$prefix}accordion-btn-active-icon-color: #{$accordion-icon-active-color},
     --#{$prefix}accordion-btn-icon-transform: #{$accordion-icon-transform},
     --#{$prefix}accordion-btn-icon-transition: #{$accordion-icon-transition},
     --#{$prefix}accordion-btn-focus-ring: #{$accordion-button-focus-ring},

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -21,8 +21,8 @@ $accordion-border-radius:                 var(--#{$prefix}border-radius) !defaul
 $accordion-button-color:                  var(--#{$prefix}body-color) !default;
 $accordion-button-bg:                     var(--#{$prefix}accordion-bg) !default;
 $accordion-transition:                    $btn-transition, border-radius .15s ease !default;
-$accordion-button-active-bg:              var(--#{$prefix}primary-bg-subtle) !default;
-$accordion-button-active-color:           var(--#{$prefix}primary-text-emphasis) !default;
+$accordion-button-active-bg:              var(--#{$prefix}secondary-bg) !default;
+$accordion-button-active-color:           var(--#{$prefix}body-color) !default;
 $accordion-active-border-color:           $accordion-border-color !default;
 
 $accordion-button-focus-ring:             var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;


### PR DESCRIPTION
The indicator was only a mask image on `.accordion-header::after`, so a custom icon had to be URL escaped into `--cui-accordion-btn-icon`, and the only thing that could change on open was its rotation. A plus that turns into a minus was not expressible at all — `--cui-accordion-btn-active-icon` existed in v5 and was dropped when the component moved onto `<details>`.

Three ways to set the icon now. An untouched accordion renders exactly as before.

**Icon as an element.** An `<svg class="accordion-icon">` inside the `<summary>` takes over: the header stops drawing its own icon as soon as it contains one (`:not(:has(.accordion-icon))::after`), so the two never double up. Nothing has to be URL escaped, and icon fonts or an `<img>` work the same way. Sizing, placement and the open-state rotation stay with the class.

**`--cui-accordion-btn-active-icon`.** Selects the mask shown while the item is open, defaulting to `--cui-accordion-btn-icon`. With `--cui-accordion-btn-icon-transform: none` this is the whole plus/minus case, in three declarations and no markup.

**`.accordion-icon-active`.** A second element that replaces the first while the item is open, for the same swap in markup. Rotation is suppressed on its own here, since a supplied open-state shape is not meant to turn.

The pseudo-element paints its mask through `currentcolor` now, so both paths take the icon color from `color`, and both keep resolving `--cui-accordion-btn-icon-color` and its active counterpart through the theme slots.

## Verification

- Five configurations checked in a real browser — default, element icon, element pair, token pair, and an element icon inside `.theme-success`. The pseudo-element resolves to `content: none` wherever an element icon is present, the pair reports `transform: none`, and the themed icon's computed `color` matches the header's.
- An unnamed inline `<svg>` shows up in the accessibility tree as a bare `[img]` node, so the docs examples carry `aria-hidden="true"` rather than only mentioning it.
- `css-lint`, `css-test` (62 specs), `css-test-class-api`, `css-lint-vars`, `docs-build` and the pre-push gate (bundlewatch included) all pass.

## Docs use our own icon set

Every custom-icon example is `cil-chevron-right`, `cil-chevron-bottom`, `cil-plus` and `cil-minus` from CoreUI Icons — as a font class where the point is the element slot, as an inline SVG where the point is that nothing has to be escaped. `.accordion-icon` now sets its font size from the icon width and centres its content, so a font glyph lands in exactly the same 20×20 box as an SVG instead of falling back to the header's 1rem off-centre.

The default chevron is deliberately unchanged: `cil-chevron-bottom` is an outlined shape that reads heavier than the stroked default at that size, and swapping it would restyle every accordion for no functional gain.
