### PR TITLE
chore(deps): bump @coreui/astro-docs to 0.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@astrojs/mdx": "^7.0.4",
         "@babel/core": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
-        "@coreui/astro-docs": "0.1.6",
+        "@coreui/astro-docs": "^0.1.7",
         "@eslint/markdown": "^7.5.1",
         "@popperjs/core": "^2.11.8",
         "@rollup/plugin-babel": "^7.1.0",
@@ -2187,9 +2187,9 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.6.tgz",
-      "integrity": "sha512-i4WUUybfTMTs5hiQDqqsKz9HarP8big2uheq77UxLInJx18eLoXPLcpPnGOCMP5HT55bzos3B/5e6vezSsa1dg==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.7.tgz",
+      "integrity": "sha512-Cp/auWb7/915Y2JGU9a65yHIP4NZYiPCypwKMDPRKWFE5KPJqZXn6Y089XrVLFsAIJU3n6biZaJWBHfONc9krg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@astrojs/mdx": "^7.0.4",
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
-    "@coreui/astro-docs": "0.1.6",
+    "@coreui/astro-docs": "^0.1.7",
     "@eslint/markdown": "^7.5.1",
     "@popperjs/core": "^2.11.8",
     "@rollup/plugin-babel": "^7.1.0",


### PR DESCRIPTION
Picks up two things from coreui/astro-docs#72:

- **The docs button focus ring reaches v6.** The engine set `--cui-btn-focus-shadow-rgb`, which v5 reads and v6 does not emit — both spellings are set now, so this build is unaffected and the v6 one is fixed.
- The engine no longer imports the library's pre-computed colour scale (`$blue-100` … `$cyan-900`), and its chrome mixes colours instead of carrying `-rgb` channels.

Docs site builds: 133 pages, no broken links. Lockfile reconciled and proved with a clean `npm ci`.