### PR TITLE
feat(Switch, Checkbox, Radio)!: adopted switch design; shared control motion

### DIFF
--- a/docs/src/content/docs/forms/checkbox.mdx
+++ b/docs/src/content/docs/forms/checkbox.mdx
@@ -210,4 +210,4 @@ Checkboxs read their own custom properties, so restyling one control does not to
 
 `.form-check` lays out the row and all three controls share their focus, active and disabled states, so these are set once rather than per control:
 
-<ScssDocs file="scss/forms/_form-check.scss" capture="form-check-variables" />
+<ScssDocs file="scss/forms/_variables.scss" capture="form-check-variables" />

--- a/docs/src/content/docs/forms/radio.mdx
+++ b/docs/src/content/docs/forms/radio.mdx
@@ -200,4 +200,4 @@ Radios read their own custom properties, so restyling one control does not touch
 
 `.form-check` lays out the row and all three controls share their focus, active and disabled states, so these are set once rather than per control:
 
-<ScssDocs file="scss/forms/_form-check.scss" capture="form-check-variables" />
+<ScssDocs file="scss/forms/_variables.scss" capture="form-check-variables" />

--- a/docs/src/content/docs/forms/switch.mdx
+++ b/docs/src/content/docs/forms/switch.mdx
@@ -123,4 +123,4 @@ Switchs read their own custom properties, so restyling one control does not touc
 
 `.form-check` lays out the row and all three controls share their focus, active and disabled states, so these are set once rather than per control:
 
-<ScssDocs file="scss/forms/_form-check.scss" capture="form-check-variables" />
+<ScssDocs file="scss/forms/_variables.scss" capture="form-check-variables" />

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1116,8 +1116,8 @@ What replaces the wrapper's modifiers:
 
 **The switch is sized by one token, and gains `.switch-sm`.** `--#{$prefix}switch-width`
 is derived from `--#{$prefix}switch-height` through the new
-`$switch-aspect-ratio` (which `$form-switch-width` still sets, as the width the
-default height produces), so a size sets the height alone. The size classes now
+`$switch-aspect-ratio` — a plain number, multiplied in the browser — so a size
+sets the height alone. The size classes now
 scale the label as well, matching `.check-sm` / `.radio-lg`; `$switch-sizes`
 replaces the width/height pairs for the new classes, while `$form-switch-widths`
 stays behind the deprecated `.form-switch-lg` / `-xl` in its original `em` scale.
@@ -1128,6 +1128,23 @@ v5's `$form-switch-transition`), so `transition: inset-inline-start var(…)`
 resolved to something invalid and every switch transition was dropped. It is two
 tokens now — `--#{$prefix}switch-transition-duration` and
 `-timing` — and the thumb slides rather than the background position.
+
+<span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+**The switch is redrawn.** The track is 1.25rem tall with a 1.75 aspect ratio
+(was a 2:1, font-relative `em` track), pill-radiused, on the tertiary surface
+with an inset shadow; the thumb is white with a drop shadow and turns
+contrast-coloured when checked. A disabled unchecked switch swaps to the
+disabled surface with a faded thumb instead of dimming wholesale; a checked one
+dims. `--#{$prefix}switch-border` splits into `-border-width` and
+`-border-color`, and `$form-switch-color`, `$form-switch-width` and
+`$form-switch-border-radius` fed only the old look and are removed. The
+deprecated `.form-switch-lg` / `-xl` sizing keeps its original `em` scale.
+
+**The controls animate on shared knobs.** `:root` carries
+`--#{$prefix}control-transition-duration` and `-timing` (an overshoot easing);
+the checkbox tick and the radio dot pop in on them, the boxes' colours animate,
+and the switch thumb slides on the same pair — the three controls move in sync
+and restyle from one place. Reduced motion disables all of it as usual.
 
 **New: checkbox and radio have sizes.** `.check-sm` / `.check-lg` and
 `.radio-sm` / `.radio-lg` — v5 had none, only the switch was sizeable. Each sets
