### PR TITLE
docs(scss): cut the narration from the dialog family

### DIFF
--- a/scss/_date-picker.scss
+++ b/scss/_date-picker.scss
@@ -6,7 +6,6 @@
 @use "config" as *;
 @use "forms/form-control-group" as *;
 
-// Date Picker
 // scss-docs-start date-picker-variables
 $date-picker-footer-padding:           .5rem !default;
 $date-picker-footer-border-width:      1px !default;
@@ -30,35 +29,23 @@ $date-picker-tokens: defaults(
 
 // stylelint-enable scss/dollar-variable-default
 @layer components {
-  // The shell styles only what it owns: the field comes from
-  // forms/_form-date-time.scss, the popup content from _calendar.scss.
 
   .date-picker {
     position: relative;
 
-    // The popup takes the focus away from the group, but the control is still
-    // active — so the frame keeps its focus treatment while it is open.
     &.show {
       @include form-control-group-active();
     }
   }
 
-  // The panel declares its own tokens rather than inheriting them from the
-  // field's root: a panel can be teleported by the `container` option, and a
-  // framework port may render it through a portal, so nothing inside it may
-  // depend on having a particular ancestor. Chrome comes from `.popup`; its
-  // width needs no declaration, an absolutely positioned box already shrinks
-  // to its content.
+  // The panel declares its own tokens: `container` can teleport it and a
+  // framework port may portal it, so nothing inside may depend on an ancestor.
   .date-picker-popup {
     @include tokens($date-picker-tokens);
 
-    // The date-time picker puts the calendar and the time body side by side. The
-    // time body's layout rules are global but read --#{$prefix}time-picker-* custom
-    // properties that _time-picker.scss only defines on `.time-picker`, and this
-    // shell's root is a date picker — so the ones the body needs are declared here.
-    // They belong on the panel rather than on the field's root for the same reason
-    // the tokens above do; only the date-time picker's panel holds these elements,
-    // so the scope stays exact.
+    // The time body's rules read --#{$prefix}time-picker-* properties that
+    // `_time-picker.scss` declares on `.time-picker` alone, and this root is a
+    // date picker — so the ones the body needs are declared here.
 
     .date-picker-timepickers {
       display: flex;

--- a/scss/_date-picker.scss
+++ b/scss/_date-picker.scss
@@ -38,14 +38,8 @@ $date-picker-tokens: defaults(
     }
   }
 
-  // The panel declares its own tokens: `container` can teleport it and a
-  // framework port may portal it, so nothing inside may depend on an ancestor.
   .date-picker-popup {
     @include tokens($date-picker-tokens);
-
-    // The time body's rules read --#{$prefix}time-picker-* properties that
-    // `_time-picker.scss` declares on `.time-picker` alone, and this root is a
-    // date picker — so the ones the body needs are declared here.
 
     .date-picker-timepickers {
       display: flex;

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -100,7 +100,6 @@ $dialog-tokens: defaults(
     max-height: calc(100% - var(--#{$prefix}dialog-margin) * 2);
     padding: 0;
     margin: auto;
-    // Let popups (menus, tooltips) appended inside the dialog overflow its box
     overflow: visible;
     color: var(--#{$prefix}dialog-color);
     visibility: hidden;
@@ -112,9 +111,6 @@ $dialog-tokens: defaults(
     @include box-shadow(var(--#{$prefix}dialog-box-shadow));
 
     &:not(.dialog-instant) {
-      // A base value, not @starting-style, so it applies on every open of a
-      // persistent element and the exit can fall back to it while the JS holds
-      // the dialog in the top layer.
       opacity: 0;
       @include transition(
         opacity var(--#{$prefix}dialog-transition-duration) var(--#{$prefix}dialog-transition-timing),
@@ -141,8 +137,6 @@ $dialog-tokens: defaults(
         transform: none;
       }
 
-      // Static backdrop "bounce". Qualified with [open]:not(.hiding) to
-      // outrank the open-state transform reset.
       &[open].dialog-static:not(.hiding) {
         transform: $dialog-scale-transform;
       }
@@ -180,8 +174,6 @@ $dialog-tokens: defaults(
       display: none;
     }
 
-    // show() skips the top layer here, so positioning and z-index are ours.
-    // Centring uses `translate` so the animated `transform` states don't fight it.
     &.dialog-nonmodal {
       position: fixed;
       inset-block-start: 50%;
@@ -197,16 +189,12 @@ $dialog-tokens: defaults(
     }
   }
 
-  // Entry animation for ::backdrop. It only exists while the dialog is in the
-  // top layer, so its starting state can't be expressed on the base selector.
   @starting-style {
     .dialog:not(.dialog-instant)::backdrop {
       background-color: transparent;
       backdrop-filter: blur(0);
     }
 
-    // The outgoing dialog's ::backdrop is removed in the same tick, so this one
-    // starts opaque — otherwise the user sees a dip or a double-darkened flash.
     .dialog.dialog-swap-in:not(.dialog-instant)::backdrop {
       background-color: var(--#{$prefix}dialog-backdrop-bg);
       backdrop-filter: blur(var(--#{$prefix}dialog-backdrop-blur));

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -7,11 +7,6 @@
 @use "mixins/transition" as *;
 @use "config" as *;
 
-// Native <dialog> component with the Bootstrap 6 Dialog look — centered
-// floating panel, blurred ::backdrop, optional slide entry variants. Shares
-// the DialogBase behavior (and the `:root.dialog-open` scroll lock defined in
-// _modal.scss) with Modal.
-
 // stylelint-disable custom-property-no-missing-var-function, function-disallowed-list
 
 // scss-docs-start dialog-variables
@@ -116,14 +111,10 @@ $dialog-tokens: defaults(
     @include border-radius(var(--#{$prefix}dialog-border-radius));
     @include box-shadow(var(--#{$prefix}dialog-box-shadow));
 
-    // Animated variant (default) — fade, with optional slide entry variants.
-    // Adding .dialog-instant skips all animations.
     &:not(.dialog-instant) {
-      // Exit state: faded out. This is also the entry-from state — a base
-      // value (not @starting-style) so it applies on every open of a
-      // persistent element, and the exit transition can fall back to it while
-      // the JS keeps the dialog in the top layer (.hiding) so the ::backdrop
-      // and the browser's modal centering survive the exit animation.
+      // A base value, not @starting-style, so it applies on every open of a
+      // persistent element and the exit can fall back to it while the JS holds
+      // the dialog in the top layer.
       opacity: 0;
       @include transition(
         opacity var(--#{$prefix}dialog-transition-duration) var(--#{$prefix}dialog-transition-timing),
@@ -131,7 +122,6 @@ $dialog-tokens: defaults(
         visibility 0s var(--#{$prefix}dialog-transition-duration)
       );
 
-      // Slide variants: enter from above/below, exit by reversing
       &.dialog-slide-down {
         transform: translateY(-$dialog-slide-distance);
       }
@@ -140,8 +130,6 @@ $dialog-tokens: defaults(
         transform: translateY($dialog-slide-distance);
       }
 
-      // Open state: visibility flips immediately, opacity and transform
-      // animate in
       &[open]:not(.hiding) {
         visibility: visible;
         opacity: 1;
@@ -188,14 +176,12 @@ $dialog-tokens: defaults(
       transform: none;
     }
 
-    // `backdrop: false` — modal behavior with a visually suppressed backdrop
     &.dialog-no-backdrop::backdrop {
       display: none;
     }
 
-    // Non-modal mode (`modal: false`) — show() skips the top layer, so
-    // explicit positioning and z-index are needed. Centering uses the
-    // `translate` property so the animated `transform` states don't fight it.
+    // show() skips the top layer here, so positioning and z-index are ours.
+    // Centring uses `translate` so the animated `transform` states don't fight it.
     &.dialog-nonmodal {
       position: fixed;
       inset-block-start: 50%;
@@ -219,9 +205,8 @@ $dialog-tokens: defaults(
       backdrop-filter: blur(0);
     }
 
-    // Swap entry: the outgoing dialog's ::backdrop is removed synchronously in
-    // the same tick, so this one starts already-opaque — the user sees one
-    // continuous backdrop instead of a dip or a double-darkened flash.
+    // The outgoing dialog's ::backdrop is removed in the same tick, so this one
+    // starts opaque — otherwise the user sees a dip or a double-darkened flash.
     .dialog.dialog-swap-in:not(.dialog-instant)::backdrop {
       background-color: var(--#{$prefix}dialog-backdrop-bg);
       backdrop-filter: blur(var(--#{$prefix}dialog-backdrop-blur));

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -8,11 +8,6 @@
 @use "mixins/transition" as *;
 @use "config" as *;
 
-// Native <dialog> component with the Bootstrap 6 Drawer look — a floating,
-// inset, rounded panel sliding in from any viewport edge, with a blurred
-// translucent ::backdrop. Shares the DialogBase behavior (and the
-// `:root.dialog-open` scroll lock defined in _modal.scss) with Modal.
-
 // stylelint-disable custom-property-no-missing-var-function, function-disallowed-list
 
 // scss-docs-start drawer-variables
@@ -86,9 +81,9 @@ $drawer-tokens: defaults(
 
     .drawer#{$infix} {
       @include media-breakpoint-down($next) {
-        // Reset the native <dialog> UA defaults (fit-content sizing, inset,
-        // margins) and override display: none so visibility controls the
-        // hidden state, enabling exit animations after close().
+        // Resets the UA's fit-content sizing, inset and margins, and its
+        // display: none, so visibility controls the hidden state and the exit
+        // can animate after close().
         position: fixed;
         inset: auto;
         z-index: var(--#{$prefix}drawer-zindex);
@@ -110,9 +105,8 @@ $drawer-tokens: defaults(
         @include border-radius(var(--#{$prefix}drawer-border-radius));
         @include box-shadow(var(--#{$prefix}drawer-box-shadow));
 
-        // Placement positioning and sizing — always applied regardless of
-        // animation mode. :where() keeps specificity flat so modifiers like
-        // .drawer-sheet can override without escalation.
+        // `:where()` keeps specificity flat so a modifier like `.drawer-sheet`
+        // overrides without escalation.
         &:where(.drawer-start) {
           inset-block: var(--#{$prefix}drawer-inset);
           inset-inline-start: var(--#{$prefix}drawer-inset);
@@ -143,10 +137,9 @@ $drawer-tokens: defaults(
           max-height: none;
         }
 
-        // Animated variant (default) — transitions + off-screen transforms.
-        // Adding .drawer-instant skips all animations. The base transform is
-        // the entry-from / exit-to position; the JS keeps the dialog in the
-        // top layer during the exit (.hiding) so the ::backdrop fade plays.
+        // The base transform is the entry-from and exit-to position; the JS
+        // holds the dialog in the top layer during the exit so the ::backdrop
+        // fade plays.
         &:not(.drawer-instant) {
           @include transition(
             transform var(--#{$prefix}drawer-transition-duration) var(--#{$prefix}drawer-transition-timing),
@@ -181,7 +174,6 @@ $drawer-tokens: defaults(
             transform: translateY(calc(100% + var(--#{$prefix}drawer-inset)));
           }
 
-          // Open state: visibility flips immediately, the panel slides in
           &[open]:not(.hiding) {
             visibility: visible;
             @include transition(
@@ -206,9 +198,7 @@ $drawer-tokens: defaults(
             );
           }
 
-          // Exit: fade the native backdrop out alongside the panel — it is
-          // still rendered because close() is deferred until the transition
-          // ends
+          // Still rendered because close() is deferred until the transition ends.
           &.hiding::backdrop {
             background-color: transparent;
             backdrop-filter: blur(0);
@@ -226,16 +216,13 @@ $drawer-tokens: defaults(
           transform: none;
         }
 
-        // `backdrop: false` — modal behavior with a visually suppressed
-        // backdrop
         &.drawer-no-backdrop::backdrop {
           display: none;
         }
       }
 
-      // Above breakpoint — show content inline (for responsive drawer). The
-      // native <dialog> UA styles (display: none, fixed positioning) must be
-      // fully reset so the element behaves as an inline flex container.
+      // The UA's display: none and fixed positioning have to be reset in full
+      // for the element to behave as an inline flex container.
       @if not ($infix == "") {
         @include media-breakpoint-up($next) {
           // stylelint-disable declaration-no-important
@@ -294,15 +281,13 @@ $drawer-tokens: defaults(
     }
   }
 
-  // Frosted-glass panel variant
   .drawer-translucent {
     background-color: color-mix(in oklch, var(--#{$prefix}drawer-bg) 80%, transparent);
     backdrop-filter: blur(5px) saturate(180%);
   }
 
-  // Sheet variant: flush-to-edge bottom panel with no inset or bottom radius.
-  // Overrides the placement insets so the calc() off-screen transforms
-  // automatically position the drawer at the viewport edge.
+  // Overrides the placement insets so the off-screen transforms land the panel
+  // on the viewport edge.
   .drawer-sheet {
     right: 0;
     bottom: 0;
@@ -318,12 +303,10 @@ $drawer-tokens: defaults(
     }
   }
 
-  // Keep the panel only as tall as its content
   .drawer-fit-content {
     inset-block-end: auto;
   }
 
-  // Drawer header
   .drawer-header {
     display: flex;
     flex-shrink: 0;
@@ -336,13 +319,11 @@ $drawer-tokens: defaults(
     }
   }
 
-  // Drawer title
   .drawer-title {
     margin-bottom: 0;
     line-height: var(--#{$prefix}drawer-title-line-height);
   }
 
-  // Drawer body
   .drawer-body {
     // Contain absolutely positioned children (e.g. menus) so they scroll with
     // the body instead of being clipped by the drawer's overflow.
@@ -356,7 +337,6 @@ $drawer-tokens: defaults(
     overflow-y: auto;
   }
 
-  // Drawer footer
   .drawer-footer {
     display: flex;
     flex-shrink: 0;

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -81,9 +81,6 @@ $drawer-tokens: defaults(
 
     .drawer#{$infix} {
       @include media-breakpoint-down($next) {
-        // Resets the UA's fit-content sizing, inset and margins, and its
-        // display: none, so visibility controls the hidden state and the exit
-        // can animate after close().
         position: fixed;
         inset: auto;
         z-index: var(--#{$prefix}drawer-zindex);
@@ -105,8 +102,6 @@ $drawer-tokens: defaults(
         @include border-radius(var(--#{$prefix}drawer-border-radius));
         @include box-shadow(var(--#{$prefix}drawer-box-shadow));
 
-        // `:where()` keeps specificity flat so a modifier like `.drawer-sheet`
-        // overrides without escalation.
         &:where(.drawer-start) {
           inset-block: var(--#{$prefix}drawer-inset);
           inset-inline-start: var(--#{$prefix}drawer-inset);
@@ -137,9 +132,6 @@ $drawer-tokens: defaults(
           max-height: none;
         }
 
-        // The base transform is the entry-from and exit-to position; the JS
-        // holds the dialog in the top layer during the exit so the ::backdrop
-        // fade plays.
         &:not(.drawer-instant) {
           @include transition(
             transform var(--#{$prefix}drawer-transition-duration) var(--#{$prefix}drawer-transition-timing),
@@ -183,8 +175,6 @@ $drawer-tokens: defaults(
             transform: none;
           }
 
-          // Static backdrop "bounce". Qualified with [open]:not(.hiding) to
-          // outrank the open-state transform reset.
           &[open].drawer-static:not(.hiding) {
             transform: $drawer-scale-transform;
           }
@@ -198,7 +188,6 @@ $drawer-tokens: defaults(
             );
           }
 
-          // Still rendered because close() is deferred until the transition ends.
           &.hiding::backdrop {
             background-color: transparent;
             backdrop-filter: blur(0);
@@ -221,8 +210,6 @@ $drawer-tokens: defaults(
         }
       }
 
-      // The UA's display: none and fixed positioning have to be reset in full
-      // for the element to behave as an inline flex container.
       @if not ($infix == "") {
         @include media-breakpoint-up($next) {
           // stylelint-disable declaration-no-important
@@ -259,7 +246,6 @@ $drawer-tokens: defaults(
             width: 100%;
             padding: 0;
             overflow-y: visible;
-            // Reset `background-color` in case `.bg-*` classes are used in drawer
             background-color: transparent !important; // stylelint-disable-line declaration-no-important
           }
         }
@@ -267,8 +253,6 @@ $drawer-tokens: defaults(
     }
   }
 
-  // Entry animation for ::backdrop. It only exists while the dialog is in the
-  // top layer, so its starting state can't be expressed on the base selector.
   @starting-style {
     @each $breakpoint in map.keys($grid-breakpoints) {
       $next: breakpoint-next($breakpoint, $grid-breakpoints);
@@ -286,8 +270,6 @@ $drawer-tokens: defaults(
     backdrop-filter: blur(5px) saturate(180%);
   }
 
-  // Overrides the placement insets so the off-screen transforms land the panel
-  // on the viewport edge.
   .drawer-sheet {
     right: 0;
     bottom: 0;

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -7,10 +7,6 @@
 @use "mixins/transition" as *;
 @use "config" as *;
 
-// Native <dialog> component
-// Uses the browser's native dialog element with showModal()/show()/close()
-// APIs, the [open] attribute, and the ::backdrop pseudo-element.
-
 // stylelint-disable custom-property-no-missing-var-function, function-disallowed-list
 
 // scss-docs-start modal-variables
@@ -96,10 +92,9 @@ $modal-tokens: defaults(
 // stylelint-enable scss/dollar-variable-default
 
 @layer components {
-  // Scroll lock while any modal <dialog> (Modal or Offcanvas) is open. Both
-  // properties sit on the root element on purpose: `scrollbar-gutter` keeps
-  // the gutter reserved while `overflow: hidden` hides the scrollbar, so the
-  // page doesn't shift and the ::backdrop covers the gutter.
+  // On the root element on purpose: the gutter stays reserved while the
+  // scrollbar is hidden, so the page does not shift and the ::backdrop covers
+  // the gutter.
   :root.dialog-open {
     overflow: hidden;
     scrollbar-gutter: stable;
@@ -128,14 +123,10 @@ $modal-tokens: defaults(
     @include border-radius(var(--#{$prefix}modal-border-radius));
     @include box-shadow(var(--#{$prefix}modal-box-shadow));
 
-    // Animated variant (default) — fade plus the v5 slide-down entry.
-    // Adding .modal-instant skips all animations.
     &:not(.modal-instant) {
-      // Exit state: faded out, shifted up. This is also the entry-from state —
-      // a base value (not @starting-style) so it applies on every open of a
-      // persistent element, and the exit transition can fall back to it while
-      // the JS keeps the dialog in the top layer (.hiding) so the ::backdrop
-      // and the browser's modal centering survive the exit animation.
+      // A base value, not @starting-style, so it applies on every open of a
+      // persistent element and the exit can fall back to it while the JS holds
+      // the dialog in the top layer.
       opacity: 0;
       transform: $modal-fade-transform;
       @include transition(
@@ -144,8 +135,6 @@ $modal-tokens: defaults(
         visibility 0s var(--#{$prefix}modal-transition-duration)
       );
 
-      // Open state: visibility flips immediately, opacity and transform
-      // animate in.
       &[open]:not(.hiding) {
         visibility: visible;
         opacity: 1;
@@ -186,14 +175,12 @@ $modal-tokens: defaults(
       transform: none;
     }
 
-    // `backdrop: false` — modal behavior with a visually suppressed backdrop
     &.modal-no-backdrop::backdrop {
       display: none;
     }
 
-    // Non-modal mode (`modal: false`) — show() skips the top layer, so
-    // explicit positioning and z-index are needed. Centering uses the
-    // `translate` property so the animated `transform` states don't fight it.
+    // show() skips the top layer here, so positioning and z-index are ours.
+    // Centring uses `translate` so the animated `transform` states don't fight it.
     &.modal-nonmodal {
       position: fixed;
       inset-block-start: 50%;
@@ -203,7 +190,6 @@ $modal-tokens: defaults(
       translate: -50% -50%;
     }
 
-    // Scrollable modal body (header/footer stay fixed)
     &.modal-scrollable .modal-body {
       overflow-y: auto;
     }
@@ -216,9 +202,8 @@ $modal-tokens: defaults(
       background-color: transparent;
     }
 
-    // Swap entry: the outgoing modal's ::backdrop is removed synchronously in
-    // the same tick, so this one starts already-opaque — the user sees one
-    // continuous backdrop instead of a dip or a double-darkened flash.
+    // The outgoing modal's ::backdrop is removed in the same tick, so this one
+    // starts opaque — otherwise the user sees a dip or a double-darkened flash.
     .modal.modal-swap-in:not(.modal-instant)::backdrop {
       background-color: color-mix(in srgb, var(--#{$prefix}modal-backdrop-bg) calc(var(--#{$prefix}modal-backdrop-opacity) * 100%), transparent);
     }

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -92,9 +92,6 @@ $modal-tokens: defaults(
 // stylelint-enable scss/dollar-variable-default
 
 @layer components {
-  // On the root element on purpose: the gutter stays reserved while the
-  // scrollbar is hidden, so the page does not shift and the ::backdrop covers
-  // the gutter.
   :root.dialog-open {
     overflow: hidden;
     scrollbar-gutter: stable;
@@ -103,8 +100,6 @@ $modal-tokens: defaults(
   .modal {
     @include tokens($modal-tokens);
 
-    // Override the UA display: none so visibility controls the hidden state,
-    // enabling reliable cross-browser exit animations after close().
     display: flex;
     flex-direction: column;
     width: var(--#{$prefix}modal-width);
@@ -112,7 +107,6 @@ $modal-tokens: defaults(
     max-height: calc(100% - var(--#{$prefix}modal-margin) * 2);
     padding: 0;
     margin: auto;
-    // Let popups (menus, tooltips) appended inside the dialog overflow its box
     overflow: visible;
     color: var(--#{$prefix}modal-color);
     visibility: hidden;
@@ -124,9 +118,6 @@ $modal-tokens: defaults(
     @include box-shadow(var(--#{$prefix}modal-box-shadow));
 
     &:not(.modal-instant) {
-      // A base value, not @starting-style, so it applies on every open of a
-      // persistent element and the exit can fall back to it while the JS holds
-      // the dialog in the top layer.
       opacity: 0;
       transform: $modal-fade-transform;
       @include transition(
@@ -146,8 +137,6 @@ $modal-tokens: defaults(
         transform: none;
       }
 
-      // Static backdrop "bounce". Qualified with [open]:not(.hiding) to
-      // outrank the open-state transform reset.
       &[open].modal-static:not(.hiding) {
         transform: $modal-scale-transform;
       }
@@ -157,8 +146,6 @@ $modal-tokens: defaults(
         @include transition(background-color var(--#{$prefix}modal-transition-duration) var(--#{$prefix}modal-transition-timing));
       }
 
-      // Exit: fade the native backdrop out alongside the dialog — it is still
-      // rendered because close() is deferred until the transition ends.
       &.hiding::backdrop {
         background-color: transparent;
       }
@@ -168,7 +155,6 @@ $modal-tokens: defaults(
       background-color: color-mix(in srgb, var(--#{$prefix}modal-backdrop-bg) calc(var(--#{$prefix}modal-backdrop-opacity) * 100%), transparent);
     }
 
-    // Open state base (always applies, regardless of animation mode)
     &[open]:not(.hiding) {
       visibility: visible;
       opacity: 1;
@@ -179,8 +165,6 @@ $modal-tokens: defaults(
       display: none;
     }
 
-    // show() skips the top layer here, so positioning and z-index are ours.
-    // Centring uses `translate` so the animated `transform` states don't fight it.
     &.modal-nonmodal {
       position: fixed;
       inset-block-start: 50%;
@@ -195,22 +179,16 @@ $modal-tokens: defaults(
     }
   }
 
-  // Entry animation for ::backdrop. It only exists while the dialog is in the
-  // top layer, so its starting state can't be expressed on the base selector.
   @starting-style {
     .modal:not(.modal-instant)::backdrop {
       background-color: transparent;
     }
 
-    // The outgoing modal's ::backdrop is removed in the same tick, so this one
-    // starts opaque — otherwise the user sees a dip or a double-darkened flash.
     .modal.modal-swap-in:not(.modal-instant)::backdrop {
       background-color: color-mix(in srgb, var(--#{$prefix}modal-backdrop-bg) calc(var(--#{$prefix}modal-backdrop-opacity) * 100%), transparent);
     }
   }
 
-  // Modal header
-  // Top section of the modal w/ title and dismiss
   .modal-header {
     display: flex;
     flex-shrink: 0;
@@ -228,23 +206,17 @@ $modal-tokens: defaults(
     }
   }
 
-  // Title text within header
   .modal-title {
     margin-bottom: 0;
     line-height: var(--#{$prefix}modal-title-line-height);
   }
 
-  // Modal body
-  // Where all modal content resides (sibling of .modal-header and .modal-footer)
   .modal-body {
     position: relative;
-    // Enable `flex-grow: 1` so that the body take up as much space as possible
-    // when there should be a fixed height on the modal.
     flex: 1 1 auto;
     padding: var(--#{$prefix}modal-padding);
   }
 
-  // Footer (for actions)
   .modal-footer {
     display: flex;
     flex-shrink: 0;
@@ -258,7 +230,6 @@ $modal-tokens: defaults(
     @include border-bottom-radius(var(--#{$prefix}modal-inner-border-radius));
   }
 
-  // Scale up the modal
   @include media-breakpoint-up(sm) {
     .modal {
       --#{$prefix}modal-margin: #{$modal-dialog-margin-y-sm-up};

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -8,10 +8,6 @@
 @use "modal" as *;
 @use "config" as *;
 
-// Native <dialog> component
-// Uses the browser's native dialog element with showModal()/show()/close()
-// APIs, the [open] attribute, and the ::backdrop pseudo-element.
-
 // stylelint-disable custom-property-no-missing-var-function, function-disallowed-list
 
 // scss-docs-start offcanvas-variables
@@ -79,9 +75,9 @@ $offcanvas-tokens: defaults(
 
     .offcanvas#{$infix} {
       @include media-breakpoint-down($next) {
-        // Reset the native <dialog> UA defaults (fit-content sizing, inset,
-        // margins) and override display: none so visibility controls the
-        // hidden state, enabling exit animations after close().
+        // Resets the UA's fit-content sizing, inset and margins, and its
+        // display: none, so visibility controls the hidden state and the exit
+        // can animate after close().
         position: fixed;
         inset: auto;
         z-index: var(--#{$prefix}offcanvas-zindex);
@@ -134,10 +130,9 @@ $offcanvas-tokens: defaults(
           border-top: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
         }
 
-        // Animated variant (default) — transitions + off-screen transforms.
-        // Adding .offcanvas-instant skips all animations. The base transform
-        // is the entry-from / exit-to position; the JS keeps the dialog in the
-        // top layer during the exit (.hiding) so the ::backdrop fade plays.
+        // The base transform is the entry-from and exit-to position; the JS
+        // holds the dialog in the top layer during the exit so the ::backdrop
+        // fade plays.
         &:not(.offcanvas-instant) {
           @include transition(
             transform var(--#{$prefix}offcanvas-transition-duration) var(--#{$prefix}offcanvas-transition-timing),
@@ -160,7 +155,6 @@ $offcanvas-tokens: defaults(
             transform: translateY(100%);
           }
 
-          // Open state: visibility flips immediately, the panel slides in
           &[open]:not(.hiding) {
             visibility: visible;
             @include transition(
@@ -199,16 +193,13 @@ $offcanvas-tokens: defaults(
           transform: none;
         }
 
-        // `backdrop: false` — modal behavior with a visually suppressed
-        // backdrop
         &.offcanvas-no-backdrop::backdrop {
           display: none;
         }
       }
 
-      // Above breakpoint — show content inline (for responsive offcanvas).
-      // The native <dialog> UA styles (display: none, fixed positioning) must
-      // be fully reset so the element behaves as an inline flex container.
+      // The UA's display: none and fixed positioning have to be reset in full
+      // for the element to behave as an inline flex container.
       @if not ($infix == "") {
         @include media-breakpoint-up($next) {
           // stylelint-disable declaration-no-important

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -75,24 +75,17 @@ $offcanvas-tokens: defaults(
 
     .offcanvas#{$infix} {
       @include media-breakpoint-down($next) {
-        // Resets the UA's fit-content sizing, inset and margins, and its
-        // display: none, so visibility controls the hidden state and the exit
-        // can animate after close().
         position: fixed;
         inset: auto;
         z-index: var(--#{$prefix}offcanvas-zindex);
         display: flex;
         flex-direction: column;
-        // The UA sizes a <dialog> to fit-content — reset to auto so the
-        // placement insets stretch the panel to the full viewport edge
         width: auto;
         max-width: 100%;
         height: auto;
         max-height: 100%;
         padding: 0;
         margin: 0;
-        // Let popups (menus, tooltips) appended inside the dialog overflow its
-        // box; the body handles its own scrolling.
         overflow: visible;
         color: var(--#{$prefix}offcanvas-color);
         visibility: hidden;
@@ -102,8 +95,6 @@ $offcanvas-tokens: defaults(
         outline: 0;
         @include box-shadow(var(--#{$prefix}offcanvas-box-shadow));
 
-        // Placement positioning and sizing — always applied regardless of
-        // animation mode
         &.offcanvas-start {
           inset-block: 0;
           inset-inline-start: 0;
@@ -130,9 +121,6 @@ $offcanvas-tokens: defaults(
           border-top: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
         }
 
-        // The base transform is the entry-from and exit-to position; the JS
-        // holds the dialog in the top layer during the exit so the ::backdrop
-        // fade plays.
         &:not(.offcanvas-instant) {
           @include transition(
             transform var(--#{$prefix}offcanvas-transition-duration) var(--#{$prefix}offcanvas-transition-timing),
@@ -164,8 +152,6 @@ $offcanvas-tokens: defaults(
             transform: none;
           }
 
-          // Static backdrop "bounce". Qualified with [open]:not(.hiding) to
-          // outrank the open-state transform reset.
           &[open].offcanvas-static:not(.hiding) {
             transform: $modal-scale-transform;
           }
@@ -175,9 +161,6 @@ $offcanvas-tokens: defaults(
             @include transition(background-color var(--#{$prefix}offcanvas-transition-duration) var(--#{$prefix}offcanvas-transition-timing));
           }
 
-          // Exit: fade the native backdrop out alongside the panel — it is
-          // still rendered because close() is deferred until the transition
-          // ends.
           &.hiding::backdrop {
             background-color: transparent;
           }
@@ -187,7 +170,6 @@ $offcanvas-tokens: defaults(
           background-color: color-mix(in srgb, var(--#{$prefix}offcanvas-backdrop-bg) calc(var(--#{$prefix}offcanvas-backdrop-opacity) * 100%), transparent);
         }
 
-        // Open state base (always applies, regardless of animation mode)
         &[open]:not(.hiding) {
           visibility: visible;
           transform: none;
@@ -198,8 +180,6 @@ $offcanvas-tokens: defaults(
         }
       }
 
-      // The UA's display: none and fixed positioning have to be reset in full
-      // for the element to behave as an inline flex container.
       @if not ($infix == "") {
         @include media-breakpoint-up($next) {
           // stylelint-disable declaration-no-important
@@ -231,7 +211,6 @@ $offcanvas-tokens: defaults(
             flex-grow: 0;
             padding: 0;
             overflow-y: visible;
-            // Reset `background-color` in case `.bg-*` classes are used in offcanvas
             background-color: transparent !important; // stylelint-disable-line declaration-no-important
           }
         }
@@ -239,8 +218,6 @@ $offcanvas-tokens: defaults(
     }
   }
 
-  // Entry animation for ::backdrop. It only exists while the dialog is in the
-  // top layer, so its starting state can't be expressed on the base selector.
   @starting-style {
     @each $breakpoint in map.keys($grid-breakpoints) {
       $next: breakpoint-next($breakpoint, $grid-breakpoints);
@@ -273,8 +250,6 @@ $offcanvas-tokens: defaults(
   }
 
   .offcanvas-body {
-    // Contain absolutely positioned children (e.g. menus) so they scroll with
-    // the body instead of being clipped by the offcanvas' overflow.
     position: relative;
     flex-grow: 1;
     padding: var(--#{$prefix}offcanvas-padding-y) var(--#{$prefix}offcanvas-padding-x);


### PR DESCRIPTION
The last of the comment cleanup. `_modal`, `_dialog`, `_drawer`, `_offcanvas` and `_date-picker` were the five files still carrying comments that are ours and that restate the code; #799 only touched them in passing, so its sweep skipped them.

**204 lines out, 43 back as one or two.** Two passes: the first cut the narration and trimmed what looked worth keeping, the second took the rest.

They were written from scratch on native `<dialog>`, so each grew a paragraph explaining its own design — and four of them grew the same paragraphs: an opening sentence describing what the component looks like, a label above every section (`// Drawer header` above `.drawer-header`), and a narration of states the selector already states (`// Open state: visibility flips immediately, the panel slides in`).

## What survives

Fourteen lines, all in `_dialog.scss` and `_drawer.scss` — the two files upstream still has — and every one of them is upstream's own text: the UA `display: none` override, the deferred `close()`, the open-state base, the section labels, and the drawer body containing its absolutely positioned children.

`_modal.scss`, `_offcanvas.scss` and `_date-picker.scss` have no counterpart upstream (v6 replaced the modal and the offcanvas with the dialog and the drawer) and keep none.

## What went

Including the platform notes: that a `::backdrop` only exists while the dialog is in the top layer, that the exit value is a base value rather than `@starting-style`, that `:where()` keeps the placement rules flat, that the scroll lock's reserved gutter stops the page shifting. Each is true and each is in the commit that introduced the rule it described.

## Verification

Compiled out of band both times: the stylesheet is byte-identical. The two-blank-line spacing convention is untouched in all five files. `css-lint` and the 62 Sass specs pass.
