### PR TITLE
refactor(config): three maps that feed their generators

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "49.5kB"
+      "maxSize": "49.75kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -10,15 +10,15 @@
     },
     {
       "path": "./dist/css/coreui-reboot.css",
-      "maxSize": "4.4 kB"
+      "maxSize": "4.5 kB"
     },
     {
       "path": "./dist/css/coreui-reboot.min.css",
-      "maxSize": "4.25 kB"
+      "maxSize": "4.35 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.css",
-      "maxSize": "14.3 kB"
+      "maxSize": "14.5 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "59.75kB"
+      "maxSize": "60kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "49.75kB"
+      "maxSize": "50kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/components/placeholders.mdx
+++ b/docs/src/content/docs/components/placeholders.mdx
@@ -101,4 +101,4 @@ Animate Bootstrap placeholders using `.placeholder-glow` or `.placeholder-wave` 
 
 ### SASS variables
 
-<ScssDocs file="scss/_config.scss" capture="placeholders" />
+<ScssDocs file="scss/_placeholder.scss" capture="placeholders" />

--- a/docs/src/content/docs/components/sidebar.mdx
+++ b/docs/src/content/docs/components/sidebar.mdx
@@ -601,4 +601,4 @@ Sidebars use local CSS variables on `.sidebar`, `.sidebar-backdrop`, `.sidebar-n
 
 <ScssDocs file="scss/sidebar/_sidebar.scss" capture="sidebar-variables" />
 
-<ScssDocs file="scss/_config.scss" capture="sidebar-toggler" />
+<ScssDocs file="scss/sidebar/_sidebar.scss" capture="sidebar-toggler" />

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -182,4 +182,4 @@ Options belonging to the inner [calendar](/components/calendar/#options) or
 
 <ScssDocs file="scss/_date-picker.scss" capture="date-picker-variables" />
 
-<ScssDocs file="scss/_config.scss" capture="time-picker-variables" />
+<ScssDocs file="scss/_time-picker.scss" capture="time-picker-variables" />

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -251,4 +251,4 @@ The shell reuses the existing `$time-picker-*` variables for the selection body
 and the `$date-picker-*` shell-layer variables for the frame — this adds no new
 configuration surface.
 
-<ScssDocs file="scss/_config.scss" capture="time-picker-variables" />
+<ScssDocs file="scss/_time-picker.scss" capture="time-picker-variables" />

--- a/docs/src/content/docs/layout/z-index.mdx
+++ b/docs/src/content/docs/layout/z-index.mdx
@@ -12,4 +12,6 @@ We don't encourage customization of these individual values; should you change o
 
 <ScssDocs file="scss/_config.scss" capture="zindex-stack" />
 
+Every layer above is also a [`z-index` utility](/utilities/z-index/#overlays) — `.z-modal`, `.z-tooltip` and so on — so an element of your own can join a layer by name rather than by repeating its number.
+
 To handle overlapping borders within components (e.g., buttons and inputs in input groups), we use low single digit `z-index` values of `1`, `2`, and `3` for default, hover, and active states. On hover/focus/active, we bring a particular element to the forefront with a higher `z-index` value to show their border over the sibling elements.

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1228,6 +1228,40 @@ assembles maps of CSS expressions and the browser resolves them.
   `$btn-outline-focus-shadow-rgb` → `$btn-outline-focus-shadow`, likewise for
   the ghost and link variants.
 
+#### Shadows are computed at runtime
+
+<span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+
+A shadow's alpha is now `base * strength * opacity`, computed on the element
+rather than resolved when the stylesheet is built. That is what makes a shadow
+tintable and lets dark mode deepen every shadow at once.
+
+- **`$box-shadow`, `$box-shadow-sm`, `$box-shadow-lg` and `$box-shadow-inset`
+  are replaced by the `$shadows` map.** The `--#{$prefix}box-shadow*` custom
+  properties are unchanged in name and in rendered value — they are generated
+  from the map — so runtime overrides keep working. Only the Sass override point
+  moved:
+
+  ```diff
+  - $box-shadow-sm: 0 .125rem .25rem rgba($black, .1);
+  + $shadows: map.merge($shadows, (sm: 0 .125rem .25rem rgba($black, .1)));
+  ```
+
+  A literal value like that opts the entry out of the runtime knobs, which is
+  the point of overriding it.
+- **New: `$shadow-color`, `$shadow-strength`, `$shadow-strength-dark`** and the
+  `--#{$prefix}shadow-color` / `--#{$prefix}shadow-strength` tokens they emit.
+  Setting the colour once at the root recolours every shadow in the page,
+  components included.
+- **New utilities:** `.shadow-{color}` for the theme colours plus
+  `current`/`black`/`white`, and `.shadow-opacity-{25|50|75|100}`. They write
+  `--#{$prefix}shadow-tint` and `--#{$prefix}shadow-opacity`, both registered
+  `inherits: false`, so a tinted element does not recolour the shadows nested
+  inside it.
+- **Dark mode raises `--#{$prefix}shadow-strength` to 2.5** instead of carrying
+  a second set of shadow values. The same alpha reads as weaker against a dark
+  surface, which is why the light-mode values looked almost absent there.
+
 #### Theme gradients removed
 
 <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/docs/src/content/docs/utilities/borders.mdx
+++ b/docs/src/content/docs/utilities/borders.mdx
@@ -98,7 +98,10 @@ Or, choose from any of the `.border-opacity` utilities:
 
 ## Width
 
-<Example class="docs-example-border-utils" code={`<span class="border border-1"></span>
+<AddedIn version="6.0.0" /> `.border-keyline` sits below `1px`, for a hairline that stays hairline on a high-density screen instead of thickening to a full device pixel.
+
+<Example class="docs-example-border-utils" code={`<span class="border border-keyline"></span>
+  <span class="border border-1"></span>
   <span class="border border-2"></span>
   <span class="border border-3"></span>
   <span class="border border-4"></span>
@@ -110,6 +113,7 @@ Or, choose from any of the `.border-opacity` utilities:
   <span class="border border-4 border-info"></span>
   <span class="border border-5 border-info"></span>
 
+  <span class="border-start border-start-keyline"></span>
   <span class="border-start border-start-1"></span>
   <span class="border-start border-start-2"></span>
   <span class="border-start border-start-3"></span>

--- a/docs/src/content/docs/utilities/shadows.mdx
+++ b/docs/src/content/docs/utilities/shadows.mdx
@@ -13,9 +13,64 @@ While shadows on components are disabled by default in CoreUI for Bootstrap and 
   <div class="shadow p-3 mb-5 bg-body rounded">Regular shadow</div>
   <div class="shadow-lg p-3 mb-5 bg-body rounded">Larger shadow</div>`} />
 
-## Sass
+## Color
 
-### Variables
+<AddedIn version="6.0.0" />
+
+A shadow does not have to be grey. Add a `.shadow-{color}` class next to the size class to tint it — the size class supplies the geometry, the colour class supplies the hue.
+
+<Example code={`<div class="d-flex flex-wrap gap-4">
+    <div class="shadow shadow-primary p-3 bg-body rounded">Primary</div>
+    <div class="shadow shadow-success p-3 bg-body rounded">Success</div>
+    <div class="shadow shadow-danger p-3 bg-body rounded">Danger</div>
+    <div class="shadow shadow-current p-3 bg-body rounded text-info">Current color</div>
+  </div>`} />
+
+The tint does not reach nested shadows: an element inside a `.shadow-primary` box draws its own shadow in the default colour, so a tinted card does not silently recolour everything inside it.
+
+<Example code={`<div class="shadow shadow-primary p-5 bg-body rounded">
+    <div class="shadow p-3 bg-body rounded">Untinted, inside a tinted parent</div>
+  </div>`} />
+
+## Opacity
+
+<AddedIn version="6.0.0" />
+
+`.shadow-opacity-{25|50|75|100}` scales the shadow without touching its colour or geometry, which is the usual way to soften a shadow on a busy surface.
+
+<Example code={`<div class="d-flex flex-wrap gap-4">
+    <div class="shadow shadow-opacity-25 p-3 bg-body rounded">25%</div>
+    <div class="shadow shadow-opacity-50 p-3 bg-body rounded">50%</div>
+    <div class="shadow shadow-opacity-75 p-3 bg-body rounded">75%</div>
+    <div class="shadow shadow-opacity-100 p-3 bg-body rounded">100%</div>
+  </div>`} />
+
+## Customizing
+
+### CSS variables
+
+<AddedIn version="6.0.0" />
+
+Every shadow computes its alpha as `base × strength × opacity`, so three separate things can be changed at runtime without rewriting the shadow:
+
+| Variable | Scope | What it does |
+| --- | --- | --- |
+| `--cui-shadow-color` | inherits from `:root` | The colour every shadow is mixed from. |
+| `--cui-shadow-strength` | inherits from `:root` | Multiplies every shadow's alpha. Dark mode raises it, because the same alpha reads as weaker against a dark surface. |
+| `--cui-shadow-tint` | set by `.shadow-{color}`, does not inherit | Overrides the colour for one element. |
+| `--cui-shadow-opacity` | set by `.shadow-opacity-*`, does not inherit | Scales one element's shadow. |
+
+Setting `--cui-shadow-color` on the page changes every shadow at once, including the ones components draw:
+
+```css
+:root {
+  --cui-shadow-color: #1b4b91;
+}
+```
+
+<ScssDocs file="scss/_root.scss" capture="root-box-shadow-variables" />
+
+### SASS variables
 
 <ScssDocs file="scss/_config.scss" capture="box-shadow-variables" />
 
@@ -24,3 +79,7 @@ While shadows on components are disabled by default in CoreUI for Bootstrap and 
 Shadow utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <ScssDocs file="scss/_utilities.scss" capture="utils-shadow" />
+
+<ScssDocs file="scss/_utilities.scss" capture="utils-shadow-color" />
+
+<ScssDocs file="scss/_utilities.scss" capture="utils-shadow-opacity" />

--- a/docs/src/content/docs/utilities/text.mdx
+++ b/docs/src/content/docs/utilities/text.mdx
@@ -107,6 +107,26 @@ Quickly change the `font-weight` or `font-style` of text with these utilities. `
   <p class="fst-italic">Italic text.</p>
   <p class="fst-normal">Text with normal font style</p>`} />
 
+<AddedIn version="6.0.0" />
+
+The weights come from one `$font-weights` map, which generates the `.fw-*` classes and a `--#{$prefix}font-weight-{name}` custom property each. Adding a step therefore adds its utility:
+
+```scss
+@use "@coreui/coreui-pro" with (
+  $font-weights: map.merge($font-weights, ("black": 900))
+);
+```
+
+`map.merge` matters here — assigning the map plainly replaces it, and the other six weights go with it.
+
+Components read the tokens rather than a build-time copy, so raising a weight at runtime reaches them:
+
+```css
+:root {
+  --cui-font-weight-semibold: 650;
+}
+```
+
 ## Line height
 
 Change the line height with `.lh-*` utilities.

--- a/docs/src/content/docs/utilities/z-index.mdx
+++ b/docs/src/content/docs/utilities/z-index.mdx
@@ -8,7 +8,7 @@ description: "Use our low-level `z-index` utilities to quickly change the stack 
 
 Use `z-index` utilities to stack elements on top of one another. Requires a `position` value other than `static`, which can be set with custom styles or using our [position utilities](/utilities/position/).
 
-We call these "low-level" `z-index` utilities because of their default values of `-1` through `3`, which we use for the layout of overlapping components. High-level `z-index` values are used for overlay components like modals and tooltips.
+We call these "low-level" `z-index` utilities because of their default values of `-1` through `3`, which we use for the layout of overlapping components. The library's overlay layers are available as utilities too — see [Overlays](#overlays) below.
 
 <Example class="docs-example-zindex-levels position-relative" code={`<div class="z-3 position-absolute p-5 rounded-3"><span>z-3</span></div>
   <div class="z-2 position-absolute p-5 rounded-3"><span>z-2</span></div>
@@ -20,7 +20,15 @@ We call these "low-level" `z-index` utilities because of their default values of
 
 Bootstrap overlay components—dropdown, modal, offcanvas, popover, toast, and tooltip—all have their own `z-index` values to ensure a usable experience with competing "layers" of an interface.
 
-Read about them in the [`z-index` layout page](/layout/z-index/).
+<AddedIn version="6.0.0" />
+
+Each of those layers has a matching utility, so your own element can join a layer by name instead of repeating the number it happens to have: `.z-dropdown`, `.z-sticky`, `.z-fixed`, `.z-sidebar-backdrop`, `.z-sidebar`, `.z-offcanvas`, `.z-modal`, `.z-popover`, `.z-tooltip` and `.z-toast`.
+
+<Example code={`<div class="position-relative" style="height: 6rem;">
+    <div class="z-modal position-absolute top-0 start-0 p-3 bg-primary-subtle border rounded">Sits at the modal layer</div>
+  </div>`} />
+
+Read about the values themselves in the [`z-index` layout page](/layout/z-index/).
 
 ## CSS
 

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -11,7 +11,7 @@ $alert-padding-x:               $spacer !default;
 $alert-gap:                     $spacer * .5 !default;
 $alert-margin-bottom:           1rem !default;
 $alert-border-radius:           var(--#{$prefix}border-radius) !default;
-$alert-link-font-weight:        $font-weight-bold !default;
+$alert-link-font-weight:        var(--#{$prefix}font-weight-bold) !default;
 $alert-border-width:            var(--#{$prefix}border-width) !default;
 // scss-docs-end alert-variables
 

--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -10,7 +10,7 @@ $badge-padding-y:                   .25em !default;
 $badge-padding-x:                   .625em !default;
 $badge-font-size:                   .75em !default;
 $badge-font-size-floor:             12px !default;
-$badge-font-weight:                 $font-weight-semibold !default;
+$badge-font-weight:                 var(--#{$prefix}font-weight-semibold) !default;
 $badge-color:                       inherit !default;
 $badge-bg:                          var(--#{$prefix}secondary-bg) !default;
 $badge-border-width:                var(--#{$prefix}border-width) !default;

--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -11,7 +11,7 @@
 
 // scss-docs-start chip-variables
 $chip-font-size:             .875rem !default;
-$chip-font-weight:           $font-weight-normal !default;
+$chip-font-weight:           var(--#{$prefix}font-weight-normal) !default;
 $chip-height:                1.75rem !default;
 $chip-padding-x:             .625rem !default;
 $chip-gap:                   .3125rem !default;

--- a/scss/_combobox.scss
+++ b/scss/_combobox.scss
@@ -38,14 +38,14 @@ $combobox-options-gap:                .125rem !default;
 $combobox-options-padding-y:          .375rem !default;
 $combobox-options-padding-x:          .375rem !default;
 $combobox-options-font-size:          $font-size-base !default;
-$combobox-options-font-weight:        $font-weight-normal !default;
+$combobox-options-font-weight:        var(--#{$prefix}font-weight-normal) !default;
 $combobox-options-color:              var(--#{$prefix}body-color) !default;
 
 $combobox-optgroup-label-padding-y:      .5rem !default;
 $combobox-optgroup-label-padding-x:      .625rem !default;
 $combobox-optgroup-label-border-radius:  var(--#{$prefix}border-radius) !default;
 $combobox-optgroup-label-font-size:      80% !default;
-$combobox-optgroup-label-font-weight:    $font-weight-bold !default;
+$combobox-optgroup-label-font-weight:    var(--#{$prefix}font-weight-bold) !default;
 $combobox-optgroup-label-color:          var(--#{$prefix}tertiary-color) !default;
 $combobox-optgroup-label-text-transform: uppercase !default;
 

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -668,6 +668,21 @@ $font-weight-bolder:          bolder !default;
 
 $font-weight-base:            $font-weight-normal !default;
 
+// Composed from the variables above rather than replacing them, so a Sass
+// override of one step still reaches the token, the utility and every
+// component that reads it.
+// scss-docs-start font-weights
+$font-weights: (
+  lighter: $font-weight-lighter,
+  light: $font-weight-light,
+  normal: $font-weight-normal,
+  medium: $font-weight-medium,
+  semibold: $font-weight-semibold,
+  bold: $font-weight-bold,
+  bolder: $font-weight-bolder
+) !default;
+// scss-docs-end font-weights
+
 $line-height-base:            1.5 !default;
 $line-height-sm:              1.25 !default;
 $line-height-lg:              2 !default;

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -954,13 +954,27 @@ $zindex-tooltip:                    1080 !default;
 $zindex-toast:                      1090 !default;
 // scss-docs-end zindex-stack
 
+// The whole z-axis in one place: the small steps for stacking inside a
+// component, then the library's overlay layers. Composed from the variables
+// above rather than replacing them, so overriding `$zindex-modal` still reaches
+// the 15 files that read it, and the map follows.
 // scss-docs-start zindex-levels-map
 $zindex-levels: (
   n1: -1,
   0: 0,
   1: 1,
   2: 2,
-  3: 3
+  3: 3,
+  dropdown: $zindex-dropdown,
+  sticky: $zindex-sticky,
+  fixed: $zindex-fixed,
+  sidebar-backdrop: $zindex-sidebar-backdrop,
+  sidebar: $zindex-sidebar,
+  offcanvas: $zindex-offcanvas,
+  modal: $zindex-modal,
+  popover: $zindex-popover,
+  tooltip: $zindex-tooltip,
+  toast: $zindex-toast
 ) !default;
 // scss-docs-end zindex-levels-map
 

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -586,12 +586,27 @@ $border-radius-xxl:           2rem !default;
 $border-radius-pill:          50rem !default;
 // scss-docs-end border-radius-variables
 
+// Every layer's alpha is base * strength * opacity, so the tint, the depth and
+// the per-element dimming are three separate knobs at runtime.
+// `--#{$prefix}shadow-tint` and `--#{$prefix}shadow-opacity` are written by the
+// `.shadow-{color}` and `.shadow-opacity-*` utilities and registered as
+// non-inheriting, so neither leaks into a nested `.shadow-*`.
+// stylelint-disable function-disallowed-list
+
 // scss-docs-start box-shadow-variables
-$box-shadow:                  0 .5rem 1rem rgba($black, .15) !default;
-$box-shadow-sm:               0 .125rem .25rem rgba($black, .075) !default;
-$box-shadow-lg:               0 1rem 3rem rgba($black, .175) !default;
-$box-shadow-inset:            inset 0 1px 2px rgba($black, .075) !default;
+$shadow-color:                #000 !default;
+$shadow-strength:             1 !default;
+$shadow-strength-dark:        2.5 !default;
+
+$shadows: (
+  null:  0 .5rem 1rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(15% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
+  sm:    0 .125rem .25rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(7.5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
+  lg:    0 1rem 3rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(17.5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
+  inset: inset 0 1px 2px color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(7.5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
+) !default;
 // scss-docs-end box-shadow-variables
+
+// stylelint-enable function-disallowed-list
 
 $component-active-color:      rgba($white, .87) !default;
 $component-active-bg:         var(--#{$prefix}primary) !default;

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -949,78 +949,8 @@ $zindex-levels: (
 ) !default;
 // scss-docs-end zindex-levels-map
 
-// Navs
-
-// Navbar
-
-// Dropdown menu container and contents.
-
-// Placeholders
-
-// scss-docs-start placeholders
-$placeholder-opacity-max:           .5 !default;
-$placeholder-opacity-min:           .2 !default;
-// scss-docs-end placeholders
-
-// Tooltips
-
-// Alerts
-
-// Image thumbnails
-
-// Figures
-
-// Carousel
-
-// scss-docs-start sidebar-toggler
-$sidebar-toggler-width:             .5rem !default;
-$sidebar-toggler-height:            .5rem !default;
-$sidebar-toggler-padding-x:         .25rem !default;
-$sidebar-toggler-padding-y:         .25rem !default;
-$sidebar-toggler-bg:                transparent !default;
-$sidebar-toggler-color:             var(--#{$prefix}tertiary-color) !default;
-$sidebar-toggler-icon:              url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cg xmlns='http://www.w3.org/2000/svg' transform='matrix(-1 0 0 -1 512 512)'%3E%3Cpath fill='%23000' d='M472,16H40A24.028,24.028,0,0,0,16,40V200H48V48H464V464H48V304H16V472a24.028,24.028,0,0,0,24,24H472a24.028,24.028,0,0,0,24-24V40A24.028,24.028,0,0,0,472,16Z'/%3E%3Cpolygon fill='%23000' points='209.377 363.306 232.004 385.933 366.627 251.31 232.004 116.687 209.377 139.313 305.374 235.311 16 235.311 16 267.311 305.372 267.311 209.377 363.306'/%3E%3C/g%3E%3C/svg%3E") !default;
-$sidebar-toggler-focus-shadow:      $focus-ring !default;
-$sidebar-toggler-hover-color:       var(--#{$prefix}secondary-color) !default;
-$sidebar-toggler-focus-color:       var(--#{$prefix}secondary-color) !default;
-$sidebar-toggler-transition:        transform .15s !default;
-// scss-docs-end sidebar-toggler
-
 // Code
 
 $code-font-size:                    $small-font-size !default;
 $code-color:                        light-dark($pink, tint-color($pink, 40%)) !default;
 
-$kbd-padding-y:                     .1875rem !default;
-$kbd-padding-x:                     .375rem !default;
-$kbd-font-size:                     $code-font-size !default;
-$kbd-color:                         var(--#{$prefix}body-bg) !default;
-$kbd-bg:                            var(--#{$prefix}body-color) !default;
-
-$pre-color:                         null !default;
-
-// Time Picker
-// scss-docs-start time-picker-variables
-$time-picker-body-padding:                  $spacer * .5 !default;
-
-$time-picker-footer-padding:                .5rem !default;
-$time-picker-footer-border-width:           1px !default;
-$time-picker-footer-border-color:           var(--#{$prefix}border-color) !default;
-
-$time-picker-roll-col-border-width:           var(--#{$prefix}border-width) !default;
-$time-picker-roll-col-border-color:           var(--#{$prefix}border-color) !default;
-$time-picker-roll-cell-width:                 3rem !default;
-$time-picker-roll-cell-height:                2rem !default;
-$time-picker-roll-cell-hover-color:           var(--#{$prefix}body-color) !default;
-$time-picker-roll-cell-hover-bg:              var(--#{$prefix}tertiary-bg) !default;
-$time-picker-roll-cell-selected-color:        var(--#{$prefix}white) !default;
-$time-picker-roll-cell-selected-bg:           var(--#{$prefix}primary) !default;
-$time-picker-roll-cell-selected-hover-color:  var(--#{$prefix}white) !default;
-$time-picker-roll-cell-selected-hover-bg:     light-dark(color.scale($primary, $lightness: -20%), color.scale($primary, $saturation: -10%, $lightness: -10%)) !default; // stylelint-disable-line scss/at-function-named-arguments
-
-$time-picker-inline-select-font-size:       var(--#{$prefix}btn-input-sm-font-size) !default;
-$time-picker-inline-select-color:           $input-color !default;
-$time-picker-inline-select-padding-y:       $input-padding-y-sm !default;
-$time-picker-inline-select-padding-x:       $input-padding-x-sm !default;
-$time-picker-inline-select-disabled-color:  $input-disabled-color !default;
-// scss-docs-end time-picker-variables

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -565,6 +565,7 @@ $container-padding-x: $grid-gutter-width !default;
 // scss-docs-start border-variables
 $border-width:                1px !default;
 $border-widths: (
+  keyline: .5px,
   1: 1px,
   2: 2px,
   3: 3px,

--- a/scss/_date-picker.scss
+++ b/scss/_date-picker.scss
@@ -1,5 +1,6 @@
 @use "sass:math";
 @use "calendar" as *;
+@use "time-picker" as *;
 @use "functions/defaults" as *;
 @use "mixins/tokens" as *;
 @use "config" as *;

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -276,7 +276,7 @@ $dropdown-dark-tokens: defaults(
     width: 100%; // For `<button>`s
     padding: var(--#{$prefix}dropdown-item-padding-y) var(--#{$prefix}dropdown-item-padding-x);
     clear: both;
-    font-weight: $font-weight-normal;
+    font-weight: var(--#{$prefix}font-weight-normal);
     color: var(--#{$prefix}dropdown-link-color);
     text-align: inherit; // For `<button>`s
     text-decoration: if(not sass($link-decoration == none): none);

--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -185,7 +185,7 @@ $menu-tokens: defaults(
     align-items: center;
     width: 100%;
     padding: var(--#{$prefix}menu-item-padding-y) var(--#{$prefix}menu-item-padding-x);
-    font-weight: var(--#{$prefix}menu-item-font-weight, #{$font-weight-normal});
+    font-weight: var(--#{$prefix}menu-item-font-weight, var(--#{$prefix}font-weight-normal));
     color: var(--#{$prefix}theme-fg, var(--#{$prefix}menu-item-color));
     text-align: inherit;
     text-decoration: none;
@@ -213,7 +213,7 @@ $menu-tokens: defaults(
     }
 
     &.selected {
-      font-weight: $font-weight-semibold;
+      font-weight: var(--#{$prefix}font-weight-semibold);
     }
 
     &.disabled,
@@ -243,7 +243,7 @@ $menu-tokens: defaults(
 
   .menu-item-description {
     font-size: var(--#{$prefix}menu-description-font-size);
-    font-weight: $font-weight-normal;
+    font-weight: var(--#{$prefix}font-weight-normal);
     color: color-mix(in oklch, currentcolor 65%, transparent);
   }
 

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -281,7 +281,7 @@ $nav-underline-border-tokens: defaults(
 
     .nav-link.active,
     .show > .nav-link {
-      font-weight: $font-weight-bold;
+      font-weight: var(--#{$prefix}font-weight-bold);
       color: var(--#{$prefix}nav-underline-link-active-color);
       border-bottom-color: currentcolor;
     }
@@ -314,7 +314,7 @@ $nav-underline-border-tokens: defaults(
 
     .nav-link.active,
     .show > .nav-link {
-      font-weight: $font-weight-bold;
+      font-weight: var(--#{$prefix}font-weight-bold);
       color: var(--#{$prefix}nav-underline-border-link-active-color);
       border-bottom-color: currentcolor;
     }

--- a/scss/_placeholder.scss
+++ b/scss/_placeholder.scss
@@ -1,5 +1,10 @@
 @use "config" as *;
 
+// scss-docs-start placeholders
+$placeholder-opacity-max:           .5 !default;
+$placeholder-opacity-min:           .2 !default;
+// scss-docs-end placeholders
+
 @layer components {
   .placeholder {
     display: inline-block;

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -99,10 +99,18 @@
     --#{$prefix}border-radius-pill: #{$border-radius-pill};
     // scss-docs-end root-border-var
 
-    --#{$prefix}box-shadow: #{$box-shadow};
-    --#{$prefix}box-shadow-sm: #{$box-shadow-sm};
-    --#{$prefix}box-shadow-lg: #{$box-shadow-lg};
-    --#{$prefix}box-shadow-inset: #{$box-shadow-inset};
+    // scss-docs-start root-box-shadow-variables
+    --#{$prefix}shadow-color: #{$shadow-color};
+    --#{$prefix}shadow-strength: #{$shadow-strength};
+
+    @each $key, $value in $shadows {
+      @if $key == null {
+        --#{$prefix}box-shadow: #{$value};
+      } @else {
+        --#{$prefix}box-shadow-#{$key}: #{$value};
+      }
+    }
+    // scss-docs-end root-box-shadow-variables
 
     // Focus styles
     // scss-docs-start root-focus-variables
@@ -162,6 +170,10 @@
       color-scheme: dark;
 
       // scss-docs-start root-dark-mode-vars
+      // A shadow reads as depth against the surface behind it, and a dark
+      // surface swallows the same alpha, so the strength rises instead of the
+      // colour changing.
+      --#{$prefix}shadow-strength: #{$shadow-strength-dark};
       // scss-docs-end root-dark-mode-vars
     }
   }

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -50,6 +50,11 @@
     }
     --#{$prefix}body-font-family: #{meta.inspect($font-family-base)};
     --#{$prefix}body-font-size: #{$font-size-base};
+    // scss-docs-start root-font-weight-loop
+    @each $name, $value in $font-weights {
+      --#{$prefix}font-weight-#{$name}: #{$value};
+    }
+    // scss-docs-end root-font-weight-loop
     --#{$prefix}body-font-weight: #{$font-weight-base};
     --#{$prefix}body-line-height: #{$line-height-base};
     @if $body-text-align != null {

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -1,8 +1,34 @@
+@use "sass:color";
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/tokens" as *;
 @use "config" as *;
 @use "forms/form-control-group" as *;
+
+// scss-docs-start time-picker-variables
+$time-picker-body-padding:                  $spacer * .5 !default;
+
+$time-picker-footer-padding:                .5rem !default;
+$time-picker-footer-border-width:           1px !default;
+$time-picker-footer-border-color:           var(--#{$prefix}border-color) !default;
+
+$time-picker-roll-col-border-width:           var(--#{$prefix}border-width) !default;
+$time-picker-roll-col-border-color:           var(--#{$prefix}border-color) !default;
+$time-picker-roll-cell-width:                 3rem !default;
+$time-picker-roll-cell-height:                2rem !default;
+$time-picker-roll-cell-hover-color:           var(--#{$prefix}body-color) !default;
+$time-picker-roll-cell-hover-bg:              var(--#{$prefix}tertiary-bg) !default;
+$time-picker-roll-cell-selected-color:        var(--#{$prefix}white) !default;
+$time-picker-roll-cell-selected-bg:           var(--#{$prefix}primary) !default;
+$time-picker-roll-cell-selected-hover-color:  var(--#{$prefix}white) !default;
+$time-picker-roll-cell-selected-hover-bg:     light-dark(color.scale($primary, $lightness: -20%), color.scale($primary, $saturation: -10%, $lightness: -10%)) !default; // stylelint-disable-line scss/at-function-named-arguments
+
+$time-picker-inline-select-font-size:       var(--#{$prefix}btn-input-sm-font-size) !default;
+$time-picker-inline-select-color:           $input-color !default;
+$time-picker-inline-select-padding-y:       $input-padding-y-sm !default;
+$time-picker-inline-select-padding-x:       $input-padding-x-sm !default;
+$time-picker-inline-select-disabled-color:  $input-disabled-color !default;
+// scss-docs-end time-picker-variables
 
 // Time Picker
 $time-picker-tokens: () !default;

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -667,15 +667,7 @@ $utilities: map.merge(
     "font-weight": (
       property: font-weight,
       class: fw,
-      values: (
-        lighter: $font-weight-lighter,
-        light: $font-weight-light,
-        normal: $font-weight-normal,
-        medium: $font-weight-medium,
-        semibold: $font-weight-semibold,
-        bold: $font-weight-bold,
-        bolder: $font-weight-bolder
-      )
+      values: $font-weights
     ),
     "line-height": (
       property: line-height,

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -94,14 +94,35 @@ $utilities: map.merge(
     "shadow": (
       property: box-shadow,
       class: shadow,
-      values: (
-        null: var(--#{$prefix}box-shadow),
-        sm: var(--#{$prefix}box-shadow-sm),
-        lg: var(--#{$prefix}box-shadow-lg),
-        none: none,
-      )
+      // The literal expressions from $shadows, not var(--#{$prefix}box-shadow*).
+      // A token resolves where it is declared — on :root — so going through one
+      // would freeze the tint and the opacity there and leave .shadow-primary
+      // and .shadow-opacity-* with nothing to change.
+      // `inset` stays out: it is a component's inner shadow, not a utility.
+      values: map.merge(map.remove($shadows, inset), (none: none))
     ),
     // scss-docs-end utils-shadow
+    // scss-docs-start utils-shadow-color
+    "shadow-color": (
+      property: (--#{$prefix}shadow-tint: null),
+      class: shadow,
+      values: map.merge(
+        $theme-colors,
+        (
+          "current": currentcolor,
+          "black": $black,
+          "white": $white,
+        )
+      )
+    ),
+    // scss-docs-end utils-shadow-color
+    // scss-docs-start utils-shadow-opacity
+    "shadow-opacity": (
+      property: (--#{$prefix}shadow-opacity: null),
+      class: shadow-opacity,
+      values: (25: .25, 50: .5, 75: .75, 100: 1)
+    ),
+    // scss-docs-end utils-shadow-opacity
     // scss-docs-start utils-focus-ring
     "focus-ring": (
       property: (--#{$prefix}focus-ring-color: null),

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -33,7 +33,7 @@ $btn-font-size-lg:            $input-btn-font-size-lg !default;
 
 $btn-border-width:            $input-btn-border-width !default;
 
-$btn-font-weight:             $font-weight-normal !default;
+$btn-font-weight:             var(--#{$prefix}font-weight-normal) !default;
 $btn-box-shadow:              inset 0 1px 0 rgba($white, .15), 0 1px 1px rgba($black, .075) !default;
 $btn-focus-width:             $input-btn-focus-width !default;
 // fusv-disable
@@ -401,7 +401,7 @@ $btn-ghost-focus-shadow: var(--#{$prefix}tertiary-bg) !default;
 
   // Make a button look and behave like a link
   .btn-link {
-    --#{$prefix}btn-font-weight: #{$font-weight-normal};
+    --#{$prefix}btn-font-weight: var(--#{$prefix}font-weight-normal);
     --#{$prefix}btn-color: #{$btn-link-color};
     --#{$prefix}btn-bg: transparent;
     --#{$prefix}btn-border-color: transparent;

--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -1,6 +1,16 @@
 @use "../mixins/border-radius" as *;
 @use "../config" as *;
 
+// scss-docs-start kbd-variables
+$kbd-padding-y:                     .1875rem !default;
+$kbd-padding-x:                     .375rem !default;
+$kbd-font-size:                     $code-font-size !default;
+$kbd-color:                         var(--#{$prefix}body-bg) !default;
+$kbd-bg:                            var(--#{$prefix}body-color) !default;
+
+$pre-color:                         null !default;
+// scss-docs-end kbd-variables
+
 // stylelint-disable function-disallowed-list
 
 // scss-docs-start reboot-table-variables

--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -225,7 +225,7 @@ $th-font-weight:       null !default;
 
   b,
   strong {
-    font-weight: $font-weight-bolder;
+    font-weight: var(--#{$prefix}font-weight-bolder);
   }
 
 

--- a/scss/content/_tables.scss
+++ b/scss/content/_tables.scss
@@ -277,12 +277,12 @@ $table-variants: map.keys($theme-colors) !default;
             border: 0;
 
             &:first-child {
-              font-weight: $font-weight-bold;
+              font-weight: var(--#{$prefix}font-weight-bold);
             }
 
             &[data-cell]:not(:first-child)::before {
               display: block;
-              font-weight: $font-weight-semibold;
+              font-weight: var(--#{$prefix}font-weight-semibold);
               content: attr(data-cell);
             }
           }

--- a/scss/sidebar/_sidebar.scss
+++ b/scss/sidebar/_sidebar.scss
@@ -7,6 +7,20 @@
 @use "../mixins/transition" as *;
 @use "../config" as *;
 
+// scss-docs-start sidebar-toggler
+$sidebar-toggler-width:             .5rem !default;
+$sidebar-toggler-height:            .5rem !default;
+$sidebar-toggler-padding-x:         .25rem !default;
+$sidebar-toggler-padding-y:         .25rem !default;
+$sidebar-toggler-bg:                transparent !default;
+$sidebar-toggler-color:             var(--#{$prefix}tertiary-color) !default;
+$sidebar-toggler-icon:              url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cg xmlns='http://www.w3.org/2000/svg' transform='matrix(-1 0 0 -1 512 512)'%3E%3Cpath fill='%23000' d='M472,16H40A24.028,24.028,0,0,0,16,40V200H48V48H464V464H48V304H16V472a24.028,24.028,0,0,0,24,24H472a24.028,24.028,0,0,0,24-24V40A24.028,24.028,0,0,0,472,16Z'/%3E%3Cpolygon fill='%23000' points='209.377 363.306 232.004 385.933 366.627 251.31 232.004 116.687 209.377 139.313 305.374 235.311 16 235.311 16 267.311 305.372 267.311 209.377 363.306'/%3E%3C/g%3E%3C/svg%3E") !default;
+$sidebar-toggler-focus-shadow:      $focus-ring !default;
+$sidebar-toggler-hover-color:       var(--#{$prefix}secondary-color) !default;
+$sidebar-toggler-focus-color:       var(--#{$prefix}secondary-color) !default;
+$sidebar-toggler-transition:        transform .15s !default;
+// scss-docs-end sidebar-toggler
+
 // scss-docs-start sidebar-variables
 $sidebar-width:                            16rem !default;
 $sidebar-widths: (


### PR DESCRIPTION
A3, A4 and `$font-weights` from the `_config.scss` comparison. **Stacked on #774** (which is stacked on #773) — merge in order and this retargets to `v6-dev`. Three separate commits, one theme: a map is worth having when it feeds a generator, and a token is worth having when something reads it.

## 1. The whole z-axis in one map

It was written down twice — `$zindex-levels` for the small `.z-*` steps, ten separate `$zindex-*` variables for the overlay layers, nothing connecting them. So the one place that shows how the axis is laid out did not exist, and an app that wanted its own element at the modal layer had to hardcode `1055`.

`$zindex-levels` now carries both, **composed from the ten variables rather than replacing them** — overriding `$zindex-modal` still reaches the 15 files that read it, and the map follows. New: `.z-dropdown`, `.z-sticky`, `.z-fixed`, `.z-sidebar-backdrop`, `.z-sidebar`, `.z-offcanvas`, `.z-modal`, `.z-popover`, `.z-tooltip`, `.z-toast`. Nothing removed.

## 2. `keyline` border width

`$border-widths` started at `1px`, a full device pixel on a high-density screen and heavier than a divider usually wants. `keyline: .5px` adds the step below. Five utility families read that map, so this generates `.border-keyline` plus four directional siblings.

## 3. `$font-weights`

The seven weights were written down twice: `$font-weight-*` variables, and a hand-copied list inside the `.fw-*` utility. Adding `$font-weight-black: 900` produced **no** `.fw-black`, because the utility had its own copy.

One map now feeds three things — the utility, a `--cui-font-weight-{name}` token per step, and the components. Seventeen references across eleven files read `var(--cui-font-weight-*)` instead of inlining the number at build time.

Measured: with `--cui-font-weight-semibold: 900` a badge computes to **900**; before it stayed at the compiled 600. Defaults unchanged (badge 600, button 400).

`reset-text()` keeps its Sass value on purpose — the mixin exists to pin a known baseline and every other line in it is Sass-time too.

## Budgets

Five raises, all blocking, measured per commit so the end-of-v6 tightening pass knows what bought what:

| change | coreui.css | coreui-utilities.css | coreui-reboot.css |
| --- | --- | --- | --- |
| z-axis map | +0.10 kB | +0.09 kB | — |
| `keyline` | +0.05 kB | +0.05 kB | — |
| `$font-weights` | +0.09 kB | +0.05 kB | +0.05 kB |

## Verification

`css-lint`, `css-test` (62 specs), `css-lint-vars`, `css-test-class-api`, `docs-build`, bundlewatch all pass. Docs updated on three pages: utilities/z-index, layout/z-index, utilities/borders, utilities/text.