### PR TITLE
refactor(scss): theme classes in the helpers layer; chip and list-group read the slots

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "61.25kB"
+      "maxSize": "61.5kB"
     },
     {
       "path": "./dist/css/coreui.min.css",

--- a/docs/src/content/docs/customize/color-modes.mdx
+++ b/docs/src/content/docs/customize/color-modes.mdx
@@ -230,83 +230,31 @@ Here's a look at the JavaScript that powers it. Feel free to inspect our own doc
 
 ## Adding theme colors
 
-Adding a new color in `$theme-colors` is not enough for some of our components like [alerts](/components/alerts/) and [list groups](/components/list-group/). New colors must also be defined in `$theme-colors-text`, `$theme-colors-bg-subtle`, and `$theme-colors-border-subtle` for light theme; but also in `$theme-colors-text-dark`, `$theme-colors-bg-subtle-dark`, and `$theme-colors-border-subtle-dark` for dark theme.
-
-This is a manual process because Sass cannot generate its own Sass variables from an existing variable or map. In future versions of Bootstrap, we'll revisit this setup to reduce the duplication.
+A theme color is one entry in the `$theme-colors` map — a map of slots covering both color modes, described on [the Theme page](/customize/theme/). Merge your entry and the library generates everything else: the `--cui-custom-color-*` tokens, the 100–900 runtime scale the slots read, and the `.theme-custom-color` class.
 
 <Callout color="info"><Fragment set:html={`<p> <strong>Heads up!</strong> Since <code>@coreui/coreui</code> v5.3.0 and <code>@coreui/coreui-pro</code> v5.10.0, we support Sass modules. </p> <p> You can now use the modern <code>@use</code> and <code>@forward</code> rules instead of <code>@import</code>, which is deprecated and will be removed in Dart Sass 3.0.0. Using <code>@import</code> will result in a compilation warning. You can learn more about this transition <a href="https://sass-lang.com/documentation/breaking-changes/import/" target="_blank">here</a>. </p>`} /></Callout>
 
 ```scss
-// Required
 @use "sass:map";
-@use "variables" as *;
-@use "maps" as *;
+@use "@coreui/coreui/scss/theme" as *;
 
-// Add a custom color to $theme-colors
-$custom-colors: (
-  "custom-color": #712cf9
-);
-$theme-colors: map.merge($theme-colors, $custom-colors);
-// Add a custom color to new theme maps
+$theme-colors: map.merge($theme-colors, (
+  "custom-color": (
+    "base":          #712cf9,
+    "contrast":      #fff,
+    "fg":            light-dark(var(--cui-custom-color-600), var(--cui-custom-color-400)),
+    "text-emphasis": light-dark(var(--cui-custom-color-800), var(--cui-custom-color-200)),
+    "bg-subtle":     light-dark(var(--cui-custom-color-100), var(--cui-custom-color-900)),
+    "bg-muted":      light-dark(var(--cui-custom-color-200), var(--cui-custom-color-800)),
+    "border-subtle": light-dark(var(--cui-custom-color-300), var(--cui-custom-color-600)),
+    "focus-ring":    color-mix(in srgb, var(--cui-custom-color) calc(var(--cui-focus-ring-opacity) * 100%), transparent),
+  ),
+));
 
-// Light mode
-$custom-colors-text: ("custom-color": #712cf9);
-$custom-colors-bg-subtle: ("custom-color": #e1d2fe);
-$custom-colors-border-subtle: ("custom-color": #bfa1fc);
-
-$theme-colors-text: map.merge($theme-colors-text, $custom-colors-text);
-$theme-colors-bg-subtle: map.merge($theme-colors-bg-subtle, $custom-colors-bg-subtle);
-$theme-colors-border-subtle: map.merge($theme-colors-border-subtle, $custom-colors-border-subtle);
-
-// Dark mode
-$custom-colors-text-dark: ("custom-color": #e1d2f2);
-$custom-colors-bg-subtle-dark: ("custom-color": #8951fa);
-$custom-colors-border-subtle-dark: ("custom-color": #e1d2f2);
-
-$theme-colors-text-dark: map.merge($theme-colors-text-dark, $custom-colors-text-dark);
-$theme-colors-bg-subtle-dark: map.merge($theme-colors-bg-subtle-dark, $custom-colors-bg-subtle-dark);
-$theme-colors-border-subtle-dark: map.merge($theme-colors-border-subtle-dark, $custom-colors-border-subtle-dark);
-
-// Import CoreUI
-@use "coreui";
-
+@use "@coreui/coreui/scss/coreui";
 ```
 
-<Callout color="warning"><Fragment set:html={`<p> <strong>Sass <code>@import</code> are deprecated and will be removed in Dart Sass 3.0.0.!</strong> </p> <p>You can also use <code>@import</code> rules, but please be aware that they are deprecated and will be removed in Dart Sass 3.0.0, resulting in a compilation warning. You can learn more about this deprecation <a href="https://sass-lang.com/documentation/breaking-changes/import/" target="_blank">here</a>.</p>`} /></Callout>
-
-```scss
-// Required
-@import "functions";
-@import "variables";
-
-// Add a custom color to $theme-colors
-$custom-colors: (
-  "custom-color": #712cf9
-);
-$theme-colors: map-merge($theme-colors, $custom-colors);
-
-@import "maps";
-@import "mixins";
-@import "utilities";
-
-// Add a custom color to new theme maps
-
-// The new color gets a --cui-custom-color-100...900 scale in :root, so its
-// emphasis text, subtle background and border can be light-dark() pairs of
-// those stops — one declaration each, covering both color modes.
-$custom-colors-text: ("custom-color": light-dark(var(--cui-custom-color-800), var(--cui-custom-color-200)));
-$custom-colors-bg-subtle: ("custom-color": light-dark(var(--cui-custom-color-100), var(--cui-custom-color-900)));
-$custom-colors-border-subtle: ("custom-color": light-dark(var(--cui-custom-color-300), var(--cui-custom-color-600)));
-
-$theme-colors-text: map-merge($theme-colors-text, $custom-colors-text);
-$theme-colors-bg-subtle: map-merge($theme-colors-bg-subtle, $custom-colors-bg-subtle);
-$theme-colors-border-subtle: map-merge($theme-colors-border-subtle, $custom-colors-border-subtle);
-
-// Remainder of CoreUI for Bootstrap imports
-@import "root";
-@import "reboot";
-// etc
-```
+The slots are `light-dark()` pairs of the runtime scale, so both color modes are covered by the one entry — there is no second, dark set of maps to fill in.
 
 ## Customizing
 

--- a/docs/src/content/docs/customize/theme.mdx
+++ b/docs/src/content/docs/customize/theme.mdx
@@ -1,0 +1,105 @@
+---
+title: "Theme"
+description: "The theme is a set of semantically named colors, each carrying a full family of slots, used to style components, utilities, and more. It is configurable via Sass or CSS and responds to color modes."
+---
+
+## How it works
+
+Theme colors are defined in the `$theme-colors` map in `scss/_theme.scss`. Each entry is a **map of slots** — one semantic name carries the solid color, its contrast color, the readable foregrounds, the subtle and muted backgrounds, the border, and the focus ring, for both light and dark mode via `light-dark()`.
+
+From this one map the library generates:
+
+- a `--cui-{color}-{slot}` custom property per slot on `:root`,
+- a 100–900 runtime scale per color (`--cui-primary-100` … `--cui-primary-900`), mixed in the browser from the color's own token,
+- a [`.theme-{color}` class](#theme-classes) per entry,
+- the color variants of themeable components and the `.text-*`, `.bg-*`, and `.border-*` utilities.
+
+## Theme colors
+
+| Theme color | Default value | Description |
+| --- | --- | --- |
+| `primary` | `#5856d6` | Main brand color for primary actions |
+| `secondary` | `#6b7785` | Less prominent actions and states |
+| `success` | `#1b9e3e` | Positive actions and successful states |
+| `info` | `#39f` | Informational messages and neutral states |
+| `warning` | `#f9b115` | Cautionary messages and states |
+| `danger` | `#e55353` | Destructive actions and error states |
+| `light` | `$gray-100` | Light surfaces and low-emphasis elements |
+| `dark` | `$gray-900` | Dark surfaces and high-contrast elements |
+
+Each base value is a standalone Sass variable (`$primary`, `$danger`, …) feeding the `base` slot of its entry, so overriding the one variable retints the whole family.
+
+## Color slots
+
+Every entry defines the same slots, emitted as `--cui-{color}-{slot}` on `:root`:
+
+| Slot | Emitted token | Description |
+| --- | --- | --- |
+| `base` | `--cui-primary` | The color itself, e.g. a solid button background |
+| `contrast` | `--cui-primary-contrast` | Text and icons sitting on the solid base |
+| `fg` | `--cui-primary-fg` | The color readable as text, one step lighter than the emphasis |
+| `text-emphasis` | `--cui-primary-text-emphasis` | High-contrast foreground text |
+| `bg-subtle` | `--cui-primary-bg-subtle` | Subtle background tint for low-emphasis surfaces |
+| `bg-muted` | `--cui-primary-bg-muted` | Muted background, between subtle and solid |
+| `border-subtle` | `--cui-primary-border-subtle` | Border color |
+| `focus-ring` | `--cui-primary-focus-ring` | The hue the color's focus ring mixes from |
+
+The slot values are `light-dark()` pairs of stops from the runtime scale, so a theme color reads correctly in both color modes without a second set of definitions:
+
+<ScssDocs file="scss/_theme.scss" capture="theme-colors-map" />
+
+## The runtime scale
+
+Every theme color gets a 100–900 scale of `color-mix()` tokens, mixed at runtime from the color's own token. Override `--cui-primary` (or `$primary`) and the whole family — subtle backgrounds, borders, emphasis text — follows, in both color schemes:
+
+<ScssDocs file="scss/_theme.scss" capture="color-scale-variables" />
+
+```css
+:root {
+  --cui-primary: #6f42c1; /* the scale, the slots and every component follow */
+}
+```
+
+## Theme classes
+
+A `.theme-{color}` class is generated for every key of `$theme-colors`. It sets the generic `--cui-theme-*` tokens that themeable components read — see [the theme variants section](/customize/components/#theme-variants) for the token table and how components consume them.
+
+<ScssDocs file="scss/_theme.scss" capture="theme-classes" />
+
+Because the tokens are ordinary custom properties, they inherit: put a `.theme-*` class on a container and every themeable component inside follows it. Components read the slots only as defaults of their own tokens, so an explicit component token override still wins over the region's theme.
+
+<Example html={[`<div class="theme-primary d-flex gap-2 align-items-center">`, `    <span class="badge">Regional</span>`, `    <span class="badge theme-danger">Local override</span>`, `  </div>`]} />
+
+## Adding a theme color
+
+A new theme color is one entry in the map. Point the slots at the runtime scale and the library generates the tokens, the scale, and the `.theme-*` class for it:
+
+```scss
+@use "sass:map";
+@use "@coreui/coreui/scss/theme" as *;
+
+$theme-colors: map.merge($theme-colors, (
+  "brand": (
+    "base":          #6f42c1,
+    "contrast":      #fff,
+    "fg":            light-dark(var(--cui-brand-600), var(--cui-brand-400)),
+    "text-emphasis": light-dark(var(--cui-brand-800), var(--cui-brand-200)),
+    "bg-subtle":     light-dark(var(--cui-brand-100), var(--cui-brand-900)),
+    "bg-muted":      light-dark(var(--cui-brand-200), var(--cui-brand-800)),
+    "border-subtle": light-dark(var(--cui-brand-300), var(--cui-brand-600)),
+    "focus-ring":    color-mix(in srgb, var(--cui-brand) calc(var(--cui-focus-ring-opacity) * 100%), transparent),
+  ),
+));
+
+@use "@coreui/coreui/scss/coreui";
+```
+
+For a runtime-only brand — no Sass compilation — set the generic tokens on a container instead, as shown in [the theme variants section](/customize/components/#theme-variants).
+
+## Customizing
+
+### SASS variables
+
+<ScssDocs file="scss/_theme.scss" capture="theme-color-variables" />
+
+<ScssDocs file="scss/_theme.scss" capture="theme-token-refs" />

--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -2,7 +2,6 @@
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/chip" as *;
-@use "mixins/focus-ring" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
 @use "theme" as *;
@@ -75,16 +74,17 @@ $chip-tokens: defaults(
     --#{$prefix}chip-remove-opacity: #{$chip-remove-opacity},
     --#{$prefix}chip-remove-hover-opacity: #{$chip-remove-hover-opacity},
     --#{$prefix}chip-transition: #{$chip-transition},
-    --#{$prefix}chip-color: var(--#{$prefix}text-emphasis, #{$chip-color}),
-    --#{$prefix}chip-bg: var(--#{$prefix}bg-subtle, #{$chip-bg}),
+    --#{$prefix}chip-color: var(--#{$prefix}theme-fg, #{$chip-color}),
+    --#{$prefix}chip-bg: var(--#{$prefix}theme-bg-subtle, #{$chip-bg}),
     --#{$prefix}chip-border-width: #{$chip-border-width},
     --#{$prefix}chip-border-color: #{$chip-border-color},
-    --#{$prefix}chip-active-color: var(--#{$prefix}contrast, #{$chip-active-color}),
-    --#{$prefix}chip-active-bg: var(--#{$prefix}color, #{$chip-active-bg}),
+    --#{$prefix}chip-active-color: var(--#{$prefix}theme-contrast, #{$chip-active-color}),
+    --#{$prefix}chip-active-bg: var(--#{$prefix}theme-base, #{$chip-active-bg}),
     --#{$prefix}chip-active-border-color: #{$chip-active-border-color},
-    --#{$prefix}chip-hover-color: var(--#{$prefix}contrast, #{$chip-hover-color}),
-    --#{$prefix}chip-hover-bg: var(--#{$prefix}color, #{$chip-hover-bg}),
+    --#{$prefix}chip-hover-color: var(--#{$prefix}theme-contrast, #{$chip-hover-color}),
+    --#{$prefix}chip-hover-bg: var(--#{$prefix}theme-base, #{$chip-hover-bg}),
     --#{$prefix}chip-hover-border-color: #{$chip-hover-border-color},
+    --#{$prefix}chip-focus-ring: var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)),
   ),
   $chip-tokens
 );
@@ -99,14 +99,14 @@ $chip-outline-tokens: () !default;
 // scss-docs-start chip-outline-css-vars
 $chip-outline-tokens: defaults(
   (
-    --#{$prefix}chip-color: var(--#{$prefix}color, var(--#{$prefix}body-color)),
+    --#{$prefix}chip-color: var(--#{$prefix}theme-base, var(--#{$prefix}body-color)),
     --#{$prefix}chip-bg: transparent,
-    --#{$prefix}chip-border-color: var(--#{$prefix}color, var(--#{$prefix}border-color)),
-    --#{$prefix}chip-hover-bg: var(--#{$prefix}bg-subtle, #{$chip-hover-bg}),
-    --#{$prefix}chip-hover-color: var(--#{$prefix}text-emphasis, #{$chip-color}),
-    --#{$prefix}chip-hover-border-color: var(--#{$prefix}color, var(--#{$prefix}border-color)),
-    --#{$prefix}chip-active-bg: var(--#{$prefix}color, #{$chip-active-bg}),
-    --#{$prefix}chip-active-color: var(--#{$prefix}contrast, #{$chip-active-color}),
+    --#{$prefix}chip-border-color: var(--#{$prefix}theme-base, var(--#{$prefix}border-color)),
+    --#{$prefix}chip-hover-bg: var(--#{$prefix}theme-bg-subtle, #{$chip-hover-bg}),
+    --#{$prefix}chip-hover-color: var(--#{$prefix}theme-fg, #{$chip-color}),
+    --#{$prefix}chip-hover-border-color: var(--#{$prefix}theme-base, var(--#{$prefix}border-color)),
+    --#{$prefix}chip-active-bg: var(--#{$prefix}theme-base, #{$chip-active-bg}),
+    --#{$prefix}chip-active-color: var(--#{$prefix}theme-contrast, #{$chip-active-color}),
   ),
   $chip-outline-tokens
 );
@@ -146,7 +146,7 @@ $chip-outline-tokens: defaults(
     }
 
     &:focus-visible {
-      @include focus-ring();
+      outline: var(--#{$prefix}chip-focus-ring);
     }
 
     .avatar {
@@ -246,8 +246,8 @@ $chip-outline-tokens: defaults(
     }
 
     &:focus-visible {
+      outline: var(--#{$prefix}chip-focus-ring);
       opacity: 1;
-      @include focus-ring();
     }
 
     > svg {
@@ -288,13 +288,11 @@ $chip-outline-tokens: defaults(
   }
 
   // scss-docs-start chip-modifiers
+  // The variant sets the theme tokens and lets the base .chip tokens read
+  // them, the way the alert and table variants do.
   @each $state in map.keys($theme-colors) {
     .chip-#{$state} {
-      --#{$prefix}bg-subtle: var(--#{$prefix}#{$state}-bg-subtle);
-      --#{$prefix}color: var(--#{$prefix}#{$state});
-      --#{$prefix}contrast: var(--#{$prefix}#{$state}-contrast);
-      --#{$prefix}text-emphasis: var(--#{$prefix}#{$state}-text-emphasis);
-      --#{$prefix}focus-ring-color: color-mix(in srgb, var(--#{$prefix}#{$state}) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent);
+      @include theme-tokens($state);
     }
   }
   // scss-docs-end chip-modifiers

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -41,23 +41,23 @@ $list-group-tokens: () !default;
 // scss-docs-start list-group-css-vars
 $list-group-tokens: defaults(
   (
-    --#{$prefix}list-group-color: #{$list-group-color},
-    --#{$prefix}list-group-bg: #{$list-group-bg},
-    --#{$prefix}list-group-border-color: #{$list-group-border-color},
+    --#{$prefix}list-group-color: var(--#{$prefix}theme-fg, #{$list-group-color}),
+    --#{$prefix}list-group-bg: var(--#{$prefix}theme-bg-subtle, #{$list-group-bg}),
+    --#{$prefix}list-group-border-color: var(--#{$prefix}theme-border, #{$list-group-border-color}),
     --#{$prefix}list-group-border-width: #{$list-group-border-width},
     --#{$prefix}list-group-border-radius: #{$list-group-border-radius},
     --#{$prefix}list-group-item-padding-x: #{$list-group-item-padding-x},
     --#{$prefix}list-group-item-padding-y: #{$list-group-item-padding-y},
     --#{$prefix}list-group-action-color: #{$list-group-action-color},
     --#{$prefix}list-group-action-hover-color: #{$list-group-action-hover-color},
-    --#{$prefix}list-group-action-hover-bg: #{$list-group-hover-bg},
+    --#{$prefix}list-group-action-hover-bg: var(--#{$prefix}theme-border, #{$list-group-hover-bg}),
     --#{$prefix}list-group-action-active-color: #{$list-group-action-active-color},
-    --#{$prefix}list-group-action-active-bg: #{$list-group-action-active-bg},
+    --#{$prefix}list-group-action-active-bg: var(--#{$prefix}theme-border, #{$list-group-action-active-bg}),
     --#{$prefix}list-group-disabled-color: #{$list-group-disabled-color},
     --#{$prefix}list-group-disabled-bg: #{$list-group-disabled-bg},
-    --#{$prefix}list-group-active-color: #{$list-group-active-color},
-    --#{$prefix}list-group-active-bg: #{$list-group-active-bg},
-    --#{$prefix}list-group-active-border-color: #{$list-group-active-border-color},
+    --#{$prefix}list-group-active-color: var(--#{$prefix}theme-bg-subtle, #{$list-group-active-color}),
+    --#{$prefix}list-group-active-bg: var(--#{$prefix}theme-fg, #{$list-group-active-bg}),
+    --#{$prefix}list-group-active-border-color: var(--#{$prefix}theme-fg, #{$list-group-active-border-color}),
   ),
   $list-group-tokens
 );
@@ -231,18 +231,23 @@ $list-group-tokens: defaults(
   // Add modifier classes to change text and background color on individual items.
   // Organizationally, this must come after the `:hover` states.
 
+  // The variant sets the theme tokens, then maps them again on the item: the
+  // base tokens resolve their var() references on .list-group, so slots set on
+  // a single item are invisible to them.
   @each $state in map.keys($theme-colors) {
     .list-group-item-#{$state} {
-      --#{$prefix}list-group-color: var(--#{$prefix}#{$state}-text-emphasis);
-      --#{$prefix}list-group-bg: var(--#{$prefix}#{$state}-bg-subtle);
-      --#{$prefix}list-group-border-color: var(--#{$prefix}#{$state}-border-subtle);
+      @include theme-tokens($state);
+
+      --#{$prefix}list-group-color: var(--#{$prefix}theme-fg);
+      --#{$prefix}list-group-bg: var(--#{$prefix}theme-bg-subtle);
+      --#{$prefix}list-group-border-color: var(--#{$prefix}theme-border);
       --#{$prefix}list-group-action-hover-color: var(--#{$prefix}emphasis-color);
-      --#{$prefix}list-group-action-hover-bg: var(--#{$prefix}#{$state}-border-subtle);
+      --#{$prefix}list-group-action-hover-bg: var(--#{$prefix}theme-border);
       --#{$prefix}list-group-action-active-color: var(--#{$prefix}emphasis-color);
-      --#{$prefix}list-group-action-active-bg: var(--#{$prefix}#{$state}-border-subtle);
-      --#{$prefix}list-group-active-color: var(--#{$prefix}#{$state}-bg-subtle);
-      --#{$prefix}list-group-active-bg: var(--#{$prefix}#{$state}-text-emphasis);
-      --#{$prefix}list-group-active-border-color: var(--#{$prefix}#{$state}-text-emphasis);
+      --#{$prefix}list-group-action-active-bg: var(--#{$prefix}theme-border);
+      --#{$prefix}list-group-active-color: var(--#{$prefix}theme-bg-subtle);
+      --#{$prefix}list-group-active-bg: var(--#{$prefix}theme-fg);
+      --#{$prefix}list-group-active-border-color: var(--#{$prefix}theme-fg);
     }
   }
   // scss-docs-end list-group-modifiers

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -293,6 +293,4 @@ $code-color: light-dark($pink, tint-color($pink, 40%)) !default;
       // scss-docs-end root-dark-mode-vars
     }
   }
-
-  @include generate-theme-classes();
 }

--- a/scss/helpers/_theme-colors.scss
+++ b/scss/helpers/_theme-colors.scss
@@ -1,0 +1,5 @@
+@use "../theme" as *;
+
+@layer helpers {
+  @include generate-theme-classes();
+}

--- a/scss/helpers/index.scss
+++ b/scss/helpers/index.scss
@@ -7,6 +7,7 @@
 @forward "ratio";
 @forward "position";
 @forward "stacks";
+@forward "theme-colors";
 @forward "visually-hidden";
 @forward "stretched-link";
 @forward "text-truncation";


### PR DESCRIPTION
Executes the settled direction for the theme system — the upstream pattern with our corrections:

- **`.theme-*` emits from `helpers/_theme-colors.scss` in `@layer helpers`** instead of `@layer root`. The modifier the user adds now wins against component-declared slots, while utilities and unlayered app CSS still win against it. Measured before moving: no component declares a `--cui-theme-*` property today, so the compiled declarations are identical — only the layer moves.
- **Chip and list-group read the theme slots** (the commit held on `refactor/theme-slot-variants-v6` since 2026-08-17, unblocked by the inheritance decision): list-group variants set the theme tokens and map them on the item; chip drops its parallel bare-named slot set (`--cui-color`, `--cui-contrast`) for `--cui-theme-*`, which also fixes the per-colour focus-ring tint that never worked. `.chip-danger` and `.list-group-item-danger` now emit exactly `theme-tokens($state)` — the per-component spelling ≡ `.theme-danger`.
- **`customize/theme` is a new docs page**: the nested `$theme-colors` map, the slot set and its emitted tokens, the 100–900 runtime scale, the generated `.theme-*` classes with region inheritance, and adding a colour as one map entry. `customize/color-modes` drops the pre-`light-dark()` instructions — the `$theme-colors-*-dark` maps it told users to fill no longer exist, and the flat merge it showed doesn't compile against the nested map.
- **`coreui.css` budget raised 61.25 → 61.5 kB** after the pre-push hook blocked: the slot-based variants cost ~50 B gzip on the expanded sheet (the minified sheet still fits); the end-of-v6 size pass reclaims it.

Slot inheritance stays the platform default (custom properties inherit): a `.theme-*` class on a container themes the region, and an explicit component-token override still wins because components read slots only in the defaults of their own tokens. A `.theme-none` opt-out is planned separately.

Verification: theme classes byte-compared before/after the layer move (8 classes, identical declarations, `root` → `helpers`), stylelint clean, css-test 62/62, class-API guard green, docs build 147 pages with the links checker green.