@@ -1370,11 +1387,10 @@ it at the colour's slots, so nothing is defined in a file that never renders it.
   `--#{$prefix}primary` at runtime) to move every active state at once, or the
   component's own knob to move one. Per instance, `.theme-*` still wins where a
   component reads `--#{$prefix}theme-*`.
-- **The switch keeps a literal colour on the deprecated path only.**
-  `$form-switch-checked-color` is interpolated into an SVG data URI, where a
-  custom property cannot reach, so it stays `$white`. The current `.switch`
-  paints its thumb with `background-color`, so `$switch-checked-thumb-bg` takes
-  the slot and no longer inherits from the deprecated variable.
+- **The switch has no SVG knob at all any more.** The thumb is painted with
+  `background-color` in every state, so `$switch-thumb-bg` and
+  `$switch-checked-thumb-bg` are ordinary colour knobs; the v5 knob images and
+  the variables that fed them (`$form-switch-bg-image` and friends) are gone.
 
 #### A theme colour is one nested map entry
 

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -277,6 +277,11 @@ $code-color: light-dark($pink, tint-color($pink, 40%)) !default;
     --#{$prefix}control-checked-border-color: #{$form-check-input-checked-border-color};
     --#{$prefix}control-indeterminate-bg: #{$form-check-input-indeterminate-bg-color};
     --#{$prefix}control-indeterminate-border-color: #{$form-check-input-indeterminate-border-color};
+    --#{$prefix}control-disabled-bg: var(--#{$prefix}tertiary-bg);
+    // Shared motion for the checkbox, radio and switch; the overshoot easing
+    // makes the mark pop as it settles.
+    --#{$prefix}control-transition-duration: .15s;
+    --#{$prefix}control-transition-timing: cubic-bezier(.34, 1.56, .64, 1);
     // scss-docs-end root-control-variables
 
   }

--- a/scss/forms/_check.scss
+++ b/scss/forms/_check.scss
@@ -1,7 +1,7 @@
 @use "sass:map";
 @use "../functions/defaults" as *;
 @use "../functions/escape-svg" as *;
-@use "form-check" as *;
+@use "variables" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/mask-icon" as *;

--- a/scss/forms/_check.scss
+++ b/scss/forms/_check.scss
@@ -6,6 +6,7 @@
 @use "../mixins/focus-ring" as *;
 @use "../mixins/mask-icon" as *;
 @use "../mixins/tokens" as *;
+@use "../mixins/transition" as *;
 @use "../config" as *;
 
 // scss-docs-start check-variables
