### PR TITLE
refactor(Button): read the shared control tokens instead of copying them

### DIFF
--- a/scss/buttons/_button-group.scss
+++ b/scss/buttons/_button-group.scss
@@ -82,8 +82,8 @@
   //
 
   .dropdown-toggle-split {
-    padding-right: $btn-padding-x * .75;
-    padding-left: $btn-padding-x * .75;
+    padding-right: calc(#{$btn-padding-x} * .75); // stylelint-disable-line function-disallowed-list
+    padding-left: calc(#{$btn-padding-x} * .75); // stylelint-disable-line function-disallowed-list
 
     &::after,
     .dropup &::after,
@@ -97,13 +97,13 @@
   }
 
   .btn-sm + .dropdown-toggle-split {
-    padding-right: $btn-padding-x-sm * .75;
-    padding-left: $btn-padding-x-sm * .75;
+    padding-right: calc(#{$btn-padding-x-sm} * .75); // stylelint-disable-line function-disallowed-list
+    padding-left: calc(#{$btn-padding-x-sm} * .75); // stylelint-disable-line function-disallowed-list
   }
 
   .btn-lg + .dropdown-toggle-split {
-    padding-right: $btn-padding-x-lg * .75;
-    padding-left: $btn-padding-x-lg * .75;
+    padding-right: calc(#{$btn-padding-x-lg} * .75); // stylelint-disable-line function-disallowed-list
+    padding-left: calc(#{$btn-padding-x-lg} * .75); // stylelint-disable-line function-disallowed-list
   }
 
 

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -16,22 +16,22 @@
 
 // scss-docs-start btn-variables
 $btn-color:                   var(--#{$prefix}body-color) !default;
-$btn-padding-y:               $input-btn-padding-y !default;
-$btn-padding-x:               $input-btn-padding-x !default;
-$btn-font-family:             $input-btn-font-family !default;
-$btn-font-size:               $input-btn-font-size !default;
-$btn-line-height:             $input-btn-line-height !default;
+$btn-padding-y:               var(--#{$prefix}btn-input-padding-y) !default;
+$btn-padding-x:               var(--#{$prefix}btn-input-padding-x) !default;
+$btn-font-family:             var(--#{$prefix}btn-input-font-family) !default;
+$btn-font-size:               var(--#{$prefix}btn-input-font-size) !default;
+$btn-line-height:             var(--#{$prefix}btn-input-line-height) !default;
 $btn-white-space:             null !default; // Set to `nowrap` to prevent text wrapping
 
-$btn-padding-y-sm:            $input-btn-padding-y-sm !default;
-$btn-padding-x-sm:            $input-btn-padding-x-sm !default;
-$btn-font-size-sm:            $input-btn-font-size-sm !default;
+$btn-padding-y-sm:            var(--#{$prefix}btn-input-sm-padding-y) !default;
+$btn-padding-x-sm:            var(--#{$prefix}btn-input-sm-padding-x) !default;
+$btn-font-size-sm:            var(--#{$prefix}btn-input-sm-font-size) !default;
 
-$btn-padding-y-lg:            $input-btn-padding-y-lg !default;
-$btn-padding-x-lg:            $input-btn-padding-x-lg !default;
-$btn-font-size-lg:            $input-btn-font-size-lg !default;
+$btn-padding-y-lg:            var(--#{$prefix}btn-input-lg-padding-y) !default;
+$btn-padding-x-lg:            var(--#{$prefix}btn-input-lg-padding-x) !default;
+$btn-font-size-lg:            var(--#{$prefix}btn-input-lg-font-size) !default;
 
-$btn-border-width:            $input-btn-border-width !default;
+$btn-border-width:            var(--#{$prefix}btn-input-border-width) !default;
 
 $btn-font-weight:             var(--#{$prefix}font-weight-normal) !default;
 $btn-box-shadow:              inset 0 1px 0 rgba($white, .15), 0 1px 1px rgba($black, .075) !default;
@@ -39,7 +39,7 @@ $btn-focus-width:             $input-btn-focus-width !default;
 // fusv-disable
 $btn-focus-ring:              $input-btn-focus-ring !default;
 // fusv-enable
-$btn-disabled-opacity:        $input-btn-disabled-opacity !default;
+$btn-disabled-opacity:        var(--#{$prefix}btn-input-disabled-opacity) !default;
 $btn-active-box-shadow:       inset 0 3px 5px rgba($black, .125) !default;
 
 $btn-link-color:              var(--#{$prefix}link-color) !default;
@@ -52,7 +52,7 @@ $btn-border-radius:           var(--#{$prefix}border-radius) !default;
 $btn-border-radius-sm:        var(--#{$prefix}border-radius-sm) !default;
 $btn-border-radius-lg:        var(--#{$prefix}border-radius-lg) !default;
 
-$btn-transition:              $input-btn-transition !default;
+$btn-transition:              var(--#{$prefix}btn-input-transition) !default;
 
 // scss-docs-end btn-variables
 


### PR DESCRIPTION
`--cui-btn-input-*` exists for one reason: so a button and a field agree on padding, font size, line height and border width, which is what keeps them the same height side by side in an input group.

Only one side honoured it. The field referenced the tokens:

```scss
--cui-control-padding-y: var(--cui-btn-input-padding-y),
```

The button copied the Sass value when the stylesheet was built:

```scss
--cui-btn-padding-y: #{$btn-padding-y};
```

So half the contract was live and half was frozen — and the half that was frozen is the one the contract exists to keep in step.

## Measured

| | `.form-control-group` | `.btn` | `.btn-sm` | `.btn-lg` |
| --- | --- | --- | --- | --- |
| default | 38px | 38px | 31px | 48px |
| after `--cui-btn-input-padding-y: 1rem`, **before** this PR | 58px | **38px** | 31px | 48px |
| after, **with** this PR | 58px | **58px** | 31px | 48px |

The middle row is the bug: the input group came apart, because the field grew and the button did not. `.btn-sm` and `.btn-lg` correctly stay put — they read their own size tokens.

Fourteen button variables reference the tokens now. `.btn-group`'s split-toggle padding became `calc(… * .75)`, for the same reason it always does: Sass cannot multiply a `var()`, and the build says so rather than failing quietly.

## Verification

Defaults unchanged. `css-lint`, `css-test` (62 specs), `css-lint-vars`, `css-test-class-api`, `docs-build`, the visual suite (35/35) and bundlewatch all pass — no budget raise needed. `@layer` order declaration still first in the compiled sheet.