### PR TITLE
fix(FocusRing): make component rings reference the global one instead of copying it

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "59.5kB"
+      "maxSize": "59.75kB"
     },
     {
       "path": "./dist/css/coreui.min.css",

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1860,6 +1860,24 @@ box-shadow ring was cut off.
 - **`focus-ring()` changed signature** to upstream's:
   `focus-ring($offset: false, $color: null)`. It no longer emits `outline: 0`.
 - `$pagination-focus-outline` is gone — the outline is now the ring itself.
+- **A component ring is a reference to the global one, not a copy of it.** Every
+  `--#{$prefix}*-focus-ring` defaults to
+  `var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring))`, so setting
+  `--#{$prefix}focus-ring-color` or `--#{$prefix}focus-ring-width` at the root
+  reaches every control, and a `.theme-{color}` region tints the rings inside
+  it. Previously each component baked the resolved value in at build time, which
+  is why a runtime change to the global ring left the components behind. The
+  per-component tokens and their Sass variables are unchanged as override
+  points; only their default moved.
+
+  ```diff
+  - --cui-pagination-focus-ring: .25rem solid rgba(88, 86, 214, .25);
+  + --cui-pagination-focus-ring: var(--cui-theme-focus-ring, var(--cui-focus-ring));
+  ```
+- **`$input-btn-focus-color` no longer reaches the input and control rings.**
+  They read the global ring now; set `$focus-ring-color` (or
+  `--#{$prefix}focus-ring-color`) instead. `$input-btn-focus-width` is
+  unaffected — it still sizes the validation rings and the button.
 
 **Sizes and colours are unchanged**, so the ring keeps its width
 (`$focus-ring-width`, `.25rem`) and its translucent theme colour. What changes is

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1857,8 +1857,14 @@ box-shadow ring was cut off.
   `$focus-ring-offset` / `--#{$prefix}focus-ring-offset` (defaults to `0`), which
   pushes the ring away from the element, and `--#{$prefix}focus-ring`, the
   composite shorthand the mixin reads.
-- **`focus-ring()` changed signature** to upstream's:
-  `focus-ring($offset: false, $color: null)`. It no longer emits `outline: 0`.
+- **`focus-ring()` changed signature** to
+  `focus-ring($offset: false, $color: null, $ring: null)`. It no longer emits
+  `outline: 0`. Every ring in the library is drawn through it now, passing the
+  component's own token as `$ring`; with no arguments it draws the global ring.
+- **`--#{$prefix}focus-ring-offset` actually applies.** The mixin emits
+  `outline-offset` wherever a ring is drawn, so one declaration moves every ring
+  in or out. It was previously read by the `.focus-ring` helper alone, which
+  made the token look supported while doing nothing on any component.
 - `$pagination-focus-outline` is gone — the outline is now the ring itself.
 - **A component ring is a reference to the global one, not a copy of it.** Every
   `--#{$prefix}*-focus-ring` defaults to

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -2,6 +2,7 @@
 @use "functions/defaults" as *;
 @use "functions/escape-svg" as *;
 @use "mixins/border-radius" as *;
+@use "mixins/focus-ring" as *;
 @use "mixins/mask-icon" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
@@ -204,7 +205,7 @@ $accordion-tokens: defaults(
     &:focus-visible {
       position: relative;
       z-index: 3;
-      outline: var(--#{$prefix}accordion-btn-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}accordion-btn-focus-ring));
     }
   }
 

--- a/scss/_calendar.scss
+++ b/scss/_calendar.scss
@@ -28,7 +28,7 @@ $calendar-nav-btn-hover-bg:                  transparent !default;
 $calendar-nav-btn-hover-border-color:        transparent !default;
 
 $calendar-nav-btn-focus-border-color:        transparent !default;
-$calendar-nav-btn-focus-ring:          $focus-ring !default;
+$calendar-nav-btn-focus-ring:          var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 
 $calendar-nav-date-font-weight:              600 !default;
 $calendar-nav-date-color:                    var(--#{$prefix}body-color) !default;
@@ -46,7 +46,7 @@ $calendar-cell-hover-color:                  var(--#{$prefix}body-color) !defaul
 $calendar-cell-hover-bg:                     var(--#{$prefix}tertiary-bg) !default;
 $calendar-cell-disabled-color:               var(--#{$prefix}tertiary-color) !default;
 
-$calendar-cell-focus-ring:             $focus-ring !default;
+$calendar-cell-focus-ring:             var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 
 $calendar-cell-selected-color:               $white !default;
 $calendar-cell-selected-bg:                  var(--#{$prefix}primary) !default;

--- a/scss/_calendar.scss
+++ b/scss/_calendar.scss
@@ -28,7 +28,7 @@ $calendar-nav-btn-hover-bg:                  transparent !default;
 $calendar-nav-btn-hover-border-color:        transparent !default;
 
 $calendar-nav-btn-focus-border-color:        transparent !default;
-$calendar-nav-btn-focus-ring:          var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
+$calendar-nav-btn-focus-ring:                var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 
 $calendar-nav-date-font-weight:              600 !default;
 $calendar-nav-date-color:                    var(--#{$prefix}body-color) !default;
@@ -46,7 +46,7 @@ $calendar-cell-hover-color:                  var(--#{$prefix}body-color) !defaul
 $calendar-cell-hover-bg:                     var(--#{$prefix}tertiary-bg) !default;
 $calendar-cell-disabled-color:               var(--#{$prefix}tertiary-color) !default;
 
-$calendar-cell-focus-ring:             var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
+$calendar-cell-focus-ring:                   var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 
 $calendar-cell-selected-color:               $white !default;
 $calendar-cell-selected-bg:                  var(--#{$prefix}primary) !default;

--- a/scss/_calendar.scss
+++ b/scss/_calendar.scss
@@ -2,6 +2,7 @@
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "layout/breakpoints" as *;
+@use "mixins/focus-ring" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
 @use "config" as *;
@@ -178,7 +179,7 @@ $calendar-tokens: defaults(
 
     &:focus-visible {
       border-color: var(--#{$prefix}calendar-nav-btn-focus-border-color);
-      outline: var(--#{$prefix}calendar-nav-btn-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}calendar-nav-btn-focus-ring));
     }
   }
 
@@ -345,7 +346,7 @@ $calendar-tokens: defaults(
       outline: 0;
 
       .calendar-cell-inner {
-        outline: var(--#{$prefix}calendar-cell-focus-ring);
+        @include focus-ring(true, $ring: var(--#{$prefix}calendar-cell-focus-ring));
         @include border-radius($border-radius);
       }
     }
@@ -390,7 +391,7 @@ $calendar-tokens: defaults(
     }
 
     &:focus-visible {
-      outline: var(--#{$prefix}calendar-cell-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}calendar-cell-focus-ring));
       @include border-radius($border-radius);
     }
   }

--- a/scss/_combobox.scss
+++ b/scss/_combobox.scss
@@ -1,6 +1,7 @@
 @use "functions/defaults" as *;
 @use "functions/escape-svg" as *;
 @use "mixins/border-radius" as *;
+@use "mixins/focus-ring" as *;
 @use "mixins/tokens" as *;
 @use "config" as *;
 @use "forms/form-check" as *;
@@ -152,7 +153,7 @@ $combobox-tokens: defaults(
     &:focus-visible {
       z-index: 5;
       border-color: var(--#{$prefix}input-focus-border-color, $input-focus-border-color);
-      outline: var(--#{$prefix}combobox-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}combobox-focus-ring));
     }
   }
 
@@ -185,7 +186,7 @@ $combobox-tokens: defaults(
     &:focus-visible {
       z-index: 5;
       border-color: var(--#{$prefix}input-focus-border-color, $input-focus-border-color);
-      outline: var(--#{$prefix}combobox-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}combobox-focus-ring));
     }
 
     &.disabled {
@@ -227,7 +228,7 @@ $combobox-tokens: defaults(
       &:focus-visible {
         z-index: 5;
         border-color: var(--#{$prefix}input-focus-border-color, $input-focus-border-color);
-        outline: var(--#{$prefix}combobox-focus-ring);
+        @include focus-ring(true, $ring: var(--#{$prefix}combobox-focus-ring));
       }
     }
   }

--- a/scss/_combobox.scss
+++ b/scss/_combobox.scss
@@ -16,7 +16,7 @@ $combobox-popup-min-width:         100% !default;
 // The panel's own ring token: the panel mounts outside the frame while open,
 // so it cannot inherit --#{$prefix}control-focus-ring from it — an inherited
 // var would resolve to nothing there and invalidate the outline.
-$combobox-focus-ring:              $focus-ring !default;
+$combobox-focus-ring:              var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 
 $combobox-header-padding-y:    .375rem !default;
 $combobox-header-padding-x:    .375rem !default;

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -858,7 +858,7 @@ $input-focus-bg:                        $input-bg !default;
 $input-focus-border-color:              tint-color($primary, 50%) !default;
 $input-focus-color:                     $input-color !default;
 $input-focus-width:                     $input-btn-focus-width !default;
-$input-focus-ring:                var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
+$input-focus-ring:                      var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 
 $input-placeholder-color:               var(--#{$prefix}secondary-color) !default;
 $input-plaintext-color:                 var(--#{$prefix}body-color) !default;

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -858,7 +858,7 @@ $input-focus-bg:                        $input-bg !default;
 $input-focus-border-color:              tint-color($primary, 50%) !default;
 $input-focus-color:                     $input-color !default;
 $input-focus-width:                     $input-btn-focus-width !default;
-$input-focus-ring:                $input-btn-focus-ring !default;
+$input-focus-ring:                var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 
 $input-placeholder-color:               var(--#{$prefix}secondary-color) !default;
 $input-plaintext-color:                 var(--#{$prefix}body-color) !default;

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -1,5 +1,6 @@
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
+@use "mixins/focus-ring" as *;
 @use "mixins/gradients" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
@@ -189,7 +190,7 @@ $nav-underline-border-tokens: defaults(
     }
 
     &:focus-visible {
-      outline: $nav-link-focus-ring;
+      @include focus-ring(true, $ring: $nav-link-focus-ring);
     }
 
     // Disabled state lightens text

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -16,7 +16,7 @@ $nav-link-color:                    var(--#{$prefix}link-color) !default;
 $nav-link-hover-color:              var(--#{$prefix}link-hover-color) !default;
 $nav-link-transition:               color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out !default;
 $nav-link-disabled-color:           var(--#{$prefix}secondary-color) !default;
-$nav-link-focus-ring:         var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
+$nav-link-focus-ring:               var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 
 $nav-tabs-border-color:             var(--#{$prefix}border-color) !default;
 $nav-tabs-border-width:             var(--#{$prefix}border-width) !default;

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -16,7 +16,7 @@ $nav-link-color:                    var(--#{$prefix}link-color) !default;
 $nav-link-hover-color:              var(--#{$prefix}link-hover-color) !default;
 $nav-link-transition:               color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out !default;
 $nav-link-disabled-color:           var(--#{$prefix}secondary-color) !default;
-$nav-link-focus-ring:         $focus-ring !default;
+$nav-link-focus-ring:         var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 
 $nav-tabs-border-color:             var(--#{$prefix}border-color) !default;
 $nav-tabs-border-width:             var(--#{$prefix}border-width) !default;

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -26,7 +26,7 @@ $pagination-border-color:           var(--#{$prefix}border-color) !default;
 
 $pagination-focus-color:            var(--#{$prefix}link-hover-color) !default;
 $pagination-focus-bg:               var(--#{$prefix}secondary-bg) !default;
-$pagination-focus-ring:       $focus-ring !default;
+$pagination-focus-ring:       var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 
 $pagination-hover-color:            var(--#{$prefix}link-hover-color) !default;
 $pagination-hover-bg:               var(--#{$prefix}tertiary-bg) !default;

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -26,7 +26,7 @@ $pagination-border-color:           var(--#{$prefix}border-color) !default;
 
 $pagination-focus-color:            var(--#{$prefix}link-hover-color) !default;
 $pagination-focus-bg:               var(--#{$prefix}secondary-bg) !default;
-$pagination-focus-ring:       var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
+$pagination-focus-ring:             var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 
 $pagination-hover-color:            var(--#{$prefix}link-hover-color) !default;
 $pagination-hover-bg:               var(--#{$prefix}tertiary-bg) !default;

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -1,5 +1,6 @@
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
+@use "mixins/focus-ring" as *;
 @use "mixins/gradients" as *;
 @use "mixins/lists" as *;
 @use "mixins/pagination" as *;
@@ -111,7 +112,7 @@ $pagination-tokens: defaults(
       z-index: 3;
       color: var(--#{$prefix}pagination-focus-color);
       background-color: var(--#{$prefix}pagination-focus-bg);
-      outline: var(--#{$prefix}pagination-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}pagination-focus-ring));
     }
 
     &.active,

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -4,6 +4,7 @@
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/box-shadow" as *;
+@use "mixins/focus-ring" as *;
 @use "mixins/gradients" as *;
 @use "mixins/ltr-rtl" as *;
 @use "mixins/tokens" as *;
@@ -193,8 +194,8 @@ $range-slider-vertical-tokens: defaults(
 
       // Pseudo-elements must be split across multiple rulesets to have an effect.
       // No box-shadow() mixin for focus accessibility.
-      &::-webkit-slider-thumb { outline: var(--#{$prefix}range-slider-thumb-focus-ring); }
-      &::-moz-range-thumb     { outline: var(--#{$prefix}range-slider-thumb-focus-ring); }
+      &::-webkit-slider-thumb { @include focus-ring(true, $ring: var(--#{$prefix}range-slider-thumb-focus-ring)); }
+      &::-moz-range-thumb     { @include focus-ring(true, $ring: var(--#{$prefix}range-slider-thumb-focus-ring)); }
     }
 
     &::-moz-focus-outer {

--- a/scss/_stepper.scss
+++ b/scss/_stepper.scss
@@ -31,7 +31,7 @@ $stepper-step-indicator-complete-border-color:  var(--#{$prefix}primary) !defaul
 $stepper-step-indicator-disabled-color:         var(--#{$prefix}secondary) !default;
 $stepper-step-indicator-disabled-bg:            transparent !default;
 $stepper-step-indicator-disabled-border-color:  var(--#{$prefix}border-color) !default;
-$stepper-step-indicator-focus-ring:       var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
+$stepper-step-indicator-focus-ring:             var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 $stepper-step-indicator-icon:                   url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpolygon fill='var(--ci-primary-color, currentColor)' points='200.359 382.269 61.057 251.673 82.943 228.327 199.641 337.731 428.686 108.687 451.314 131.313 200.359 382.269' class='ci-primary'/%3E%3C/svg%3E") !default;
 $stepper-step-indicator-icon-color:             var(--#{$prefix}white) !default;
 $stepper-step-indicator-icon-size:              1rem !default;

--- a/scss/_stepper.scss
+++ b/scss/_stepper.scss
@@ -31,7 +31,7 @@ $stepper-step-indicator-complete-border-color:  var(--#{$prefix}primary) !defaul
 $stepper-step-indicator-disabled-color:         var(--#{$prefix}secondary) !default;
 $stepper-step-indicator-disabled-bg:            transparent !default;
 $stepper-step-indicator-disabled-border-color:  var(--#{$prefix}border-color) !default;
-$stepper-step-indicator-focus-ring:       $focus-ring !default;
+$stepper-step-indicator-focus-ring:       var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 $stepper-step-indicator-icon:                   url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpolygon fill='var(--ci-primary-color, currentColor)' points='200.359 382.269 61.057 251.673 82.943 228.327 199.641 337.731 428.686 108.687 451.314 131.313 200.359 382.269' class='ci-primary'/%3E%3C/svg%3E") !default;
 $stepper-step-indicator-icon-color:             var(--#{$prefix}white) !default;
 $stepper-step-indicator-icon-size:              1rem !default;

--- a/scss/_stepper.scss
+++ b/scss/_stepper.scss
@@ -1,5 +1,6 @@
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
+@use "mixins/focus-ring" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
 @use "config" as *;
@@ -184,7 +185,7 @@ $stepper-tokens: defaults(
     &:focus {
 
       .stepper-step-indicator {
-        outline: var(--#{$prefix}stepper-step-indicator-focus-ring);
+        @include focus-ring(true, $ring: var(--#{$prefix}stepper-step-indicator-focus-ring));
       }
     }
   }

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -7,6 +7,7 @@
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
 @use "../mixins/color-mode" as *;
+@use "../mixins/focus-ring" as *;
 @use "../mixins/gradients" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
@@ -231,14 +232,14 @@ $btn-ghost-focus-shadow: var(--#{$prefix}tertiary-bg) !default;
       @include gradient-bg(var(--#{$prefix}btn-hover-bg));
       border-color: var(--#{$prefix}btn-hover-border-color);
       // Avoid using mixin so we can pass custom focus shadow properly
-      outline: var(--#{$prefix}btn-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}btn-focus-ring));
     }
 
     #{$btn-check-deprecated}:focus-visible + &,
     &.btn-check:has(input:focus-visible) {
       border-color: var(--#{$prefix}btn-hover-border-color);
       // Avoid using mixin so we can pass custom focus shadow properly
-      outline: var(--#{$prefix}btn-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}btn-focus-ring));
     }
 
     #{$btn-check-deprecated}:checked + &,
@@ -257,14 +258,14 @@ $btn-ghost-focus-shadow: var(--#{$prefix}tertiary-bg) !default;
 
       &:focus-visible {
         // Avoid using mixin so we can pass custom focus shadow properly
-        outline: var(--#{$prefix}btn-focus-ring);
+        @include focus-ring(true, $ring: var(--#{$prefix}btn-focus-ring));
       }
     }
 
     #{$btn-check-deprecated}:checked:focus-visible + &,
     &.btn-check:has(input:checked:focus-visible) {
       // Avoid using mixin so we can pass custom focus shadow properly
-      outline: var(--#{$prefix}btn-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}btn-focus-ring));
     }
 
     &:disabled,

--- a/scss/buttons/_search-button.scss
+++ b/scss/buttons/_search-button.scss
@@ -1,6 +1,7 @@
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
+@use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
 @use "../config" as *;
@@ -100,7 +101,7 @@ $search-button-tokens: defaults(
       color: var(--#{$prefix}search-button-focus-color);
       background-color: var(--#{$prefix}search-button-focus-bg);
       border-color: var(--#{$prefix}search-button-focus-border-color);
-      outline: var(--#{$prefix}search-button-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}search-button-focus-ring));
     }
   }
 

--- a/scss/forms/_check.scss
+++ b/scss/forms/_check.scss
@@ -123,7 +123,7 @@ $check-selector: if(sass($enable-deprecated-form-check): ".check, .form-check-in
 
     &:focus {
       border-color: var(--#{$prefix}check-focus-border);
-      outline: var(--#{$prefix}check-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}check-focus-ring));
     }
 
     &:active {

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -34,7 +34,7 @@ $form-check-label-cursor:                 null !default;
 
 $form-check-input-active-filter:          brightness(90%) !default;
 $form-check-input-focus-border:           $input-focus-border-color !default;
-$form-check-input-focus-ring:             $focus-ring !default;
+$form-check-input-focus-ring:             var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
 
 $form-check-input-disabled-opacity:        .5 !default;
 $form-check-label-disabled-opacity:        $form-check-input-disabled-opacity !default;

--- a/scss/forms/_form-control-group.scss
+++ b/scss/forms/_form-control-group.scss
@@ -1,5 +1,6 @@
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
+@use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
 @use "../config" as *;
@@ -65,7 +66,7 @@ $form-control-group-tokens: defaults(
 // indicators and no way to tell which one answers the keys (WCAG 2.4.7).
 @mixin form-control-group-focus() {
   @include form-control-group-active();
-  outline: var(--#{$prefix}control-focus-ring);
+  @include focus-ring(true, $ring: var(--#{$prefix}control-focus-ring));
 }
 // scss-docs-end form-control-group-focus-mixin
 
@@ -222,7 +223,7 @@ $form-control-group-tokens: defaults(
 
     &:focus-visible {
       z-index: 5;
-      outline: var(--#{$prefix}focus-ring);
+      @include focus-ring(true);
     }
 
     &:disabled {

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -4,6 +4,7 @@
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
 @use "../mixins/color-mode" as *;
+@use "../mixins/focus-ring" as *;
 @use "../mixins/gradients" as *;
 @use "../mixins/ltr-rtl" as *;
 @use "../mixins/tokens" as *;
@@ -148,7 +149,7 @@ $form-control-select-tokens: defaults(
       color: var(--#{$prefix}control-focus-color);
       background-color: var(--#{$prefix}control-focus-bg);
       border-color: var(--#{$prefix}control-focus-border-color);
-      outline: var(--#{$prefix}control-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}control-focus-ring));
     }
 
     &::-webkit-date-and-time-value {

--- a/scss/forms/_form-date-time.scss
+++ b/scss/forms/_form-date-time.scss
@@ -1,5 +1,6 @@
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
+@use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
 @use "../config" as *;
 @use "floating-labels" as *;
@@ -66,7 +67,7 @@ $form-date-time-tokens: defaults(
       color: var(--#{$prefix}control-focus-color);
       background-color: var(--#{$prefix}control-focus-bg);
       border-color: var(--#{$prefix}control-focus-border-color);
-      outline: var(--#{$prefix}control-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}control-focus-ring));
     }
 
     &.disabled {

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -2,6 +2,7 @@
 @use "../functions/math" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
+@use "../mixins/focus-ring" as *;
 @use "../mixins/gradients" as *;
 @use "../mixins/transition" as *;
 @use "../config" as *;
@@ -46,8 +47,8 @@ $form-range-thumb-transition:              background-color .15s ease-in-out, bo
 
       // Pseudo-elements must be split across multiple rulesets to have an effect.
       // No box-shadow() mixin for focus accessibility.
-      &::-webkit-slider-thumb { outline: $form-range-thumb-focus-ring; }
-      &::-moz-range-thumb     { outline: $form-range-thumb-focus-ring; }
+      &::-webkit-slider-thumb { @include focus-ring(true, $ring: $form-range-thumb-focus-ring); }
+      &::-moz-range-thumb     { @include focus-ring(true, $ring: $form-range-thumb-focus-ring); }
     }
 
     &::-moz-focus-outer {

--- a/scss/forms/_otp-input.scss
+++ b/scss/forms/_otp-input.scss
@@ -2,6 +2,7 @@
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
+@use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
 @use "../config" as *;
@@ -124,7 +125,7 @@ $form-otp-control-tokens: defaults(
       color: var(--#{$prefix}control-focus-color);
       background-color: var(--#{$prefix}control-focus-bg);
       border-color: var(--#{$prefix}control-focus-border-color);
-      outline: var(--#{$prefix}control-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}control-focus-ring));
     }
   }
 

--- a/scss/forms/_radio.scss
+++ b/scss/forms/_radio.scss
@@ -3,6 +3,7 @@
 @use "../functions/escape-svg" as *;
 @use "form-check" as *;
 @use "check" as *;
+@use "../mixins/focus-ring" as *;
 @use "../mixins/mask-icon" as *;
 @use "../mixins/tokens" as *;
 @use "../config" as *;
@@ -95,7 +96,7 @@ $radio-selector: if(sass($enable-deprecated-form-check): ".radio, .form-check-in
 
     &:focus {
       border-color: var(--#{$prefix}radio-focus-border);
-      outline: var(--#{$prefix}radio-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}radio-focus-ring));
     }
 
     &:active {

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -4,6 +4,7 @@
 @use "../functions/escape-svg" as *;
 @use "form-check" as *;
 @use "../mixins/border-radius" as *;
+@use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
 @use "../config" as *;
@@ -140,7 +141,7 @@ $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch
 
     &:focus {
       border-color: var(--#{$prefix}switch-focus-border);
-      outline: var(--#{$prefix}switch-focus-ring);
+      @include focus-ring(true, $ring: var(--#{$prefix}switch-focus-ring));
     }
 
     &:disabled {

--- a/scss/helpers/_focus-ring.scss
+++ b/scss/helpers/_focus-ring.scss
@@ -1,8 +1,8 @@
+@use "../mixins/focus-ring" as *;
 @use "../config" as *;
 
 @layer helpers {
   .focus-ring:focus {
-    outline: var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring));
-    outline-offset: var(--#{$prefix}focus-ring-offset);
+    @include focus-ring(true);
   }
 }

--- a/scss/helpers/_focus-ring.scss
+++ b/scss/helpers/_focus-ring.scss
@@ -2,7 +2,7 @@
 
 @layer helpers {
   .focus-ring:focus {
-    outline: var(--#{$prefix}focus-ring);
+    outline: var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring));
     outline-offset: var(--#{$prefix}focus-ring-offset);
   }
 }

--- a/scss/mixins/_focus-ring.scss
+++ b/scss/mixins/_focus-ring.scss
@@ -4,11 +4,13 @@
 // upstream v6. An outline is not clipped by an ancestor's `overflow`, so the
 // ring stays visible inside scroll containers, where a box-shadow was cut off.
 
-@mixin focus-ring($offset: false, $color: null) {
-  @if $color != null {
+@mixin focus-ring($offset: false, $color: null, $ring: null) {
+  @if $ring != null {
+    outline: $ring;
+  } @else if $color != null {
     outline: var(--#{$prefix}focus-ring-width) solid #{$color};
   } @else {
-    outline: var(--#{$prefix}focus-ring);
+    outline: var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring));
   }
   @if $offset {
     outline-offset: var(--#{$prefix}focus-ring-offset);

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -3,6 +3,7 @@
 @use "../functions/math" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
+@use "../mixins/focus-ring" as *;
 @use "../mixins/ltr-rtl" as *;
 @use "../mixins/tokens" as *;
 @use "../config" as *;
@@ -148,7 +149,7 @@ $validated-controls: if(sass($enable-deprecated-form-check): ".check, .radio, .s
 
       &:focus {
         border-color: $border-color;
-        outline: $focus-ring;
+        @include focus-ring(true, $ring: $focus-ring);
       }
     }
   }
@@ -237,7 +238,7 @@ $validated-controls: if(sass($enable-deprecated-form-check): ".check, .radio, .s
       }
 
       &:focus {
-        outline: $focus-ring;
+        @include focus-ring(true, $ring: $focus-ring);
       }
 
       ~ label {


### PR DESCRIPTION
Eleven `--cui-*-focus-ring` tokens were composed in Sass from `$focus-ring`, so the built stylesheet carried eleven copies of `.25rem solid rgba(88, 86, 214, .25)`. The chain ended there — two consequences, both measured in a browser:

- changing `--cui-focus-ring-color` at runtime updated the global `--cui-focus-ring` and **nothing else**;
- a `.theme-{color}` region painted its state colour everywhere except the focus rings inside it (indigo rings on a green accordion).

Their defaults are now `var(--cui-theme-focus-ring, var(--cui-focus-ring))`, the shape `--cui-accordion-btn-focus-ring` already used. `.focus-ring` reads the theme slot too, which it did not before.

## What moves

| | before | after |
| --- | --- | --- |
| `--cui-focus-ring-color: #d00` at the root | components stay indigo | pagination / check / control all `.25rem solid #d00` |
| inside `.theme-success` | indigo ring | `color-mix(in srgb, #1b9e3e 25%, transparent)` |
| untouched page | `.25rem solid rgba(88, 86, 214, .25)` | identical — the chain resolves to what used to be inlined |

Covers pagination, form-check, radio, switch, combobox, calendar (cell + nav), stepper, range slider, search button, nav underline and the shared control ring. The per-component tokens and their Sass variables are unchanged as override points; only their default moved.

## Deliberately left composed

- **The button's ring** mixes its colour per variant from `--cui-btn-focus-shadow`, and **the validation ring** mixes from the state colour. Both are already live through those `var()`s.
- **Their widths** are still Sass-time values. `--cui-focus-ring-width` cannot reach them until `$input-focus-width` stops being used in arithmetic (`_form-range.scss:39` multiplies it), which is its own change.

## One Sass regression, documented

`$input-btn-focus-color` no longer feeds the input and control rings — they read the global ring now, so `$focus-ring-color` is the knob. `$input-btn-focus-width` is unaffected.

## Verification

`css-lint`, `css-test` (62 specs), `css-lint-vars`, `css-test-class-api`, `docs-build` and the pre-push gate all pass. Before/after token values read from `getComputedStyle` on a real page, not from the source.

## The mixin is now what draws every ring

Twenty-eight call sites wrote `outline: var(--cui-<component>-focus-ring)` by hand, so the mixin the library ships was used by exactly one file. The decision to draw a ring as an outline lived in 28 places, and `--cui-focus-ring-offset` — a token the migration guide advertises as new in v6 — reached nothing but the `.focus-ring` helper, because no component emitted `outline-offset` at all.

`focus-ring()` takes a `$ring` argument now, so a component passes its own token and keeps its override point:

```scss
&:focus-visible {
  @include focus-ring(true, $ring: var(--#{$prefix}pagination-focus-ring));
}
```

With no arguments it draws `var(--cui-theme-focus-ring, var(--cui-focus-ring))`, which is what `.focus-ring` and the control-group wrapper want.

Setting `--cui-focus-ring-offset: 3px` now moves all 33 rings — measured on a focused control alongside `--cui-focus-ring-color`, both arrive (`4px solid rgb(221, 0, 0)`, offset `3px`). Bundlewatch passes unchanged: 59.23 KB against a 59.5 KB budget.

## Not in this PR

`:focus` vs `:focus-visible` is still mixed across the library. It is not a sweep — a text input should keep showing its ring on mouse focus, a button should not — so it needs a verdict per component rather than a find-and-replace.