@@ -89,6 +90,7 @@ $check-selector: if(sass($enable-deprecated-form-check): ".check, .form-check-in
     appearance: none;
     background-color: var(--#{$prefix}check-bg);
     border: var(--#{$prefix}check-border);
+    @include transition(background-color var(--#{$prefix}control-transition-duration) var(--#{$prefix}control-transition-timing), border-color var(--#{$prefix}control-transition-duration) var(--#{$prefix}control-transition-timing));
     print-color-adjust: exact;
     @include border-radius(var(--#{$prefix}check-border-radius));
 
@@ -99,7 +101,9 @@ $check-selector: if(sass($enable-deprecated-form-check): ".check, .form-check-in
       content: "";
       background-color: var(--#{$prefix}check-mark-color);
       opacity: 0;
+      transform: scale(0);
       @include mask-icon(var(--#{$prefix}check-mark-checked));
+      @include transition(opacity var(--#{$prefix}control-transition-duration) var(--#{$prefix}control-transition-timing), transform var(--#{$prefix}control-transition-duration) var(--#{$prefix}control-transition-timing));
     }
 
     &:checked {
@@ -108,6 +112,7 @@ $check-selector: if(sass($enable-deprecated-form-check): ".check, .form-check-in
 
       &::before {
         opacity: 1;
+        transform: scale(1);
       }
     }
 
@@ -118,6 +123,7 @@ $check-selector: if(sass($enable-deprecated-form-check): ".check, .form-check-in
       &::before {
         opacity: 1;
         mask-image: var(--#{$prefix}check-mark-indeterminate);
+        transform: scale(1);
       }
     }
 

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -1,61 +1,7 @@
-@use "sass:map";
 @use "../forms/variables" as *;
 @use "../functions/defaults" as *;
-@use "../functions/escape-svg" as *;
-@use "../mixins/border-radius" as *;
-@use "../mixins/color-mode" as *;
 @use "../mixins/tokens" as *;
-@use "../mixins/transition" as *;
-@use "../colors" as *;
 @use "../config" as *;
-
-$form-check-inline-margin-end:    1rem !default;
-
-// The values each control's own variables default to. A consumer sets
-// `$check-*` / `$radio-*` / `$switch-*` (documented on their pages); these are
-// what those fall back to, and what still works for a v5-era override.
-// scss-docs-start form-check-defaults
-$form-check-input-width:                  1em !default;
-
-$form-check-input-bg:                     $input-bg !default;
-$form-check-input-border:                 var(--#{$prefix}border-width) solid var(--#{$prefix}border-color) !default;
-$form-check-input-border-radius:          .25em !default;
-$form-check-radio-border-radius:          50% !default;
-
-$form-check-input-checked-color:          var(--#{$prefix}primary-contrast) !default;
-// scss-docs-end form-check-defaults
-
-// What the wrapper owns and what all three controls share: the row, the label,
-// and the focus / active / disabled states.
-// scss-docs-start form-check-variables
-$form-check-min-height:                   calc(var(--#{$prefix}body-font-size) * var(--#{$prefix}body-line-height)) !default; // stylelint-disable-line function-disallowed-list
-$form-check-margin-bottom:                .125rem !default;
-$form-check-inline-margin-end:            1rem !default;
-
-$form-check-label-color:                  null !default;
-$form-check-label-cursor:                 null !default;
-
-$form-check-input-active-filter:          brightness(90%) !default;
-$form-check-input-focus-border:           $input-focus-border-color !default;
-$form-check-input-focus-ring:             var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
-
-$form-check-input-disabled-opacity:        .5 !default;
-$form-check-label-disabled-opacity:        $form-check-input-disabled-opacity !default;
-// scss-docs-end form-check-variables
-
-// scss-docs-start form-switch-variables
-
-$form-switch-widths: (
-  lg: (
-    width: 2.5em,
-    height: 1.25em
-  ),
-  xl: (
-    width: 3em,
-    height: 1.5em
-  )
-) !default;
-// scss-docs-end form-switch-variables
 
 // stylelint-disable scss/dollar-variable-default
 
@@ -71,22 +17,6 @@ $form-check-tokens: defaults(
   $form-check-tokens
 );
 // scss-docs-end form-check-tokens
-
-// stylelint-enable scss/dollar-variable-default
-
-// stylelint-disable scss/dollar-variable-default
-
-// scss-docs-start form-check-input-tokens
-// Tokens the input owns, so it still styles itself when used outside .form-check
-// — an input group, for instance. Keeping them off the wrapper means a wrapper
-// or :root override is not shadowed by the input's own declaration.
-$form-check-input-tokens: () !default;
-$form-check-input-tokens: defaults(
-  (
-  ),
-  $form-check-input-tokens
-);
-// scss-docs-end form-check-input-tokens
 
 // stylelint-enable scss/dollar-variable-default
 

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -44,9 +44,6 @@ $form-check-label-disabled-opacity:        $form-check-input-disabled-opacity !d
 // scss-docs-end form-check-variables
 
 // scss-docs-start form-switch-variables
-$form-switch-color:               rgba($black, .25) !default;
-$form-switch-width:               2em !default;
-$form-switch-border-radius:       $form-switch-width !default;
 
 $form-switch-widths: (
   lg: (

--- a/scss/forms/_radio.scss
+++ b/scss/forms/_radio.scss
@@ -1,7 +1,7 @@
 @use "sass:map";
 @use "../functions/defaults" as *;
 @use "../functions/escape-svg" as *;
-@use "form-check" as *;
+@use "variables" as *;
 @use "check" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/mask-icon" as *;

--- a/scss/forms/_radio.scss
+++ b/scss/forms/_radio.scss
@@ -6,6 +6,7 @@
 @use "../mixins/focus-ring" as *;
 @use "../mixins/mask-icon" as *;
 @use "../mixins/tokens" as *;
+@use "../mixins/transition" as *;
 @use "../config" as *;
 
 // The radio's own theming surface — see the note in `_checkbox.scss`.
@@ -71,6 +72,7 @@ $radio-selector: if(sass($enable-deprecated-form-check): ".radio, .form-check-in
     appearance: none;
     background-color: var(--#{$prefix}radio-bg);
     border: var(--#{$prefix}radio-border);
+    @include transition(background-color var(--#{$prefix}control-transition-duration) var(--#{$prefix}control-transition-timing), border-color var(--#{$prefix}control-transition-duration) var(--#{$prefix}control-transition-timing));
     print-color-adjust: exact;
     // stylelint-disable-next-line property-disallowed-list
     border-radius: var(--#{$prefix}radio-border-radius);
@@ -82,7 +84,9 @@ $radio-selector: if(sass($enable-deprecated-form-check): ".radio, .form-check-in
       content: "";
       background-color: var(--#{$prefix}radio-mark-color);
       opacity: 0;
+      transform: scale(0);
       @include mask-icon(var(--#{$prefix}radio-mark));
+      @include transition(opacity var(--#{$prefix}control-transition-duration) var(--#{$prefix}control-transition-timing), transform var(--#{$prefix}control-transition-duration) var(--#{$prefix}control-transition-timing));
     }
 
     &:checked {
@@ -91,6 +95,7 @@ $radio-selector: if(sass($enable-deprecated-form-check): ".radio, .form-check-in
 
       &::before {
         opacity: 1;
+        transform: scale(1);
       }
     }
 

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -8,21 +8,26 @@
 @use "../config" as *;
 
 // scss-docs-start switch-variables
-$switch-aspect-ratio:         2 !default;
-$switch-height:               $form-check-input-width !default;
-$switch-border-radius:        $form-switch-border-radius !default;
-$switch-transition-duration:  .15s !default;
-$switch-transition-timing:    ease-in-out !default;
-$switch-bg:                   $form-check-input-bg !default;
-$switch-border:               $form-check-input-border !default;
-$switch-padding:              .125em !default;
-$switch-thumb-bg:             $form-switch-color !default;
+$switch-aspect-ratio:         1.75 !default;
+$switch-height:               1.25rem !default;
+$switch-border-radius:        var(--#{$prefix}border-radius-pill) !default;
+$switch-transition-duration:  var(--#{$prefix}control-transition-duration) !default;
+$switch-transition-timing:    var(--#{$prefix}control-transition-timing) !default;
+$switch-bg:                   var(--#{$prefix}tertiary-bg) !default;
+$switch-box-shadow:           inset 0 1px 2px color-mix(in srgb, var(--#{$prefix}black) 5%, transparent) !default;
+$switch-border-width:         var(--#{$prefix}border-width) !default;
+$switch-border-color:         var(--#{$prefix}border-color) !default;
+$switch-padding:              .0625rem !default;
+$switch-thumb-bg:             var(--#{$prefix}white) !default;
+$switch-thumb-shadow:         0 1px 2px color-mix(in srgb, var(--#{$prefix}black) 10%, transparent) !default;
 $switch-checked-thumb-bg:     var(--#{$prefix}primary-contrast) !default;
+$switch-disabled-bg:          var(--#{$prefix}control-disabled-bg) !default;
+$switch-disabled-thumb-bg:    var(--#{$prefix}tertiary-color) !default;
 
 $switch-sizes: (
-  sm: (height: .875rem, font-size: var(--#{$prefix}font-size-sm)),
-  lg: (height: 1.25rem, font-size: var(--#{$prefix}font-size-lg)),
-  xl: (height: 1.5rem, font-size: var(--#{$prefix}font-size-lg))
+  sm: (height: 1rem,    font-size: var(--#{$prefix}font-size-sm)),
+  lg: (height: 1.5rem,  font-size: var(--#{$prefix}font-size-lg)),
+  xl: (height: 1.75rem, font-size: var(--#{$prefix}font-size-lg))
 ) !default;
 // scss-docs-end switch-variables
 
@@ -39,13 +44,18 @@ $switch-tokens: defaults(
     --#{$prefix}switch-transition-duration: #{$switch-transition-duration},
     --#{$prefix}switch-transition-timing: #{$switch-transition-timing},
     --#{$prefix}switch-bg: #{$switch-bg},
-    --#{$prefix}switch-border: #{$switch-border},
+    --#{$prefix}switch-box-shadow: #{$switch-box-shadow},
+    --#{$prefix}switch-border-width: #{$switch-border-width},
+    --#{$prefix}switch-border-color: #{$switch-border-color},
     --#{$prefix}switch-padding: #{$switch-padding},
     --#{$prefix}switch-thumb-bg: #{$switch-thumb-bg},
-    --#{$prefix}switch-thumb-size: calc(var(--#{$prefix}switch-height) - var(--#{$prefix}switch-padding) * 2),
+    --#{$prefix}switch-thumb-size: calc(var(--#{$prefix}switch-height) - var(--#{$prefix}switch-padding) * 2 - var(--#{$prefix}switch-border-width) * 2),
+    --#{$prefix}switch-thumb-shadow: #{$switch-thumb-shadow},
     --#{$prefix}switch-checked-bg: var(--#{$prefix}theme-base, var(--#{$prefix}control-checked-bg)),
     --#{$prefix}switch-checked-border-color: var(--#{$prefix}theme-base, var(--#{$prefix}control-checked-border-color)),
     --#{$prefix}switch-checked-thumb-bg: #{$switch-checked-thumb-bg},
+    --#{$prefix}switch-disabled-bg: #{$switch-disabled-bg},
+    --#{$prefix}switch-disabled-thumb-bg: #{$switch-disabled-thumb-bg},
     --#{$prefix}switch-disabled-opacity: #{$form-check-input-disabled-opacity},
     --#{$prefix}switch-margin-top: calc((var(--#{$prefix}body-line-height) * 1em - var(--#{$prefix}switch-height)) * .5),
     --#{$prefix}switch-focus-border: #{$form-check-input-focus-border},
@@ -74,7 +84,8 @@ $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch
     vertical-align: top;
     appearance: none;
     background-color: var(--#{$prefix}switch-bg);
-    border: var(--#{$prefix}switch-border);
+    border: var(--#{$prefix}switch-border-width) solid var(--#{$prefix}switch-border-color);
+    box-shadow: var(--#{$prefix}switch-box-shadow);
     print-color-adjust: exact;
     @include border-radius(var(--#{$prefix}switch-border-radius), 0);
     @include transition(background-color var(--#{$prefix}switch-transition-duration) var(--#{$prefix}switch-transition-timing), border-color var(--#{$prefix}switch-transition-duration) var(--#{$prefix}switch-transition-timing));
@@ -89,6 +100,7 @@ $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch
       background-color: var(--#{$prefix}switch-thumb-bg);
       // stylelint-disable-next-line property-disallowed-list
       border-radius: 50%;
+      box-shadow: var(--#{$prefix}switch-thumb-shadow);
       transform: translateY(-50%);
       @include transition(inset-inline-start var(--#{$prefix}switch-transition-duration) var(--#{$prefix}switch-transition-timing), background-color var(--#{$prefix}switch-transition-duration) var(--#{$prefix}switch-transition-timing));
     }
@@ -112,7 +124,19 @@ $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch
     &:disabled {
       pointer-events: none;
       filter: none;
-      opacity: var(--#{$prefix}switch-disabled-opacity);
+
+      &:not(:checked) {
+        background-color: var(--#{$prefix}switch-disabled-bg);
+
+        &::before {
+          background-color: var(--#{$prefix}switch-disabled-thumb-bg);
+          opacity: .4;
+        }
+      }
+
+      &:checked {
+        opacity: var(--#{$prefix}switch-disabled-opacity);
+      }
 
       ~ label {
         cursor: default;

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -1,6 +1,6 @@
 @use "sass:map";
 @use "../functions/defaults" as *;
-@use "form-check" as *;
+@use "variables" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;

--- a/scss/forms/_variables.scss
+++ b/scss/forms/_variables.scss
@@ -90,3 +90,49 @@ $form-validation-states: (
   )
 ) !default;
 // scss-docs-end form-validation-states
+
+// The values each control's own variables default to. A consumer sets
+// `$check-*` / `$radio-*` / `$switch-*` (documented on their pages); these are
+// what those fall back to, and what still works for a v5-era override.
+// scss-docs-start form-check-defaults
+$form-check-input-width:                  1em !default;
+
+$form-check-input-bg:                     $input-bg !default;
+$form-check-input-border:                 var(--#{$prefix}border-width) solid var(--#{$prefix}border-color) !default;
+$form-check-input-border-radius:          .25em !default;
+$form-check-radio-border-radius:          50% !default;
+
+$form-check-input-checked-color:          var(--#{$prefix}primary-contrast) !default;
+// scss-docs-end form-check-defaults
+
+// What the wrapper owns and what all three controls share: the row, the label,
+// and the focus / active / disabled states.
+// scss-docs-start form-check-variables
+$form-check-min-height:                   calc(var(--#{$prefix}body-font-size) * var(--#{$prefix}body-line-height)) !default; // stylelint-disable-line function-disallowed-list
+$form-check-margin-bottom:                .125rem !default;
+$form-check-inline-margin-end:            1rem !default;
+
+$form-check-label-color:                  null !default;
+$form-check-label-cursor:                 null !default;
+
+$form-check-input-active-filter:          brightness(90%) !default;
+$form-check-input-focus-border:           $input-focus-border-color !default;
+$form-check-input-focus-ring:             var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring)) !default;
+
+$form-check-input-disabled-opacity:        .5 !default;
+$form-check-label-disabled-opacity:        $form-check-input-disabled-opacity !default;
+// scss-docs-end form-check-variables
+
+// scss-docs-start form-switch-variables
+
+$form-switch-widths: (
+  lg: (
+    width: 2.5em,
+    height: 1.25em
+  ),
+  xl: (
+    width: 3em,
+    height: 1.5em
+  )
+) !default;
+// scss-docs-end form-switch-variables


### PR DESCRIPTION
The three adoptions from the switch comparison, executed:

- **The switch is redrawn to the adopted proportions** <span title="breaking">⚠️</span>: a 1.25rem track with a 1.75 ratio (was a font-relative 2:1 `em` track), pill radius, tertiary surface with an inset shadow, white thumb with a drop shadow turning contrast-coloured when checked. The border splits into `-border-width`/`-border-color` tokens so the thumb size subtracts the real border. `$form-switch-color`, `-width` and `-border-radius` fed only the old look and are gone; the deprecated `.form-switch-lg`/`-xl` sizing keeps its original `em` scale.
- **Richer disabled state**: an unchecked disabled switch swaps to `--cui-control-disabled-bg` with a faded thumb instead of dimming wholesale; a checked one dims. The knob lives on `:root`, shared with future consumers.
- **Shared control motion**: `:root` carries `--cui-control-transition-duration`/`-timing` (overshoot easing); the checkbox tick and radio dot pop in on them (`scale(0)→scale(1)` + opacity), box colours animate, and the switch thumb slides on the same pair — three controls in sync, restyled from one place, reduced-motion honoured by the transition mixin.
- **`_form-check.scss` is only the deprecated wrapper now**: the shared defaults the three controls bridge from (and the v5 switch sizing map) move to `forms/_variables.scss` — a CSS-emitting file holding variables imported by three modules is the exact shape that reordered the cascade layers in #776. Swept on the way out: a twice-declared variable, an empty token map with markers, six dead imports; the file is 45 lines and says exactly why it exists. Docs captures repointed here and in the React v6 docs (companion PR, merges together with this stack).

Migration guide carries the redesign and motion entries and two rewritten stale statements (the aspect ratio is a plain number; there is no SVG knob anywhere any more). Verification: fusv clean, stylelint clean, css-test 62/62, class-API guard green, docs build 147 pages, pre-push full gate green; the compiled sheet changes are the intended redesign — the form-check move itself is byte-neutral.