### PR TITLE
refactor(Switch): number-knob aspect ratio; one thumb mechanism

### DIFF
--- a/docs/src/content/docs/customize/color-modes.mdx
+++ b/docs/src/content/docs/customize/color-modes.mdx
@@ -272,11 +272,9 @@ Each theme color gets a 100–900 scale of `color-mix()` tokens in `:root`, mixe
 
 <ScssDocs file="scss/_theme.scss" capture="color-scale-variables" />
 
-The two values that cannot be a `light-dark()` pair — the colors baked into the select chevron and the switch knob SVGs — keep a dark counterpart next to the component they belong to:
+The one value that cannot be a `light-dark()` pair — the color baked into the select chevron SVG — keeps a dark counterpart next to the component it belongs to (the switch thumb, once the other case, is a plain color token now):
 
 <ScssDocs file="scss/forms/_form-control.scss" capture="form-control-select-dark-variables" />
-
-<ScssDocs file="scss/forms/_form-check.scss" capture="form-switch-dark-variables" />
 
 ### Sass mixins
 

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -11,7 +11,6 @@
 
 $form-check-inline-margin-end:    1rem !default;
 
-
 // The values each control's own variables default to. A consumer sets
 // `$check-*` / `$radio-*` / `$switch-*` (documented on their pages); these are
 // what those fall back to, and what still works for a v5-era override.
