### PR TITLE
refactor(scss)!: keyboard-only focus rings; the button ring is the theme ring

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1267,11 +1267,32 @@ assembles maps of CSS expressions and the browser resolves them.
   utilities. It was disabled by default (`$enable-elevations: false`), so the
   utilities were the only reachable part. Use the shadow utilities
   (`.shadow`, `.shadow-sm`, `.shadow-lg`) or set `box-shadow` directly.
-- **Button focus rings take a colour, not channels.**
-  `--#{$prefix}btn-focus-shadow-rgb` becomes
-  `--#{$prefix}btn-focus-shadow`, and the Sass variables follow:
-  `$btn-outline-focus-shadow-rgb` → `$btn-outline-focus-shadow`, likewise for
-  the ghost and link variants.
+- **The button focus ring is the theme ring.** `--#{$prefix}btn-focus-shadow-rgb`
+  and the per-variant `$btn-*-focus-shadow-rgb` Sass variables are gone without
+  a renamed successor: the button reads
+  `var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring))`, so a colour
+  button rings in its colour through the theme slot and a neutral one gets the
+  global ring. To restyle it, set `--#{$prefix}btn-focus-ring` (any outline
+  shorthand) or the global focus-ring tokens. Two visible consequences: a
+  colour button's ring uses the focus-ring opacity (fainter than the old 50%
+  mix), and the neutral outline/ghost buttons ring in the global colour
+  instead of a grey.
+
+#### Focus rings are keyboard-only on activation controls
+
+<span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+
+Controls you click to act — checkboxes, radios, switches, both range sliders,
+pagination links, stepper buttons, the search, close, sidebar and navbar
+togglers — draw their focus ring on `:focus-visible`, so clicking no longer
+flashes it and keyboard focus still shows it, joining the buttons which
+already worked this way. Fields you type into — text inputs, the OTP cells,
+the date-time sections — keep `:focus`: a field shows its ring on mouse focus
+by design.
+
+Two suppressed rings are restored: the header toggler and the carousel
+controls declared `outline: 0` with no replacement, so keyboard focus was
+invisible on both.
 
 #### A validation state is a theme colour, not a palette of its own
 

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -145,7 +145,6 @@ $carousel-transition:                transform $carousel-transition-duration eas
     &:focus {
       color: var(--#{$prefix}carousel-control-color);
       text-decoration: none;
-      outline: 0;
       opacity: $carousel-control-hover-opacity;
     }
   }

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -226,10 +226,6 @@ $header-tokens: defaults(
       text-decoration: none;
     }
 
