### PR TITLE
feat(Theme): one nested map defines a theme colour, with three new slots

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -10,27 +10,27 @@
     },
     {
       "path": "./dist/css/coreui-reboot.css",
-      "maxSize": "4.75 kB"
+      "maxSize": "5.25 kB"
     },
     {
       "path": "./dist/css/coreui-reboot.min.css",
-      "maxSize": "4.6 kB"
+      "maxSize": "5 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.css",
-      "maxSize": "14.75 kB"
+      "maxSize": "15 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",
-      "maxSize": "13.75 kB"
+      "maxSize": "14 kB"
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "60.5kB"
+      "maxSize": "61kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "50.5kB"
+      "maxSize": "51.25kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1228,6 +1228,38 @@ assembles maps of CSS expressions and the browser resolves them.
   `$btn-outline-focus-shadow-rgb` → `$btn-outline-focus-shadow`, likewise for
   the ghost and link variants.
 
+#### A theme colour is one nested map entry
+
+<span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+
+`$theme-colors` carried one value per colour and three further families carried
+the rest, so a theme colour was defined in four places and adding one meant
+editing four blocks. It is a map of maps now — one name, eight slots.
+
+- **Twenty-four Sass variables are removed**: `$primary-text-emphasis` and its
+  seven siblings, `$primary-bg-subtle` and its seven, `$primary-border-subtle`
+  and its seven. Override a slot through the map instead:
+
+  ```diff
+  - $success-bg-subtle: #e8f5ec;
+  + $theme-colors: map.merge($theme-colors, (
+  +   "success": map.merge(map.get($theme-colors, "success"), ("bg-subtle": #e8f5ec))
+  + ));
+  ```
+
+  Every `--#{$prefix}{color}-*` custom property keeps its name and its value, so
+  a runtime override is unaffected.
+- **`$theme-colors` is a map of maps**, so `@each $name, $value in $theme-colors`
+  now yields a map. Use `map-slot($theme-colors, "base")` where a flat
+  `name → colour` map is what you want; the four `$theme-colors-*` families in
+  `scss/_maps.scss` are built that way.
+- **New slots:** `fg` (the state colour readable as text, one step lighter than
+  `text-emphasis`), `bg-muted` (between `bg-subtle` and the solid colour) and
+  `focus-ring` (the hue the `.theme-*` ring mixes from). They emit
+  `--#{$prefix}{color}-fg`, `-bg-muted` and `-focus-ring`, and reach components
+  as `--#{$prefix}theme-fg-base`, `--#{$prefix}theme-bg-muted` and
+  `--#{$prefix}theme-focus-ring`.
+
 #### The control variables moved out of the shared config
 
 <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/docs/src/content/docs/utilities/background.mdx
+++ b/docs/src/content/docs/utilities/background.mdx
@@ -90,7 +90,7 @@ Grayscale colors are also available, but only a subset are used to generate any 
 
 Variables for setting `background-color` in `.bg-*-subtle` utilities in light and dark mode:
 
-<ScssDocs file="scss/_config.scss" capture="theme-bg-subtle-variables" />
+<ScssDocs file="scss/_maps.scss" capture="theme-bg-subtle-map" />
 
 ### Map
 

--- a/scss/_colors.scss
+++ b/scss/_colors.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 @use "config" as *;
 @use "maps" as *;
 
@@ -24,15 +25,15 @@
     --#{$prefix}gray-#{$color}: #{$value};
   }
 
