### PR TITLE
refactor(config): move single-consumer variables out of the shared config

### DIFF
--- a/docs/src/content/docs/components/placeholders.mdx
+++ b/docs/src/content/docs/components/placeholders.mdx
@@ -101,4 +101,4 @@ Animate Bootstrap placeholders using `.placeholder-glow` or `.placeholder-wave` 
 
 ### SASS variables
 
-<ScssDocs file="scss/_config.scss" capture="placeholders" />
+<ScssDocs file="scss/_placeholder.scss" capture="placeholders" />

--- a/docs/src/content/docs/components/sidebar.mdx
+++ b/docs/src/content/docs/components/sidebar.mdx
@@ -601,4 +601,4 @@ Sidebars use local CSS variables on `.sidebar`, `.sidebar-backdrop`, `.sidebar-n
 
 <ScssDocs file="scss/sidebar/_sidebar.scss" capture="sidebar-variables" />
 
-<ScssDocs file="scss/_config.scss" capture="sidebar-toggler" />
+<ScssDocs file="scss/sidebar/_sidebar.scss" capture="sidebar-toggler" />

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -182,4 +182,4 @@ Options belonging to the inner [calendar](/components/calendar/#options) or
 
 <ScssDocs file="scss/_date-picker.scss" capture="date-picker-variables" />
 
-<ScssDocs file="scss/_config.scss" capture="time-picker-variables" />
+<ScssDocs file="scss/_time-picker.scss" capture="time-picker-variables" />

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -251,4 +251,4 @@ The shell reuses the existing `$time-picker-*` variables for the selection body
 and the `$date-picker-*` shell-layer variables for the frame — this adds no new
 configuration surface.
 
-<ScssDocs file="scss/_config.scss" capture="time-picker-variables" />
+<ScssDocs file="scss/_time-picker.scss" capture="time-picker-variables" />

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -949,78 +949,8 @@ $zindex-levels: (
 ) !default;
 // scss-docs-end zindex-levels-map
 
-// Navs
-
-// Navbar
-
-// Dropdown menu container and contents.
-
-// Placeholders
-
-// scss-docs-start placeholders
-$placeholder-opacity-max:           .5 !default;
-$placeholder-opacity-min:           .2 !default;
-// scss-docs-end placeholders
-
-// Tooltips
-
-// Alerts
-
-// Image thumbnails
-
-// Figures
-
-// Carousel
-
-// scss-docs-start sidebar-toggler
-$sidebar-toggler-width:             .5rem !default;
-$sidebar-toggler-height:            .5rem !default;
-$sidebar-toggler-padding-x:         .25rem !default;
-$sidebar-toggler-padding-y:         .25rem !default;
-$sidebar-toggler-bg:                transparent !default;
-$sidebar-toggler-color:             var(--#{$prefix}tertiary-color) !default;
-$sidebar-toggler-icon:              url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cg xmlns='http://www.w3.org/2000/svg' transform='matrix(-1 0 0 -1 512 512)'%3E%3Cpath fill='%23000' d='M472,16H40A24.028,24.028,0,0,0,16,40V200H48V48H464V464H48V304H16V472a24.028,24.028,0,0,0,24,24H472a24.028,24.028,0,0,0,24-24V40A24.028,24.028,0,0,0,472,16Z'/%3E%3Cpolygon fill='%23000' points='209.377 363.306 232.004 385.933 366.627 251.31 232.004 116.687 209.377 139.313 305.374 235.311 16 235.311 16 267.311 305.372 267.311 209.377 363.306'/%3E%3C/g%3E%3C/svg%3E") !default;
-$sidebar-toggler-focus-shadow:      $focus-ring !default;
-$sidebar-toggler-hover-color:       var(--#{$prefix}secondary-color) !default;
-$sidebar-toggler-focus-color:       var(--#{$prefix}secondary-color) !default;
-$sidebar-toggler-transition:        transform .15s !default;
-// scss-docs-end sidebar-toggler
-
 // Code
 
 $code-font-size:                    $small-font-size !default;
 $code-color:                        light-dark($pink, tint-color($pink, 40%)) !default;
 
-$kbd-padding-y:                     .1875rem !default;
-$kbd-padding-x:                     .375rem !default;
-$kbd-font-size:                     $code-font-size !default;
-$kbd-color:                         var(--#{$prefix}body-bg) !default;
-$kbd-bg:                            var(--#{$prefix}body-color) !default;
-
-$pre-color:                         null !default;
-
-// Time Picker
-// scss-docs-start time-picker-variables
-$time-picker-body-padding:                  $spacer * .5 !default;
-
-$time-picker-footer-padding:                .5rem !default;
-$time-picker-footer-border-width:           1px !default;
-$time-picker-footer-border-color:           var(--#{$prefix}border-color) !default;
-
-$time-picker-roll-col-border-width:           var(--#{$prefix}border-width) !default;
-$time-picker-roll-col-border-color:           var(--#{$prefix}border-color) !default;
-$time-picker-roll-cell-width:                 3rem !default;
-$time-picker-roll-cell-height:                2rem !default;
-$time-picker-roll-cell-hover-color:           var(--#{$prefix}body-color) !default;
-$time-picker-roll-cell-hover-bg:              var(--#{$prefix}tertiary-bg) !default;
-$time-picker-roll-cell-selected-color:        var(--#{$prefix}white) !default;
-$time-picker-roll-cell-selected-bg:           var(--#{$prefix}primary) !default;
-$time-picker-roll-cell-selected-hover-color:  var(--#{$prefix}white) !default;
-$time-picker-roll-cell-selected-hover-bg:     light-dark(color.scale($primary, $lightness: -20%), color.scale($primary, $saturation: -10%, $lightness: -10%)) !default; // stylelint-disable-line scss/at-function-named-arguments
-
-$time-picker-inline-select-font-size:       var(--#{$prefix}btn-input-sm-font-size) !default;
-$time-picker-inline-select-color:           $input-color !default;
-$time-picker-inline-select-padding-y:       $input-padding-y-sm !default;
-$time-picker-inline-select-padding-x:       $input-padding-x-sm !default;
-$time-picker-inline-select-disabled-color:  $input-disabled-color !default;
-// scss-docs-end time-picker-variables

--- a/scss/_date-picker.scss
+++ b/scss/_date-picker.scss
@@ -1,5 +1,6 @@
 @use "sass:math";
 @use "calendar" as *;
+@use "time-picker" as *;
 @use "functions/defaults" as *;
 @use "mixins/tokens" as *;
 @use "config" as *;

--- a/scss/_placeholder.scss
+++ b/scss/_placeholder.scss
@@ -1,5 +1,10 @@
 @use "config" as *;
 
+// scss-docs-start placeholders
+$placeholder-opacity-max:           .5 !default;
+$placeholder-opacity-min:           .2 !default;
+// scss-docs-end placeholders
+
 @layer components {
   .placeholder {
     display: inline-block;

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -1,8 +1,34 @@
+@use "sass:color";
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/tokens" as *;
 @use "config" as *;
 @use "forms/form-control-group" as *;
+
+// scss-docs-start time-picker-variables
+$time-picker-body-padding:                  $spacer * .5 !default;
+
+$time-picker-footer-padding:                .5rem !default;
+$time-picker-footer-border-width:           1px !default;
+$time-picker-footer-border-color:           var(--#{$prefix}border-color) !default;
+
+$time-picker-roll-col-border-width:           var(--#{$prefix}border-width) !default;
+$time-picker-roll-col-border-color:           var(--#{$prefix}border-color) !default;
+$time-picker-roll-cell-width:                 3rem !default;
+$time-picker-roll-cell-height:                2rem !default;
+$time-picker-roll-cell-hover-color:           var(--#{$prefix}body-color) !default;
+$time-picker-roll-cell-hover-bg:              var(--#{$prefix}tertiary-bg) !default;
+$time-picker-roll-cell-selected-color:        var(--#{$prefix}white) !default;
+$time-picker-roll-cell-selected-bg:           var(--#{$prefix}primary) !default;
+$time-picker-roll-cell-selected-hover-color:  var(--#{$prefix}white) !default;
+$time-picker-roll-cell-selected-hover-bg:     light-dark(color.scale($primary, $lightness: -20%), color.scale($primary, $saturation: -10%, $lightness: -10%)) !default; // stylelint-disable-line scss/at-function-named-arguments
+
+$time-picker-inline-select-font-size:       var(--#{$prefix}btn-input-sm-font-size) !default;
+$time-picker-inline-select-color:           $input-color !default;
+$time-picker-inline-select-padding-y:       $input-padding-y-sm !default;
+$time-picker-inline-select-padding-x:       $input-padding-x-sm !default;
+$time-picker-inline-select-disabled-color:  $input-disabled-color !default;
+// scss-docs-end time-picker-variables
 
 // Time Picker
 $time-picker-tokens: () !default;

--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -1,6 +1,16 @@
 @use "../mixins/border-radius" as *;
 @use "../config" as *;
 
+// scss-docs-start kbd-variables
+$kbd-padding-y:                     .1875rem !default;
+$kbd-padding-x:                     .375rem !default;
+$kbd-font-size:                     $code-font-size !default;
+$kbd-color:                         var(--#{$prefix}body-bg) !default;
+$kbd-bg:                            var(--#{$prefix}body-color) !default;
+
+$pre-color:                         null !default;
+// scss-docs-end kbd-variables
+
 // stylelint-disable function-disallowed-list
 
 // scss-docs-start reboot-table-variables

--- a/scss/sidebar/_sidebar.scss
+++ b/scss/sidebar/_sidebar.scss
@@ -7,6 +7,20 @@
 @use "../mixins/transition" as *;
 @use "../config" as *;
 
+// scss-docs-start sidebar-toggler
+$sidebar-toggler-width:             .5rem !default;
+$sidebar-toggler-height:            .5rem !default;
+$sidebar-toggler-padding-x:         .25rem !default;
+$sidebar-toggler-padding-y:         .25rem !default;
+$sidebar-toggler-bg:                transparent !default;
+$sidebar-toggler-color:             var(--#{$prefix}tertiary-color) !default;
+$sidebar-toggler-icon:              url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cg xmlns='http://www.w3.org/2000/svg' transform='matrix(-1 0 0 -1 512 512)'%3E%3Cpath fill='%23000' d='M472,16H40A24.028,24.028,0,0,0,16,40V200H48V48H464V464H48V304H16V472a24.028,24.028,0,0,0,24,24H472a24.028,24.028,0,0,0,24-24V40A24.028,24.028,0,0,0,472,16Z'/%3E%3Cpolygon fill='%23000' points='209.377 363.306 232.004 385.933 366.627 251.31 232.004 116.687 209.377 139.313 305.374 235.311 16 235.311 16 267.311 305.372 267.311 209.377 363.306'/%3E%3C/g%3E%3C/svg%3E") !default;
+$sidebar-toggler-focus-shadow:      $focus-ring !default;
+$sidebar-toggler-hover-color:       var(--#{$prefix}secondary-color) !default;
+$sidebar-toggler-focus-color:       var(--#{$prefix}secondary-color) !default;
+$sidebar-toggler-transition:        transform .15s !default;
+// scss-docs-end sidebar-toggler
+
 // scss-docs-start sidebar-variables
 $sidebar-width:                            16rem !default;
 $sidebar-widths: (


### PR DESCRIPTION
First of the items from the `_config.scss` comparison against upstream v6. Their config is 320 lines of genuinely global configuration; ours was 1026, still carrying leftovers of the v5 monolith.

## What moves

Variable blocks that exactly one file reads, moved to that file:

| block | now lives in |
| --- | --- |
| `$placeholder-*` (2) | `_placeholder.scss` |
| `$sidebar-toggler-*` (11) | `sidebar/_sidebar.scss` |
| `$kbd-*` + `$pre-color` (6) | `content/_reboot.scss` |
| `$time-picker-*` (19) | `_time-picker.scss`, imported by `_date-picker.scss` |

Plus nine section headers left behind when their variables were moved out in an earlier pass — `// Navs`, `// Navbar`, `// Dropdown menu container and contents.`, `// Tooltips`, `// Alerts`, `// Image thumbnails`, `// Figures`, `// Carousel`, `// Time Picker`.

1026 → 956 lines.

## What deliberately stays

Checked rather than assumed — how many files read each group:

- `$input-*` → 15 files
- `$zindex-*` → 15
- `$form-*` → 7
- `$input-btn-*` → 3

That is the shared contract, not a backlog, and moving it would only relocate the coupling. `$code-*` stays as well: `_root.scss` reads it, and a global token file must not depend on a content file.

## Verification

Compiled CSS is byte-identical in content. The only difference is position: the `.time-picker` block moves 110 lines earlier, because `_date-picker.scss` now pulls the module first and Sass emits a module where it is first used. Verified this cannot change the cascade — a diff of the sorted stylesheets reports zero differences, and none of the block's 20 selectors appears anywhere else in the sheet.

`css-lint`, `css-test` (62 specs), `css-lint-vars`, `css-test-class-api` all pass.