### PR TITLE
feat(Shadows): compute shadows at runtime so colour, depth and opacity are knobs

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "49.5kB"
+      "maxSize": "49.75kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/components/placeholders.mdx
+++ b/docs/src/content/docs/components/placeholders.mdx
@@ -101,4 +101,4 @@ Animate Bootstrap placeholders using `.placeholder-glow` or `.placeholder-wave` 
 
 ### SASS variables
 
-<ScssDocs file="scss/_config.scss" capture="placeholders" />
+<ScssDocs file="scss/_placeholder.scss" capture="placeholders" />

--- a/docs/src/content/docs/components/sidebar.mdx
+++ b/docs/src/content/docs/components/sidebar.mdx
@@ -601,4 +601,4 @@ Sidebars use local CSS variables on `.sidebar`, `.sidebar-backdrop`, `.sidebar-n
 
 <ScssDocs file="scss/sidebar/_sidebar.scss" capture="sidebar-variables" />
 
-<ScssDocs file="scss/_config.scss" capture="sidebar-toggler" />
+<ScssDocs file="scss/sidebar/_sidebar.scss" capture="sidebar-toggler" />

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -182,4 +182,4 @@ Options belonging to the inner [calendar](/components/calendar/#options) or
 
 <ScssDocs file="scss/_date-picker.scss" capture="date-picker-variables" />
 
-<ScssDocs file="scss/_config.scss" capture="time-picker-variables" />
+<ScssDocs file="scss/_time-picker.scss" capture="time-picker-variables" />

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -251,4 +251,4 @@ The shell reuses the existing `$time-picker-*` variables for the selection body
 and the `$date-picker-*` shell-layer variables for the frame — this adds no new
 configuration surface.
 
-<ScssDocs file="scss/_config.scss" capture="time-picker-variables" />
+<ScssDocs file="scss/_time-picker.scss" capture="time-picker-variables" />

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1228,6 +1228,40 @@ assembles maps of CSS expressions and the browser resolves them.
   `$btn-outline-focus-shadow-rgb` → `$btn-outline-focus-shadow`, likewise for
   the ghost and link variants.
 
+#### Shadows are computed at runtime
+
+<span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+
+A shadow's alpha is now `base * strength * opacity`, computed on the element
+rather than resolved when the stylesheet is built. That is what makes a shadow
+tintable and lets dark mode deepen every shadow at once.
+
+- **`$box-shadow`, `$box-shadow-sm`, `$box-shadow-lg` and `$box-shadow-inset`
+  are replaced by the `$shadows` map.** The `--#{$prefix}box-shadow*` custom
+  properties are unchanged in name and in rendered value — they are generated
+  from the map — so runtime overrides keep working. Only the Sass override point
+  moved:
+
+  ```diff
+  - $box-shadow-sm: 0 .125rem .25rem rgba($black, .1);
+  + $shadows: map.merge($shadows, (sm: 0 .125rem .25rem rgba($black, .1)));
+  ```
+
+  A literal value like that opts the entry out of the runtime knobs, which is
+  the point of overriding it.
+- **New: `$shadow-color`, `$shadow-strength`, `$shadow-strength-dark`** and the
+  `--#{$prefix}shadow-color` / `--#{$prefix}shadow-strength` tokens they emit.
+  Setting the colour once at the root recolours every shadow in the page,
+  components included.
+- **New utilities:** `.shadow-{color}` for the theme colours plus
+  `current`/`black`/`white`, and `.shadow-opacity-{25|50|75|100}`. They write
+  `--#{$prefix}shadow-tint` and `--#{$prefix}shadow-opacity`, both registered
+  `inherits: false`, so a tinted element does not recolour the shadows nested
+  inside it.
+- **Dark mode raises `--#{$prefix}shadow-strength` to 2.5** instead of carrying
+  a second set of shadow values. The same alpha reads as weaker against a dark
+  surface, which is why the light-mode values looked almost absent there.
+
 #### Theme gradients removed
 
 <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/docs/src/content/docs/utilities/shadows.mdx
