### PR TITLE
fix(TimePicker): the roll is reachable with the arrow keys again

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,27 +34,27 @@
     },
     {
       "path": "./dist/js/coreui.bundle.js",
-      "maxSize": "120kB"
+      "maxSize": "120.5 kB"
     },
     {
       "path": "./dist/js/coreui.bundle.min.js",
-      "maxSize": "76.75kB"
+      "maxSize": "77 kB"
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "109kB"
+      "maxSize": "109.5 kB"
     },
     {
       "path": "./dist/js/coreui.esm.min.js",
-      "maxSize": "78kB"
+      "maxSize": "78.5 kB"
     },
     {
       "path": "./dist/js/coreui.js",
-      "maxSize": "109.75kB"
+      "maxSize": "110.25 kB"
     },
     {
       "path": "./dist/js/coreui.min.js",
-      "maxSize": "70.5kB"
+      "maxSize": "71 kB"
     }
   ],
   "ci": {

--- a/js/src/util/time-selection.ts
+++ b/js/src/util/time-selection.ts
@@ -5,6 +5,7 @@
  * --------------------------------------------------------------------------
  */
 
+import EventHandler from '../dom/event-handler.js'
 import Manipulator from '../dom/manipulator.js'
 import SelectorEngine from '../dom/selector-engine.js'
 import Config from './config.js'
@@ -16,7 +17,7 @@ import {
   getSelectedSeconds,
   isAmPm
 } from './time.js'
-import { execute } from './index.js'
+import { execute, getNextActiveElement, isRTL } from './index.js'
 
 /**
  * Constants
@@ -30,8 +31,21 @@ const CLASS_NAME_ROLL_CELL = 'time-picker-roll-cell'
 const CLASS_NAME_ROLL_COL = 'time-picker-roll-col'
 const CLASS_NAME_SELECTED = 'selected'
 
+const ARROW_DOWN_KEY = 'ArrowDown'
+const ARROW_LEFT_KEY = 'ArrowLeft'
+const ARROW_RIGHT_KEY = 'ArrowRight'
+const ARROW_UP_KEY = 'ArrowUp'
+const END_KEY = 'End'
 const ENTER_KEY = 'Enter'
+const HOME_KEY = 'Home'
 const SPACE_KEY = 'Space'
+
+const EVENT_KEY = '.coreui.time-selection'
+const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
+
+const SELECTOR_ROLL_CELL = `.${CLASS_NAME_ROLL_CELL}`
+const SELECTOR_ROLL_CELL_FOCUSABLE = `.${CLASS_NAME_ROLL_CELL}[tabindex="0"]`
+const SELECTOR_ROLL_COL = `.${CLASS_NAME_ROLL_COL}`
 
 const Default = {
   ariaSelectHoursLabel: 'Select hours',
@@ -113,6 +127,7 @@ class TimeSelection extends Config {
   }
 
   dispose(): void {
+    EventHandler.off(this._element, EVENT_KEYDOWN)
     this._element!.innerHTML = ''
     this._element = null
   }
@@ -131,9 +146,11 @@ class TimeSelection extends Config {
     this._element!.classList.toggle(CLASS_NAME_ROLL, this._config.variant === 'roll')
 
     if (this._config.variant === 'select') {
+      EventHandler.off(this._element, EVENT_KEYDOWN)
       this._renderSelects()
     } else {
       this._renderRoll()
+      this._addRollKeyboardNavigation()
     }
 
     this._markSelected(true)
@@ -185,6 +202,7 @@ class TimeSelection extends Config {
           if (event.code === SPACE_KEY || event.key === ENTER_KEY) {
             event.preventDefault()
             this._change(part.name, (option as HTMLSelectElement).value)
+            this._moveFocusToColumn(cell, 1)
           }
         })
 
@@ -193,6 +211,59 @@ class TimeSelection extends Config {
 
       this._element!.append(column)
     }
+  }
+
+  // A roving tabindex reaches one cell per column with Tab; the rest of the
+  // options are only reachable with the arrows.
+  _addRollKeyboardNavigation(): void {
+    EventHandler.off(this._element, EVENT_KEYDOWN)
+    EventHandler.on(this._element, EVENT_KEYDOWN, SELECTOR_ROLL_CELL, (event: any) => {
+      const target = event.target as HTMLElement
+
+      if (event.key === ARROW_DOWN_KEY || event.key === ARROW_UP_KEY) {
+        event.preventDefault()
+        const items = SelectorEngine.find(SELECTOR_ROLL_CELL, target.parentElement as HTMLElement)
+
+        if (items.length === 0) {
+          return
+        }
+
+        const nextElement = getNextActiveElement(
+          items, target, event.key === ARROW_DOWN_KEY, !items.includes(target)
+        )
+        nextElement?.focus()
+        return
+      }
+
+      if (event.key === HOME_KEY || event.key === END_KEY) {
+        event.preventDefault()
+        const items = SelectorEngine.find(SELECTOR_ROLL_CELL, target.parentElement as HTMLElement)
+
+        if (items.length === 0) {
+          return
+        }
+
+        items[event.key === HOME_KEY ? 0 : items.length - 1].focus()
+        return
+      }
+
+      if (event.key === ARROW_LEFT_KEY || event.key === ARROW_RIGHT_KEY) {
+        event.preventDefault()
+        const goLeft = (event.key === ARROW_LEFT_KEY && !isRTL()) || (event.key === ARROW_RIGHT_KEY && isRTL())
+        this._moveFocusToColumn(target, goLeft ? -1 : 1)
+      }
+    })
+  }
+
+  _moveFocusToColumn(cell: HTMLElement, offset: number): void {
+    const columns = SelectorEngine.find(SELECTOR_ROLL_COL, this._element as HTMLElement)
+    const index = columns.indexOf(cell.parentElement as HTMLElement) + offset
+
+    if (index < 0 || index > columns.length - 1) {
+      return
+    }
+
+    SelectorEngine.findOne(SELECTOR_ROLL_CELL_FOCUSABLE, columns[index])?.focus()
   }
 
   _renderSelects(): void {

--- a/js/tests/unit/time-picker.spec.js
+++ b/js/tests/unit/time-picker.spec.js
@@ -282,4 +282,62 @@ describe('TimePicker', () => {
       expect(fixtureEl.querySelector('.time-picker-popup [data-coreui-picker-action="now"]').disabled).toBeFalse()
     })
   })
+
+  describe('roll keyboard navigation', () => {
+    const openRoll = () => {
+      const picker = buildPicker({ seconds: false })
+      picker.show()
+      return fixtureEl.querySelector('.time-picker-roll')
+    }
+
+    const cellsOf = column => Array.from(column.querySelectorAll('.time-picker-roll-cell'))
+
+    it('should move down and up within a column', () => {
+      const roll = openRoll()
+      const [hours] = roll.querySelectorAll('.time-picker-roll-col')
+      const cells = cellsOf(hours)
+
+      cells[0].focus()
+      cells[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      expect(document.activeElement).toEqual(cells[1])
+
+      document.activeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }))
+      expect(document.activeElement).toEqual(cells[0])
+    })
+
+    it('should jump to the first and the last option', () => {
+      const roll = openRoll()
+      const [hours] = roll.querySelectorAll('.time-picker-roll-col')
+      const cells = cellsOf(hours)
+
+      cells[0].focus()
+      cells[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }))
+      expect(document.activeElement).toEqual(cells[cells.length - 1])
+
+      document.activeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }))
+      expect(document.activeElement).toEqual(cells[0])
+    })
+
+    it('should move between columns', () => {
+      const roll = openRoll()
+      const [hours, minutes] = roll.querySelectorAll('.time-picker-roll-col')
+
+      cellsOf(hours)[0].focus()
+      document.activeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+      expect(minutes.contains(document.activeElement)).toBeTrue()
+
+      document.activeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+      expect(hours.contains(document.activeElement)).toBeTrue()
+    })
+
+    it('should stay in the first column on ArrowLeft', () => {
+      const roll = openRoll()
+      const [hours] = roll.querySelectorAll('.time-picker-roll-col')
+      const first = cellsOf(hours)[0]
+
+      first.focus()
+      first.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+      expect(document.activeElement).toEqual(first)
+    })
+  })
 })


### PR DESCRIPTION
The roll builds each column as an ARIA listbox: `role="listbox"` over `role="option"` cells, with a roving tabindex — 0 on the selected cell, -1 on the rest. That pattern hands navigation to the arrow keys.

The picker rewrite (`884e90e62`, #666) kept only the Space/Enter handler. So Tab reached one cell per column and nothing reached the others: **every hour and minute except the selected one was unreachable from the keyboard.** Counting the two trees:

| | v5 | v6 before |
| --- | --- | --- |
| `ArrowUp` / `ArrowDown` | yes | — |
| `ArrowLeft` / `ArrowRight` | yes | — |
| `Home` / `End` | yes | — |
| focus to next column after a pick | yes | — |

## The fix

What v5 bound on the picker body, restored in `util/time-selection.ts` as a delegated handler so it survives a re-render (v5 rebound per cell):

- `ArrowDown` / `ArrowUp` move within the column, through `getNextActiveElement`
- `Home` / `End` jump to the first and last option
- `ArrowLeft` / `ArrowRight` move between columns, mirrored under RTL
- Space / Enter hands focus to the next column again, so setting a time is one pass across the roll

The handler is bound for the roll variant only and removed on `dispose()` and when the picker re-renders as selects.

Date picker and date-time picker mount the same module, so they get it too.

## Tests

Four specs in `time-picker.spec.js`. Three of them fail against the source as it was — checked by reverting the module and re-running.

`js-typecheck`, `eslint` and the 3208 JS specs pass. The restored navigation is about 250 bytes gzipped, which takes the six JS bundles past their ceilings, so those move up a step.