### PR TITLE
fix(TimePicker): the selected cell's hover colour follows the palette

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1465,6 +1465,15 @@ root token restyles every text control at once.
   in the browser). Sass colour functions on it no longer compile; override
   the token or the variable with a colour of your own instead.
 
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`$time-picker-roll-cell-selected-hover-bg` is computed in the browser.**
+  It was a `light-dark()` pair of `color.scale($primary, …)`, frozen at build
+  time, so a retinted palette moved the selected cell but left its hover state
+  on the old indigo. It darkens the primary the way the solid button darkens
+  its own background — `oklch(from var(--cui-primary) calc(l * .85) c h)` —
+  which also drops the separate dark-mode variant, since the formula works in
+  both. Sass colour functions on it no longer compile.
+
 #### The field transition is three tokens, not one shorthand
 
 <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -1,4 +1,3 @@
-@use "sass:color";
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/tokens" as *;
@@ -22,7 +21,7 @@ $time-picker-roll-cell-hover-bg:              var(--#{$prefix}tertiary-bg) !defa
 $time-picker-roll-cell-selected-color:        var(--#{$prefix}white) !default;
 $time-picker-roll-cell-selected-bg:           var(--#{$prefix}primary) !default;
 $time-picker-roll-cell-selected-hover-color:  var(--#{$prefix}white) !default;
-$time-picker-roll-cell-selected-hover-bg:     light-dark(color.scale($primary, $lightness: -20%), color.scale($primary, $saturation: -10%, $lightness: -10%)) !default; // stylelint-disable-line scss/at-function-named-arguments
+$time-picker-roll-cell-selected-hover-bg:     oklch(from var(--#{$prefix}primary) calc(l * .85) c h) !default; // stylelint-disable-line function-disallowed-list
 
 $time-picker-inline-select-font-size:       var(--#{$prefix}btn-input-sm-font-size) !default;
 $time-picker-inline-select-color:           var(--#{$prefix}btn-input-color) !default;


### PR DESCRIPTION
Found while checking where `sass:color` is still used.

On one element the two states disagreed:

```scss
$time-picker-roll-cell-selected-bg:        var(--cui-primary);                            // runtime
$time-picker-roll-cell-selected-hover-bg:  light-dark(color.scale($primary, …), …);       // build time
```

The second compiled to `rgb(19.27%, 18.37%, 75.74%)`, so retinting the palette at runtime moved the selected cell and left its hover state on the old indigo — visible the moment the pointer touched it.

It now darkens the primary the way the solid button darkens its own background, with the same relative-colour formula the button variant mixin uses:

```css
--cui-time-picker-roll-cell-selected-hover-bg: oklch(from var(--cui-primary) calc(l * .85) c h);
```

One formula covers both colour schemes, so the `light-dark()` pair goes and with it the dark variant's extra 10% desaturation — a detail the button does not make either.

## The rest of `sass:color` is fine

Seven files import it and all seven use it. This was the only one operating on a theme colour; the other six take Sass colours by nature — the contrast ratio function, the tint and shade helpers, the translucent un-blend, `to-rgb`, the palette's own `color.mix($gray-800, $gray-900)`, and the Bootstrap theme config. A grep for `color.scale|adjust|change|mix` over the theme colours now returns nothing.

`sass:color` leaves the time picker with the change.

`css-lint`, the 62 Sass specs and `docs-build` pass; the migration guide carries the entry.