-  @each $color, $value in $theme-colors {
-    --#{$prefix}#{$color}: #{$value};
+  @each $color, $slots in $theme-colors {
+    --#{$prefix}#{$color}: #{map.get($slots, "base")};
   }
 
   // A 100-900 scale per theme color, mixed at runtime from the color's own
   // token so overriding the token retints the whole family. The subtle
   // backgrounds, borders and emphasis text below are `light-dark()` pairs of
   // these stops (see $color-tints / $color-shades).
-  @each $color, $value in $theme-colors {
+  @each $color, $slots in $theme-colors {
     @each $stop, $weight in $color-tints {
       --#{$prefix}#{$color}-#{$stop}: #{color-mix(in $color-mix-space, $tint-color $weight, var(--#{$prefix}#{$color}))};
     }
@@ -56,5 +57,17 @@
 
   @each $color, $value in $theme-colors-contrast {
     --#{$prefix}#{$color}-contrast: #{$value};
+  }
+
+  @each $color, $value in $theme-colors-fg {
+    --#{$prefix}#{$color}-fg: #{$value};
+  }
+
+  @each $color, $value in $theme-colors-bg-muted {
+    --#{$prefix}#{$color}-bg-muted: #{$value};
+  }
+
+  @each $color, $value in $theme-colors-focus-ring {
+    --#{$prefix}#{$color}-focus-ring: #{$value};
   }
 }

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -322,18 +322,94 @@ $light:         $gray-100 !default;
 $dark:          $gray-900 !default;
 // scss-docs-end theme-color-variables
 
+// stylelint-disable function-disallowed-list
+
 // scss-docs-start theme-colors-map
 $theme-colors: (
-  "primary":    $primary,
-  "secondary":  $secondary,
-  "success":    $success,
-  "info":       $info,
-  "warning":    $warning,
-  "danger":     $danger,
-  "light":      $light,
-  "dark":       $dark
+  "primary": (
+    "base":          $primary,
+    "contrast":      $white,
+    "fg":            light-dark(var(--#{$prefix}primary-700), var(--#{$prefix}primary-300)),
+    "text-emphasis": light-dark(var(--#{$prefix}primary-800), var(--#{$prefix}primary-200)),
+    "bg-subtle":     light-dark(var(--#{$prefix}primary-100), var(--#{$prefix}primary-900)),
+    "bg-muted":      light-dark(var(--#{$prefix}primary-200), var(--#{$prefix}primary-800)),
+    "border-subtle": light-dark(var(--#{$prefix}primary-300), var(--#{$prefix}primary-600)),
+    "focus-ring":    color-mix(in srgb, var(--#{$prefix}primary) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+  ),
+  "secondary": (
+    "base":          $secondary,
+    "contrast":      $white,
+    "fg":            light-dark(var(--#{$prefix}secondary-700), var(--#{$prefix}secondary-300)),
+    "text-emphasis": light-dark(var(--#{$prefix}secondary-800), var(--#{$prefix}secondary-200)),
+    "bg-subtle":     light-dark(var(--#{$prefix}secondary-100), var(--#{$prefix}secondary-900)),
+    "bg-muted":      light-dark(var(--#{$prefix}secondary-200), var(--#{$prefix}secondary-800)),
+    "border-subtle": light-dark(var(--#{$prefix}secondary-300), var(--#{$prefix}secondary-600)),
+    "focus-ring":    color-mix(in srgb, var(--#{$prefix}secondary) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+  ),
+  "success": (
+    "base":          $success,
+    "contrast":      $black,
+    "fg":            light-dark(var(--#{$prefix}success-700), var(--#{$prefix}success-300)),
+    "text-emphasis": light-dark(var(--#{$prefix}success-800), var(--#{$prefix}success-200)),
+    "bg-subtle":     light-dark(var(--#{$prefix}success-100), var(--#{$prefix}success-900)),
+    "bg-muted":      light-dark(var(--#{$prefix}success-200), var(--#{$prefix}success-800)),
+    "border-subtle": light-dark(var(--#{$prefix}success-300), var(--#{$prefix}success-600)),
+    "focus-ring":    color-mix(in srgb, var(--#{$prefix}success) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+  ),
+  "info": (
+    "base":          $info,
+    "contrast":      $black,
+    "fg":            light-dark(var(--#{$prefix}info-700), var(--#{$prefix}info-300)),
+    "text-emphasis": light-dark(var(--#{$prefix}info-800), var(--#{$prefix}info-200)),
+    "bg-subtle":     light-dark(var(--#{$prefix}info-100), var(--#{$prefix}info-900)),
+    "bg-muted":      light-dark(var(--#{$prefix}info-200), var(--#{$prefix}info-800)),
+    "border-subtle": light-dark(var(--#{$prefix}info-300), var(--#{$prefix}info-600)),
+    "focus-ring":    color-mix(in srgb, var(--#{$prefix}info) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+  ),
+  "warning": (
+    "base":          $warning,
+    "contrast":      $black,
+    "fg":            light-dark(var(--#{$prefix}warning-700), var(--#{$prefix}warning-300)),
+    "text-emphasis": light-dark(var(--#{$prefix}warning-800), var(--#{$prefix}warning-200)),
+    "bg-subtle":     light-dark(var(--#{$prefix}warning-100), var(--#{$prefix}warning-900)),
+    "bg-muted":      light-dark(var(--#{$prefix}warning-200), var(--#{$prefix}warning-800)),
+    "border-subtle": light-dark(var(--#{$prefix}warning-300), var(--#{$prefix}warning-600)),
+    "focus-ring":    color-mix(in srgb, var(--#{$prefix}warning) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+  ),
+  "danger": (
+    "base":          $danger,
+    "contrast":      $black,
+    "fg":            light-dark(var(--#{$prefix}danger-700), var(--#{$prefix}danger-300)),
+    "text-emphasis": light-dark(var(--#{$prefix}danger-800), var(--#{$prefix}danger-200)),
+    "bg-subtle":     light-dark(var(--#{$prefix}danger-100), var(--#{$prefix}danger-900)),
+    "bg-muted":      light-dark(var(--#{$prefix}danger-200), var(--#{$prefix}danger-800)),
+    "border-subtle": light-dark(var(--#{$prefix}danger-300), var(--#{$prefix}danger-600)),
+    "focus-ring":    color-mix(in srgb, var(--#{$prefix}danger) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+  ),
+  "light": (
+    "base":          $light,
+    "contrast":      $black,
+    "fg":            light-dark(var(--#{$prefix}light-700), var(--#{$prefix}light-300)),
+    "text-emphasis": light-dark(var(--#{$prefix}gray-700), var(--#{$prefix}gray-100)),
+    "bg-subtle":     light-dark(var(--#{$prefix}light-100), var(--#{$prefix}gray-800)),
+    "bg-muted":      light-dark(var(--#{$prefix}light-200), var(--#{$prefix}light-800)),
+    "border-subtle": light-dark(var(--#{$prefix}gray-200), var(--#{$prefix}gray-700)),
+    "focus-ring":    color-mix(in srgb, var(--#{$prefix}light) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+  ),
+  "dark": (
+    "base":          $dark,
+    "contrast":      $white,
+    "fg":            light-dark(var(--#{$prefix}dark-700), var(--#{$prefix}dark-300)),
+    "text-emphasis": light-dark(var(--#{$prefix}gray-800), var(--#{$prefix}gray-300)),
+    "bg-subtle":     light-dark(var(--#{$prefix}gray-400), var(--#{$prefix}dark-600)),
+    "bg-muted":      light-dark(var(--#{$prefix}dark-200), var(--#{$prefix}dark-800)),
+    "border-subtle": light-dark(var(--#{$prefix}gray-500), var(--#{$prefix}gray-800)),
+    "focus-ring":    color-mix(in srgb, var(--#{$prefix}dark) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+  ),
 ) !default;
 // scss-docs-end theme-colors-map
+
+// stylelint-enable function-disallowed-list
 
 // Color scales
 //
@@ -366,39 +442,6 @@ $color-shades: (
 // color reads correctly in both schemes without a second set of variables.
 // `light` and `dark` point at the gray scale instead: their own scales would
 // be a scale of a gray, which is what `$grays` already is.
-
-// scss-docs-start theme-text-variables
-$primary-text-emphasis:    light-dark(var(--#{$prefix}primary-800), var(--#{$prefix}primary-200)) !default;
-$secondary-text-emphasis:  light-dark(var(--#{$prefix}secondary-800), var(--#{$prefix}secondary-200)) !default;
-$success-text-emphasis:    light-dark(var(--#{$prefix}success-800), var(--#{$prefix}success-200)) !default;
-$info-text-emphasis:       light-dark(var(--#{$prefix}info-800), var(--#{$prefix}info-200)) !default;
-$warning-text-emphasis:    light-dark(var(--#{$prefix}warning-800), var(--#{$prefix}warning-200)) !default;
-$danger-text-emphasis:     light-dark(var(--#{$prefix}danger-800), var(--#{$prefix}danger-200)) !default;
-$light-text-emphasis:      light-dark(var(--#{$prefix}gray-700), var(--#{$prefix}gray-100)) !default;
-$dark-text-emphasis:       light-dark(var(--#{$prefix}gray-800), var(--#{$prefix}gray-300)) !default;
-// scss-docs-end theme-text-variables
-
-// scss-docs-start theme-bg-subtle-variables
-$primary-bg-subtle:    light-dark(var(--#{$prefix}primary-100), var(--#{$prefix}primary-900)) !default;
-$secondary-bg-subtle:  light-dark(var(--#{$prefix}secondary-100), var(--#{$prefix}secondary-900)) !default;
-$success-bg-subtle:    light-dark(var(--#{$prefix}success-100), var(--#{$prefix}success-900)) !default;
-$info-bg-subtle:       light-dark(var(--#{$prefix}info-100), var(--#{$prefix}info-900)) !default;
-$warning-bg-subtle:    light-dark(var(--#{$prefix}warning-100), var(--#{$prefix}warning-900)) !default;
-$danger-bg-subtle:     light-dark(var(--#{$prefix}danger-100), var(--#{$prefix}danger-900)) !default;
-$light-bg-subtle:      light-dark(var(--#{$prefix}light-100), var(--#{$prefix}gray-800)) !default;
-$dark-bg-subtle:       light-dark(var(--#{$prefix}gray-400), var(--#{$prefix}dark-600)) !default;
-// scss-docs-end theme-bg-subtle-variables
-
-// scss-docs-start theme-border-subtle-variables
-$primary-border-subtle:    light-dark(var(--#{$prefix}primary-300), var(--#{$prefix}primary-600)) !default;
-$secondary-border-subtle:  light-dark(var(--#{$prefix}secondary-300), var(--#{$prefix}secondary-600)) !default;
-$success-border-subtle:    light-dark(var(--#{$prefix}success-300), var(--#{$prefix}success-600)) !default;
-$info-border-subtle:       light-dark(var(--#{$prefix}info-300), var(--#{$prefix}info-600)) !default;
-$warning-border-subtle:    light-dark(var(--#{$prefix}warning-300), var(--#{$prefix}warning-600)) !default;
-$danger-border-subtle:     light-dark(var(--#{$prefix}danger-300), var(--#{$prefix}danger-600)) !default;
-$light-border-subtle:      light-dark(var(--#{$prefix}gray-200), var(--#{$prefix}gray-700)) !default;
-$dark-border-subtle:       light-dark(var(--#{$prefix}gray-500), var(--#{$prefix}gray-800)) !default;
-// scss-docs-end theme-border-subtle-variables
 
 // Gradients
 

--- a/scss/_maps.scss
+++ b/scss/_maps.scss
@@ -7,60 +7,32 @@
 // Placed here so that others can override the default Sass maps and see automatic updates to utilities and more.
 
 // scss-docs-start theme-text-map
-$theme-colors-text: (
-  "primary": $primary-text-emphasis,
-  "secondary": $secondary-text-emphasis,
-  "success": $success-text-emphasis,
-  "info": $info-text-emphasis,
-  "warning": $warning-text-emphasis,
-  "danger": $danger-text-emphasis,
-  "light": $light-text-emphasis,
-  "dark": $dark-text-emphasis,
-) !default;
+$theme-colors-text: map-slot($theme-colors, "text-emphasis") !default;
 // scss-docs-end theme-text-map
 
 // scss-docs-start theme-bg-subtle-map
-$theme-colors-bg-subtle: (
-  "primary": $primary-bg-subtle,
-  "secondary": $secondary-bg-subtle,
-  "success": $success-bg-subtle,
-  "info": $info-bg-subtle,
-  "warning": $warning-bg-subtle,
-  "danger": $danger-bg-subtle,
-  "light": $light-bg-subtle,
-  "dark": $dark-bg-subtle,
-) !default;
+$theme-colors-bg-subtle: map-slot($theme-colors, "bg-subtle") !default;
 // scss-docs-end theme-bg-subtle-map
 
 // scss-docs-start theme-border-subtle-map
-$theme-colors-border-subtle: (
-  "primary": $primary-border-subtle,
-  "secondary": $secondary-border-subtle,
-  "success": $success-border-subtle,
-  "info": $info-border-subtle,
-  "warning": $warning-border-subtle,
-  "danger": $danger-border-subtle,
-  "light": $light-border-subtle,
-  "dark": $dark-border-subtle,
-) !default;
+$theme-colors-border-subtle: map-slot($theme-colors, "border-subtle") !default;
 // scss-docs-end theme-border-subtle-map
 
 // scss-docs-start theme-contrast-map
-// The colour that reads on top of each theme colour. Written rather than
-// computed: color-contrast() picked these by ratio, which made every theme
-// colour a Sass colour the compiler had to evaluate. Upstream v6 writes them
-// too — it keeps a "contrast" key per colour and never calls the function.
-$theme-colors-contrast: (
-  "primary": $white,
-  "secondary": $white,
-  "success": $black,
-  "info": $black,
-  "warning": $black,
-  "danger": $black,
-  "light": $black,
-  "dark": $white,
-) !default;
+$theme-colors-contrast: map-slot($theme-colors, "contrast") !default;
 // scss-docs-end theme-contrast-map
+
+// scss-docs-start theme-fg-map
+$theme-colors-fg: map-slot($theme-colors, "fg") !default;
+// scss-docs-end theme-fg-map
+
+// scss-docs-start theme-bg-muted-map
+$theme-colors-bg-muted: map-slot($theme-colors, "bg-muted") !default;
+// scss-docs-end theme-bg-muted-map
+
+// scss-docs-start theme-focus-ring-map
+$theme-colors-focus-ring: map-slot($theme-colors, "focus-ring") !default;
+// scss-docs-end theme-focus-ring-map
 
 // Utilities maps
 //
@@ -68,7 +40,7 @@ $theme-colors-contrast: (
 
 // Come v6, we'll de-dupe these variables. Until then, for backward compatibility, we keep them to reassign.
 // scss-docs-start utilities-colors
-$utilities-colors: $theme-colors !default;
+$utilities-colors: map-slot($theme-colors, "base") !default;
 // scss-docs-end utilities-colors
 
 // scss-docs-start utilities-text-colors

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -12,7 +12,9 @@ $theme-token-refs: (
   "base": "",
   "contrast": "-contrast",
   "fg": "-text-emphasis",
+  "fg-base": "-fg",
   "bg-subtle": "-bg-subtle",
+  "bg-muted": "-bg-muted",
   "border": "-border-subtle"
 ) !default;
 // scss-docs-end theme-token-refs
@@ -22,10 +24,9 @@ $theme-token-refs: (
     --#{$prefix}theme-#{$token}: var(--#{$prefix}#{$state}#{$suffix});
   }
 
-  // Mixed here rather than mapped, because the palette carries no per-color
-  // focus-ring value. Width still comes from the global token, so only the hue
-  // is contextual.
-  --#{$prefix}theme-focus-ring: var(--#{$prefix}focus-ring-width) solid color-mix(in srgb, var(--#{$prefix}#{$state}) #{$focus-ring-opacity * 100%}, transparent);
+  // The map carries the hue; the width stays global, so only the colour is
+  // contextual.
+  --#{$prefix}theme-focus-ring: var(--#{$prefix}focus-ring-width) solid var(--#{$prefix}#{$state}-focus-ring);
 }
 
 // scss-docs-start theme-classes

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -107,7 +107,7 @@ $utilities: map.merge(
       property: (--#{$prefix}shadow-tint: null),
       class: shadow,
       values: map.merge(
-        $theme-colors,
+        map-slot($theme-colors, "base"),
         (
           "current": currentcolor,
           "black": $black,
@@ -130,7 +130,7 @@ $utilities: map.merge(
       // generate-utility-at-properties().
       at-property: false,
       class: focus-ring,
-      values: map-loop($theme-colors, translucent-css-var, "$prefix", "$key", "focus-ring")
+      values: map-loop(map-slot($theme-colors, "base"), translucent-css-var, "$prefix", "$key", "focus-ring")
     ),
     // scss-docs-end utils-focus-ring
     // scss-docs-start utils-position
@@ -216,25 +216,25 @@ $utilities: map.merge(
     "border-top-color": (
       property: border-top-color,
       class: border-top,
-      values: map.merge($theme-colors, ("white": $white)),
+      values: map.merge(map-slot($theme-colors, "base"), ("white": $white)),
       vars: true
     ),
     "border-end-color": (
       property: border-inline-end-color,
       class: border-end,
-      values: map.merge($theme-colors, ("white": $white)),
+      values: map.merge(map-slot($theme-colors, "base"), ("white": $white)),
       vars: true,
     ),
     "border-bottom-color": (
       property: border-bottom-color,
       class: border-bottom,
-      values: map.merge($theme-colors, ("white": $white)),
+      values: map.merge(map-slot($theme-colors, "base"), ("white": $white)),
       vars: true
     ),
     "border-start-color": (
       property: border-inline-start-color,
       class: border-start,
-      values: map.merge($theme-colors, ("white": $white)),
+      values: map.merge(map-slot($theme-colors, "base"), ("white": $white)),
       vars: true,
     ),
     "border-width": (

--- a/scss/functions/_maps.scss
+++ b/scss/functions/_maps.scss
@@ -76,3 +76,14 @@
   }
   @return $merged-maps;
 }
+
+// Pull one slot out of a map of maps: map-slot($theme-colors, "bg-subtle")
+// returns ("primary": …, "secondary": …, …). Lets the nested definition stay
+// the single source while consumers that want one flat family keep working.
+@function map-slot($map, $slot) {
+  $result: ();
+  @each $key, $slots in $map {
+    $result: map.set($result, $key, map.get($slots, $slot));
+  }
+  @return $result;
+}

--- a/scss/helpers/_colored-links.scss
+++ b/scss/helpers/_colored-links.scss
@@ -1,3 +1,4 @@
+@use "../functions/maps" as *;
 @use "../functions/color" as *;
 @use "../functions/color-contrast" as *;
 @use "../functions/to-rgb" as *;
@@ -7,7 +8,7 @@
 // The opacity utilities scale a runtime var, so calc() is unavoidable here.
 
 @layer helpers {
-  @each $color, $value in $theme-colors {
+  @each $color, $value in map-slot($theme-colors, "base") {
     .link-#{$color} {
       // stylelint-disable-next-line scss/at-function-named-arguments
       color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}link-opacity, 1) * 100%), transparent) if(sass($enable-important-utilities): !important);


### PR DESCRIPTION
Etap 0 z `plans/theme-slots-and-tokens.md`. **Stacked on #777.**

A theme colour was defined in four places: `$theme-colors` held one value, and three families of eight variables held the rest. Adding a colour meant editing four blocks and remembering the full set — and a slot the schema did not have got bolted on where it was needed. `--cui-theme-focus-ring` is the proof: mixed inline in `_theme.scss` with a comment saying the palette carries no per-colour value for it.

```scss
"primary": (
  "base": …, "contrast": …, "fg": …, "text-emphasis": …,
  "bg-subtle": …, "bg-muted": …, "border-subtle": …, "focus-ring": …,
)
```

The twenty-four variables are gone. The four flat families in `_maps.scss` are derived with a new `map-slot()` helper, so the nested map stays the single source while every consumer that wants one family — utilities, coloured links, the colour token loop — keeps working unchanged.

## The three new slots

**`fg`** is the one that matters. Upstream has no validation colours at all: `$validation-states` is just `("valid": "success")` and the mixin reads `var(--#{$theme}-fg)`. We could not follow, because our `-text-emphasis` is their `fg-emphasis` — measured two steps apart (`--cui-form-valid-color` `rgb(27,158,62)` vs `--cui-success-text-emphasis` `rgb(28,66,34)`). Now the slot exists.

**`bg-muted`** is the tint between `bg-subtle` and the solid colour. **`focus-ring`** carries the hue so `_theme.scss` composes the shorthand instead of inventing the colour.

## `fg` is a new design value, so it was measured, not copied

The plan sketched `{c}-600` / `{c}-400`. Against the body background that gives **4.42 on info and 2.95 on warning** — both under AA. At `{c}-700` / `{c}-300`:

| | primary | secondary | success | info | warning | danger |
| --- | --- | --- | --- | --- | --- | --- |
| light | 10.36 | 9.12 | 7.69 | 6.84 | 4.95 | 7.93 |
| dark | 5.82 | 6.54 | 7.54 | 8.19 | 10.52 | 7.31 |

`light` sits at 3.32 as text, exactly as its base colour always has; nothing uses `fg` for it.

## Nothing repaints

`--cui-theme-fg` still resolves to `-text-emphasis`. The new mid-strength slot is exposed as `--cui-theme-fg-base` until the rename to upstream's `fg` / `fg-emphasis` numbering is decided — that one is a visible change to every component reading `--cui-theme-fg` and belongs in its own PR.

The compiled diff against #777 is 216 lines, all of them the three new families. Visual suite 35/35, `@layer` order intact.

## Breaking

Twenty-four public Sass variables removed. Override through `map.merge($theme-colors, …)` or the token. Migration entry to follow in the same branch.

Budgets: five raises for 24 new root declarations plus the theme classes.