-    &:focus {
-      outline: 0;
-    }
-
     // Opinionated: add "hand" cursor to non-disabled .navbar-toggler elements
     &:not(:disabled) {
       cursor: pointer;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -33,7 +33,7 @@ $navbar-toggler-padding-y:          .25rem !default;
 $navbar-toggler-padding-x:          .75rem !default;
 $navbar-toggler-font-size:          var(--#{$prefix}font-size-lg) !default;
 $navbar-toggler-border-radius:      $btn-border-radius !default;
-$navbar-toggler-focus-width:        $btn-focus-width !default;
+$navbar-toggler-focus-width:        var(--#{$prefix}focus-ring-width) !default;
 $navbar-toggler-transition:         box-shadow .15s ease-in-out !default;
 
 $navbar-light-color:                color-mix(in srgb, var(--#{$prefix}emphasis-color) 65%, transparent) !default;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -289,7 +289,7 @@ $navbar-dark-tokens: defaults(
       text-decoration: none;
     }
 
-    &:focus {
+    &:focus-visible {
       text-decoration: none;
       outline: 0;
       box-shadow: 0 0 0 var(--#{$prefix}navbar-toggler-focus-width);

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -108,7 +108,7 @@ $pagination-tokens: defaults(
       border-color: var(--#{$prefix}pagination-hover-border-color);
     }
 
-    &:focus {
+    &:focus-visible {
       z-index: 3;
       color: var(--#{$prefix}pagination-focus-color);
       background-color: var(--#{$prefix}pagination-focus-bg);

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -189,7 +189,7 @@ $range-slider-vertical-tokens: defaults(
       opacity: 1;
     }
 
-    &:focus {
+    &:focus-visible {
       outline: 0;
 
       // Pseudo-elements must be split across multiple rulesets to have an effect.

--- a/scss/_stepper.scss
+++ b/scss/_stepper.scss
@@ -182,7 +182,7 @@ $stepper-tokens: defaults(
       display: none;
     }
 
-    &:focus {
+    &:focus-visible {
 
       .stepper-step-indicator {
         @include focus-ring(true, $ring: var(--#{$prefix}stepper-step-indicator-focus-ring));

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -1,7 +1,5 @@
-@use "sass:color";
 @use "sass:map";
 @use "../functions/color" as *;
-@use "../functions/color-contrast-variables" as *;
 @use "../functions/defaults" as *;
 @use "../functions/to-rgb" as *;
 @use "../mixins/border-radius" as *;
@@ -37,17 +35,13 @@ $btn-border-width:            var(--#{$prefix}btn-input-border-width) !default;
 
 $btn-font-weight:             var(--#{$prefix}font-weight-normal) !default;
 $btn-box-shadow:              inset 0 1px 0 color-mix(in srgb, var(--#{$prefix}white) 15%, transparent), 0 1px 1px color-mix(in srgb, var(--#{$prefix}black) 7.5%, transparent) !default;
-$btn-focus-width:             var(--#{$prefix}focus-ring-width) !default;
-// fusv-disable
 $btn-focus-ring:              var(--#{$prefix}focus-ring) !default;
-// fusv-enable
 $btn-disabled-opacity:        var(--#{$prefix}btn-input-disabled-opacity) !default;
 $btn-active-box-shadow:       inset 0 3px 5px color-mix(in srgb, var(--#{$prefix}black) 12.5%, transparent) !default;
 
 $btn-link-color:              var(--#{$prefix}link-color) !default;
 $btn-link-hover-color:        var(--#{$prefix}link-hover-color) !default;
 $btn-link-disabled-color:     var(--#{$prefix}gray-600) !default;
-$btn-link-focus-shadow:   color.mix(color-contrast-variables($link-color, $color-contrast-dark, $color-contrast-light, var(--#{$prefix}white), var(--#{$prefix}black), $min-contrast-ratio), $link-color, 15%) !default;
 
 // Allows for customizing button radius independently from global border radius
 $btn-border-radius:           var(--#{$prefix}border-radius) !default;
@@ -74,7 +68,6 @@ $btn-outline-disabled-border-color: var(--#{$prefix}border-color) !default;
 $btn-outline-hover-color: var(--#{$prefix}body-color) !default;
 $btn-outline-hover-bg: var(--#{$prefix}tertiary-bg) !default;
 $btn-outline-hover-border-color: var(--#{$prefix}border-color) !default;
-$btn-outline-focus-shadow: var(--#{$prefix}tertiary-bg) !default;
 // scss-docs-end btn-outline-variables
 // Lightness applied to a theme color for the hover and active states. Upstream
 // uses .95/.9; these are tuned to land near the shade-color() amounts CoreUI
@@ -146,7 +139,6 @@ $button-variants: defaults(
   }
 
   --#{$prefix}btn-active-shadow: #{$btn-active-box-shadow};
-  --#{$prefix}btn-focus-shadow: var(--#{$prefix}theme-base);
 }
 // scss-docs-end btn-variant-mixin
 
@@ -166,7 +158,6 @@ $btn-ghost-active-bg: var(--#{$prefix}tertiary-bg) !default;
 $btn-ghost-disabled-color: var(--#{$prefix}secondary-color) !default;
 $btn-ghost-hover-color: var(--#{$prefix}body-color) !default;
 $btn-ghost-hover-bg: var(--#{$prefix}tertiary-bg) !default;
-$btn-ghost-focus-shadow: var(--#{$prefix}tertiary-bg) !default;
 // scss-docs-end btn-ghost-variables
 
 @layer components {
@@ -190,7 +181,7 @@ $btn-ghost-focus-shadow: var(--#{$prefix}tertiary-bg) !default;
     --#{$prefix}btn-hover-border-color: transparent;
     --#{$prefix}btn-box-shadow: #{$btn-box-shadow};
     --#{$prefix}btn-disabled-opacity: #{$btn-disabled-opacity};
-    --#{$prefix}btn-focus-ring: #{$btn-focus-width} solid color-mix(in srgb, var(--#{$prefix}btn-focus-shadow) 50%, transparent);
+    --#{$prefix}btn-focus-ring: var(--#{$prefix}theme-focus-ring, #{$btn-focus-ring});
     // scss-docs-end btn-css-vars
 
     display: inline-block;
@@ -344,7 +335,6 @@ $btn-ghost-focus-shadow: var(--#{$prefix}tertiary-bg) !default;
     --#{$prefix}btn-hover-color: #{$btn-ghost-hover-color};
     --#{$prefix}btn-hover-bg: #{$btn-ghost-hover-bg};
     --#{$prefix}btn-hover-border-color: #{$btn-ghost-hover-bg};
-    --#{$prefix}btn-focus-ring: #{$btn-focus-width} solid color-mix(in srgb, #{$btn-outline-focus-shadow} 50%, transparent);
     // scss-docs-end btn-ghost-css-vars
   }
 
@@ -360,7 +350,6 @@ $btn-ghost-focus-shadow: var(--#{$prefix}tertiary-bg) !default;
     --#{$prefix}btn-hover-color: #{$btn-outline-hover-color};
     --#{$prefix}btn-hover-bg: #{$btn-outline-hover-bg};
     --#{$prefix}btn-hover-border-color: #{$btn-outline-hover-border-color};
-    --#{$prefix}btn-focus-ring: #{$btn-focus-width} solid color-mix(in srgb, #{$btn-ghost-focus-shadow} 50%, transparent);
     // scss-docs-end btn-outline-css-vars
   }
 
@@ -413,7 +402,6 @@ $btn-ghost-focus-shadow: var(--#{$prefix}tertiary-bg) !default;
     --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color};
     --#{$prefix}btn-disabled-border-color: transparent;
     --#{$prefix}btn-box-shadow: none;
-    --#{$prefix}btn-focus-shadow: #{$btn-link-focus-shadow};
 
     text-decoration: $link-decoration;
     @if $enable-gradients {

--- a/scss/buttons/_close.scss
+++ b/scss/buttons/_close.scss
@@ -71,7 +71,7 @@ $close-tokens: defaults(
       opacity: var(--#{$prefix}btn-close-hover-opacity);
     }
 
-    &:focus {
+    &:focus-visible {
       outline: 0;
       box-shadow: var(--#{$prefix}btn-close-focus-shadow);
       opacity: var(--#{$prefix}btn-close-focus-opacity);

--- a/scss/buttons/_search-button.scss
+++ b/scss/buttons/_search-button.scss
@@ -98,7 +98,7 @@ $search-button-tokens: defaults(
     @include box-shadow(var(--#{$prefix}search-button-box-shadow));
     @include transition(var(--#{$prefix}search-button-transition));
 
-    &:focus {
+    &:focus-visible {
       color: var(--#{$prefix}search-button-focus-color);
       background-color: var(--#{$prefix}search-button-focus-bg);
       border-color: var(--#{$prefix}search-button-focus-border-color);

--- a/scss/forms/_check.scss
+++ b/scss/forms/_check.scss
@@ -121,7 +121,7 @@ $check-selector: if(sass($enable-deprecated-form-check): ".check, .form-check-in
       }
     }
 
-    &:focus {
+    &:focus-visible {
       border-color: var(--#{$prefix}check-focus-border);
       @include focus-ring(true, $ring: var(--#{$prefix}check-focus-ring));
     }

--- a/scss/forms/_form-date-time.scss
+++ b/scss/forms/_form-date-time.scss
@@ -9,7 +9,7 @@
 // scss-docs-start form-date-time-variables
 $form-date-time-placeholder-color:       $input-placeholder-color !default;
 $form-date-time-section-border-radius:   .25rem !default;
-$form-date-time-section-focus-bg:        color-mix(in srgb, var(--#{$prefix}primary) 25%, transparent) !default;
+$form-date-time-section-focus-bg:        color-mix(in srgb, var(--#{$prefix}theme-base, var(--#{$prefix}primary)) 25%, transparent) !default;
 // scss-docs-end form-date-time-variables
 
 // stylelint-disable scss/dollar-variable-default

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -42,7 +42,7 @@ $form-range-thumb-transition:              background-color .15s ease-in-out, bo
     appearance: none;
     background-color: transparent;
 
-    &:focus {
+    &:focus-visible {
       outline: 0;
 
       // Pseudo-elements must be split across multiple rulesets to have an effect.

--- a/scss/forms/_radio.scss
+++ b/scss/forms/_radio.scss
@@ -94,7 +94,7 @@ $radio-selector: if(sass($enable-deprecated-form-check): ".radio, .form-check-in
       }
     }
 
-    &:focus {
+    &:focus-visible {
       border-color: var(--#{$prefix}radio-focus-border);
       @include focus-ring(true, $ring: var(--#{$prefix}radio-focus-ring));
     }

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -139,7 +139,7 @@ $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch
       }
     }
 
-    &:focus {
+    &:focus-visible {
       border-color: var(--#{$prefix}switch-focus-border);
       @include focus-ring(true, $ring: var(--#{$prefix}switch-focus-ring));
     }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -241,7 +241,7 @@ $validated-controls: if(sass($enable-deprecated-form-check): ".check, .radio, .s
         background-color: $color;
       }
 
-      &:focus {
+      &:focus-visible {
         @include focus-ring(true, $ring: $focus-ring);
       }
 

--- a/scss/sidebar/_sidebar.scss
+++ b/scss/sidebar/_sidebar.scss
@@ -263,7 +263,7 @@ $sidebar-narrow-unfoldable-box-shadow:     var(--#{$prefix}box-shadow) !default;
       }
     }
 
-    &:focus {
+    &:focus-visible {
       outline: 0;
       box-shadow: var(--#{$prefix}sidebar-toggler-focus-shadow);
 


### PR DESCRIPTION
Closes the focus thread — the per-component `:focus` → `:focus-visible` verdicts, the orphaned `$btn-focus-ring`, and the button's reconciliation with `--cui-theme-focus-ring` — decided against the upstream inventory, not by sed.

**The verdict model** (upstream's, verified site by site): the *ring* draws on `:focus-visible`; *hover/focus colour pairs* stay on `:focus`; *fields you type into* keep `:focus` — a text field shows its ring on mouse focus by design.

- **Moved to `:focus-visible`**: checks, radios, switches (both spellings via the shared selector), both range sliders, pagination links, stepper buttons, the search, close, sidebar and navbar togglers, and the checked-control validation ring. Clicking no longer flashes the ring; keyboard focus still shows it.
- **Kept on `:focus`**: text fields, the OTP cells, the date-time sections, and every hover/focus colour pair (menu, dropdown, nav, navbar, header, list-group, combobox options, colored links). The range-slider tooltip still reveals on `:focus` — a mouse drag needs the value read-out.
- **The button ring is `var(--cui-theme-focus-ring, $btn-focus-ring)`.** The bespoke 50% `color-mix` formula around `--cui-btn-focus-shadow` is gone, along with `$btn-focus-width` and the three per-variant shadow variables — whose outline/ghost pair had been quietly swapped (same value, latent bug). A colour button rings in its colour through the slot, a neutral one gets the global ring; the orphaned `$btn-focus-ring` is the consumed fallback, fusv guard removed.
- **Two suppressed rings restored**: the header toggler and the carousel controls declared `outline: 0` with no replacement, so keyboard focus was invisible on both.
- **The last hardcoded-primary row closes**: the date-time section highlight is a selection surface (stays `:focus`) and reads the theme slot inside its 25% mix.

Migration guide: a new keyboard-only-rings entry, and the stale "focus rings take a colour, not channels" bullet rewritten to the final state (`--cui-btn-focus-shadow-rgb` and variants are gone without a renamed successor; restyle via `--cui-btn-focus-ring` or the global tokens).

Follow-up filed in the workspace: the docs engine sets `--cui-btn-focus-shadow` for its violet buttons — after this lands it should set `--cui-theme-focus-ring` instead (backward-compatible addition, next engine release).

Verification: stylelint clean, fusv clean (the deleted variables and the consumed orphan are its territory), css-test 62/62, class-API guard green, docs build 147 pages, pre-push full gate green.