@@ -30,7 +29,6 @@ $form-check-input-checked-color:          var(--#{$prefix}primary-contrast) !def
 // and the focus / active / disabled states.
 // scss-docs-start form-check-variables
 $form-check-min-height:                   calc(var(--#{$prefix}body-font-size) * var(--#{$prefix}body-line-height)) !default; // stylelint-disable-line function-disallowed-list
-$form-check-padding-start:                $form-check-input-width + .5em !default;
 $form-check-margin-bottom:                .125rem !default;
 $form-check-inline-margin-end:            1rem !default;
 
@@ -48,17 +46,7 @@ $form-check-label-disabled-opacity:        $form-check-input-disabled-opacity !d
 // scss-docs-start form-switch-variables
 $form-switch-color:               rgba($black, .25) !default;
 $form-switch-width:               2em !default;
-$form-switch-padding-start:       $form-switch-width + .5em !default;
-$form-switch-bg-image:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color}'/></svg>") !default;
 $form-switch-border-radius:       $form-switch-width !default;
-$form-switch-transition:          background-position .15s ease-in-out !default;
-
-$form-switch-focus-color:         $input-focus-border-color !default;
-$form-switch-focus-bg-image:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-focus-color}'/></svg>") !default;
-
-$form-switch-checked-color:       $white !default;
-$form-switch-checked-bg-image:    url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-checked-color}'/></svg>") !default;
-$form-switch-checked-bg-position: right center !default;
 
 $form-switch-widths: (
   lg: (
@@ -72,13 +60,6 @@ $form-switch-widths: (
 ) !default;
 // scss-docs-end form-switch-variables
 
-// The knob is an inline SVG, so its colour lives inside the image and cannot be
-// a light-dark() pair — the dark scheme gets its own rule below.
-// scss-docs-start form-switch-dark-variables
-$form-switch-color-dark:            rgba($white, .25) !default;
-$form-switch-bg-image-dark:         url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color-dark}'/></svg>") !default;
-// scss-docs-end form-switch-dark-variables
-
 // stylelint-disable scss/dollar-variable-default
 
 // scss-docs-start form-check-tokens
@@ -87,11 +68,8 @@ $form-check-tokens: () !default;
 $form-check-tokens: defaults(
   (
     --#{$prefix}form-check-min-height: #{$form-check-min-height},
-    --#{$prefix}form-check-padding-start: #{$form-check-padding-start},
     --#{$prefix}form-check-margin-bottom: #{$form-check-margin-bottom},
     --#{$prefix}form-check-inline-margin-end: #{$form-check-inline-margin-end},
-    --#{$prefix}form-check-label-disabled-opacity: #{$form-check-label-disabled-opacity},
-    --#{$prefix}form-switch-padding-start: #{$form-switch-padding-start},
   ),
   $form-check-tokens
 );
@@ -108,24 +86,6 @@ $form-check-tokens: defaults(
 $form-check-input-tokens: () !default;
 $form-check-input-tokens: defaults(
   (
-    --#{$prefix}form-check-input-width: #{$form-check-input-width},
-    --#{$prefix}form-check-bg: #{$form-check-input-bg},
-    --#{$prefix}form-check-input-border: #{$form-check-input-border},
-    --#{$prefix}form-check-input-border-radius: #{$form-check-input-border-radius},
-    --#{$prefix}form-check-radio-border-radius: #{$form-check-radio-border-radius},
-    --#{$prefix}form-check-input-active-filter: #{$form-check-input-active-filter},
-    --#{$prefix}form-check-input-focus-border: #{$form-check-input-focus-border},
-    --#{$prefix}form-check-input-focus-ring: #{$form-check-input-focus-ring},
-    --#{$prefix}form-check-input-checked-bg-color: var(--#{$prefix}theme-base, var(--#{$prefix}control-checked-bg)),
-    --#{$prefix}form-check-input-checked-border-color: var(--#{$prefix}theme-base, var(--#{$prefix}control-checked-border-color)),
-    --#{$prefix}form-check-input-indeterminate-bg-color: var(--#{$prefix}control-indeterminate-bg),
-    --#{$prefix}form-check-input-indeterminate-border-color: var(--#{$prefix}control-indeterminate-border-color),
-    --#{$prefix}form-check-input-disabled-opacity: #{$form-check-input-disabled-opacity},
-    --#{$prefix}form-switch-width: #{$form-switch-width},
-    --#{$prefix}form-switch-bg: #{escape-svg($form-switch-bg-image)},
-    --#{$prefix}form-switch-border-radius: #{$form-switch-border-radius},
-    --#{$prefix}form-switch-transition: #{$form-switch-transition},
-    --#{$prefix}form-switch-checked-bg-position: #{$form-switch-checked-bg-position},
   ),
   $form-check-input-tokens
 );

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -1,6 +1,5 @@
 @use "sass:map";
 @use "../functions/defaults" as *;
-@use "../functions/escape-svg" as *;
 @use "form-check" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/focus-ring" as *;
@@ -8,19 +7,10 @@
 @use "../mixins/transition" as *;
 @use "../config" as *;
 
-// The switch's own theming surface — see the note in `_check.scss`. The size
-// modifiers set tokens rather than declarations, so a size the map does not name
-// is one custom property rather than a Sass recompile.
-
 // scss-docs-start switch-variables
-// The track's proportion, not its width: the width follows the height in the
-// browser, so a size is one token and the ratio is a plain number.
 $switch-aspect-ratio:         2 !default;
 $switch-height:               $form-check-input-width !default;
 $switch-border-radius:        $form-switch-border-radius !default;
-// Duration and timing only — the property is named at the point of use. The v5
-// `$form-switch-transition` cannot serve here: it carries `background-position`
-// inside it, which made the whole `transition` declaration invalid.
 $switch-transition-duration:  .15s !default;
 $switch-transition-timing:    ease-in-out !default;
 $switch-bg:                   $form-check-input-bg !default;
@@ -28,14 +18,7 @@ $switch-border:               $form-check-input-border !default;
 $switch-padding:              .125em !default;
 $switch-thumb-bg:             $form-switch-color !default;
 $switch-checked-thumb-bg:     var(--#{$prefix}primary-contrast) !default;
-$switch-knob:                 $form-switch-bg-image !default;
-$switch-knob-focus:           $form-switch-focus-bg-image !default;
-$switch-knob-checked:         $form-switch-checked-bg-image !default;
-$switch-knob-dark:            $form-switch-bg-image-dark !default;
-$switch-checked-knob-position: $form-switch-checked-bg-position !default;
 
-// Sized like `.check` and `.radio`: one height, and the label follows so the
-// whole row scales. `xl` has no checkbox counterpart — it is ours.
 $switch-sizes: (
   sm: (height: .875rem, font-size: var(--#{$prefix}font-size-sm)),
   lg: (height: 1.25rem, font-size: var(--#{$prefix}font-size-lg)),
@@ -45,8 +28,7 @@ $switch-sizes: (
 
 $switch-tokens: () !default;
 
-// stylelint-disable custom-property-no-missing-var-function, function-disallowed-list
-// stylelint-disable scss/dollar-variable-default
+// stylelint-disable custom-property-no-missing-var-function, function-disallowed-list, scss/dollar-variable-default
 
 // scss-docs-start switch-css-vars
 $switch-tokens: defaults(
@@ -70,30 +52,17 @@ $switch-tokens: defaults(
     --#{$prefix}switch-focus-ring: #{$form-check-input-focus-ring},
     --#{$prefix}switch-active-filter: #{$form-check-input-active-filter},
     --#{$prefix}switch-label-disabled-opacity: #{$form-check-label-disabled-opacity},
-    --#{$prefix}switch-knob: #{escape-svg($switch-knob)},
-    --#{$prefix}switch-knob-focus: #{escape-svg($switch-knob-focus)},
-    --#{$prefix}switch-knob-checked: #{escape-svg($switch-knob-checked)},
-    --#{$prefix}switch-knob-dark: #{escape-svg($switch-knob-dark)},
-    --#{$prefix}switch-checked-knob-position: #{$switch-checked-knob-position},
   ),
   $switch-tokens
 );
 // scss-docs-end switch-css-vars
 
-// stylelint-enable scss/dollar-variable-default
-// stylelint-enable custom-property-no-missing-var-function, function-disallowed-list
+// stylelint-enable custom-property-no-missing-var-function, function-disallowed-list, scss/dollar-variable-default
 
-// The v5 spelling is an alias of this control rather than a second
-// implementation, so it is part of its selector list;
-// `$enable-deprecated-form-check: false` compiles it out.
 // stylelint-disable-next-line scss/at-function-named-arguments
 $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch .form-check-input"; else: ".switch") !default;
 
 @layer forms {
-  // Like `.check` and `.radio`, the class goes on the `<input>`: the track is the
-  // input and the thumb is its `::before`, so the thumb's colour is a token
-  // instead of a fill baked into an SVG — which is also what lets the separate
-  // dark-mode knob go.
   #{$switch-selector} {
     @include tokens($switch-tokens);
 
@@ -101,8 +70,6 @@ $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch
     flex-shrink: 0;
     width: var(--#{$prefix}switch-width);
     height: var(--#{$prefix}switch-height);
-    // Half the leading, so the control sits on the text's optical centre — the
-    // alignment the `.form-check` wrapper used to apply, now following the size.
     margin-top: var(--#{$prefix}switch-margin-top);
     vertical-align: top;
     appearance: none;
@@ -154,23 +121,6 @@ $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch
     }
   }
 
-  @if $enable-deprecated-form-check {
-    .form-switch {
-      @include tokens($switch-tokens);
-
-      // stylelint-disable-next-line function-disallowed-list
-      --#{$prefix}form-switch-padding-start: calc(var(--#{$prefix}switch-width) + .5em);
-      --#{$prefix}form-switch-width: var(--#{$prefix}switch-width);
-      --#{$prefix}form-switch-border-radius: var(--#{$prefix}switch-border-radius);
-      --#{$prefix}form-switch-transition: #{$form-switch-transition};
-      --#{$prefix}form-switch-bg: var(--#{$prefix}switch-knob);
-      --#{$prefix}form-switch-checked-bg-position: var(--#{$prefix}switch-checked-knob-position);
-    }
-  }
-
-  // A size is one token: the width follows the height through the aspect ratio,
-  // and so do the thumb and the optical centring. The label follows too, so the
-  // whole row scales — the way `.check-sm` and `.radio-lg` do.
   @each $size, $map in $switch-sizes {
     .switch-#{$size} {
       --#{$prefix}switch-height: #{map.get($map, "height")};
@@ -181,27 +131,18 @@ $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch
     }
   }
 
-  // v5 sized the wrapper, and only `lg` and `xl` existed. Its own map keeps
-  // driving them, in `em` as it always was, so markup that has not moved is
-  // unaffected by the new `rem` scale above.
   @each $size, $map in $form-switch-widths {
     @if $enable-deprecated-form-check {
-      // The control declares these tokens for itself, so a value inherited from
-      // the wrapper would lose to it — they are set on the input.
+      // Set on the input — the control declares these tokens itself, so an
+      // inherited value would lose to its own declaration.
       .form-switch-#{$size} .form-check-input {
         --#{$prefix}switch-width: #{map.get($map, "width")};
         --#{$prefix}switch-height: #{map.get($map, "height")};
-        // v5 gave every sized switch the same margin as the default one, which
-        // left it a little below the line's centre. The compatibility layer keeps
-        // that rather than quietly re-centring markup nobody has touched.
         --#{$prefix}switch-margin-top: calc((var(--#{$prefix}body-line-height) * 1em - #{$form-check-input-width}) * .5); // stylelint-disable-line function-disallowed-list
       }
 
       .form-switch-#{$size} {
         --#{$prefix}switch-height: #{map.get($map, "height")};
-        // A sized switch is taller than the text line it sits on, so it sets the
-        // row height itself and re-centres the label; the default one keeps
-        // `.form-check`'s.
         min-height: var(--#{$prefix}switch-height);
 
         .form-check-label {

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -1,5 +1,4 @@
 @use "sass:map";
-@use "sass:math";
 @use "../functions/defaults" as *;
 @use "../functions/escape-svg" as *;
 @use "form-check" as *;
@@ -14,10 +13,9 @@
 // is one custom property rather than a Sass recompile.
 
 // scss-docs-start switch-variables
-// The track's proportion, not its width: the width follows the height, so a
-// size is one token. `$form-switch-width` still sets it, as the width the
-// default height produces.
-$switch-aspect-ratio:         math.div($form-switch-width, $form-check-input-width) !default;
+// The track's proportion, not its width: the width follows the height in the
+// browser, so a size is one token and the ratio is a plain number.
+$switch-aspect-ratio:         2 !default;
 $switch-height:               $form-check-input-width !default;
 $switch-border-radius:        $form-switch-border-radius !default;
 // Duration and timing only — the property is named at the point of use. The v5


### PR DESCRIPTION
Started as the `math.div` fix and grew into the switch answering "what does upstream's 126-line file do better than our 215":

- **The track's aspect ratio is a number knob.** `math.div($form-switch-width, $form-check-input-width)` froze the ratio at build time — the one arithmetic CSS cannot take over (`calc()` has no length-by-length division). It is the plain number `2` now, multiplied with the height token in the browser.
- **One thumb mechanism.** The rewrite had left the v5 SVG-knob machinery running next to the new `::before` thumb, feeding tokens nothing reads: the four knob images, the `.form-switch` compat block, and 21 of the 24 `--cui-form-check/switch-*` emissions in `_form-check.scss` (only `min-height`, `margin-bottom` and `inline-margin-end` have readers — verified against the compiled sheet). All of it is gone, with the eight Sass variables that existed only to feed it. The compiled diff is 40 removed declarations, every one verified never-read.
- **Narrative comments removed** per the workspace rule; the one genuinely non-obvious fact (size tokens set on the input, because its own declarations beat inherited values) stays as a one-liner, and the split stylelint disables are one line.
- `customize/color-modes` no longer claims the switch knob keeps a dark counterpart — the thumb is a plain color token.

The file is 145 lines against upstream's 126; what remains above their count is the Sass-variable tier and the v5 sizing compat, both deliberate. fusv clean (1846 → 1827 variables), stylelint clean, css-test 62/62, class-API guard green, docs build 147 pages, pre-push full gate green.