+++ b/docs/src/content/docs/utilities/shadows.mdx
@@ -13,9 +13,64 @@ While shadows on components are disabled by default in CoreUI for Bootstrap and 
   <div class="shadow p-3 mb-5 bg-body rounded">Regular shadow</div>
   <div class="shadow-lg p-3 mb-5 bg-body rounded">Larger shadow</div>`} />
 
-## Sass
+## Color
 
-### Variables
+<AddedIn version="6.0.0" />
+
+A shadow does not have to be grey. Add a `.shadow-{color}` class next to the size class to tint it — the size class supplies the geometry, the colour class supplies the hue.
+
+<Example code={`<div class="d-flex flex-wrap gap-4">
+    <div class="shadow shadow-primary p-3 bg-body rounded">Primary</div>
+    <div class="shadow shadow-success p-3 bg-body rounded">Success</div>
+    <div class="shadow shadow-danger p-3 bg-body rounded">Danger</div>
+    <div class="shadow shadow-current p-3 bg-body rounded text-info">Current color</div>
+  </div>`} />
+
+The tint does not reach nested shadows: an element inside a `.shadow-primary` box draws its own shadow in the default colour, so a tinted card does not silently recolour everything inside it.
+
+<Example code={`<div class="shadow shadow-primary p-5 bg-body rounded">
+    <div class="shadow p-3 bg-body rounded">Untinted, inside a tinted parent</div>
+  </div>`} />
+
+## Opacity
+
+<AddedIn version="6.0.0" />
+
+`.shadow-opacity-{25|50|75|100}` scales the shadow without touching its colour or geometry, which is the usual way to soften a shadow on a busy surface.
+
+<Example code={`<div class="d-flex flex-wrap gap-4">
+    <div class="shadow shadow-opacity-25 p-3 bg-body rounded">25%</div>
+    <div class="shadow shadow-opacity-50 p-3 bg-body rounded">50%</div>
+    <div class="shadow shadow-opacity-75 p-3 bg-body rounded">75%</div>
+    <div class="shadow shadow-opacity-100 p-3 bg-body rounded">100%</div>
+  </div>`} />
+
+## Customizing
+
+### CSS variables
+
+<AddedIn version="6.0.0" />
+
+Every shadow computes its alpha as `base × strength × opacity`, so three separate things can be changed at runtime without rewriting the shadow:
+
+| Variable | Scope | What it does |
+| --- | --- | --- |
+| `--cui-shadow-color` | inherits from `:root` | The colour every shadow is mixed from. |
+| `--cui-shadow-strength` | inherits from `:root` | Multiplies every shadow's alpha. Dark mode raises it, because the same alpha reads as weaker against a dark surface. |
+| `--cui-shadow-tint` | set by `.shadow-{color}`, does not inherit | Overrides the colour for one element. |
+| `--cui-shadow-opacity` | set by `.shadow-opacity-*`, does not inherit | Scales one element's shadow. |
+
+Setting `--cui-shadow-color` on the page changes every shadow at once, including the ones components draw:
+
+```css
+:root {
+  --cui-shadow-color: #1b4b91;
+}
+```
+
+<ScssDocs file="scss/_root.scss" capture="root-box-shadow-variables" />
+
+### SASS variables
 
 <ScssDocs file="scss/_config.scss" capture="box-shadow-variables" />
 
@@ -24,3 +79,7 @@ While shadows on components are disabled by default in CoreUI for Bootstrap and 
 Shadow utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <ScssDocs file="scss/_utilities.scss" capture="utils-shadow" />
+
+<ScssDocs file="scss/_utilities.scss" capture="utils-shadow-color" />
+
+<ScssDocs file="scss/_utilities.scss" capture="utils-shadow-opacity" />

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -586,12 +586,27 @@ $border-radius-xxl:           2rem !default;
 $border-radius-pill:          50rem !default;
 // scss-docs-end border-radius-variables
 
+// Every layer's alpha is base * strength * opacity, so the tint, the depth and
+// the per-element dimming are three separate knobs at runtime.
+// `--#{$prefix}shadow-tint` and `--#{$prefix}shadow-opacity` are written by the
+// `.shadow-{color}` and `.shadow-opacity-*` utilities and registered as
+// non-inheriting, so neither leaks into a nested `.shadow-*`.
+// stylelint-disable function-disallowed-list
+
 // scss-docs-start box-shadow-variables
