### PR TITLE
refactor(config): components read the z-axis and the spacing scale as tokens

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "50.25kB"
+      "maxSize": "50.5kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -10,11 +10,11 @@
     },
     {
       "path": "./dist/css/coreui-reboot.css",
-      "maxSize": "4.5 kB"
+      "maxSize": "4.75 kB"
     },
     {
       "path": "./dist/css/coreui-reboot.min.css",
-      "maxSize": "4.35 kB"
+      "maxSize": "4.6 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.css",
@@ -22,15 +22,15 @@
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",
-      "maxSize": "13.5 kB"
+      "maxSize": "13.75 kB"
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "60kB"
+      "maxSize": "60.25kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "50kB"
+      "maxSize": "50.25kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "60.5kB"
+      "maxSize": "61kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "50.5kB"
+      "maxSize": "51kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -18,7 +18,7 @@
     },
     {
       "path": "./dist/css/coreui-utilities.css",
-      "maxSize": "14.5 kB"
+      "maxSize": "14.75 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "60.25kB"
+      "maxSize": "60.5kB"
     },
     {
       "path": "./dist/css/coreui.min.css",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "61kB"
+      "maxSize": "60.5kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "51kB"
+      "maxSize": "50.5kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/docs/.astro/dev.json
+++ b/docs/docs/.astro/dev.json
@@ -1,0 +1,13 @@
+{
+	"pid": 15938,
+	"port": 9001,
+	"url": "http://localhost:9001",
+	"urls": {
+		"local": [
+			"http://localhost:9001/"
+		],
+		"network": []
+	},
+	"background": true,
+	"startedAt": "2026-08-08T20:08:50.187Z"
+}

--- a/docs/docs/.astro/settings.json
+++ b/docs/docs/.astro/settings.json
@@ -1,0 +1,5 @@
+{
+	"_variables": {
+		"lastUpdateCheck": 1786218183369
+	}
+}

--- a/docs/docs/.astro/types.d.ts
+++ b/docs/docs/.astro/types.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/docs/src/content/docs/forms/form-control.mdx
+++ b/docs/src/content/docs/forms/form-control.mdx
@@ -154,7 +154,7 @@ Learn more about [support for datalist elements](https://caniuse.com/datalist).
 
 `$input-*` are shared across most of our form controls (and not buttons).
 
-<ScssDocs file="scss/forms/_form-control.scss" capture="form-input-variables" />
+<ScssDocs file="scss/forms/_variables.scss" capture="form-input-variables" />
 
 `$form-label-*` and `$form-text-*` are for our `<label>`s and `.form-text` component.
 

--- a/docs/src/content/docs/forms/form-control.mdx
+++ b/docs/src/content/docs/forms/form-control.mdx
@@ -154,7 +154,7 @@ Learn more about [support for datalist elements](https://caniuse.com/datalist).
 
 `$input-*` are shared across most of our form controls (and not buttons).
 
-<ScssDocs file="scss/_config.scss" capture="form-input-variables" />
+<ScssDocs file="scss/forms/_form-control.scss" capture="form-input-variables" />
 
 `$form-label-*` and `$form-text-*` are for our `<label>`s and `.form-text` component.
 

--- a/docs/src/content/docs/forms/password-input.mdx
+++ b/docs/src/content/docs/forms/password-input.mdx
@@ -97,7 +97,7 @@ field, or globally to restyle every field component at once:
 
 `$input-*` are shared across every form control:
 
-<ScssDocs file="scss/forms/_form-control.scss" capture="form-input-variables" />
+<ScssDocs file="scss/forms/_variables.scss" capture="form-input-variables" />
 
 `$form-control-group-*` cover the frame and its adornments:
 

--- a/docs/src/content/docs/forms/password-input.mdx
+++ b/docs/src/content/docs/forms/password-input.mdx
@@ -97,7 +97,7 @@ field, or globally to restyle every field component at once:
 
 `$input-*` are shared across every form control:
 
-<ScssDocs file="scss/_config.scss" capture="form-input-variables" />
+<ScssDocs file="scss/forms/_form-control.scss" capture="form-input-variables" />
 
 `$form-control-group-*` cover the frame and its adornments:
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1228,6 +1228,27 @@ assembles maps of CSS expressions and the browser resolves them.
   `$btn-outline-focus-shadow-rgb` → `$btn-outline-focus-shadow`, likewise for
   the ghost and link variants.
 
+#### The control variables moved out of the shared config
+
+<span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+
+`$input-*` described one thing — the frame every field component draws — but sat
+in `_config.scss` next to the breakpoints and the spacing scale. It lives in
+`scss/forms/_form-control.scss` now, with `.form-control` itself.
+
+- **Nothing changes for CSS.** The compiled stylesheet is identical; the
+  `--#{$prefix}control-*` and `--#{$prefix}btn-input-*` tokens are untouched, so
+  runtime customisation is unaffected.
+- **A Sass override needs the new path** when you `@use` the partial directly.
+  Overriding through `@use "@coreui/coreui-pro" with (...)` is unchanged.
+- **`$input-btn-*` stays in the config**: those are the values the button and
+  the field agree on, and `buttons/_button.scss` reads them.
+- **`$input-height`, `$input-height-sm` and `$input-height-lg` are removed.**
+  They existed to be baked into `--#{$prefix}btn-input-min-height`, which now
+  computes from `--#{$prefix}btn-input-line-height`, `-padding-y` and
+  `-border-width` in the browser. Set those tokens, or
+  `--#{$prefix}btn-input-min-height` itself, instead of recompiling.
+
 #### Shadows are computed at runtime
 
 <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -6,9 +6,9 @@
 @use "config" as *;
 
 // scss-docs-start alert-variables
-$alert-padding-y:               $spacer !default;
-$alert-padding-x:               $spacer !default;
-$alert-gap:                     $spacer * .5 !default;
+$alert-padding-y:               var(--#{$prefix}spacer-3) !default;
+$alert-padding-x:               var(--#{$prefix}spacer-3) !default;
+$alert-gap:                     var(--#{$prefix}spacer-2) !default;
 $alert-margin-bottom:           1rem !default;
 $alert-border-radius:           var(--#{$prefix}border-radius) !default;
 $alert-link-font-weight:        var(--#{$prefix}font-weight-bold) !default;

--- a/scss/_callout.scss
+++ b/scss/_callout.scss
@@ -5,9 +5,9 @@
 
 // Callouts
 // scss-docs-start callout-variables
-$callout-padding-y:                 $spacer !default;
-$callout-padding-x:                 $spacer !default;
-$callout-margin-y:                  $spacer !default;
+$callout-padding-y:                 var(--#{$prefix}spacer-3) !default;
+$callout-padding-x:                 var(--#{$prefix}spacer-3) !default;
+$callout-margin-y:                  var(--#{$prefix}spacer-3) !default;
 $callout-margin-x:                  0 !default;
 $callout-border-radius:             var(--#{$prefix}border-radius) !default;
 $callout-border-width:              var(--#{$prefix}border-width) !default;

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -7,9 +7,9 @@
 @use "config" as *;
 
 // scss-docs-start card-variables
-$card-spacer-y:                     $spacer !default;
-$card-spacer-x:                     $spacer !default;
-$card-title-spacer-y:               $spacer * .5 !default;
+$card-spacer-y:                     var(--#{$prefix}spacer-3) !default;
+$card-spacer-x:                     var(--#{$prefix}spacer-3) !default;
+$card-title-spacer-y:               var(--#{$prefix}spacer-2) !default;
 $card-title-color:                  null !default;
 $card-subtitle-color:               null !default;
 $card-border-width:                 var(--#{$prefix}border-width) !default;
@@ -17,14 +17,14 @@ $card-border-color:                 var(--#{$prefix}border-color-translucent) !d
 $card-border-radius:                var(--#{$prefix}border-radius) !default;
 $card-box-shadow:                   null !default;
 $card-inner-border-radius:          subtract($card-border-radius, $card-border-width) !default;
-$card-cap-padding-y:                $card-spacer-y * .5 !default;
+$card-cap-padding-y:                calc(#{$card-spacer-y} * .5) !default; // stylelint-disable-line function-disallowed-list
 $card-cap-padding-x:                $card-spacer-x !default;
 $card-cap-bg:                       color-mix(in srgb, var(--#{$prefix}body-color) 3%, transparent) !default;
 $card-cap-color:                    null !default;
 $card-height:                       null !default;
 $card-color:                        null !default;
 $card-bg:                           var(--#{$prefix}body-bg) !default;
-$card-img-overlay-padding:          $spacer !default;
+$card-img-overlay-padding:          var(--#{$prefix}spacer-3) !default;
 $card-group-margin:                 $grid-gutter-width * .5 !default;
 // scss-docs-end card-variables
 

--- a/scss/_combobox.scss
+++ b/scss/_combobox.scss
@@ -1,4 +1,4 @@
-@use "forms/form-control" as *;
+@use "forms/variables" as *;
 @use "functions/defaults" as *;
 @use "functions/escape-svg" as *;
 @use "mixins/border-radius" as *;

--- a/scss/_combobox.scss
+++ b/scss/_combobox.scss
@@ -1,3 +1,4 @@
+@use "forms/form-control" as *;
 @use "functions/defaults" as *;
 @use "functions/escape-svg" as *;
 @use "mixins/border-radius" as *;

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -797,10 +797,10 @@ $mark-bg:                     light-dark($yellow-100, $yellow-800) !default;
 
 // Icons
 $icon-size-base:  1rem !default;
-$icon-size-sm:    $icon-size-base * .875 !default;
-$icon-size-lg:    $icon-size-base * 1.25 !default;
-$icon-size-xl:    $icon-size-base * 1.5 !default;
-$icon-size-xxl:   $icon-size-base * 2 !default;
+$icon-size-sm:    calc(var(--#{$prefix}icon-size-base) * .875) !default; // stylelint-disable-line function-disallowed-list
+$icon-size-lg:    calc(var(--#{$prefix}icon-size-base) * 1.25) !default; // stylelint-disable-line function-disallowed-list
+$icon-size-xl:    calc(var(--#{$prefix}icon-size-base) * 1.5) !default; // stylelint-disable-line function-disallowed-list
+$icon-size-xxl:   calc(var(--#{$prefix}icon-size-base) * 2) !default; // stylelint-disable-line function-disallowed-list
 
 // Customizes the `.table` component with basic values, each used across all table variations.
 

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -896,13 +896,13 @@ $input-plaintext-color:                 var(--#{$prefix}body-color) !default;
 
 $input-height-border:                   calc(#{$input-border-width} * 2) !default; // stylelint-disable-line function-disallowed-list
 
-$input-height-inner:                    add($input-line-height * 1em, $input-padding-y * 2) !default;
-$input-height-inner-half:               add($input-line-height * .5em, $input-padding-y) !default;
-$input-height-inner-quarter:            add($input-line-height * .25em, $input-padding-y * .5) !default;
+$input-height-inner:                    calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2) !default; // stylelint-disable-line function-disallowed-list
+$input-height-inner-half:               calc(var(--#{$prefix}btn-input-line-height) * .5em + var(--#{$prefix}btn-input-padding-y)) !default; // stylelint-disable-line function-disallowed-list
+$input-height-inner-quarter:            calc(var(--#{$prefix}btn-input-line-height) * .25em + var(--#{$prefix}btn-input-padding-y) * .5) !default; // stylelint-disable-line function-disallowed-list
 
-$input-height:                          add($input-line-height * 1em, add($input-padding-y * 2, $input-height-border, false)) !default;
-$input-height-sm:                       add($input-line-height * 1em, add($input-padding-y-sm * 2, $input-height-border, false)) !default;
-$input-height-lg:                       add($input-line-height * 1em, add($input-padding-y-lg * 2, $input-height-border, false)) !default;
+$input-height:                          calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2) !default; // stylelint-disable-line function-disallowed-list
+$input-height-sm:                       calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-sm-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2) !default; // stylelint-disable-line function-disallowed-list
+$input-height-lg:                       calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-lg-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2) !default; // stylelint-disable-line function-disallowed-list
 
 $input-transition:                      border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -655,8 +655,8 @@ $font-family-code:            var(--#{$prefix}font-monospace) !default;
 // $font-size-base affects the font size of the body text
 $font-size-root:              null !default;
 $font-size-base:              1rem !default; // Assumes the browser default, typically `16px`
-$font-size-sm:                $font-size-base * .875 !default;
-$font-size-lg:                $font-size-base * 1.25 !default;
+$font-size-sm:                calc(var(--#{$prefix}body-font-size) * .875) !default; // stylelint-disable-line function-disallowed-list
+$font-size-lg:                calc(var(--#{$prefix}body-font-size) * 1.25) !default; // stylelint-disable-line function-disallowed-list
 
 $font-weight-lighter:         lighter !default;
 $font-weight-light:           300 !default;
@@ -691,12 +691,12 @@ $h1-font-size:                clamp(1.375rem, 1.375rem + 1.5vw, 2.5rem) !default
 $h2-font-size:                clamp(1.325rem, 1.325rem + .9vw, 2rem) !default;
 $h3-font-size:                clamp(1.3rem, 1.3rem + .6vw, 1.75rem) !default;
 $h4-font-size:                clamp(1.275rem, 1.275rem + .3vw, 1.5rem) !default;
-$h5-font-size:                $font-size-base * 1.25 !default;
-$h6-font-size:                $font-size-base !default;
+$h5-font-size:                calc(var(--#{$prefix}body-font-size) * 1.25) !default; // stylelint-disable-line function-disallowed-list
+$h6-font-size:                var(--#{$prefix}body-font-size) !default;
 // scss-docs-end font-variables
 
 // scss-docs-start headings-variables
-$headings-margin-bottom:      $spacer * .5 !default;
+$headings-margin-bottom:      var(--#{$prefix}spacer-2) !default;
 $headings-font-family:        null !default;
 $headings-font-style:         null !default;
 $headings-font-weight:        500 !default;
@@ -757,7 +757,7 @@ $display-line-height: $headings-line-height !default;
 // scss-docs-end display-headings
 
 // scss-docs-start type-variables
-$lead-font-size:                $font-size-base * 1.25 !default;
+$lead-font-size:                calc(var(--#{$prefix}body-font-size) * 1.25) !default; // stylelint-disable-line function-disallowed-list
 $lead-font-weight:              300 !default;
 
 $small-font-size:               .875em !default;
@@ -767,7 +767,7 @@ $sub-sup-font-size:             .75em !default;
 $initialism-font-size:        $small-font-size !default;
 
 $blockquote-margin-y:         $spacer !default;
-$blockquote-font-size:        $font-size-base * 1.25 !default;
+$blockquote-font-size:        calc(var(--#{$prefix}body-font-size) * 1.25) !default; // stylelint-disable-line function-disallowed-list
 $blockquote-footer-color:     $gray-600 !default;
 $blockquote-footer-font-size: $small-font-size !default;
 

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -856,59 +856,6 @@ $form-text-font-weight:                 null !default;
 $form-text-color:                       var(--#{$prefix}secondary-color) !default;
 // scss-docs-end form-text-variables
 
-// scss-docs-start form-input-variables
-$input-padding-y:                       $input-btn-padding-y !default;
-$input-padding-x:                       $input-btn-padding-x !default;
-$input-font-family:                     $input-btn-font-family !default;
-$input-font-size:                       $input-btn-font-size !default;
-$input-font-weight:                     $font-weight-base !default;
-$input-line-height:                     $input-btn-line-height !default;
-
-$input-padding-y-sm:                    $input-btn-padding-y-sm !default;
-$input-padding-x-sm:                    $input-btn-padding-x-sm !default;
-$input-font-size-sm:                    $input-btn-font-size-sm !default;
-
-$input-padding-y-lg:                    $input-btn-padding-y-lg !default;
-$input-font-size-lg:                    $input-btn-font-size-lg !default;
-
-$input-bg:                              var(--#{$prefix}body-bg) !default;
-$input-disabled-color:                  var(--#{$prefix}body-color) !default;
-$input-disabled-bg:                     var(--#{$prefix}secondary-bg) !default;
-$input-disabled-border-color:           var(--#{$prefix}border-color) !default;
-
-$input-color:                           var(--#{$prefix}body-color) !default;
-$input-border-color:                    var(--#{$prefix}border-color) !default;
-$input-border-width:                    $input-btn-border-width !default;
-$input-box-shadow:                      var(--#{$prefix}box-shadow-inset) !default;
-
-$input-border-radius:                   var(--#{$prefix}border-radius) !default;
-$input-border-radius-sm:                var(--#{$prefix}border-radius-sm) !default;
-$input-border-radius-lg:                var(--#{$prefix}border-radius-lg) !default;
-
-$input-focus-bg:                        $input-bg !default;
-$input-focus-border-color:              tint-color($primary, 50%) !default;
-$input-focus-color:                     $input-color !default;
-$input-focus-width:                     $input-btn-focus-width !default;
-$input-focus-ring:                      var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
-
-$input-placeholder-color:               var(--#{$prefix}secondary-color) !default;
-$input-plaintext-color:                 var(--#{$prefix}body-color) !default;
-
-$input-height-border:                   calc(#{$input-border-width} * 2) !default; // stylelint-disable-line function-disallowed-list
-
-$input-height-inner:                    calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2) !default; // stylelint-disable-line function-disallowed-list
-$input-height-inner-half:               calc(var(--#{$prefix}btn-input-line-height) * .5em + var(--#{$prefix}btn-input-padding-y)) !default; // stylelint-disable-line function-disallowed-list
-$input-height-inner-quarter:            calc(var(--#{$prefix}btn-input-line-height) * .25em + var(--#{$prefix}btn-input-padding-y) * .5) !default; // stylelint-disable-line function-disallowed-list
-
-$input-height:                          calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2) !default; // stylelint-disable-line function-disallowed-list
-$input-height-sm:                       calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-sm-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2) !default; // stylelint-disable-line function-disallowed-list
-$input-height-lg:                       calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-lg-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2) !default; // stylelint-disable-line function-disallowed-list
-
-$input-transition:                      border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
-
-$form-color-width:                      3rem !default;
-// scss-docs-end form-input-variables
-
 $form-check-inline-margin-end:    1rem !default;
 
 // Form validation
@@ -940,7 +887,7 @@ $form-validation-states: (
     "icon": $form-feedback-icon-valid,
     "tooltip-color": #fff,
     "tooltip-bg-color": var(--#{$prefix}success),
-    "focus-ring": $input-focus-width solid color-mix(in srgb, var(--#{$prefix}success) math.percentage($input-btn-focus-color-opacity), transparent),
+    "focus-ring": $input-btn-focus-width solid color-mix(in srgb, var(--#{$prefix}success) math.percentage($input-btn-focus-color-opacity), transparent),
     "border-color": var(--#{$prefix}form-valid-border-color),
   ),
   "invalid": (
@@ -948,7 +895,7 @@ $form-validation-states: (
     "icon": $form-feedback-icon-invalid,
     "tooltip-color": #fff,
     "tooltip-bg-color": var(--#{$prefix}danger),
-    "focus-ring": $input-focus-width solid color-mix(in srgb, var(--#{$prefix}danger) math.percentage($input-btn-focus-color-opacity), transparent),
+    "focus-ring": $input-btn-focus-width solid color-mix(in srgb, var(--#{$prefix}danger) math.percentage($input-btn-focus-color-opacity), transparent),
     "border-color": var(--#{$prefix}form-invalid-border-color),
   )
 ) !default;
@@ -998,4 +945,3 @@ $zindex-levels: (
 
 $code-font-size:                    $small-font-size !default;
 $code-color:                        light-dark($pink, tint-color($pink, 40%)) !default;
-

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -16,7 +16,7 @@
 // stylelint-disable function-disallowed-list
 
 // scss-docs-start dialog-variables
-$dialog-padding:                    $spacer !default;
+$dialog-padding:                    var(--#{$prefix}spacer-3) !default;
 $dialog-width:                      500px !default;
 $dialog-margin:                     1.75rem !default;
 $dialog-color:                      var(--#{$prefix}body-color) !default;
@@ -31,11 +31,11 @@ $dialog-slide-distance:             3rem !default;
 $dialog-scale-transform:            scale(1.02) !default;
 $dialog-backdrop-bg:                light-dark(rgb(0 0 0 / 50%), rgb(0 0 0 / 65%)) !default;
 $dialog-backdrop-blur:              8px !default;
-$dialog-header-padding:             $spacer !default;
+$dialog-header-padding:             var(--#{$prefix}spacer-3) !default;
 $dialog-header-border-color:        var(--#{$prefix}border-color-translucent) !default;
 $dialog-header-border-width:        var(--#{$prefix}border-width) !default;
 $dialog-title-line-height:          $line-height-base !default;
-$dialog-footer-padding:             $spacer !default;
+$dialog-footer-padding:             var(--#{$prefix}spacer-3) !default;
 $dialog-footer-border-color:        var(--#{$prefix}border-color-translucent) !default;
 $dialog-footer-border-width:        var(--#{$prefix}border-width) !default;
 $dialog-footer-gap:                 .5rem !default;

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -64,7 +64,7 @@ $dialog-tokens: () !default;
 // scss-docs-start dialog-css-vars
 $dialog-tokens: defaults(
   (
-    --#{$prefix}dialog-zindex: #{$zindex-modal},
+    --#{$prefix}dialog-zindex: var(--#{$prefix}z-modal),
     --#{$prefix}dialog-padding: #{$dialog-padding},
     --#{$prefix}dialog-width: #{$dialog-width},
     --#{$prefix}dialog-margin: #{$dialog-margin},

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -45,7 +45,7 @@ $drawer-tokens: () !default;
 $drawer-tokens: defaults(
   (
     --#{$prefix}drawer-inset: #{$drawer-inset},
-    --#{$prefix}drawer-zindex: #{$zindex-offcanvas},
+    --#{$prefix}drawer-zindex: var(--#{$prefix}z-offcanvas),
     --#{$prefix}drawer-width: #{$drawer-width},
     --#{$prefix}drawer-height: #{$drawer-height},
     --#{$prefix}drawer-padding-x: #{$drawer-padding-x},

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -17,11 +17,11 @@
 // stylelint-disable function-disallowed-list
 
 // scss-docs-start drawer-variables
-$drawer-inset:                      $spacer !default;
+$drawer-inset:                      var(--#{$prefix}spacer-3) !default;
 $drawer-width:                      400px !default;
 $drawer-height:                     30vh !default;
-$drawer-padding-y:                  $spacer !default;
-$drawer-padding-x:                  $spacer !default;
+$drawer-padding-y:                  var(--#{$prefix}spacer-3) !default;
+$drawer-padding-x:                  var(--#{$prefix}spacer-3) !default;
 $drawer-color:                      var(--#{$prefix}body-color) !default;
 $drawer-bg:                         var(--#{$prefix}body-bg) !default;
 $drawer-border-color:               var(--#{$prefix}border-color-translucent) !default;

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -63,7 +63,7 @@ $dropdown-tokens: () !default;
 // scss-docs-start dropdown-css-vars
 $dropdown-tokens: defaults(
   (
-    --#{$prefix}dropdown-zindex: #{$zindex-dropdown},
+    --#{$prefix}dropdown-zindex: var(--#{$prefix}z-dropdown),
     --#{$prefix}dropdown-min-width: #{$dropdown-min-width},
     --#{$prefix}dropdown-padding-x: #{$dropdown-padding-x},
     --#{$prefix}dropdown-padding-y: #{$dropdown-padding-y},

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -21,7 +21,7 @@ $dropdown-border-radius:            var(--#{$prefix}border-radius) !default;
 $dropdown-border-width:             var(--#{$prefix}border-width) !default;
 $dropdown-inner-border-radius:      calc(#{$dropdown-border-radius} - #{$dropdown-border-width}) !default; // stylelint-disable-line function-disallowed-list
 $dropdown-divider-bg:               $dropdown-border-color !default;
-$dropdown-divider-margin-y:         $spacer * .5 !default;
+$dropdown-divider-margin-y:         var(--#{$prefix}spacer-2) !default;
 $dropdown-box-shadow:               var(--#{$prefix}box-shadow) !default;
 
 $dropdown-link-color:               var(--#{$prefix}body-color) !default;
@@ -33,8 +33,8 @@ $dropdown-link-active-bg:           $component-active-bg !default;
 
 $dropdown-link-disabled-color:      var(--#{$prefix}tertiary-color) !default;
 
-$dropdown-item-padding-y:           $spacer * .25 !default;
-$dropdown-item-padding-x:           $spacer !default;
+$dropdown-item-padding-y:           var(--#{$prefix}spacer-1) !default;
+$dropdown-item-padding-x:           var(--#{$prefix}spacer-3) !default;
 
 $dropdown-header-color:             $gray-600 !default;
 $dropdown-header-padding-x:         $dropdown-item-padding-x !default;

--- a/scss/_footer.scss
+++ b/scss/_footer.scss
@@ -5,8 +5,8 @@
 // Footer
 // scss-docs-start footer-variables
 $footer-min-height:    3rem !default;
-$footer-padding-y:     $spacer * .5 !default;
-$footer-padding-x:     $spacer !default;
+$footer-padding-y:     var(--#{$prefix}spacer-2) !default;
+$footer-padding-x:     var(--#{$prefix}spacer-3) !default;
 $footer-bg:            var(--#{$prefix}tertiary-bg) !default;
 $footer-color:         var(--#{$prefix}body-color) !default;
 $footer-border-width:  var(--#{$prefix}border-width) !default;

--- a/scss/_footer.scss
+++ b/scss/_footer.scss
@@ -51,6 +51,6 @@ $footer-tokens: defaults(
   .footer-sticky {
     position: sticky;
     bottom: 0;
-    z-index: $zindex-fixed;
+    z-index: var(--#{$prefix}z-fixed);
   }
 }

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -25,8 +25,8 @@ $header-disabled-color:         color-mix(in srgb, var(--#{$prefix}emphasis-colo
 $header-transition:             box-shadow .15s ease-in-out !default;
 
 // Compute the header-brand padding-y so the header-brand will have the same height as header-text and nav-link
-$header-brand-height:           $header-brand-font-size * $line-height-base !default;
-$header-brand-padding-y:        ($nav-link-height - $header-brand-height) * .5 !default;
+$header-brand-height:           calc(#{$header-brand-font-size} * var(--#{$prefix}body-line-height)) !default; // stylelint-disable-line function-disallowed-list
+$header-brand-padding-y:        calc((#{$nav-link-height} - #{$header-brand-height}) * .5) !default; // stylelint-disable-line function-disallowed-list
 $header-brand-margin-end:       1rem !default;
 $header-brand-font-size:        $font-size-lg !default;
 $header-brand-color:            $gray-900 !default;
@@ -242,7 +242,7 @@ $header-tokens: defaults(
 
   .header-toggler-icon {
     display: block;
-    height: $header-toggler-font-size * 1.25;
+    height: calc(#{$header-toggler-font-size} * 1.25); // stylelint-disable-line function-disallowed-list
     background-image: var(--#{$prefix}header-toggler-icon-bg);
     background-repeat: no-repeat;
     background-position: center center;

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -126,7 +126,7 @@ $header-tokens: defaults(
     &.header-sticky {
       position: sticky;
       top: 0;
-      z-index: $zindex-sticky;
+      z-index: var(--#{$prefix}z-sticky);
     }
   }
 

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -12,8 +12,8 @@
 
 // Header
 // scss-docs-start header-variables
-$header-padding-y:              $spacer * .5 !default;
-$header-padding-x:              $spacer * .5 !default;
+$header-padding-y:              var(--#{$prefix}spacer-2) !default;
+$header-padding-x:              var(--#{$prefix}spacer-2) !default;
 $header-brand-font-size:        $font-size-lg !default;
 $header-color:                  color-mix(in srgb, var(--#{$prefix}emphasis-color) 65%, transparent) !default;
 $header-bg:                     var(--#{$prefix}body-bg) !default;

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -9,7 +9,7 @@
     vertical-align: -.125rem; // Fix the position of icon
     fill: currentcolor;
     &:not(.icon-c-s):not(.icon-custom-size) {
-      @include icon-size($icon-size-base);
+      @include icon-size(var(--#{$prefix}icon-size-base));
 
       &.icon-xxl {
         @include icon-size($icon-size-xxl);
@@ -29,7 +29,7 @@
 
       @for $i from 3 through 9 {
         &.icon-#{$i}xl {
-          @include icon-size($i * $icon-size-base);
+          @include icon-size(calc(#{$i} * var(--#{$prefix}icon-size-base)));
         }
       }
     }

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -15,8 +15,8 @@ $list-group-border-color:           var(--#{$prefix}border-color) !default;
 $list-group-border-width:           var(--#{$prefix}border-width) !default;
 $list-group-border-radius:          var(--#{$prefix}border-radius) !default;
 
-$list-group-item-padding-y:         $spacer * .5 !default;
-$list-group-item-padding-x:         $spacer !default;
+$list-group-item-padding-y:         var(--#{$prefix}spacer-2) !default;
+$list-group-item-padding-x:         var(--#{$prefix}spacer-3) !default;
 
 $list-group-hover-bg:               var(--#{$prefix}tertiary-bg) !default;
 $list-group-active-color:           $component-active-color !default;

--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -38,7 +38,7 @@ $menu-item-padding-x:           .75rem !default;
 $menu-item-padding-y:           .25rem !default;
 $menu-item-border-radius:       $border-radius-sm !default;
 $menu-icon-size:                1rem !default;
-$menu-description-font-size:    $font-size-base * .75 !default;
+$menu-description-font-size:    calc(var(--#{$prefix}body-font-size) * .75) !default; // stylelint-disable-line function-disallowed-list
 $menu-check-color:              currentcolor !default;
 $menu-header-color:             var(--#{$prefix}tertiary-color) !default;
 $menu-header-padding-x:         .75rem !default;

--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -11,7 +11,7 @@
 // built around (see js/src/menu.ts).
 
 // scss-docs-start menu-variables
-$menu-zindex:                   $zindex-dropdown !default;
+$menu-zindex:                   var(--#{$prefix}z-dropdown) !default;
 $menu-gap:                      .125rem !default;
 $menu-min-width:                10rem !default;
 $menu-padding-x:                .25rem !default;

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -16,7 +16,7 @@
 // stylelint-disable function-disallowed-list
 
 // scss-docs-start modal-variables
-$modal-inner-padding:               $spacer !default;
+$modal-inner-padding:               var(--#{$prefix}spacer-3) !default;
 
 $modal-footer-margin-between:       .5rem !default;
 

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -65,7 +65,7 @@ $modal-tokens: () !default;
 // scss-docs-start modal-css-vars
 $modal-tokens: defaults(
   (
-    --#{$prefix}modal-zindex: #{$zindex-modal},
+    --#{$prefix}modal-zindex: var(--#{$prefix}z-modal),
     --#{$prefix}modal-width: #{$modal-md},
     --#{$prefix}modal-padding: #{$modal-inner-padding},
     --#{$prefix}modal-margin: #{$modal-dialog-margin},

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -17,7 +17,7 @@
 // stylelint-disable custom-property-no-missing-var-function
 
 // scss-docs-start navbar-variables
-$navbar-padding-y:                  $spacer * .5 !default;
+$navbar-padding-y:                  var(--#{$prefix}spacer-2) !default;
 $navbar-padding-x:                  null !default;
 
 $navbar-nav-link-padding-x:         .5rem !default;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -24,9 +24,9 @@ $navbar-nav-link-padding-x:         .5rem !default;
 
 $navbar-brand-font-size:            $font-size-lg !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
-$nav-link-height:                   $font-size-base * $line-height-base + $nav-link-padding-y * 2 !default;
-$navbar-brand-height:               $navbar-brand-font-size * $line-height-base !default;
-$navbar-brand-padding-y:            ($nav-link-height - $navbar-brand-height) * .5 !default;
+$nav-link-height:                   calc(var(--#{$prefix}body-font-size) * var(--#{$prefix}body-line-height) + #{$nav-link-padding-y} * 2) !default; // stylelint-disable-line function-disallowed-list
+$navbar-brand-height:               calc(#{$navbar-brand-font-size} * var(--#{$prefix}body-line-height)) !default; // stylelint-disable-line function-disallowed-list
+$navbar-brand-padding-y:            calc((#{$nav-link-height} - #{$navbar-brand-height}) * .5) !default; // stylelint-disable-line function-disallowed-list
 $navbar-brand-margin-end:           1rem !default;
 
 $navbar-toggler-padding-y:          .25rem !default;

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -39,7 +39,7 @@ $offcanvas-tokens: () !default;
 // scss-docs-start offcanvas-css-vars
 $offcanvas-tokens: defaults(
   (
-    --#{$prefix}offcanvas-zindex: #{$zindex-offcanvas},
+    --#{$prefix}offcanvas-zindex: var(--#{$prefix}z-offcanvas),
     --#{$prefix}offcanvas-width: #{$offcanvas-horizontal-width},
     --#{$prefix}offcanvas-height: #{$offcanvas-vertical-height},
     --#{$prefix}offcanvas-padding-x: #{$offcanvas-padding-x},

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -42,7 +42,7 @@ $popover-tokens: () !default;
 // scss-docs-start popover-css-vars
 $popover-tokens: defaults(
   (
-    --#{$prefix}popover-zindex: #{$zindex-popover},
+    --#{$prefix}popover-zindex: var(--#{$prefix}z-popover),
     --#{$prefix}popover-max-width: #{$popover-max-width},
     --#{$prefix}popover-bg: #{$popover-bg},
     --#{$prefix}popover-border-width: #{$popover-border-width},

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -19,11 +19,11 @@ $popover-header-font-size:          $font-size-base !default;
 $popover-header-bg:                 var(--#{$prefix}secondary-bg) !default;
 $popover-header-color:              $headings-color !default;
 $popover-header-padding-y:          .5rem !default;
-$popover-header-padding-x:          $spacer !default;
+$popover-header-padding-x:          var(--#{$prefix}spacer-3) !default;
 
 $popover-body-color:                var(--#{$prefix}body-color) !default;
-$popover-body-padding-y:            $spacer !default;
-$popover-body-padding-x:            $spacer !default;
+$popover-body-padding-y:            var(--#{$prefix}spacer-3) !default;
+$popover-body-padding-x:            var(--#{$prefix}spacer-3) !default;
 
 $popover-arrow-width:               1rem !default;
 $popover-arrow-height:              .5rem !default;

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -18,8 +18,8 @@ $progress-bar-animation-timing:     1s linear infinite !default;
 $progress-bar-transition:           width .6s ease !default;
 
 // TODO: clean-up ???
-$progress-group-margin-bottom:         $spacer !default;
-$progress-group-header-margin-bottom:  $spacer * .25 !default;
+$progress-group-margin-bottom:         var(--#{$prefix}spacer-3) !default;
+$progress-group-header-margin-bottom:  var(--#{$prefix}spacer-1) !default;
 // scss-docs-end progress-variables
 
 $progress-tokens: () !default;

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -8,7 +8,7 @@
 
 // scss-docs-start progress-variables
 $progress-height:                   1rem !default;
-$progress-font-size:                $font-size-base * .75 !default;
+$progress-font-size:                calc(var(--#{$prefix}body-font-size) * .75) !default; // stylelint-disable-line function-disallowed-list
 $progress-bg:                       var(--#{$prefix}secondary-bg) !default;
 $progress-border-radius:            var(--#{$prefix}border-radius) !default;
 $progress-box-shadow:               var(--#{$prefix}box-shadow-inset) !default;

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -89,7 +89,7 @@ $range-slider-tokens: defaults(
     --#{$prefix}range-slider-thumb-active-bg: #{$range-slider-thumb-active-bg},
     --#{$prefix}range-slider-thumb-disabled-bg: #{$range-slider-thumb-disabled-bg},
     --#{$prefix}range-slider-thumb-transition: #{$range-slider-thumb-transition},
-    --#{$prefix}range-slider-tooltip-zindex: #{$zindex-tooltip},
+    --#{$prefix}range-slider-tooltip-zindex: var(--#{$prefix}z-tooltip),
     --#{$prefix}range-slider-tooltip-max-width: #{$range-slider-tooltip-max-width},
     --#{$prefix}range-slider-tooltip-padding-y: #{$range-slider-tooltip-padding-y},
     --#{$prefix}range-slider-tooltip-padding-x: #{$range-slider-tooltip-padding-x},

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -1,4 +1,5 @@
 @use "sass:string";
+@use "forms/form-control" as *;
 @use "forms/form-range" as *;
 @use "functions/color" as *;
 @use "functions/defaults" as *;

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -42,8 +42,8 @@ $range-slider-thumb-disabled-bg:           color-mix(in srgb, var(--#{$prefix}se
 $range-slider-thumb-transition:            background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 
 $range-slider-tooltip-max-width:           200px !default;
-$range-slider-tooltip-padding-y:           $spacer * .25 !default;
-$range-slider-tooltip-padding-x:           $spacer * .5 !default;
+$range-slider-tooltip-padding-y:           var(--#{$prefix}spacer-1) !default;
+$range-slider-tooltip-padding-x:           var(--#{$prefix}spacer-2) !default;
 $range-slider-tooltip-margin-end:          .25rem !default;
 $range-slider-tooltip-margin-bottom:       .25rem !default;
 $range-slider-tooltip-font-size:           $font-size-sm !default;

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -1,5 +1,5 @@
 @use "sass:string";
-@use "forms/form-control" as *;
+@use "forms/variables" as *;
 @use "forms/form-range" as *;
 @use "functions/color" as *;
 @use "functions/defaults" as *;

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -157,19 +157,19 @@
     --#{$prefix}btn-input-border-width: #{$input-btn-border-width};
     --#{$prefix}btn-input-transition: #{$input-btn-transition};
     --#{$prefix}btn-input-disabled-opacity: #{$input-btn-disabled-opacity};
-    --#{$prefix}btn-input-color: #{$input-color};
-    --#{$prefix}btn-input-bg: #{$input-bg};
-    --#{$prefix}btn-input-min-height: #{$input-height};
+    --#{$prefix}btn-input-color: var(--#{$prefix}body-color);
+    --#{$prefix}btn-input-bg: var(--#{$prefix}body-bg);
+    --#{$prefix}btn-input-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2); // stylelint-disable-line function-disallowed-list
 
     --#{$prefix}btn-input-sm-padding-y: #{$input-btn-padding-y-sm};
     --#{$prefix}btn-input-sm-padding-x: #{$input-btn-padding-x-sm};
     --#{$prefix}btn-input-sm-font-size: #{$input-btn-font-size-sm};
-    --#{$prefix}btn-input-sm-min-height: #{$input-height-sm};
+    --#{$prefix}btn-input-sm-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-sm-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2); // stylelint-disable-line function-disallowed-list
 
     --#{$prefix}btn-input-lg-padding-y: #{$input-btn-padding-y-lg};
     --#{$prefix}btn-input-lg-padding-x: #{$input-btn-padding-x-lg};
     --#{$prefix}btn-input-lg-font-size: #{$input-btn-font-size-lg};
-    --#{$prefix}btn-input-lg-min-height: #{$input-height-lg};
+    --#{$prefix}btn-input-lg-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-lg-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2); // stylelint-disable-line function-disallowed-list
     // scss-docs-end root-btn-input-variables
 
     // scss-docs-start root-control-variables

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -50,6 +50,15 @@
     }
     --#{$prefix}body-font-family: #{meta.inspect($font-family-base)};
     --#{$prefix}body-font-size: #{$font-size-base};
+    // scss-docs-start root-spacer-loop
+    // One token per stop of the spacing scale, so rescaling the system is a
+    // runtime change rather than a recompile. Components read these instead of
+    // multiplying `$spacer` when the stylesheet is built.
+    @each $key, $value in $spacers {
+      --#{$prefix}spacer-#{$key}: #{$value};
+    }
+    // scss-docs-end root-spacer-loop
+
     // scss-docs-start root-zindex-loop
     // One token per stop of the z-axis, so a page can relayer the library
     // without recompiling — a third-party overlay that must sit above the

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -50,6 +50,15 @@
     }
     --#{$prefix}body-font-family: #{meta.inspect($font-family-base)};
     --#{$prefix}body-font-size: #{$font-size-base};
+    // scss-docs-start root-zindex-loop
+    // One token per stop of the z-axis, so a page can relayer the library
+    // without recompiling — a third-party overlay that must sit above the
+    // modal sets --#{$prefix}z-modal instead of guessing its number.
+    @each $name, $value in $zindex-levels {
+      --#{$prefix}z-#{$name}: #{$value};
+    }
+    // scss-docs-end root-zindex-loop
+
     // scss-docs-start root-font-weight-loop
     @each $name, $value in $font-weights {
       --#{$prefix}font-weight-#{$name}: #{$value};

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -50,6 +50,8 @@
     }
     --#{$prefix}body-font-family: #{meta.inspect($font-family-base)};
     --#{$prefix}body-font-size: #{$font-size-base};
+    --#{$prefix}icon-size-base: #{$icon-size-base};
+
     // scss-docs-start root-spacer-loop
     // One token per stop of the spacing scale, so rescaling the system is a
     // runtime change rather than a recompile. Components read these instead of

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -6,7 +6,7 @@
 @use "forms/form-control-group" as *;
 
 // scss-docs-start time-picker-variables
-$time-picker-body-padding:                  $spacer * .5 !default;
+$time-picker-body-padding:                  var(--#{$prefix}spacer-2) !default;
 
 $time-picker-footer-padding:                .5rem !default;
 $time-picker-footer-border-width:           1px !default;

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -1,4 +1,5 @@
 @use "sass:color";
+@use "forms/form-control" as *;
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/tokens" as *;

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -1,5 +1,5 @@
 @use "sass:color";
-@use "forms/form-control" as *;
+@use "forms/variables" as *;
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/tokens" as *;

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -33,7 +33,7 @@ $toast-tokens: () !default;
 // scss-docs-start toast-css-vars
 $toast-tokens: defaults(
   (
-    --#{$prefix}toast-zindex: #{$zindex-toast},
+    --#{$prefix}toast-zindex: var(--#{$prefix}z-toast),
     --#{$prefix}toast-padding-x: #{$toast-padding-x},
     --#{$prefix}toast-padding-y: #{$toast-padding-y},
     --#{$prefix}toast-spacing: #{$toast-spacing},
@@ -98,7 +98,7 @@ $toast-tokens: defaults(
   }
 
   .toast-container {
-    --#{$prefix}toast-zindex: #{$zindex-toast};
+    --#{$prefix}toast-zindex: var(--#{$prefix}z-toast);
 
     position: absolute;
     z-index: var(--#{$prefix}toast-zindex);

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -12,8 +12,8 @@ $tooltip-color:                     var(--#{$prefix}body-bg) !default;
 $tooltip-bg:                        var(--#{$prefix}emphasis-color) !default;
 $tooltip-border-radius:             var(--#{$prefix}border-radius) !default;
 $tooltip-opacity:                   .9 !default;
-$tooltip-padding-y:                 $spacer * .25 !default;
-$tooltip-padding-x:                 $spacer * .5 !default;
+$tooltip-padding-y:                 var(--#{$prefix}spacer-1) !default;
+$tooltip-padding-x:                 var(--#{$prefix}spacer-2) !default;
 $tooltip-margin:                    null !default; // TODO: remove this in v6
 
 $tooltip-arrow-width:               .8rem !default;

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -27,7 +27,7 @@ $tooltip-tokens: () !default;
 // scss-docs-start tooltip-css-vars
 $tooltip-tokens: defaults(
   (
-    --#{$prefix}tooltip-zindex: #{$zindex-tooltip},
+    --#{$prefix}tooltip-zindex: var(--#{$prefix}z-tooltip),
     --#{$prefix}tooltip-max-width: #{$tooltip-max-width},
     --#{$prefix}tooltip-padding-x: #{$tooltip-padding-x},
     --#{$prefix}tooltip-padding-y: #{$tooltip-padding-y},

--- a/scss/buttons/_search-button.scss
+++ b/scss/buttons/_search-button.scss
@@ -1,3 +1,4 @@
+@use "../forms/form-control" as *;
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;

--- a/scss/buttons/_search-button.scss
+++ b/scss/buttons/_search-button.scss
@@ -1,4 +1,4 @@
-@use "../forms/form-control" as *;
+@use "../forms/variables" as *;
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;

--- a/scss/content/_images.scss
+++ b/scss/content/_images.scss
@@ -52,7 +52,7 @@ $figure-caption-color:              var(--#{$prefix}secondary-color) !default;
   }
 
   .figure-img {
-    margin-bottom: $spacer * .5;
+    margin-bottom: var(--#{$prefix}spacer-2);
     line-height: 1;
   }
 

--- a/scss/content/_tables.scss
+++ b/scss/content/_tables.scss
@@ -96,7 +96,7 @@ $table-variants: map.keys($theme-colors) !default;
     --#{$prefix}table-hover-bg: #{$table-hover-bg};
 
     width: 100%;
-    margin-bottom: $spacer;
+    margin-bottom: var(--#{$prefix}spacer-3);
     vertical-align: $table-cell-vertical-align;
     border-color: var(--#{$prefix}table-border-color);
 

--- a/scss/forms/_chip-input.scss
+++ b/scss/forms/_chip-input.scss
@@ -1,4 +1,4 @@
-@use "../forms/form-control" as *;
+@use "../forms/variables" as *;
 @use "../functions/defaults" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;

--- a/scss/forms/_chip-input.scss
+++ b/scss/forms/_chip-input.scss
@@ -1,3 +1,4 @@
+@use "../forms/form-control" as *;
 @use "../functions/defaults" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -1,3 +1,4 @@
+@use "../forms/form-control" as *;
 @use "../functions/defaults" as *;
 @use "../functions/math" as *;
 @use "../mixins/border-radius" as *;

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -1,4 +1,4 @@
-@use "../forms/form-control" as *;
+@use "../forms/variables" as *;
 @use "../functions/defaults" as *;
 @use "../functions/math" as *;
 @use "../mixins/border-radius" as *;

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -1,4 +1,5 @@
 @use "sass:map";
+@use "../forms/form-control" as *;
 @use "../functions/defaults" as *;
 @use "../functions/escape-svg" as *;
 @use "../mixins/border-radius" as *;

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -1,5 +1,5 @@
 @use "sass:map";
-@use "../forms/form-control" as *;
+@use "../forms/variables" as *;
 @use "../functions/defaults" as *;
 @use "../functions/escape-svg" as *;
 @use "../mixins/border-radius" as *;

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -24,7 +24,7 @@ $form-check-input-checked-color:          $component-active-color !default;
 // What the wrapper owns and what all three controls share: the row, the label,
 // and the focus / active / disabled states.
 // scss-docs-start form-check-variables
-$form-check-min-height:                   $font-size-base * $line-height-base !default;
+$form-check-min-height:                   calc(var(--#{$prefix}body-font-size) * var(--#{$prefix}body-line-height)) !default; // stylelint-disable-line function-disallowed-list
 $form-check-padding-start:                $form-check-input-width + .5em !default;
 $form-check-margin-bottom:                .125rem !default;
 $form-check-inline-margin-end:            1rem !default;

--- a/scss/forms/_form-control-group.scss
+++ b/scss/forms/_form-control-group.scss
@@ -5,6 +5,7 @@
 @use "../mixins/transition" as *;
 @use "../config" as *;
 @use "form-control" as *;
+@use "variables" as *;
 
 // scss-docs-start form-control-group-variables
 $form-control-group-gap:              .5rem !default;

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -1,4 +1,3 @@
-@use "../functions/color" as *;
 @use "sass:math";
 @use "../functions/defaults" as *;
 @use "../functions/escape-svg" as *;
@@ -11,59 +10,7 @@
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
 @use "../config" as *;
-
-// The control contract: every field component draws its frame with these, so
-// they live with `.form-control` rather than in the shared config.
-
-// scss-docs-start form-input-variables
-$input-padding-y:                       $input-btn-padding-y !default;
-$input-padding-x:                       $input-btn-padding-x !default;
-$input-font-family:                     $input-btn-font-family !default;
-$input-font-size:                       $input-btn-font-size !default;
-$input-font-weight:                     $font-weight-base !default;
-$input-line-height:                     $input-btn-line-height !default;
-
-$input-padding-y-sm:                    $input-btn-padding-y-sm !default;
-$input-padding-x-sm:                    $input-btn-padding-x-sm !default;
-$input-font-size-sm:                    $input-btn-font-size-sm !default;
-
-$input-padding-y-lg:                    $input-btn-padding-y-lg !default;
-$input-font-size-lg:                    $input-btn-font-size-lg !default;
-
-$input-bg:                              var(--#{$prefix}body-bg) !default;
-$input-disabled-color:                  var(--#{$prefix}body-color) !default;
-$input-disabled-bg:                     var(--#{$prefix}secondary-bg) !default;
-$input-disabled-border-color:           var(--#{$prefix}border-color) !default;
-
-$input-color:                           var(--#{$prefix}body-color) !default;
-$input-border-color:                    var(--#{$prefix}border-color) !default;
-$input-border-width:                    $input-btn-border-width !default;
-$input-box-shadow:                      var(--#{$prefix}box-shadow-inset) !default;
-
-$input-border-radius:                   var(--#{$prefix}border-radius) !default;
-$input-border-radius-sm:                var(--#{$prefix}border-radius-sm) !default;
-$input-border-radius-lg:                var(--#{$prefix}border-radius-lg) !default;
-
-$input-focus-bg:                        $input-bg !default;
-$input-focus-border-color:              tint-color($primary, 50%) !default;
-$input-focus-color:                     $input-color !default;
-$input-focus-width:                     $input-btn-focus-width !default;
-$input-focus-ring:                      var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
-
-$input-placeholder-color:               var(--#{$prefix}secondary-color) !default;
-$input-plaintext-color:                 var(--#{$prefix}body-color) !default;
-
-$input-height-border:                   calc(#{$input-border-width} * 2) !default; // stylelint-disable-line function-disallowed-list
-
-$input-height-inner:                    calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2) !default; // stylelint-disable-line function-disallowed-list
-$input-height-inner-half:               calc(var(--#{$prefix}btn-input-line-height) * .5em + var(--#{$prefix}btn-input-padding-y)) !default; // stylelint-disable-line function-disallowed-list
-$input-height-inner-quarter:            calc(var(--#{$prefix}btn-input-line-height) * .25em + var(--#{$prefix}btn-input-padding-y) * .5) !default; // stylelint-disable-line function-disallowed-list
-
-
-$input-transition:                      border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
-
-$form-color-width:                      3rem !default;
-// scss-docs-end form-input-variables
+@use "variables" as *;
 
 // scss-docs-start form-file-variables
 $form-file-button-color:          $input-color !default;

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -1,3 +1,4 @@
+@use "../functions/color" as *;
 @use "sass:math";
 @use "../functions/defaults" as *;
 @use "../functions/escape-svg" as *;
@@ -10,6 +11,59 @@
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
 @use "../config" as *;
+
+// The control contract: every field component draws its frame with these, so
+// they live with `.form-control` rather than in the shared config.
+
+// scss-docs-start form-input-variables
+$input-padding-y:                       $input-btn-padding-y !default;
+$input-padding-x:                       $input-btn-padding-x !default;
+$input-font-family:                     $input-btn-font-family !default;
+$input-font-size:                       $input-btn-font-size !default;
+$input-font-weight:                     $font-weight-base !default;
+$input-line-height:                     $input-btn-line-height !default;
+
+$input-padding-y-sm:                    $input-btn-padding-y-sm !default;
+$input-padding-x-sm:                    $input-btn-padding-x-sm !default;
+$input-font-size-sm:                    $input-btn-font-size-sm !default;
+
+$input-padding-y-lg:                    $input-btn-padding-y-lg !default;
+$input-font-size-lg:                    $input-btn-font-size-lg !default;
+
+$input-bg:                              var(--#{$prefix}body-bg) !default;
+$input-disabled-color:                  var(--#{$prefix}body-color) !default;
+$input-disabled-bg:                     var(--#{$prefix}secondary-bg) !default;
+$input-disabled-border-color:           var(--#{$prefix}border-color) !default;
+
+$input-color:                           var(--#{$prefix}body-color) !default;
+$input-border-color:                    var(--#{$prefix}border-color) !default;
+$input-border-width:                    $input-btn-border-width !default;
+$input-box-shadow:                      var(--#{$prefix}box-shadow-inset) !default;
+
+$input-border-radius:                   var(--#{$prefix}border-radius) !default;
+$input-border-radius-sm:                var(--#{$prefix}border-radius-sm) !default;
+$input-border-radius-lg:                var(--#{$prefix}border-radius-lg) !default;
+
+$input-focus-bg:                        $input-bg !default;
+$input-focus-border-color:              tint-color($primary, 50%) !default;
+$input-focus-color:                     $input-color !default;
+$input-focus-width:                     $input-btn-focus-width !default;
+$input-focus-ring:                      var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
+
+$input-placeholder-color:               var(--#{$prefix}secondary-color) !default;
+$input-plaintext-color:                 var(--#{$prefix}body-color) !default;
+
+$input-height-border:                   calc(#{$input-border-width} * 2) !default; // stylelint-disable-line function-disallowed-list
+
+$input-height-inner:                    calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2) !default; // stylelint-disable-line function-disallowed-list
+$input-height-inner-half:               calc(var(--#{$prefix}btn-input-line-height) * .5em + var(--#{$prefix}btn-input-padding-y)) !default; // stylelint-disable-line function-disallowed-list
+$input-height-inner-quarter:            calc(var(--#{$prefix}btn-input-line-height) * .25em + var(--#{$prefix}btn-input-padding-y) * .5) !default; // stylelint-disable-line function-disallowed-list
+
+
+$input-transition:                      border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
+
+$form-color-width:                      3rem !default;
+// scss-docs-end form-input-variables
 
 // scss-docs-start form-file-variables
 $form-file-button-color:          $input-color !default;

--- a/scss/forms/_form-date-time.scss
+++ b/scss/forms/_form-date-time.scss
@@ -1,3 +1,4 @@
+@use "../forms/form-control" as *;
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/focus-ring" as *;

--- a/scss/forms/_form-date-time.scss
+++ b/scss/forms/_form-date-time.scss
@@ -1,4 +1,4 @@
-@use "../forms/form-control" as *;
+@use "../forms/variables" as *;
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/focus-ring" as *;

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -1,3 +1,4 @@
+@use "../forms/form-control" as *;
 @use "../functions/color" as *;
 @use "../functions/math" as *;
 @use "../mixins/border-radius" as *;

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -1,4 +1,4 @@
-@use "../forms/form-control" as *;
+@use "../forms/variables" as *;
 @use "../functions/color" as *;
 @use "../functions/math" as *;
 @use "../mixins/border-radius" as *;

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -1,5 +1,6 @@
 @use "sass:map";
 @use "sass:string";
+@use "../forms/form-control" as *;
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/tokens" as *;

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -1,6 +1,6 @@
 @use "sass:map";
 @use "sass:string";
-@use "../forms/form-control" as *;
+@use "../forms/variables" as *;
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/tokens" as *;

--- a/scss/forms/_labels.scss
+++ b/scss/forms/_labels.scss
@@ -1,4 +1,4 @@
-@use "../forms/form-control" as *;
+@use "../forms/variables" as *;
 @use "../functions/math" as *;
 @use "../config" as *;
 

--- a/scss/forms/_labels.scss
+++ b/scss/forms/_labels.scss
@@ -1,3 +1,4 @@
+@use "../forms/form-control" as *;
 @use "../functions/math" as *;
 @use "../config" as *;
 

--- a/scss/forms/_otp-input.scss
+++ b/scss/forms/_otp-input.scss
@@ -1,5 +1,5 @@
 @use "sass:math";
-@use "../forms/form-control" as *;
+@use "../forms/variables" as *;
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;

--- a/scss/forms/_otp-input.scss
+++ b/scss/forms/_otp-input.scss
@@ -1,4 +1,5 @@
 @use "sass:math";
+@use "../forms/form-control" as *;
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;

--- a/scss/forms/_variables.scss
+++ b/scss/forms/_variables.scss
@@ -1,0 +1,56 @@
+@use "../functions/color" as *;
+@use "../config" as *;
+
+// The control contract: every field component draws its frame with these.
+// A variables-only partial on purpose — pulling it into a module that loads
+// early must not drag a `@layer` block above the `@layer` order declaration.
+
+// scss-docs-start form-input-variables
+$input-padding-y:                       $input-btn-padding-y !default;
+$input-padding-x:                       $input-btn-padding-x !default;
+$input-font-family:                     $input-btn-font-family !default;
+$input-font-size:                       $input-btn-font-size !default;
+$input-font-weight:                     $font-weight-base !default;
+$input-line-height:                     $input-btn-line-height !default;
+
+$input-padding-y-sm:                    $input-btn-padding-y-sm !default;
+$input-padding-x-sm:                    $input-btn-padding-x-sm !default;
+$input-font-size-sm:                    $input-btn-font-size-sm !default;
+
+$input-padding-y-lg:                    $input-btn-padding-y-lg !default;
+$input-font-size-lg:                    $input-btn-font-size-lg !default;
+
+$input-bg:                              var(--#{$prefix}body-bg) !default;
+$input-disabled-color:                  var(--#{$prefix}body-color) !default;
+$input-disabled-bg:                     var(--#{$prefix}secondary-bg) !default;
+$input-disabled-border-color:           var(--#{$prefix}border-color) !default;
+
+$input-color:                           var(--#{$prefix}body-color) !default;
+$input-border-color:                    var(--#{$prefix}border-color) !default;
+$input-border-width:                    $input-btn-border-width !default;
+$input-box-shadow:                      var(--#{$prefix}box-shadow-inset) !default;
+
+$input-border-radius:                   var(--#{$prefix}border-radius) !default;
+$input-border-radius-sm:                var(--#{$prefix}border-radius-sm) !default;
+$input-border-radius-lg:                var(--#{$prefix}border-radius-lg) !default;
+
+$input-focus-bg:                        $input-bg !default;
+$input-focus-border-color:              tint-color($primary, 50%) !default;
+$input-focus-color:                     $input-color !default;
+$input-focus-width:                     $input-btn-focus-width !default;
+$input-focus-ring:                      var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
+
+$input-placeholder-color:               var(--#{$prefix}secondary-color) !default;
+$input-plaintext-color:                 var(--#{$prefix}body-color) !default;
+
+$input-height-border:                   calc(#{$input-border-width} * 2) !default; // stylelint-disable-line function-disallowed-list
+
+$input-height-inner:                    calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2) !default; // stylelint-disable-line function-disallowed-list
+$input-height-inner-half:               calc(var(--#{$prefix}btn-input-line-height) * .5em + var(--#{$prefix}btn-input-padding-y)) !default; // stylelint-disable-line function-disallowed-list
+$input-height-inner-quarter:            calc(var(--#{$prefix}btn-input-line-height) * .25em + var(--#{$prefix}btn-input-padding-y) * .5) !default; // stylelint-disable-line function-disallowed-list
+
+
+$input-transition:                      border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
+
+$form-color-width:                      3rem !default;
+// scss-docs-end form-input-variables

--- a/scss/helpers/_position.scss
+++ b/scss/helpers/_position.scss
@@ -10,7 +10,7 @@
     top: 0;
     right: 0;
     left: 0;
-    z-index: $zindex-fixed;
+    z-index: var(--#{$prefix}z-fixed);
   }
 
   .fixed-bottom {
@@ -18,7 +18,7 @@
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: $zindex-fixed;
+    z-index: var(--#{$prefix}z-fixed);
   }
 
   // Responsive sticky top and bottom
@@ -29,13 +29,13 @@
       .sticky#{$infix}-top {
         position: sticky;
         top: 0;
-        z-index: $zindex-sticky;
+        z-index: var(--#{$prefix}z-sticky);
       }
 
       .sticky#{$infix}-bottom {
         position: sticky;
         bottom: 0;
-        z-index: $zindex-sticky;
+        z-index: var(--#{$prefix}z-sticky);
       }
     }
   }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -1,3 +1,4 @@
+@use "../forms/form-control" as *;
 @use "../functions/defaults" as *;
 @use "../functions/escape-svg" as *;
 @use "../functions/math" as *;

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -1,4 +1,4 @@
-@use "../forms/form-control" as *;
+@use "../forms/variables" as *;
 @use "../functions/defaults" as *;
 @use "../functions/escape-svg" as *;
 @use "../functions/math" as *;

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -16,8 +16,8 @@
 // tooltip's default formulas. The Sass-level derivation from $tooltip-* is
 // gone — the runtime link through var(--#{$prefix}tooltip-*) replaces it.
 // scss-docs-start tooltip-feedback-variables
-$form-feedback-tooltip-padding-y:     $spacer * .25 !default;
-$form-feedback-tooltip-padding-x:     $spacer * .5 !default;
+$form-feedback-tooltip-padding-y:     var(--#{$prefix}spacer-1) !default;
+$form-feedback-tooltip-padding-x:     var(--#{$prefix}spacer-2) !default;
 $form-feedback-tooltip-font-size:     $font-size-sm !default;
 $form-feedback-tooltip-line-height:   null !default;
 $form-feedback-tooltip-opacity:       .9 !default;

--- a/scss/sidebar/_sidebar-nav.scss
+++ b/scss/sidebar/_sidebar-nav.scss
@@ -7,8 +7,8 @@
 // Sidebar navigation
 
 // scss-docs-start sidebar-nav-variables
-$sidebar-nav-padding-y:                       $sidebar-padding-y * .5 !default;
-$sidebar-nav-padding-x:                       $sidebar-padding-x * .5 !default;
+$sidebar-nav-padding-y:                       calc(#{$sidebar-padding-y} * .5) !default; // stylelint-disable-line function-disallowed-list
+$sidebar-nav-padding-x:                       calc(#{$sidebar-padding-x} * .5) !default; // stylelint-disable-line function-disallowed-list
 $sidebar-nav-gap:                             1px !default;
 
 $sidebar-nav-title-padding-y:                 .75rem !default;

--- a/scss/sidebar/_sidebar.scss
+++ b/scss/sidebar/_sidebar.scss
@@ -47,7 +47,7 @@ $sidebar-narrow-unfoldable-box-shadow:     var(--#{$prefix}box-shadow) !default;
 @layer components {
   .sidebar {
     // scss-docs-start sidebar-css-vars
-    --#{$prefix}sidebar-zindex: #{$zindex-sidebar};
+    --#{$prefix}sidebar-zindex: var(--#{$prefix}z-sidebar);
     --#{$prefix}sidebar-width: #{$sidebar-width};
     --#{$prefix}sidebar-bg: #{$sidebar-bg};
     --#{$prefix}sidebar-padding-x: #{$sidebar-padding-x};
@@ -282,7 +282,7 @@ $sidebar-narrow-unfoldable-box-shadow:     var(--#{$prefix}box-shadow) !default;
 
   .sidebar-backdrop {
     // scss-docs-start sidebar-backdrop-css-vars
-    --#{$prefix}backdrop-zindex: #{$zindex-sidebar-backdrop};
+    --#{$prefix}backdrop-zindex: var(--#{$prefix}z-sidebar-backdrop);
     --#{$prefix}backdrop-bg: #{$sidebar-backdrop-bg};
     --#{$prefix}backdrop-opacity: #{$sidebar-backdrop-opacity};
     // scss-docs-end sidebar-backdrop-css-vars

--- a/scss/sidebar/_sidebar.scss
+++ b/scss/sidebar/_sidebar.scss
@@ -28,8 +28,8 @@ $sidebar-widths: (
   lg: 20rem,
   xl: 24rem
 ) !default;
-$sidebar-padding-y:                        $spacer !default;
-$sidebar-padding-x:                        $spacer !default;
+$sidebar-padding-y:                        var(--#{$prefix}spacer-3) !default;
+$sidebar-padding-x:                        var(--#{$prefix}spacer-3) !default;
 $sidebar-color:                            var(--#{$prefix}body-color) !default;
 $sidebar-bg:                               var(--#{$prefix}body-bg) !default;
 $sidebar-transition:                       margin-left .15s, margin-right .15s, box-shadow .075s, transform .15s, width .15s, z-index 0s ease .15s !default;


### PR DESCRIPTION
From the `_root.scss` comparison: their scale maps become token families that **component tokens then read**, which is the half we were missing. Generating the tokens is cheap; what makes them worth anything is the consumption side, so both changes repoint the callers in the same commit.

## The z-axis

Every component wrote its layer as a Sass value, so the stack was fixed at build time. The usual consequence is a third-party overlay that must sit above the modal: today that means finding out the modal is 1055, writing 1056 somewhere, and being wrong the moment we move it.

`:root` carries one token per stop of `$zindex-levels`, and all **twenty** references read them — the ten `--cui-*-zindex` tokens plus the plain `z-index` declarations in the footer, header and position helpers.

Measured: `.fixed-top` goes from `1030` to `3000` under a `--cui-z-fixed` override.

## The spacing scale

Forty-one component variables multiplied `$spacer` at build time, so `--cui-spacer-*` did not exist and rescaling the system meant recompiling.

Measured with `--cui-spacer-3: 2rem`: an alert goes 16px → 32px, a card header 8px/16px → 16px/32px.

**Three derived values needed care.** The card's cap padding and the sidebar nav's two paddings were `$source * .5`, which Sass cannot do once the source is a `var()` — it fails the build, which is how they were found. They became `calc(… * .5)`, so they keep following what they are derived from rather than freezing at half of whatever the source happened to be. The card-header number above proves it: the derived value scaled with its source.

`loading-button` keeps `$spacer * -2` — minus two spacers is not a stop on the scale, so there is no token to point at.

## Budgets

| change | coreui.css | coreui-reboot.css |
| --- | --- | --- |
| z-axis (15 tokens, 20 references) | +0.15 kB | +0.17 kB |
| spacing (6 tokens, 41 references) | +0.13 kB | +0.03 kB |

Five raises, all blocking, measured per commit for the end-of-v6 tightening pass.

## Verification

`css-lint`, `css-test` (62 specs), `css-lint-vars`, `css-test-class-api`, `docs-build`, bundlewatch pass. Defaults unchanged throughout — every measurement above starts from the same value the compiled sheet had before.