### PR TITLE
feat(RangeSlider, Range): themeable sliders; dark-correct pressed thumb

### DIFF
--- a/docs/src/content/docs/forms/range-slider.mdx
+++ b/docs/src/content/docs/forms/range-slider.mdx
@@ -7,6 +7,8 @@ otherFrameworks:
   - range-slider
 ---
 
+import { getData } from '@coreui/astro-docs/data'
+
 import rangeSliderCustomLabels from './snippets/range-slider-custom-labels.js?raw'
 import rangeSliderCustomTooltips from './snippets/range-slider-custom-tooltips.js?raw'
 
@@ -124,6 +126,12 @@ If you set `data-coreui-track` to `false`, the slider's track will not display a
 <Example pro code={`<div class="mb-3" data-coreui-toggle="range-slider" data-coreui-track="false" data-coreui-value="50" ></div>
   <div class="mb-3" data-coreui-toggle="range-slider" data-coreui-track="false" data-coreui-value="50, 75"></div>
   <div data-coreui-toggle="range-slider" data-coreui-track="false" data-coreui-value="25, 50, 75"></div>`} />
+
+## Theme colors
+
+Color the filled track and the handles by adding a [`.theme-{color}` class](/customize/components/#theme-variants) to the slider element.
+
+<Example pro class="d-flex flex-column gap-3" code={getData('theme-colors').map((c) => `<div class="theme-${c.name}" data-coreui-toggle="range-slider" data-coreui-value="25, 75" aria-label="${c.title} range slider"></div>`)} />
 
 ## Usage
 

--- a/docs/src/content/docs/forms/range.mdx
+++ b/docs/src/content/docs/forms/range.mdx
@@ -6,6 +6,8 @@ otherFrameworks:
   - range
 ---
 
+import { getData } from '@coreui/astro-docs/data'
+
 ## Overview
 
 Create custom `<input type="range" />` controls with `.form-range`. The track (the background) and thumb (the value) are both styled to appear the same across browsers. As only Firefox supports "filling" their track from the left or right of the thumb as a means to visually indicate progress, we do not currently support it.
@@ -51,6 +53,13 @@ The value of the range input can be shown using the `output` element and a bit o
       rangeOutput.textContent = this.value;
     });
   </script>`} />
+
+## Theme colors
+
+Color the thumb by adding a [`.theme-{color}` class](/customize/components/#theme-variants) to the input or a wrapper.
+
+<Example class="d-flex flex-column gap-2" code={getData('theme-colors').map((c) => `<label for="range-${c.name}" class="form-label">${c.title} range</label>
+  <input type="range" class="form-range theme-${c.name}" id="range-${c.name}">`)} />
 
 ## Customizing
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -896,6 +896,17 @@ adornment in the library — so the button needs no icon markup at all:
   back to the nearest `[dir]` ancestor, but placement first is the reliable
   path).
 
+#### Range / Range Slider
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The pressed thumb adapts to the color mode.** Its color was 70% white
+  mixed into the theme color at build time, so in dark mode the pressed
+  thumb flashed a near-white pastel. It now mixes toward `--cui-body-bg` at
+  runtime — identical in light mode, dark and correct in dark mode.
+- **Both sliders are themeable**: the filled track and the thumbs read the
+  theme slots, so a `.theme-*` class recolors them; without one they stay
+  on primary as before.
+
 #### ScrollSpy
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -1,7 +1,6 @@
 @use "sass:string";
 @use "forms/variables" as *;
 @use "forms/form-range" as *;
-@use "functions/color" as *;
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/box-shadow" as *;
@@ -10,7 +9,6 @@
 @use "mixins/ltr-rtl" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
-@use "theme" as *;
 @use "config" as *;
 
 // stylelint-disable custom-property-no-missing-var-function
@@ -24,7 +22,7 @@ $range-slider-track-bg:                    var(--#{$prefix}secondary-bg) !defaul
 $range-slider-track-border-radius:         1rem !default;
 $range-slider-track-box-shadow:            var(--#{$prefix}box-shadow-inset) !default;
 
-$range-slider-track-in-range-bg:           color-mix(in srgb, var(--#{$prefix}primary) 50%, transparent) !default;
+$range-slider-track-in-range-bg:           color-mix(in srgb, var(--#{$prefix}theme-base, var(--#{$prefix}primary)) 50%, transparent) !default;
 $range-slider-disabled-track-in-range-bg:  color-mix(in srgb, var(--#{$prefix}secondary) 37.5%, transparent) !default;
 
 $range-slider-label-padding-y:             0 !default;
@@ -34,12 +32,12 @@ $range-slider-label-color:                 var(--#{$prefix}body-color) !default;
 
 $range-slider-thumb-width:                 1rem !default;
 $range-slider-thumb-height:                $range-slider-thumb-width !default;
-$range-slider-thumb-bg:                    var(--#{$prefix}primary) !default;
+$range-slider-thumb-bg:                    var(--#{$prefix}theme-base, var(--#{$prefix}primary)) !default;
 $range-slider-thumb-border:                0 !default;
 $range-slider-thumb-border-radius:         1rem !default;
 $range-slider-thumb-box-shadow:            0 .1rem .25rem color-mix(in srgb, var(--#{$prefix}black) 10%, transparent) !default;
 $range-slider-thumb-focus-ring:      $input-focus-ring !default;
-$range-slider-thumb-active-bg:             tint-color($primary, 70%) !default;
+$range-slider-thumb-active-bg:             color-mix(in srgb, var(--#{$prefix}theme-base, var(--#{$prefix}primary)) 30%, var(--#{$prefix}body-bg)) !default;
 $range-slider-thumb-disabled-bg:           color-mix(in srgb, var(--#{$prefix}secondary) 100%, transparent) !default;
 $range-slider-thumb-transition:            background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -1,12 +1,10 @@
 @use "../forms/variables" as *;
-@use "../functions/color" as *;
 @use "../functions/math" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/gradients" as *;
 @use "../mixins/transition" as *;
-@use "../theme" as *;
 @use "../config" as *;
 
 // scss-docs-start form-range-variables
@@ -19,13 +17,13 @@ $form-range-track-box-shadow:     var(--#{$prefix}box-shadow-inset) !default;
 
 $form-range-thumb-width:                   1rem !default;
 $form-range-thumb-height:                  $form-range-thumb-width !default;
-$form-range-thumb-bg:                      var(--#{$prefix}primary) !default;
+$form-range-thumb-bg:                      var(--#{$prefix}theme-base, var(--#{$prefix}primary)) !default;
 $form-range-thumb-border:                  0 !default;
 $form-range-thumb-border-radius:           1rem !default;
 $form-range-thumb-box-shadow:              0 .1rem .25rem color-mix(in srgb, var(--#{$prefix}black) 10%, transparent) !default;
 $form-range-thumb-focus-ring:        $input-focus-ring !default;
 $form-range-thumb-focus-ring-width:  $input-focus-width !default; // For focus box shadow issue in Edge
-$form-range-thumb-active-bg:               tint-color($primary, 70%) !default;
+$form-range-thumb-active-bg:               color-mix(in srgb, var(--#{$prefix}theme-base, var(--#{$prefix}primary)) 30%, var(--#{$prefix}body-bg)) !default;
 $form-range-thumb-disabled-bg:             var(--#{$prefix}secondary-color) !default;
 $form-range-thumb-transition:              background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 // scss-docs-end form-range-variables


### PR DESCRIPTION
The range-slider tail of the theming sweep (upstream has no range slider, so this is our design following the slot pattern):

- **Both sliders read the theme slots** — the filled track (inside its existing 50% translucent mix) and the thumbs read `--cui-theme-base` in their token defaults, so a `.theme-*` class recolors them; primary stays as the fallback (the fill is content, like the progress bar).
- **The pressed thumb adapts to the color mode.** It was `tint-color($primary, 70%)` — 70% white frozen at build time, which rendered a near-white pastel in dark mode. It now mixes toward `--cui-body-bg` at runtime (upstream's shape for their native range thumb): byte-identical in light mode, dark and correct in dark mode, and it follows the theme. Migration guide carries the Breaking entry.
- **Docs with the feature**: the Range Slider and Range pages each gain a Theme colors section iterating every theme color, in the same idiom as the checked controls.
- The `functions/color` and `theme` Sass imports both files no longer need are pruned.

Verification: stylelint clean, css-test 62/62, class-API guard green, docs build 147 pages, pre-push full gate green (bundlewatch within the raised budgets).