-$box-shadow:                  0 .5rem 1rem rgba($black, .15) !default;
-$box-shadow-sm:               0 .125rem .25rem rgba($black, .075) !default;
-$box-shadow-lg:               0 1rem 3rem rgba($black, .175) !default;
-$box-shadow-inset:            inset 0 1px 2px rgba($black, .075) !default;
+$shadow-color:                #000 !default;
+$shadow-strength:             1 !default;
+$shadow-strength-dark:        2.5 !default;
+
+$shadows: (
+  null:  0 .5rem 1rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(15% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
+  sm:    0 .125rem .25rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(7.5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
+  lg:    0 1rem 3rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(17.5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
+  inset: inset 0 1px 2px color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(7.5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
+) !default;
 // scss-docs-end box-shadow-variables
+
+// stylelint-enable function-disallowed-list
 
 $component-active-color:      rgba($white, .87) !default;
 $component-active-bg:         var(--#{$prefix}primary) !default;

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -949,78 +949,8 @@ $zindex-levels: (
 ) !default;
 // scss-docs-end zindex-levels-map
 
-// Navs
-
-// Navbar
-
-// Dropdown menu container and contents.
-
-// Placeholders
-
-// scss-docs-start placeholders
-$placeholder-opacity-max:           .5 !default;
-$placeholder-opacity-min:           .2 !default;
-// scss-docs-end placeholders
-
-// Tooltips
-
-// Alerts
-
-// Image thumbnails
-
-// Figures
-
-// Carousel
-
-// scss-docs-start sidebar-toggler
-$sidebar-toggler-width:             .5rem !default;
-$sidebar-toggler-height:            .5rem !default;
-$sidebar-toggler-padding-x:         .25rem !default;
-$sidebar-toggler-padding-y:         .25rem !default;
-$sidebar-toggler-bg:                transparent !default;
-$sidebar-toggler-color:             var(--#{$prefix}tertiary-color) !default;
-$sidebar-toggler-icon:              url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cg xmlns='http://www.w3.org/2000/svg' transform='matrix(-1 0 0 -1 512 512)'%3E%3Cpath fill='%23000' d='M472,16H40A24.028,24.028,0,0,0,16,40V200H48V48H464V464H48V304H16V472a24.028,24.028,0,0,0,24,24H472a24.028,24.028,0,0,0,24-24V40A24.028,24.028,0,0,0,472,16Z'/%3E%3Cpolygon fill='%23000' points='209.377 363.306 232.004 385.933 366.627 251.31 232.004 116.687 209.377 139.313 305.374 235.311 16 235.311 16 267.311 305.372 267.311 209.377 363.306'/%3E%3C/g%3E%3C/svg%3E") !default;
-$sidebar-toggler-focus-shadow:      $focus-ring !default;
-$sidebar-toggler-hover-color:       var(--#{$prefix}secondary-color) !default;
-$sidebar-toggler-focus-color:       var(--#{$prefix}secondary-color) !default;
-$sidebar-toggler-transition:        transform .15s !default;
-// scss-docs-end sidebar-toggler
-
 // Code
 
 $code-font-size:                    $small-font-size !default;
 $code-color:                        light-dark($pink, tint-color($pink, 40%)) !default;
 
-$kbd-padding-y:                     .1875rem !default;
-$kbd-padding-x:                     .375rem !default;
-$kbd-font-size:                     $code-font-size !default;
-$kbd-color:                         var(--#{$prefix}body-bg) !default;
-$kbd-bg:                            var(--#{$prefix}body-color) !default;
-
-$pre-color:                         null !default;
-
-// Time Picker
-// scss-docs-start time-picker-variables
-$time-picker-body-padding:                  $spacer * .5 !default;
-
-$time-picker-footer-padding:                .5rem !default;
-$time-picker-footer-border-width:           1px !default;
-$time-picker-footer-border-color:           var(--#{$prefix}border-color) !default;
-
-$time-picker-roll-col-border-width:           var(--#{$prefix}border-width) !default;
-$time-picker-roll-col-border-color:           var(--#{$prefix}border-color) !default;
-$time-picker-roll-cell-width:                 3rem !default;
-$time-picker-roll-cell-height:                2rem !default;
-$time-picker-roll-cell-hover-color:           var(--#{$prefix}body-color) !default;
-$time-picker-roll-cell-hover-bg:              var(--#{$prefix}tertiary-bg) !default;
-$time-picker-roll-cell-selected-color:        var(--#{$prefix}white) !default;
-$time-picker-roll-cell-selected-bg:           var(--#{$prefix}primary) !default;
-$time-picker-roll-cell-selected-hover-color:  var(--#{$prefix}white) !default;
-$time-picker-roll-cell-selected-hover-bg:     light-dark(color.scale($primary, $lightness: -20%), color.scale($primary, $saturation: -10%, $lightness: -10%)) !default; // stylelint-disable-line scss/at-function-named-arguments
-
-$time-picker-inline-select-font-size:       var(--#{$prefix}btn-input-sm-font-size) !default;
-$time-picker-inline-select-color:           $input-color !default;
-$time-picker-inline-select-padding-y:       $input-padding-y-sm !default;
-$time-picker-inline-select-padding-x:       $input-padding-x-sm !default;
-$time-picker-inline-select-disabled-color:  $input-disabled-color !default;
-// scss-docs-end time-picker-variables

--- a/scss/_date-picker.scss
+++ b/scss/_date-picker.scss
@@ -1,5 +1,6 @@
 @use "sass:math";
 @use "calendar" as *;
+@use "time-picker" as *;
 @use "functions/defaults" as *;
 @use "mixins/tokens" as *;
 @use "config" as *;

--- a/scss/_placeholder.scss
+++ b/scss/_placeholder.scss
@@ -1,5 +1,10 @@
 @use "config" as *;
 
+// scss-docs-start placeholders
+$placeholder-opacity-max:           .5 !default;
+$placeholder-opacity-min:           .2 !default;
+// scss-docs-end placeholders
+
 @layer components {
   .placeholder {
     display: inline-block;

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -99,10 +99,18 @@
     --#{$prefix}border-radius-pill: #{$border-radius-pill};
     // scss-docs-end root-border-var
 
-    --#{$prefix}box-shadow: #{$box-shadow};
-    --#{$prefix}box-shadow-sm: #{$box-shadow-sm};
-    --#{$prefix}box-shadow-lg: #{$box-shadow-lg};
-    --#{$prefix}box-shadow-inset: #{$box-shadow-inset};
+    // scss-docs-start root-box-shadow-variables
+    --#{$prefix}shadow-color: #{$shadow-color};
+    --#{$prefix}shadow-strength: #{$shadow-strength};
+
+    @each $key, $value in $shadows {
+      @if $key == null {
+        --#{$prefix}box-shadow: #{$value};
+      } @else {
+        --#{$prefix}box-shadow-#{$key}: #{$value};
+      }
+    }
+    // scss-docs-end root-box-shadow-variables
 
     // Focus styles
     // scss-docs-start root-focus-variables
@@ -162,6 +170,10 @@
       color-scheme: dark;
 
       // scss-docs-start root-dark-mode-vars
+      // A shadow reads as depth against the surface behind it, and a dark
+      // surface swallows the same alpha, so the strength rises instead of the
+      // colour changing.
+      --#{$prefix}shadow-strength: #{$shadow-strength-dark};
       // scss-docs-end root-dark-mode-vars
     }
   }

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -1,8 +1,34 @@
+@use "sass:color";
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/tokens" as *;
 @use "config" as *;
 @use "forms/form-control-group" as *;
+
+// scss-docs-start time-picker-variables
+$time-picker-body-padding:                  $spacer * .5 !default;
+
+$time-picker-footer-padding:                .5rem !default;
+$time-picker-footer-border-width:           1px !default;
+$time-picker-footer-border-color:           var(--#{$prefix}border-color) !default;
+
+$time-picker-roll-col-border-width:           var(--#{$prefix}border-width) !default;
+$time-picker-roll-col-border-color:           var(--#{$prefix}border-color) !default;
+$time-picker-roll-cell-width:                 3rem !default;
+$time-picker-roll-cell-height:                2rem !default;
+$time-picker-roll-cell-hover-color:           var(--#{$prefix}body-color) !default;
+$time-picker-roll-cell-hover-bg:              var(--#{$prefix}tertiary-bg) !default;
+$time-picker-roll-cell-selected-color:        var(--#{$prefix}white) !default;
+$time-picker-roll-cell-selected-bg:           var(--#{$prefix}primary) !default;
+$time-picker-roll-cell-selected-hover-color:  var(--#{$prefix}white) !default;
+$time-picker-roll-cell-selected-hover-bg:     light-dark(color.scale($primary, $lightness: -20%), color.scale($primary, $saturation: -10%, $lightness: -10%)) !default; // stylelint-disable-line scss/at-function-named-arguments
+
+$time-picker-inline-select-font-size:       var(--#{$prefix}btn-input-sm-font-size) !default;
+$time-picker-inline-select-color:           $input-color !default;
+$time-picker-inline-select-padding-y:       $input-padding-y-sm !default;
+$time-picker-inline-select-padding-x:       $input-padding-x-sm !default;
+$time-picker-inline-select-disabled-color:  $input-disabled-color !default;
+// scss-docs-end time-picker-variables
 
 // Time Picker
 $time-picker-tokens: () !default;

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -94,14 +94,35 @@ $utilities: map.merge(
     "shadow": (
       property: box-shadow,
       class: shadow,
-      values: (
-        null: var(--#{$prefix}box-shadow),
-        sm: var(--#{$prefix}box-shadow-sm),
-        lg: var(--#{$prefix}box-shadow-lg),
-        none: none,
-      )
+      // The literal expressions from $shadows, not var(--#{$prefix}box-shadow*).
+      // A token resolves where it is declared — on :root — so going through one
+      // would freeze the tint and the opacity there and leave .shadow-primary
+      // and .shadow-opacity-* with nothing to change.
+      // `inset` stays out: it is a component's inner shadow, not a utility.
+      values: map.merge(map.remove($shadows, inset), (none: none))
     ),
     // scss-docs-end utils-shadow
+    // scss-docs-start utils-shadow-color
+    "shadow-color": (
+      property: (--#{$prefix}shadow-tint: null),
+      class: shadow,
+      values: map.merge(
+        $theme-colors,
+        (
+          "current": currentcolor,
+          "black": $black,
+          "white": $white,
+        )
+      )
+    ),
+    // scss-docs-end utils-shadow-color
+    // scss-docs-start utils-shadow-opacity
+    "shadow-opacity": (
+      property: (--#{$prefix}shadow-opacity: null),
+      class: shadow-opacity,
+      values: (25: .25, 50: .5, 75: .75, 100: 1)
+    ),
+    // scss-docs-end utils-shadow-opacity
     // scss-docs-start utils-focus-ring
     "focus-ring": (
       property: (--#{$prefix}focus-ring-color: null),

--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -1,6 +1,16 @@
 @use "../mixins/border-radius" as *;
 @use "../config" as *;
 
+// scss-docs-start kbd-variables
+$kbd-padding-y:                     .1875rem !default;
+$kbd-padding-x:                     .375rem !default;
+$kbd-font-size:                     $code-font-size !default;
+$kbd-color:                         var(--#{$prefix}body-bg) !default;
+$kbd-bg:                            var(--#{$prefix}body-color) !default;
+
+$pre-color:                         null !default;
+// scss-docs-end kbd-variables
+
 // stylelint-disable function-disallowed-list
 
 // scss-docs-start reboot-table-variables

--- a/scss/sidebar/_sidebar.scss
+++ b/scss/sidebar/_sidebar.scss
@@ -7,6 +7,20 @@
 @use "../mixins/transition" as *;
 @use "../config" as *;
 
+// scss-docs-start sidebar-toggler
+$sidebar-toggler-width:             .5rem !default;
+$sidebar-toggler-height:            .5rem !default;
+$sidebar-toggler-padding-x:         .25rem !default;
+$sidebar-toggler-padding-y:         .25rem !default;
+$sidebar-toggler-bg:                transparent !default;
+$sidebar-toggler-color:             var(--#{$prefix}tertiary-color) !default;
+$sidebar-toggler-icon:              url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cg xmlns='http://www.w3.org/2000/svg' transform='matrix(-1 0 0 -1 512 512)'%3E%3Cpath fill='%23000' d='M472,16H40A24.028,24.028,0,0,0,16,40V200H48V48H464V464H48V304H16V472a24.028,24.028,0,0,0,24,24H472a24.028,24.028,0,0,0,24-24V40A24.028,24.028,0,0,0,472,16Z'/%3E%3Cpolygon fill='%23000' points='209.377 363.306 232.004 385.933 366.627 251.31 232.004 116.687 209.377 139.313 305.374 235.311 16 235.311 16 267.311 305.372 267.311 209.377 363.306'/%3E%3C/g%3E%3C/svg%3E") !default;
+$sidebar-toggler-focus-shadow:      $focus-ring !default;
+$sidebar-toggler-hover-color:       var(--#{$prefix}secondary-color) !default;
+$sidebar-toggler-focus-color:       var(--#{$prefix}secondary-color) !default;
+$sidebar-toggler-transition:        transform .15s !default;
+// scss-docs-end sidebar-toggler
+
 // scss-docs-start sidebar-variables
 $sidebar-width:                            16rem !default;
 $sidebar-widths: (


### PR DESCRIPTION
Second item from the `_config.scss` comparison. **Stacked on #773** — merge that first, then this retargets to `v6-dev`.

The four `$box-shadow*` variables were resolved when the stylesheet was built, so every shadow in the library was a frozen `rgba(0, 0, 0, .15)`. A page that wanted a blue-cast shadow had to rewrite the whole `box-shadow`, and dark mode kept the same alpha against a much darker surface, where it reads as almost nothing.

## What changes

`$shadows` is a map, and each layer computes its alpha as `base × strength × opacity`:

```
color-mix(in oklch, var(--cui-shadow-tint, var(--cui-shadow-color))
          calc(15% * var(--cui-shadow-strength) * var(--cui-shadow-opacity, 1)),
          transparent)
```

| token | scope | effect |
| --- | --- | --- |
| `--cui-shadow-color` | inherits from `:root` | one declaration recolours every shadow, components included |
| `--cui-shadow-strength` | inherits from `:root` | dark mode raises it to 2.5 instead of shipping a second set of values |
| `--cui-shadow-tint` | `.shadow-{color}`, `inherits: false` | tints one element |
| `--cui-shadow-opacity` | `.shadow-opacity-*`, `inherits: false` | dims one element |

New utilities: `.shadow-{color}` for the nine theme colours plus `current`/`black`/`white`, and `.shadow-opacity-{25,50,75,100}`.

## Measured

| case | computed `box-shadow` |
| --- | --- |
| `.shadow` | `oklch(0 0 none / 0.15)` — same alpha as the old `rgba(0,0,0,.15)` |
| `.shadow.shadow-primary` | `oklch(0.529 0.191 278 / 0.15)` |
| `.shadow.shadow-opacity-25` | `oklch(0 0 none / 0.0375)` |
| `.shadow` inside `.shadow-primary` | `oklch(0 0 none / 0.15)` — no leak |
| `.shadow` in dark mode | `oklch(0 0 none / 0.375)` |

Geometry and default alphas are unchanged, so an untouched page renders as before.

## Why not upstream's expressions verbatim

They use relative colour syntax, `oklch(from var(--sc) l c h / calc(…))`. Per MDN BCD that needs **Safari 18 / iOS 18**, and our floor is **17.5** — their version would drop every shadow on the floor browser. `color-mix()` has been in Safari since 16.2 and expresses the same three knobs.

`inset` is deliberately not a utility: it is a component's inner shadow, not something to hang on an element. Upstream excludes it too.

## Verification

`css-lint`, `css-test` (62 specs), `css-lint-vars`, `css-test-class-api`, `docs-build` pass. Bundlewatch: `coreui.min.css` 49.5 → **49.75 kB** for the 16 new utility classes, with the reason in the commit.