### PR TITLE
feat(Button): flex layout, theme-driven variants, full token surface

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "62kB"
+      "maxSize": "62.75kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "51.75kB"
+      "maxSize": "52.5kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -286,11 +286,11 @@ Each variant class rewrites those variables from the theme tokens, falling back 
 
 <ScssDocs file="scss/buttons/_button.scss" capture="btn-solid-tokens" />
 
-Here's an example of building a custom `.btn-*` modifier class like we do for the buttons unique to our docs by reassigning Bootstrap's CSS variables with a mixture of our own CSS and Sass variables.
+A brand colour of your own is a theme, not a button: set the theme tokens on a class and every variant follows, in plain CSS.
 
-<Example html={[`<button type="button" class="btn btn-cd-primary">Custom button</button>`]} />
+<Example html={[`<style>`, `    .theme-brand {`, `      --cui-theme-base: #6f42c1;`, `      --cui-theme-contrast: #fff;`, `      --cui-theme-hover: #6134ae;`, `      --cui-theme-active: #56309b;`, `      --cui-theme-bg-subtle: #e9e0f7;`, `      --cui-theme-fg: #59359a;`, `      --cui-theme-fg-emphasis: #432a72;`, `    }`, `  </style>`, `  <button type="button" class="btn-solid theme-brand">Solid</button>`, `  <button type="button" class="btn-outline theme-brand">Outline</button>`, `  <button type="button" class="btn-subtle theme-brand">Subtle</button>`, `  <button type="button" class="btn-ghost theme-brand">Ghost</button>`]} />
 
-<ScssDocs file="@docs/_buttons.scss" capture="btn-css-vars-example" />
+To restyle a single button instead, set the `--cui-btn-*` variables on it directly.
 
 ### SASS variables
 

--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -38,13 +38,21 @@ Relying on color to convey meaning creates a visual cue that assistive technolog
 
 ### With icons
 
-You can combine button with our [CoreUI Icons](https://coreui.io/icons/).
+You can combine button with our [CoreUI Icons](https://coreui.io/icons/). The button lays its content out in a row and separates the parts with `--cui-btn-gap`, so the icon keeps its distance from the label whether or not there is whitespace between them in your markup.
 
 <Example code={[...getData('theme-colors').map((c) => `<button type="button" class="btn btn-${c.name}"><span class="cil-contrast"></span> ${c.title}</button>`), ``, `<button type="button" class="btn btn-link">Link</button>`]} />
 
+### Icon only
+
+<AddedIn version="6.0.0" />
+
+Add `.btn-icon` for a button that holds nothing but an icon. It drops the padding and takes its width from its height, so the result is square at every size.
+
+<Example code={[`<button type="button" class="btn btn-primary btn-icon btn-sm"><span class="cil-contrast"></span></button>`, `<button type="button" class="btn btn-primary btn-icon"><span class="cil-contrast"></span></button>`, `<button type="button" class="btn btn-primary btn-icon btn-lg"><span class="cil-contrast"></span></button>`]} />
+
 ## Disable text wrapping
 
-If you don't want the button text to wrap, you can add the `.text-nowrap` class to the button. In Sass, you can set `$btn-white-space: nowrap` to disable text wrapping for each button.
+If you don't want the button text to wrap, you can add the `.text-nowrap` class to the button, or set `--cui-btn-white-space: nowrap` on it. In Sass, `$btn-white-space: nowrap` disables text wrapping for every button.
 
 ## Button tags
 
@@ -248,9 +256,9 @@ document.querySelectorAll('.btn').forEach(buttonElement => {
 
 Buttons use local CSS variables on `.btn` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
 
-<ScssDocs file="scss/buttons/_button.scss" capture="btn-css-vars" />
+<ScssDocs file="scss/buttons/_button.scss" capture="btn-tokens" />
 
-Each `.btn-*` modifier class updates the appropriate CSS variables to minimize additional CSS rules with our `button-variant()` and `button-size()` mixins.
+Each `.btn-*` modifier class updates the appropriate CSS variables to minimize additional CSS rules with our `button-variant()` mixin.
 
 Here's an example of building a custom `.btn-*` modifier class like we do for the buttons unique to our docs by reassigning Bootstrap's CSS variables with a mixture of our own CSS and Sass variables.
 
@@ -266,15 +274,15 @@ Here's an example of building a custom `.btn-*` modifier class like we do for th
 
 CoreUI's button component is built with a base-modifier class approach. This means the bulk of the styling is contained to a base class `.btn` while style variations are confined to modifier classes (e.g., `.btn-danger`). These modifier classes are built from the `$button-variants` map to make customizing the number and name of our modifier classes.
 
-There are two mixins for buttons: a variant mixin and a size mixin. Both live in `scss/_buttons.scss`.
-
 `button-variant()` takes a variant name rather than colors. It reads that variant's entry from `$button-variants`, which maps each button token to a `--cui-theme-*` token, and derives the hover and active states from the same token in CSS. That is what lets a theme color you add yourself get correct states without compiling Sass.
 
 <ScssDocs file="scss/buttons/_button.scss" capture="btn-variants" />
 
 <ScssDocs file="scss/buttons/_button.scss" capture="btn-variant-mixin" />
 
-<ScssDocs file="scss/buttons/_button.scss" capture="btn-size-mixin" />
+Sizes need no mixin: each entry in `$button-sizes` points the button's tokens at the matching `--cui-btn-input-*` set, so `.btn-sm` and `.btn-lg` line up with form controls of the same size.
+
+<ScssDocs file="scss/buttons/_button.scss" capture="btn-sizes-loop" />
 
 ### SASS loops
 

--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -12,21 +12,28 @@ import { getData } from '@coreui/astro-docs/data'
 
 ## Base class
 
-CoreUI has a base `.btn` class that sets up basic styles such as padding and content alignment. By default, `.btn` controls have a transparent border and background color, and lack any explicit focus and hover styles.
+The `.btn` class sets up the shape of a button — size, spacing, radius, the focus ring — and paints it in the neutral surface colour, so it is a usable button on its own.
 
 <Example code={`<button type="button" class="btn">Base class</button>`} />
 
-The `.btn` class is intended to be used in conjunction with our button variants, or to serve as a basis for your own custom styles.
-
-<Callout color="warning">
-If you are using the `.btn` class on its own, remember to at least define some explicit `:focus` and/or `:focus-visible` styles.
-</Callout>
-
 ## Variants
 
-CoreUI includes a bunch of predefined Bootstrap buttons, each serving its own semantic purpose. CoreUI also offers some unique buttons styles.
+A button is a **shape plus a colour**. The shape is the variant — how much ink the button uses — and the colour comes from a theme:
 
-Buttons show what action will happen when the user clicks or touches it. Bootstrap buttons are used to initialize operations, both in the background or foreground of an experience.
+| Variant | Shape |
+| --- | --- |
+| `.btn-solid` | Filled with the theme colour. The default weight for the primary action on a screen. |
+| `.btn-outline` | Border and text in the theme colour, no fill until hover. |
+| `.btn-subtle` | Filled with the theme's tinted background, text in the theme's foreground. |
+| `.btn-ghost` | Text only; the fill appears on hover. |
+
+<Example class="d-flex flex-wrap gap-2" code={[`<button type="button" class="btn-solid theme-primary">Solid</button>`, `<button type="button" class="btn-outline theme-primary">Outline</button>`, `<button type="button" class="btn-subtle theme-primary">Subtle</button>`, `<button type="button" class="btn-ghost theme-primary">Ghost</button>`]} />
+
+The colour is a [`.theme-*` class](/customize/components/#theme-variants), which may sit on the button or on any element above it — theme a toolbar and every button inside follows. Without one, the variant renders in the neutral surface colours.
+
+<Example class="d-flex flex-wrap gap-2" code={[`<button type="button" class="btn-solid">Solid</button>`, `<button type="button" class="btn-outline">Outline</button>`, `<button type="button" class="btn-subtle">Subtle</button>`, `<button type="button" class="btn-ghost">Ghost</button>`]} />
+
+Every theme colour also has a class of its own, which is the spelling most of these docs use: `.btn-{color}` for solid, `.btn-{variant}-{color}` for the rest. It carries the theme and the variant together, so `.btn-primary` is `.btn-solid.theme-primary`.
 
 <Example code={[...getData('theme-colors').map((c) => `<button type="button" class="btn btn-${c.name}">${c.title}</button>`), ``, `<button type="button" class="btn btn-link">Link</button>`]} />
 
@@ -108,15 +115,32 @@ To apply theme colors to ghost buttons, use `.btn-ghost-*` classes. These varian
 
 <Example code={getData('theme-colors').map((c) => `<button type="button" class="btn btn-ghost-${c.name}">${c.title}</button>`)} />
 
+## Subtle buttons
+
+<AddedIn version="6.0.0" />
+
+`.btn-subtle` fills the button with the theme's tinted background instead of the colour itself, so it carries the meaning of the colour without the weight of a solid button. Use it where a solid button would shout: a secondary action next to a primary one, or a row of actions that all matter equally.
+
+<Example code={`<button type="button" class="btn btn-subtle">Base subtle button</button>
+  <button type="button" class="btn btn-subtle active">Active state</button>
+  <button type="button" class="btn btn-subtle" disabled>Disabled state</button>`} />
+
+<Example code={getData('theme-colors').map((c) => `<button type="button" class="btn btn-subtle-${c.name}">${c.title}</button>`)} />
+
 ## Sizes
 
-Larger or smaller buttons? Add `.btn-lg` or `.btn-sm` for additional sizes.
+Larger or smaller buttons? Add `.btn-xs`, `.btn-sm` or `.btn-lg` for additional sizes.
 
 <Example code={`<button type="button" class="btn btn-primary btn-lg">Large button</button>
   <button type="button" class="btn btn-secondary btn-lg">Large button</button>`} />
 
 <Example code={`<button type="button" class="btn btn-primary btn-sm">Small button</button>
   <button type="button" class="btn btn-secondary btn-sm">Small button</button>`} />
+
+<Example code={`<button type="button" class="btn btn-primary btn-xs">Extra small button</button>
+  <button type="button" class="btn btn-secondary btn-xs">Extra small button</button>`} />
+
+Each size points the button's tokens at the matching `--cui-btn-input-{size}-*` set, the same one the form controls read, so a button and a field of the same size line up.
 
 You can even roll your own custom sizing with CSS variables:
 
@@ -258,7 +282,9 @@ Buttons use local CSS variables on `.btn` for enhanced real-time customization. 
 
 <ScssDocs file="scss/buttons/_button.scss" capture="btn-tokens" />
 
-Each `.btn-*` modifier class updates the appropriate CSS variables to minimize additional CSS rules with our `button-variant()` mixin.
+Each variant class rewrites those variables from the theme tokens, falling back to a neutral value, which is why one set of rules serves every colour — including a theme colour you add yourself, with no Sass to compile:
+
+<ScssDocs file="scss/buttons/_button.scss" capture="btn-solid-tokens" />
 
 Here's an example of building a custom `.btn-*` modifier class like we do for the buttons unique to our docs by reassigning Bootstrap's CSS variables with a mixture of our own CSS and Sass variables.
 
@@ -268,24 +294,24 @@ Here's an example of building a custom `.btn-*` modifier class like we do for th
 
 ### SASS variables
 
+The variables below are the neutral fallbacks — what a variant renders as when no theme colour reaches it.
+
 <ScssDocs file="scss/buttons/_button.scss" capture="btn-variables" />
 
-### SASS mixins
+### SASS maps
 
-CoreUI's button component is built with a base-modifier class approach. This means the bulk of the styling is contained to a base class `.btn` while style variations are confined to modifier classes (e.g., `.btn-danger`). These modifier classes are built from the `$button-variants` map to make customizing the number and name of our modifier classes.
+One map per variant decides which theme token each button variable reads, so adding a variant is a map plus a rule, not a new mixin.
 
-`button-variant()` takes a variant name rather than colors. It reads that variant's entry from `$button-variants`, which maps each button token to a `--cui-theme-*` token, and derives the hover and active states from the same token in CSS. That is what lets a theme color you add yourself get correct states without compiling Sass.
+<ScssDocs file="scss/buttons/_button.scss" capture="btn-outline-tokens" />
+
+<ScssDocs file="scss/buttons/_button.scss" capture="btn-subtle-tokens" />
+
+<ScssDocs file="scss/buttons/_button.scss" capture="btn-ghost-tokens" />
+
+Both spellings of every variant come out of `$button-variants` — the variant class and the `.btn-{variant}-{color}` class — while `$button-sizes` points each size at the shared `--cui-btn-input-{size}-*` tokens.
 
 <ScssDocs file="scss/buttons/_button.scss" capture="btn-variants" />
 
-<ScssDocs file="scss/buttons/_button.scss" capture="btn-variant-mixin" />
-
-Sizes need no mixin: each entry in `$button-sizes` points the button's tokens at the matching `--cui-btn-input-*` set, so `.btn-sm` and `.btn-lg` line up with form controls of the same size.
+<ScssDocs file="scss/buttons/_button.scss" capture="btn-variant-loops" />
 
 <ScssDocs file="scss/buttons/_button.scss" capture="btn-sizes-loop" />
-
-### SASS loops
-
-Button variants pair the `button-variant()` mixin with our `$theme-colors` map to generate the modifier classes in `scss/_buttons.scss`. Each class sets the theme tokens for its color and then the variant's token mapping, so `.btn-primary` and `.theme-primary` stay in step.
-
-<ScssDocs file="scss/buttons/_button.scss" capture="btn-variant-loops" />

--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -282,9 +282,7 @@ Buttons use local CSS variables on `.btn` for enhanced real-time customization. 
 
 <ScssDocs file="scss/buttons/_button.scss" capture="btn-tokens" />
 
-Each variant class rewrites those variables from the theme tokens, falling back to a neutral value, which is why one set of rules serves every colour — including a theme colour you add yourself, with no Sass to compile:
-
-<ScssDocs file="scss/buttons/_button.scss" capture="btn-solid-tokens" />
+Each variant class rewrites those variables from the theme tokens, falling back to a neutral value, which is why one set of rules serves every colour — including a theme colour you add yourself, with no Sass to compile.
 
 A brand colour of your own is a theme, not a button: set the theme tokens on a class and every variant follows, in plain CSS.
 
@@ -300,17 +298,17 @@ The variables below are the neutral fallbacks — what a variant renders as when
 
 ### SASS maps
 
-One map per variant decides which theme token each button variable reads, so adding a variant is a map plus a rule, not a new mixin.
-
-<ScssDocs file="scss/buttons/_button.scss" capture="btn-outline-tokens" />
-
-<ScssDocs file="scss/buttons/_button.scss" capture="btn-subtle-tokens" />
-
-<ScssDocs file="scss/buttons/_button.scss" capture="btn-ghost-tokens" />
-
-Both spellings of every variant come out of `$button-variants` — the variant class and the `.btn-{variant}-{color}` class — while `$button-sizes` points each size at the shared `--cui-btn-input-{size}-*` tokens.
+`$button-variants` holds every variant. Each entry names, per state, the theme token a button variable reads and the neutral value behind it; `disabled` repeats `base`. Add an entry and both spellings of the new variant are generated — the variant class and the `.btn-{variant}-{color}` class.
 
 <ScssDocs file="scss/buttons/_button.scss" capture="btn-variants" />
+
+### SASS mixins
+
+`button-variant()` turns one entry of that map into the button's variables.
+
+<ScssDocs file="scss/buttons/_button.scss" capture="btn-variant-mixin" />
+
+### SASS loops
 
 <ScssDocs file="scss/buttons/_button.scss" capture="btn-variant-loops" />
 

--- a/docs/src/content/docs/customize/components.mdx
+++ b/docs/src/content/docs/customize/components.mdx
@@ -34,6 +34,8 @@ Themeable components also support a single family of composable `.theme-*` class
 | `--cui-theme-bg-subtle` | Subtle background tint for low-emphasis surfaces |
 | `--cui-theme-bg-muted` | Muted background, between subtle and solid |
 | `--cui-theme-border` | Border color |
+| `--cui-theme-hover` | The theme color shifted in lightness for a hover state |
+| `--cui-theme-active` | The same, one step further, for a pressed state |
 | `--cui-theme-focus-ring` | Focus ring color, translucent at `$focus-ring-opacity` |
 
 The `.theme-{name}` classes mirror the keys of the `$theme-colors` map in `scss/_theme.scss` — `.theme-primary`, `.theme-success`, `.theme-danger`, and so on — so adding or renaming a theme color automatically produces a matching class. Each entry defines the tokens for both light and dark mode via `light-dark()`.

--- a/docs/src/content/docs/customize/theme.mdx
+++ b/docs/src/content/docs/customize/theme.mdx
@@ -111,3 +111,7 @@ Four style utilities pair a themed surface with its matching text color — comp
 <ScssDocs file="scss/_theme.scss" capture="theme-color-variables" />
 
 <ScssDocs file="scss/_theme.scss" capture="theme-token-refs" />
+
+Each theme class also carries its own interaction shades, computed from the color in the browser, so a component asking for "this color, one step darker" reads a token instead of recomputing it. A color that is already dark brightens instead — that is what the overrides map is for.
+
+<ScssDocs file="scss/_theme.scss" capture="theme-interaction-variables" />

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1043,6 +1043,29 @@ adornment in the library — so the button needs no icon markup at all:
   from the gap instead of its own margin.
 - **`.btn-icon` (new).** A button that holds nothing but an icon: no padding,
   and its width follows its height, so it stays square at every size.
+- **A variant is a shape, the colour is a theme.** `.btn-solid`, `.btn-outline`,
+  `.btn-subtle` (new) and `.btn-ghost` take their colour from a `.theme-*` class
+  on the button or on any element above it, and each carries the base button
+  styles on its own — `.btn` is no longer required next to them:
+
+  ```diff
+  - <button class="btn btn-primary">Save</button>
+  + <button class="btn-solid theme-primary">Save</button>
+  ```
+
+  **The colour classes keep working** and stay the spelling the docs use:
+  `.btn-primary` is `.btn-solid.theme-primary`, `.btn-outline-primary` is
+  `.btn-outline.theme-primary`, and `.btn-subtle-*` completes the set. What
+  changes is that one rule per variant now serves every colour, so a theme
+  colour of your own gets the whole set for free.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **A bare `.btn` is a neutral button, not an invisible one.** It renders in the
+  surface colours (`--cui-secondary-bg`, one step darker on hover) instead of
+  being transparent and unstyled. Buttons that carry a variant or a colour class
+  are unaffected. For the old behaviour use `.btn-ghost`, which is transparent
+  by design.
+- **`.btn-xs` (new).** A fourth size below `.btn-sm`, reading the shared
+  `--cui-btn-input-xs-*` tokens.
 
 #### Navbar
 
@@ -1882,25 +1905,33 @@ Upstream v6 does the same, with a `mask-icon()` mixin.
 
 #### Buttons
 
-- **`button-variant()` changed signature** — it takes a variant name from the
-  new `$button-variants` map (`"solid"`, `"outline"`, `"ghost"`) instead of a
-  color pair, and reads the theme tokens.
-  <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
-  `button-outline-variant()` and `button-ghost-variant()` mixins are **removed**
-  (replaced by map entries), and `scss/mixins/_buttons.scss` no longer exists —
-  the variant and size mixins live in `scss/_buttons.scss`.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`button-variant()`, `button-outline-variant()` and `button-ghost-variant()`
+  are removed**, and so is `scss/mixins/_buttons.scss`. A variant is a token map
+  now — `$button-solid-tokens`, `$button-outline-tokens`,
+  `$button-subtle-tokens`, `$button-ghost-tokens` — where each button variable
+  names the theme token it reads and the neutral value it falls back to. Adding
+  a variant is a map plus one rule; `$button-variants` collects them and
+  generates both spellings of each class.
 - **Hover and active shades are computed in CSS** with
-  `oklch(from var(--cui-theme-base) calc(l * …) c h)` instead of precompiled
+  `oklch(from var(--cui-primary) calc(l * …) c h)` instead of precompiled
   `shade-color()`/`tint-color()`. Shades shift slightly (measured 8–23 per RGB
-  channel); `.btn-dark` keeps brightening on hover via the
-  `$btn-lightness-overrides` map. The win: a theme color you add yourself gets
-  correct hover/active states without compiling Sass.
+  channel). The win: a theme color you add yourself gets correct hover/active
+  states without compiling Sass.
 - **The eight shade/tint amount knobs are removed**:
   `$btn-hover-bg-shade-amount`, `$btn-hover-bg-tint-amount`,
   `$btn-hover-border-shade-amount`, `$btn-hover-border-tint-amount` and the four
   `$btn-active-*` counterparts. They fed the Sass mixes that no longer happen.
-  The runtime equivalents are `$btn-hover-lightness`, `$btn-active-lightness` and
-  the per-colour `$btn-lightness-overrides` map.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The interaction shade belongs to the theme, not to the button.** Every
+  `.theme-*` class emits `--cui-theme-hover` and `--cui-theme-active` — its own
+  colour, shifted in lightness — and the button variants read them, so a
+  component that wants "this theme colour, one step darker" no longer has to
+  recompute it. The knobs moved with them: `$btn-hover-lightness`,
+  `$btn-active-lightness` and `$btn-lightness-overrides` are now
+  `$theme-hover-lightness`, `$theme-active-lightness` and
+  `$theme-lightness-overrides` in `scss/_theme.scss` (dark still brightens
+  instead of darkening).
 - **The dark-mode button block is gone** (~160 lines of CSS) — variants follow
   the root color tokens, which already switch in dark mode.
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1032,6 +1032,17 @@ adornment in the library — so the button needs no icon markup at all:
   missing attribute on `DOMContentLoaded`, reading the `.active` class to pick
   the value; an attribute you wrote yourself is left alone. Write it in your
   markup anyway, so the state is correct before our JavaScript runs.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`.btn` is a flex container.** It lays its content out in a row, centres it
+  on both axes and separates the parts with `--cui-btn-gap`, so an icon next to
+  a label no longer depends on a whitespace text node in your markup — and no
+  longer gets a second space where you did leave one. `--cui-btn-min-height`
+  keeps a button that holds only an icon as tall as one that holds text. Custom
+  CSS that positioned button content with `display`, `line-height` or margins
+  needs a second look; the caret of a `.dropdown-toggle` now takes its distance
+  from the gap instead of its own margin.
+- **`.btn-icon` (new).** A button that holds nothing but an icon: no padding,
+  and its width follows its height, so it stays square at every size.
 
 #### Navbar
 
@@ -1892,6 +1903,28 @@ Upstream v6 does the same, with a `mask-icon()` mixin.
   the per-colour `$btn-lightness-overrides` map.
 - **The dark-mode button block is gone** (~160 lines of CSS) — variants follow
   the root color tokens, which already switch in dark mode.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The `$btn-*` variables that only forwarded a shared value are removed**:
+  `$btn-color`, `$btn-padding-y`, `$btn-padding-x`, `$btn-font-family`,
+  `$btn-font-size`, `$btn-line-height`, `$btn-border-width`,
+  `$btn-border-radius`, `$btn-disabled-opacity`, `$btn-transition-*` and the
+  `-sm`/`-lg` pairs. They pointed at `--cui-btn-input-*`, so a value assigned to
+  them was overwritten by the token anyway. Configure the frame once on `:root`
+  with the `$input-btn-*` variables, or set `--cui-btn-*` on the button.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`button-size()` is removed.** Sizes are a loop over `$button-sizes`, which
+  points the button's tokens at the matching `--cui-btn-input-{size}-*` set. Add
+  a size by adding its tokens on `:root` and its name to the map.
+- **New tokens on `.btn`:** `--cui-btn-gap`, `--cui-btn-min-height`,
+  `--cui-btn-white-space` and `--cui-btn-transition-property` /
+  `-duration` / `-timing`. The transition was read straight from the shared
+  `--cui-btn-input-*` tokens before, so it could not be retuned per button.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`.btn-close` draws its focus ring as an `outline`,** like every other
+  control; `$btn-close-focus-shadow` and `--cui-btn-close-focus-shadow` are
+  removed. A box-shadow ring was clipped by the `overflow: hidden` of the modal,
+  toast or drawer the close button usually sits in. Its geometry is tokens now
+  too: `--cui-btn-close-width`, `-height`, `-padding-x`, `-padding-y`.
 - `.btn-primary`, `.btn-outline-*`, `.btn-ghost-*` class APIs are unchanged.
 - **Toggle buttons: `.btn-check` moves onto the `<label>`, with the input nested
   inside.** A toggle button was two elements held together by an `id`/`for`

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1906,13 +1906,13 @@ Upstream v6 does the same, with a `mask-icon()` mixin.
 #### Buttons
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
-  **`button-variant()`, `button-outline-variant()` and `button-ghost-variant()`
-  are removed**, and so is `scss/mixins/_buttons.scss`. A variant is a token map
-  now — `$button-solid-tokens`, `$button-outline-tokens`,
-  `$button-subtle-tokens`, `$button-ghost-tokens` — where each button variable
-  names the theme token it reads and the neutral value it falls back to. Adding
-  a variant is a map plus one rule; `$button-variants` collects them and
-  generates both spellings of each class.
+  **`button-variant()` takes a variant name, not a colour pair**, and reads it
+  from `$button-variants`. Each entry of that map names, per state, the theme
+  token a button variable reads and the neutral value behind it; `disabled`
+  repeats `base`. `button-outline-variant()` and `button-ghost-variant()` are
+  **removed** (they are entries in the map now), and `scss/mixins/_buttons.scss`
+  no longer exists — the mixin lives next to the map in
+  `scss/buttons/_button.scss`.
 - **Hover and active shades are computed in CSS** with
   `oklch(from var(--cui-primary) calc(l * …) c h)` instead of precompiled
   `shade-color()`/`tint-color()`. Shades shift slightly (measured 8–23 per RGB

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -258,6 +258,14 @@ $dropdown-dark-tokens: defaults(
     }
   }
 
+  // In a button the caret is a flex item, so the gap already sets it apart.
+  .btn.dropdown-toggle {
+    &::after,
+    &::before {
+      margin-inline: 0;
+    }
+  }
+
 
   // Dividers (basically an `<hr>`) within the dropdown
   .dropdown-divider {

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -39,7 +39,7 @@ $header-toggler-padding-x:      .75rem !default;
 $header-toggler-font-size:      var(--#{$prefix}font-size-lg) !default;
 $header-toggler-color:          color-mix(in srgb, var(--#{$prefix}emphasis-color) 65%, transparent) !default;
 $header-toggler-bg:             transparent !default;
-$header-toggler-border-radius:  $btn-border-radius !default;
+$header-toggler-border-radius:  var(--#{$prefix}border-radius) !default;
 $header-toggler-hover-color:    color-mix(in srgb, var(--#{$prefix}emphasis-color) 100%, transparent) !default;
 
 $header-toggler-icon-bg:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='black' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg>") !default;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -32,7 +32,7 @@ $navbar-brand-margin-end:           1rem !default;
 $navbar-toggler-padding-y:          .25rem !default;
 $navbar-toggler-padding-x:          .75rem !default;
 $navbar-toggler-font-size:          var(--#{$prefix}font-size-lg) !default;
-$navbar-toggler-border-radius:      $btn-border-radius !default;
+$navbar-toggler-border-radius:      var(--#{$prefix}border-radius) !default;
 $navbar-toggler-focus-width:        var(--#{$prefix}focus-ring-width) !default;
 $navbar-toggler-transition:         box-shadow .15s ease-in-out !default;
 

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -101,6 +101,11 @@ $input-btn-transition-property:          "border-color, box-shadow" !default;
 $input-btn-action-transition-property:   "color, background-color, border-color, box-shadow" !default;
 $input-btn-disabled-opacity:  .65 !default;
 
+$input-btn-gap-xs:            .25rem !default;
+$input-btn-padding-y-xs:      .125rem !default;
+$input-btn-padding-x-xs:      .5rem !default;
+$input-btn-font-size-xs:      var(--#{$prefix}font-size-xs) !default;
+
 $input-btn-gap-sm:            .375rem !default;
 $input-btn-padding-y-sm:      .25rem !default;
 $input-btn-padding-x-sm:      .5rem !default;
@@ -279,6 +284,13 @@ $code-color: light-dark($pink, tint-color($pink, 40%)) !default;
     --#{$prefix}btn-input-focus-bg: var(--#{$prefix}btn-input-bg);
     --#{$prefix}btn-input-focus-border-color: color-mix(in srgb, var(--#{$prefix}primary) 50%, var(--#{$prefix}white));
     --#{$prefix}btn-input-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2); // stylelint-disable-line function-disallowed-list
+
+    --#{$prefix}btn-input-xs-gap: #{$input-btn-gap-xs};
+    --#{$prefix}btn-input-xs-padding-y: #{$input-btn-padding-y-xs};
+    --#{$prefix}btn-input-xs-padding-x: #{$input-btn-padding-x-xs};
+    --#{$prefix}btn-input-xs-font-size: #{$input-btn-font-size-xs};
+    --#{$prefix}btn-input-xs-border-radius: var(--#{$prefix}border-radius-sm);
+    --#{$prefix}btn-input-xs-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-xs-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2); // stylelint-disable-line function-disallowed-list
 
     --#{$prefix}btn-input-sm-gap: #{$input-btn-gap-sm};
     --#{$prefix}btn-input-sm-padding-y: #{$input-btn-padding-y-sm};

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -88,6 +88,7 @@ $small-font-size:             .875em !default;
 $font-weight-base:            var(--#{$prefix}font-weight-normal) !default;
 
 // scss-docs-start input-btn-variables
+$input-btn-gap:               .375rem !default;
 $input-btn-padding-y:         .375rem !default;
 $input-btn-padding-x:         .75rem !default;
 $input-btn-font-family:       null !default;
@@ -100,10 +101,12 @@ $input-btn-transition-property:          "border-color, box-shadow" !default;
 $input-btn-action-transition-property:   "color, background-color, border-color, box-shadow" !default;
 $input-btn-disabled-opacity:  .65 !default;
 
+$input-btn-gap-sm:            .375rem !default;
 $input-btn-padding-y-sm:      .25rem !default;
 $input-btn-padding-x-sm:      .5rem !default;
 $input-btn-font-size-sm:      var(--#{$prefix}font-size-sm) !default;
 
+$input-btn-gap-lg:            .375rem !default;
 $input-btn-padding-y-lg:      .5rem !default;
 $input-btn-padding-x-lg:      1rem !default;
 $input-btn-font-size-lg:      var(--#{$prefix}font-size-lg) !default;
@@ -254,6 +257,7 @@ $code-color: light-dark($pink, tint-color($pink, 40%)) !default;
     // scss-docs-start root-btn-input-variables
     // Sizing shared by buttons and form controls, so neither has to reach for
     // the other's Sass variables to line up.
+    --#{$prefix}btn-input-gap: #{$input-btn-gap};
     --#{$prefix}btn-input-padding-y: #{$input-btn-padding-y};
     --#{$prefix}btn-input-padding-x: #{$input-btn-padding-x};
     --#{$prefix}btn-input-font-family: #{$input-btn-font-family};
@@ -276,12 +280,14 @@ $code-color: light-dark($pink, tint-color($pink, 40%)) !default;
     --#{$prefix}btn-input-focus-border-color: color-mix(in srgb, var(--#{$prefix}primary) 50%, var(--#{$prefix}white));
     --#{$prefix}btn-input-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2); // stylelint-disable-line function-disallowed-list
 
+    --#{$prefix}btn-input-sm-gap: #{$input-btn-gap-sm};
     --#{$prefix}btn-input-sm-padding-y: #{$input-btn-padding-y-sm};
     --#{$prefix}btn-input-sm-padding-x: #{$input-btn-padding-x-sm};
     --#{$prefix}btn-input-sm-font-size: #{$input-btn-font-size-sm};
     --#{$prefix}btn-input-sm-border-radius: var(--#{$prefix}border-radius-sm);
     --#{$prefix}btn-input-sm-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-sm-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2); // stylelint-disable-line function-disallowed-list
 
+    --#{$prefix}btn-input-lg-gap: #{$input-btn-gap-lg};
     --#{$prefix}btn-input-lg-padding-y: #{$input-btn-padding-y-lg};
     --#{$prefix}btn-input-lg-padding-x: #{$input-btn-padding-x-lg};
     --#{$prefix}btn-input-lg-font-size: #{$input-btn-font-size-lg};

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -184,9 +184,28 @@ $theme-token-refs: (
 ) !default;
 // scss-docs-end theme-token-refs
 
+// scss-docs-start theme-interaction-variables
+// Tuned to land near the shade-color() amounts compiled before the states moved into CSS.
+$theme-hover-lightness:   .85 !default;
+$theme-active-lightness:  .8 !default;
+
+// Dark theme colors sit too low to darken any further, so they brighten instead.
+$theme-lightness-overrides: (
+  "dark": ("hover": 1.48, "active": 1.62)
+) !default;
+// scss-docs-end theme-interaction-variables
+
 @mixin theme-tokens($state) {
   @each $token, $suffix in $theme-token-refs {
     --#{$prefix}theme-#{$token}: var(--#{$prefix}#{$state}#{$suffix});
+  }
+
+  $overrides: map.get($theme-lightness-overrides, $state) or ();
+
+  @each $token, $lightness in ("hover": $theme-hover-lightness, "active": $theme-active-lightness) {
+    $shift: map.get($overrides, $token) or $lightness;
+    // stylelint-disable-next-line function-disallowed-list
+    --#{$prefix}theme-#{$token}: oklch(from var(--#{$prefix}#{$state}) calc(l * #{$shift}) c h);
   }
 }
 

--- a/scss/buttons/_button-group.scss
+++ b/scss/buttons/_button-group.scss
@@ -42,12 +42,12 @@
   }
 
   .btn-group {
-    @include border-radius($btn-border-radius);
+    @include border-radius(var(--#{$prefix}border-radius));
 
     // Prevent double borders when buttons are next to each other
     > :not(#{$btn-check-deprecated}:first-child) + .btn,
     > .btn-group:not(:first-child) {
-      margin-inline-start: calc(-1 * #{$btn-border-width}); // stylelint-disable-line function-disallowed-list
+      margin-inline-start: calc(-1 * var(--#{$prefix}btn-border-width)); // stylelint-disable-line function-disallowed-list
     }
 
     // Reset rounded corners
@@ -69,37 +69,8 @@
     }
   }
 
-  // Sizing
-  //
-  // Remix the default button sizing classes into new ones for easier manipulation.
-
-  .btn-group-sm > .btn { @extend .btn-sm; }
-  .btn-group-lg > .btn { @extend .btn-lg; }
-
-
   .dropdown-toggle-split {
-    padding-right: calc(#{$btn-padding-x} * .75); // stylelint-disable-line function-disallowed-list
-    padding-left: calc(#{$btn-padding-x} * .75); // stylelint-disable-line function-disallowed-list
-
-    &::after,
-    .dropup &::after,
-    .dropend &::after {
-      margin-inline-start: 0;
-    }
-
-    .dropstart &::before {
-      margin-inline-end: 0;
-    }
-  }
-
-  .btn-sm + .dropdown-toggle-split {
-    padding-right: calc(#{$btn-padding-x-sm} * .75); // stylelint-disable-line function-disallowed-list
-    padding-left: calc(#{$btn-padding-x-sm} * .75); // stylelint-disable-line function-disallowed-list
-  }
-
-  .btn-lg + .dropdown-toggle-split {
-    padding-right: calc(#{$btn-padding-x-lg} * .75); // stylelint-disable-line function-disallowed-list
-    padding-left: calc(#{$btn-padding-x-lg} * .75); // stylelint-disable-line function-disallowed-list
+    padding-inline: calc(var(--#{$prefix}btn-padding-x) * .75); // stylelint-disable-line function-disallowed-list
   }
 
 
@@ -131,7 +102,7 @@
 
     > .btn:not(:first-child),
     > .btn-group:not(:first-child) {
-      margin-top: calc(-1 * #{$btn-border-width}); // stylelint-disable-line function-disallowed-list
+      margin-top: calc(-1 * var(--#{$prefix}btn-border-width)); // stylelint-disable-line function-disallowed-list
     }
 
     // Reset rounded corners

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -94,16 +94,16 @@ $button-solid-tokens: defaults(
   (
     --#{$prefix}btn-color: var(--#{$prefix}theme-contrast, #{$btn-color}),
     --#{$prefix}btn-bg: var(--#{$prefix}theme-base, #{$btn-bg}),
-    --#{$prefix}btn-border-color: var(--#{$prefix}theme-base, #{$btn-bg}),
-    --#{$prefix}btn-hover-color: var(--#{$prefix}theme-contrast, #{$btn-color}),
+    --#{$prefix}btn-border-color: var(--#{$prefix}btn-bg),
+    --#{$prefix}btn-hover-color: var(--#{$prefix}btn-color),
     --#{$prefix}btn-hover-bg: var(--#{$prefix}theme-hover, #{$btn-hover-bg}),
-    --#{$prefix}btn-hover-border-color: var(--#{$prefix}theme-hover, #{$btn-hover-bg}),
-    --#{$prefix}btn-active-color: var(--#{$prefix}theme-contrast, #{$btn-color}),
+    --#{$prefix}btn-hover-border-color: var(--#{$prefix}btn-hover-bg),
+    --#{$prefix}btn-active-color: var(--#{$prefix}btn-color),
     --#{$prefix}btn-active-bg: var(--#{$prefix}theme-active, #{$btn-hover-bg}),
-    --#{$prefix}btn-active-border-color: var(--#{$prefix}theme-active, #{$btn-hover-bg}),
-    --#{$prefix}btn-disabled-color: var(--#{$prefix}theme-contrast, #{$btn-color}),
-    --#{$prefix}btn-disabled-bg: var(--#{$prefix}theme-base, #{$btn-bg}),
-    --#{$prefix}btn-disabled-border-color: var(--#{$prefix}theme-base, #{$btn-bg})
+    --#{$prefix}btn-active-border-color: var(--#{$prefix}btn-active-bg),
+    --#{$prefix}btn-disabled-color: var(--#{$prefix}btn-color),
+    --#{$prefix}btn-disabled-bg: var(--#{$prefix}btn-bg),
+    --#{$prefix}btn-disabled-border-color: var(--#{$prefix}btn-bg)
   ),
   $button-solid-tokens
 );
@@ -120,12 +120,12 @@ $button-outline-tokens: defaults(
     --#{$prefix}btn-hover-color: var(--#{$prefix}theme-contrast, #{$btn-outline-hover-color}),
     --#{$prefix}btn-hover-bg: var(--#{$prefix}theme-hover, #{$btn-outline-hover-bg}),
     --#{$prefix}btn-hover-border-color: var(--#{$prefix}theme-hover, #{$btn-outline-border-color}),
-    --#{$prefix}btn-active-color: var(--#{$prefix}theme-contrast, #{$btn-outline-hover-color}),
+    --#{$prefix}btn-active-color: var(--#{$prefix}btn-hover-color),
     --#{$prefix}btn-active-bg: var(--#{$prefix}theme-active, #{$btn-outline-hover-bg}),
     --#{$prefix}btn-active-border-color: var(--#{$prefix}theme-active, #{$btn-outline-border-color}),
-    --#{$prefix}btn-disabled-color: var(--#{$prefix}theme-base, #{$btn-outline-color}),
+    --#{$prefix}btn-disabled-color: var(--#{$prefix}btn-color),
     --#{$prefix}btn-disabled-bg: transparent,
-    --#{$prefix}btn-disabled-border-color: var(--#{$prefix}theme-base, #{$btn-outline-border-color})
+    --#{$prefix}btn-disabled-border-color: var(--#{$prefix}btn-border-color)
   ),
   $button-outline-tokens
 );
@@ -142,11 +142,11 @@ $button-subtle-tokens: defaults(
     --#{$prefix}btn-hover-color: var(--#{$prefix}theme-fg-emphasis, #{$btn-subtle-color}),
     --#{$prefix}btn-hover-bg: var(--#{$prefix}theme-bg-muted, #{$btn-subtle-hover-bg}),
     --#{$prefix}btn-hover-border-color: transparent,
-    --#{$prefix}btn-active-color: var(--#{$prefix}theme-fg-emphasis, #{$btn-subtle-color}),
-    --#{$prefix}btn-active-bg: var(--#{$prefix}theme-bg-muted, #{$btn-subtle-hover-bg}),
+    --#{$prefix}btn-active-color: var(--#{$prefix}btn-hover-color),
+    --#{$prefix}btn-active-bg: var(--#{$prefix}btn-hover-bg),
     --#{$prefix}btn-active-border-color: transparent,
-    --#{$prefix}btn-disabled-color: var(--#{$prefix}theme-fg, #{$btn-subtle-color}),
-    --#{$prefix}btn-disabled-bg: var(--#{$prefix}theme-bg-subtle, #{$btn-subtle-bg}),
+    --#{$prefix}btn-disabled-color: var(--#{$prefix}btn-color),
+    --#{$prefix}btn-disabled-bg: var(--#{$prefix}btn-bg),
     --#{$prefix}btn-disabled-border-color: transparent
   ),
   $button-subtle-tokens
@@ -163,11 +163,11 @@ $button-ghost-tokens: defaults(
     --#{$prefix}btn-border-color: transparent,
     --#{$prefix}btn-hover-color: var(--#{$prefix}theme-contrast, #{$btn-ghost-hover-color}),
     --#{$prefix}btn-hover-bg: var(--#{$prefix}theme-hover, #{$btn-ghost-hover-bg}),
-    --#{$prefix}btn-hover-border-color: var(--#{$prefix}theme-hover, #{$btn-ghost-hover-bg}),
-    --#{$prefix}btn-active-color: var(--#{$prefix}theme-contrast, #{$btn-ghost-hover-color}),
+    --#{$prefix}btn-hover-border-color: var(--#{$prefix}btn-hover-bg),
+    --#{$prefix}btn-active-color: var(--#{$prefix}btn-hover-color),
     --#{$prefix}btn-active-bg: var(--#{$prefix}theme-active, #{$btn-ghost-hover-bg}),
-    --#{$prefix}btn-active-border-color: var(--#{$prefix}theme-active, #{$btn-ghost-hover-bg}),
-    --#{$prefix}btn-disabled-color: var(--#{$prefix}theme-base, #{$btn-ghost-color}),
+    --#{$prefix}btn-active-border-color: var(--#{$prefix}btn-active-bg),
+    --#{$prefix}btn-disabled-color: var(--#{$prefix}btn-color),
     --#{$prefix}btn-disabled-bg: transparent,
     --#{$prefix}btn-disabled-border-color: transparent
   ),

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -1,94 +1,153 @@
 @use "sass:map";
-@use "../functions/color" as *;
 @use "../functions/defaults" as *;
-@use "../functions/to-rgb" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
-@use "../mixins/color-mode" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/gradients" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
 @use "../theme" as *;
-@use "../colors" as *;
 @use "../config" as *;
 
-
 // scss-docs-start btn-variables
-$btn-color:                   var(--#{$prefix}body-color) !default;
-$btn-padding-y:               var(--#{$prefix}btn-input-padding-y) !default;
-$btn-padding-x:               var(--#{$prefix}btn-input-padding-x) !default;
-$btn-font-family:             var(--#{$prefix}btn-input-font-family) !default;
-$btn-font-size:               var(--#{$prefix}btn-input-font-size) !default;
-$btn-line-height:             var(--#{$prefix}btn-input-line-height) !default;
 $btn-white-space:             null !default; // Set to `nowrap` to prevent text wrapping
 
-$btn-padding-y-sm:            var(--#{$prefix}btn-input-sm-padding-y) !default;
-$btn-padding-x-sm:            var(--#{$prefix}btn-input-sm-padding-x) !default;
-$btn-font-size-sm:            var(--#{$prefix}btn-input-sm-font-size) !default;
-
-$btn-padding-y-lg:            var(--#{$prefix}btn-input-lg-padding-y) !default;
-$btn-padding-x-lg:            var(--#{$prefix}btn-input-lg-padding-x) !default;
-$btn-font-size-lg:            var(--#{$prefix}btn-input-lg-font-size) !default;
-
-$btn-border-width:            var(--#{$prefix}btn-input-border-width) !default;
-
-$btn-font-weight:             var(--#{$prefix}font-weight-normal) !default;
 $btn-box-shadow:              inset 0 1px 0 color-mix(in srgb, var(--#{$prefix}white) 15%, transparent), 0 1px 1px color-mix(in srgb, var(--#{$prefix}black) 7.5%, transparent) !default;
-$btn-disabled-opacity:        var(--#{$prefix}btn-input-disabled-opacity) !default;
 $btn-active-box-shadow:       inset 0 3px 5px color-mix(in srgb, var(--#{$prefix}black) 12.5%, transparent) !default;
 
 $btn-link-color:              var(--#{$prefix}link-color) !default;
 $btn-link-hover-color:        var(--#{$prefix}link-hover-color) !default;
 $btn-link-disabled-color:     var(--#{$prefix}gray-600) !default;
 
-// Allows for customizing button radius independently from global border radius
-$btn-border-radius:           var(--#{$prefix}border-radius) !default;
-$btn-border-radius-sm:        var(--#{$prefix}border-radius-sm) !default;
-$btn-border-radius-lg:        var(--#{$prefix}border-radius-lg) !default;
-
-$btn-transition-property:     var(--#{$prefix}btn-input-action-transition-property) !default;
-$btn-transition-duration:     var(--#{$prefix}btn-input-transition-duration) !default;
-$btn-transition-timing:       var(--#{$prefix}btn-input-transition-timing) !default;
-
-// scss-docs-end btn-variables
-
-// The two toggle-button spellings each select themselves: the v6 one puts
-// `.btn-check` on the `<label>` alongside the button classes, so the deprecated
-// one — the class on the input — is the `.btn-check` that is not a `.btn`.
-$btn-check-deprecated: ".btn-check:not(.btn)" !default;
-
-// scss-docs-start btn-outline-variables
-$btn-outline-color: var(--#{$prefix}secondary-color) !default;
-$btn-outline-border-color: var(--#{$prefix}border-color) !default;
-$btn-outline-active-color: var(--#{$prefix}body-color) !default;
-$btn-outline-active-bg: var(--#{$prefix}tertiary-bg) !default;
-$btn-outline-active-border-color: var(--#{$prefix}border-color) !default;
-$btn-outline-disabled-color: var(--#{$prefix}secondary-color) !default;
+$btn-outline-color:                 var(--#{$prefix}secondary-color) !default;
+$btn-outline-border-color:          var(--#{$prefix}border-color) !default;
+$btn-outline-hover-color:           var(--#{$prefix}body-color) !default;
+$btn-outline-hover-bg:              var(--#{$prefix}tertiary-bg) !default;
+$btn-outline-hover-border-color:    var(--#{$prefix}border-color) !default;
+$btn-outline-active-color:          var(--#{$prefix}body-color) !default;
+$btn-outline-active-bg:             var(--#{$prefix}tertiary-bg) !default;
+$btn-outline-active-border-color:   var(--#{$prefix}border-color) !default;
+$btn-outline-disabled-color:        var(--#{$prefix}secondary-color) !default;
 $btn-outline-disabled-border-color: var(--#{$prefix}border-color) !default;
-$btn-outline-hover-color: var(--#{$prefix}body-color) !default;
-$btn-outline-hover-bg: var(--#{$prefix}tertiary-bg) !default;
-$btn-outline-hover-border-color: var(--#{$prefix}border-color) !default;
-// scss-docs-end btn-outline-variables
-// Lightness applied to a theme color for the hover and active states. Upstream
-// uses .95/.9; these are tuned to land near the shade-color() amounts CoreUI
-// compiled before the states moved into CSS.
-$btn-hover-lightness: .85 !default;
-$btn-active-lightness: .8 !default;
 
-// Dark theme colors are already near the bottom of the lightness range, so
-// darkening them further reads as no hover at all. They brighten instead, the
-// direction tint-color() used to take them.
+$btn-ghost-color:             var(--#{$prefix}secondary-color) !default;
+$btn-ghost-hover-color:       var(--#{$prefix}body-color) !default;
+$btn-ghost-hover-bg:          var(--#{$prefix}tertiary-bg) !default;
+$btn-ghost-active-color:      var(--#{$prefix}body-color) !default;
+$btn-ghost-active-bg:         var(--#{$prefix}tertiary-bg) !default;
+$btn-ghost-disabled-color:    var(--#{$prefix}secondary-color) !default;
+
+// Tuned to land near the shade-color() amounts compiled before the states moved into CSS.
+$btn-hover-lightness:         .85 !default;
+$btn-active-lightness:        .8 !default;
+
+// Dark theme colors sit too low to darken any further, so they brighten instead.
 $btn-lightness-overrides: (
   "dark": ("hover": 1.48, "active": 1.62)
 ) !default;
+// scss-docs-end btn-variables
 
-// stylelint-disable scss/dollar-variable-default
+// The v6 spelling puts `.btn-check` on the `<label>` next to `.btn`, so the
+// deprecated one — the class on the input — is the `.btn-check` that is not a `.btn`.
+$btn-check-deprecated: ".btn-check:not(.btn)" !default;
+
+// stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
+
+$button-tokens: () !default;
+
+// scss-docs-start btn-tokens
+$button-tokens: defaults(
+  (
+    --#{$prefix}btn-gap: var(--#{$prefix}btn-input-gap),
+    --#{$prefix}btn-min-height: var(--#{$prefix}btn-input-min-height),
+    --#{$prefix}btn-padding-y: var(--#{$prefix}btn-input-padding-y),
+    --#{$prefix}btn-padding-x: var(--#{$prefix}btn-input-padding-x),
+    --#{$prefix}btn-font-family: var(--#{$prefix}btn-input-font-family),
+    --#{$prefix}btn-font-size: var(--#{$prefix}btn-input-font-size),
+    --#{$prefix}btn-font-weight: var(--#{$prefix}font-weight-normal),
+    --#{$prefix}btn-line-height: var(--#{$prefix}btn-input-line-height),
+    --#{$prefix}btn-color: var(--#{$prefix}body-color),
+    --#{$prefix}btn-bg: transparent,
+    --#{$prefix}btn-white-space: $btn-white-space,
+    --#{$prefix}btn-border-width: var(--#{$prefix}btn-input-border-width),
+    --#{$prefix}btn-border-color: transparent,
+    --#{$prefix}btn-border-radius: var(--#{$prefix}border-radius),
+    --#{$prefix}btn-hover-border-color: transparent,
+    --#{$prefix}btn-box-shadow: #{$btn-box-shadow},
+    --#{$prefix}btn-disabled-opacity: var(--#{$prefix}btn-input-disabled-opacity),
+    --#{$prefix}btn-transition-property: var(--#{$prefix}btn-input-action-transition-property),
+    --#{$prefix}btn-transition-duration: var(--#{$prefix}btn-input-transition-duration),
+    --#{$prefix}btn-transition-timing: var(--#{$prefix}btn-input-transition-timing)
+  ),
+  $button-tokens
+);
+// scss-docs-end btn-tokens
+
+$button-outline-tokens: () !default;
+
+// scss-docs-start btn-outline-tokens
+$button-outline-tokens: defaults(
+  (
+    --#{$prefix}btn-color: #{$btn-outline-color},
+    --#{$prefix}btn-border-color: #{$btn-outline-border-color},
+    --#{$prefix}btn-hover-color: #{$btn-outline-hover-color},
+    --#{$prefix}btn-hover-bg: #{$btn-outline-hover-bg},
+    --#{$prefix}btn-hover-border-color: #{$btn-outline-hover-border-color},
+    --#{$prefix}btn-active-color: #{$btn-outline-active-color},
+    --#{$prefix}btn-active-bg: #{$btn-outline-active-bg},
+    --#{$prefix}btn-active-border-color: #{$btn-outline-active-border-color},
+    --#{$prefix}btn-disabled-color: #{$btn-outline-disabled-color},
+    --#{$prefix}btn-disabled-border-color: #{$btn-outline-disabled-border-color}
+  ),
+  $button-outline-tokens
+);
+// scss-docs-end btn-outline-tokens
+
+$button-ghost-tokens: () !default;
+
+// scss-docs-start btn-ghost-tokens
+$button-ghost-tokens: defaults(
+  (
+    --#{$prefix}btn-color: #{$btn-ghost-color},
+    --#{$prefix}btn-border-color: transparent,
+    --#{$prefix}btn-hover-color: #{$btn-ghost-hover-color},
+    --#{$prefix}btn-hover-bg: #{$btn-ghost-hover-bg},
+    --#{$prefix}btn-hover-border-color: #{$btn-ghost-hover-bg},
+    --#{$prefix}btn-active-color: #{$btn-ghost-active-color},
+    --#{$prefix}btn-active-bg: #{$btn-ghost-active-bg},
+    --#{$prefix}btn-active-border-color: #{$btn-ghost-active-bg},
+    --#{$prefix}btn-disabled-color: #{$btn-ghost-disabled-color},
+    --#{$prefix}btn-disabled-border-color: transparent
+  ),
+  $button-ghost-tokens
+);
+// scss-docs-end btn-ghost-tokens
+
+$button-link-tokens: () !default;
+
+// scss-docs-start btn-link-tokens
+$button-link-tokens: defaults(
+  (
+    --#{$prefix}btn-font-weight: var(--#{$prefix}font-weight-normal),
+    --#{$prefix}btn-color: #{$btn-link-color},
+    --#{$prefix}btn-bg: transparent,
+    --#{$prefix}btn-border-color: transparent,
+    --#{$prefix}btn-hover-color: #{$btn-link-hover-color},
+    --#{$prefix}btn-hover-border-color: transparent,
+    --#{$prefix}btn-active-border-color: transparent,
+    --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color},
+    --#{$prefix}btn-disabled-border-color: transparent,
+    --#{$prefix}btn-box-shadow: none
+  ),
+  $button-link-tokens
+);
+// scss-docs-end btn-link-tokens
+
+// scss-docs-start btn-sizes
+$button-sizes: ("sm", "lg") !default;
+// scss-docs-end btn-sizes
 
 // scss-docs-start btn-variants
-// Each variant maps a button token to a --#{$prefix}theme-* token, so one set of
-// rules serves every theme color. Hover and active are derived in CSS from the
-// same token, which is what lets a custom theme color work without Sass.
 $button-variants: () !default;
 $button-variants: defaults(
   (
@@ -112,7 +171,7 @@ $button-variants: defaults(
 );
 // scss-docs-end btn-variants
 
-// stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function, scss/dollar-variable-default
 
 // scss-docs-start btn-variant-mixin
 @mixin button-variant($variant, $hover-lightness: $btn-hover-lightness, $active-lightness: $btn-active-lightness) {
@@ -143,48 +202,19 @@ $button-variants: defaults(
 }
 // scss-docs-end btn-variant-mixin
 
-// scss-docs-start btn-size-mixin
-@mixin button-size($padding-y, $padding-x, $font-size, $border-radius) {
-  --#{$prefix}btn-padding-y: #{$padding-y};
-  --#{$prefix}btn-padding-x: #{$padding-x};
-  --#{$prefix}btn-font-size: #{$font-size};
-  --#{$prefix}btn-border-radius: #{$border-radius};
-}
-// scss-docs-end btn-size-mixin
-
-// scss-docs-start btn-ghost-variables
-$btn-ghost-color: var(--#{$prefix}secondary-color) !default;
-$btn-ghost-active-color: var(--#{$prefix}body-color) !default;
-$btn-ghost-active-bg: var(--#{$prefix}tertiary-bg) !default;
-$btn-ghost-disabled-color: var(--#{$prefix}secondary-color) !default;
-$btn-ghost-hover-color: var(--#{$prefix}body-color) !default;
-$btn-ghost-hover-bg: var(--#{$prefix}tertiary-bg) !default;
-// scss-docs-end btn-ghost-variables
-
 @layer components {
   //
   // Base styles
   //
 
   .btn {
-    // scss-docs-start btn-css-vars
-    --#{$prefix}btn-padding-x: #{$btn-padding-x};
-    --#{$prefix}btn-padding-y: #{$btn-padding-y};
-    --#{$prefix}btn-font-family: #{$btn-font-family};
-    --#{$prefix}btn-font-size: #{$btn-font-size};
-    --#{$prefix}btn-font-weight: #{$btn-font-weight};
-    --#{$prefix}btn-line-height: #{$btn-line-height};
-    --#{$prefix}btn-color: #{$btn-color};
-    --#{$prefix}btn-bg: transparent;
-    --#{$prefix}btn-border-width: #{$btn-border-width};
-    --#{$prefix}btn-border-color: transparent;
-    --#{$prefix}btn-border-radius: #{$btn-border-radius};
-    --#{$prefix}btn-hover-border-color: transparent;
-    --#{$prefix}btn-box-shadow: #{$btn-box-shadow};
-    --#{$prefix}btn-disabled-opacity: #{$btn-disabled-opacity};
-    // scss-docs-end btn-css-vars
+    @include tokens($button-tokens);
 
-    display: inline-block;
+    display: inline-flex;
+    gap: var(--#{$prefix}btn-gap);
+    align-items: center;
+    justify-content: center;
+    min-height: var(--#{$prefix}btn-min-height);
     padding: var(--#{$prefix}btn-padding-y) var(--#{$prefix}btn-padding-x);
     font-family: var(--#{$prefix}btn-font-family);
     font-size: var(--#{$prefix}btn-font-size);
@@ -193,7 +223,7 @@ $btn-ghost-hover-bg: var(--#{$prefix}tertiary-bg) !default;
     color: var(--#{$prefix}btn-color);
     text-align: center;
     text-decoration: if(not sass($link-decoration == none): none);
-    white-space: $btn-white-space;
+    white-space: var(--#{$prefix}btn-white-space);
     vertical-align: middle;
     // stylelint-disable-next-line scss/at-function-named-arguments
     cursor: if(sass($enable-button-pointers): pointer);
@@ -202,7 +232,11 @@ $btn-ghost-hover-bg: var(--#{$prefix}tertiary-bg) !default;
     @include border-radius(var(--#{$prefix}btn-border-radius));
     @include gradient-bg(var(--#{$prefix}btn-bg));
     @include box-shadow(var(--#{$prefix}btn-box-shadow));
-    @include transition-props($btn-transition-property, $btn-transition-duration, $btn-transition-timing);
+    @include transition-props(
+      var(--#{$prefix}btn-transition-property),
+      var(--#{$prefix}btn-transition-duration),
+      var(--#{$prefix}btn-transition-timing)
+    );
 
     &:hover {
       color: var(--#{$prefix}btn-hover-color);
@@ -214,7 +248,6 @@ $btn-ghost-hover-bg: var(--#{$prefix}tertiary-bg) !default;
 
     #{$btn-check-deprecated} + &:hover,
     &.btn-check:hover {
-      // override for the checkbox/radio buttons
       color: var(--#{$prefix}btn-color);
       background-color: var(--#{$prefix}btn-bg);
       border-color: var(--#{$prefix}btn-border-color);
@@ -224,14 +257,12 @@ $btn-ghost-hover-bg: var(--#{$prefix}tertiary-bg) !default;
       color: var(--#{$prefix}btn-hover-color);
       @include gradient-bg(var(--#{$prefix}btn-hover-bg));
       border-color: var(--#{$prefix}btn-hover-border-color);
-      // Avoid using mixin so we can pass custom focus shadow properly
       @include focus-ring(true);
     }
 
     #{$btn-check-deprecated}:focus-visible + &,
     &.btn-check:has(input:focus-visible) {
       border-color: var(--#{$prefix}btn-hover-border-color);
-      // Avoid using mixin so we can pass custom focus shadow properly
       @include focus-ring(true);
     }
 
@@ -243,21 +274,18 @@ $btn-ghost-hover-bg: var(--#{$prefix}tertiary-bg) !default;
     &.show {
       color: var(--#{$prefix}btn-active-color);
       background-color: var(--#{$prefix}btn-active-bg);
-      // Remove CSS gradients if they're enabled
       // stylelint-disable-next-line scss/at-function-named-arguments
       background-image: if(sass($enable-gradients): none);
       border-color: var(--#{$prefix}btn-active-border-color);
       @include box-shadow(var(--#{$prefix}btn-active-shadow));
 
       &:focus-visible {
-        // Avoid using mixin so we can pass custom focus shadow properly
         @include focus-ring(true);
       }
     }
 
     #{$btn-check-deprecated}:checked:focus-visible + &,
     &.btn-check:has(input:checked:focus-visible) {
-      // Avoid using mixin so we can pass custom focus shadow properly
       @include focus-ring(true);
     }
 
@@ -275,17 +303,15 @@ $btn-ghost-hover-bg: var(--#{$prefix}tertiary-bg) !default;
     }
   }
 
+  .btn-icon {
+    aspect-ratio: 1;
+    padding: 0;
+  }
+
 
   //
   // Toggle buttons (.btn-check)
   //
-  // A checkbox or radio that looks like a button. The class goes on the
-  // `<label>` with the button classes, and the input nests inside it, so the
-  // button is one element and needs no `id`/`for` pair to hold it together:
-  //
-  //   <label class="btn btn-primary btn-check"><input type="checkbox">Toggle</label>
-  //
-  // Its states are the `&.btn-check:has(input:…)` rules in the base block above.
 
   .btn-check > input {
     position: absolute;
@@ -293,9 +319,7 @@ $btn-ghost-hover-bg: var(--#{$prefix}tertiary-bg) !default;
     pointer-events: none;
   }
 
-  // Dimmed rather than repainted, so a disabled toggle that is checked still
-  // reads as checked — the behavior of the deprecated spelling, where the
-  // `:disabled` input never matched the label's own disabled rules.
+  // Dimmed rather than repainted, so a disabled toggle still reads as checked.
   .btn-check:has(input:disabled) {
     pointer-events: none;
     filter: none;
@@ -320,33 +344,11 @@ $btn-ghost-hover-bg: var(--#{$prefix}tertiary-bg) !default;
 
 
   .btn-ghost {
-    // scss-docs-start btn-ghost-css-vars
-    --#{$prefix}btn-color: #{$btn-ghost-color};
-    --#{$prefix}btn-border-color: #{transparent};
-    --#{$prefix}btn-active-color: #{$btn-ghost-active-color};
-    --#{$prefix}btn-active-bg: #{$btn-ghost-active-bg};
-    --#{$prefix}btn-active-border-color: #{$btn-ghost-active-bg};
-    --#{$prefix}btn-disabled-color: #{$btn-ghost-disabled-color};
-    --#{$prefix}btn-disabled-border-color: #{transparent};
-    --#{$prefix}btn-hover-color: #{$btn-ghost-hover-color};
-    --#{$prefix}btn-hover-bg: #{$btn-ghost-hover-bg};
-    --#{$prefix}btn-hover-border-color: #{$btn-ghost-hover-bg};
-    // scss-docs-end btn-ghost-css-vars
+    @include tokens($button-ghost-tokens);
   }
 
   .btn-outline {
-    // scss-docs-start btn-outline-css-vars
-    --#{$prefix}btn-color: #{$btn-outline-color};
-    --#{$prefix}btn-border-color: #{$btn-outline-border-color};
-    --#{$prefix}btn-active-color: #{$btn-outline-active-color};
-    --#{$prefix}btn-active-bg: #{$btn-outline-active-bg};
-    --#{$prefix}btn-active-border-color: #{$btn-outline-active-border-color};
-    --#{$prefix}btn-disabled-color: #{$btn-outline-disabled-color};
-    --#{$prefix}btn-disabled-border-color: #{$btn-outline-disabled-border-color};
-    --#{$prefix}btn-hover-color: #{$btn-outline-hover-color};
-    --#{$prefix}btn-hover-bg: #{$btn-outline-hover-bg};
-    --#{$prefix}btn-hover-border-color: #{$btn-outline-hover-border-color};
-    // scss-docs-end btn-outline-css-vars
+    @include tokens($button-outline-tokens);
   }
 
   .btn-transparent {
@@ -356,9 +358,6 @@ $btn-ghost-hover-bg: var(--#{$prefix}tertiary-bg) !default;
   }
 
   // scss-docs-start btn-variant-loops
-  // .btn-outline and .btn-ghost keep their standalone neutral meaning, so the
-  // colour-bearing spellings below are the composable form: the variant's token
-  // mapping plus the matching theme tokens.
   @each $color in map.keys($theme-colors) {
     $overrides: map.get($btn-lightness-overrides, $color) or ();
     $hover-l: map.get($overrides, "hover") or $btn-hover-lightness;
@@ -388,16 +387,7 @@ $btn-ghost-hover-bg: var(--#{$prefix}tertiary-bg) !default;
 
   // Make a button look and behave like a link
   .btn-link {
-    --#{$prefix}btn-font-weight: var(--#{$prefix}font-weight-normal);
-    --#{$prefix}btn-color: #{$btn-link-color};
-    --#{$prefix}btn-bg: transparent;
-    --#{$prefix}btn-border-color: transparent;
-    --#{$prefix}btn-hover-color: #{$btn-link-hover-color};
-    --#{$prefix}btn-hover-border-color: transparent;
-    --#{$prefix}btn-active-border-color: transparent;
-    --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color};
-    --#{$prefix}btn-disabled-border-color: transparent;
-    --#{$prefix}btn-box-shadow: none;
+    @include tokens($button-link-tokens);
 
     text-decoration: $link-decoration;
     @if $enable-gradients {
@@ -421,12 +411,18 @@ $btn-ghost-hover-bg: var(--#{$prefix}tertiary-bg) !default;
   // Button Sizes
   //
 
-  .btn-lg {
-    @include button-size($btn-padding-y-lg, $btn-padding-x-lg, $btn-font-size-lg, $btn-border-radius-lg);
+  // scss-docs-start btn-sizes-loop
+  @each $size in $button-sizes {
+    .btn-#{$size},
+    .btn-group-#{$size} > .btn,
+    .input-group-#{$size} > .btn {
+      --#{$prefix}btn-gap: var(--#{$prefix}btn-input-#{$size}-gap);
+      --#{$prefix}btn-min-height: var(--#{$prefix}btn-input-#{$size}-min-height);
+      --#{$prefix}btn-padding-y: var(--#{$prefix}btn-input-#{$size}-padding-y);
+      --#{$prefix}btn-padding-x: var(--#{$prefix}btn-input-#{$size}-padding-x);
+      --#{$prefix}btn-font-size: var(--#{$prefix}btn-input-#{$size}-font-size);
+      --#{$prefix}btn-border-radius: var(--#{$prefix}btn-input-#{$size}-border-radius);
+    }
   }
-
-  .btn-sm {
-    @include button-size($btn-padding-y-sm, $btn-padding-x-sm, $btn-font-size-sm, $btn-border-radius-sm);
-  }
-
+  // scss-docs-end btn-sizes-loop
 }

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -1,5 +1,6 @@
 @use "sass:list";
 @use "sass:map";
+@use "sass:meta";
 @use "sass:string";
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
@@ -59,21 +60,12 @@ $button-tokens: defaults(
     --#{$prefix}btn-line-height: var(--#{$prefix}btn-input-line-height),
     --#{$prefix}btn-white-space: $btn-white-space,
     --#{$prefix}btn-color: #{$btn-color},
-    --#{$prefix}btn-bg: #{$btn-bg},
     --#{$prefix}btn-border-width: var(--#{$prefix}btn-input-border-width),
     --#{$prefix}btn-border-color: transparent,
     --#{$prefix}btn-border-radius: var(--#{$prefix}border-radius),
-    --#{$prefix}btn-hover-color: #{$btn-color},
-    --#{$prefix}btn-hover-bg: #{$btn-hover-bg},
     --#{$prefix}btn-hover-border-color: transparent,
-    --#{$prefix}btn-active-color: #{$btn-color},
-    --#{$prefix}btn-active-bg: #{$btn-hover-bg},
-    --#{$prefix}btn-active-border-color: transparent,
-    --#{$prefix}btn-active-shadow: #{$btn-active-box-shadow},
-    --#{$prefix}btn-disabled-color: #{$btn-color},
-    --#{$prefix}btn-disabled-bg: #{$btn-bg},
-    --#{$prefix}btn-disabled-border-color: transparent,
     --#{$prefix}btn-box-shadow: #{$btn-box-shadow},
+    --#{$prefix}btn-active-shadow: #{$btn-active-box-shadow},
     --#{$prefix}btn-disabled-opacity: var(--#{$prefix}btn-input-disabled-opacity),
     --#{$prefix}btn-transition-property: var(--#{$prefix}btn-input-action-transition-property),
     --#{$prefix}btn-transition-duration: var(--#{$prefix}btn-input-transition-duration),
@@ -83,97 +75,86 @@ $button-tokens: defaults(
 );
 // scss-docs-end btn-tokens
 
-// Every variant reads the theme tokens and falls back to a neutral value, so
-// the class alone is a grey button and a theme colour — from `.theme-*`, from a
-// `.btn-*-{color}` class or from an ancestor — colours the whole variant.
-
-$button-solid-tokens: () !default;
-
-// scss-docs-start btn-solid-tokens
-$button-solid-tokens: defaults(
+// scss-docs-start btn-variants
+// Each entry names the theme token a button variable reads and the neutral
+// value behind it, so the variant class alone is a grey button and any theme
+// colour — from `.theme-*`, from a `.btn-*-{color}` class or from an ancestor —
+// colours the whole set. `disabled` repeats `base`.
+$button-variants: () !default;
+$button-variants: defaults(
   (
-    --#{$prefix}btn-color: var(--#{$prefix}theme-contrast, #{$btn-color}),
-    --#{$prefix}btn-bg: var(--#{$prefix}theme-base, #{$btn-bg}),
-    --#{$prefix}btn-border-color: var(--#{$prefix}btn-bg),
-    --#{$prefix}btn-hover-color: var(--#{$prefix}btn-color),
-    --#{$prefix}btn-hover-bg: var(--#{$prefix}theme-hover, #{$btn-hover-bg}),
-    --#{$prefix}btn-hover-border-color: var(--#{$prefix}btn-hover-bg),
-    --#{$prefix}btn-active-color: var(--#{$prefix}btn-color),
-    --#{$prefix}btn-active-bg: var(--#{$prefix}theme-active, #{$btn-hover-bg}),
-    --#{$prefix}btn-active-border-color: var(--#{$prefix}btn-active-bg),
-    --#{$prefix}btn-disabled-color: var(--#{$prefix}btn-color),
-    --#{$prefix}btn-disabled-bg: var(--#{$prefix}btn-bg),
-    --#{$prefix}btn-disabled-border-color: var(--#{$prefix}btn-bg)
+    "solid": (
+      "base": (
+        "color": ("contrast", $btn-color),
+        "bg": ("base", $btn-bg),
+        "border-color": ("base", $btn-bg)
+      ),
+      "hover": (
+        "color": ("contrast", $btn-color),
+        "bg": ("hover", $btn-hover-bg),
+        "border-color": ("hover", $btn-hover-bg)
+      ),
+      "active": (
+        "color": ("contrast", $btn-color),
+        "bg": ("active", $btn-hover-bg),
+        "border-color": ("active", $btn-hover-bg)
+      )
+    ),
+    "outline": (
+      "base": (
+        "color": ("base", $btn-outline-color),
+        "bg": "transparent",
+        "border-color": ("base", $btn-outline-border-color)
+      ),
+      "hover": (
+        "color": ("contrast", $btn-outline-hover-color),
+        "bg": ("hover", $btn-outline-hover-bg),
+        "border-color": ("hover", $btn-outline-border-color)
+      ),
+      "active": (
+        "color": ("contrast", $btn-outline-hover-color),
+        "bg": ("active", $btn-outline-hover-bg),
+        "border-color": ("active", $btn-outline-border-color)
+      )
+    ),
+    "subtle": (
+      "base": (
+        "color": ("fg", $btn-subtle-color),
+        "bg": ("bg-subtle", $btn-subtle-bg),
+        "border-color": "transparent"
+      ),
+      "hover": (
+        "color": ("fg-emphasis", $btn-subtle-color),
+        "bg": ("bg-muted", $btn-subtle-hover-bg),
+        "border-color": "transparent"
+      ),
+      "active": (
+        "color": ("fg-emphasis", $btn-subtle-color),
+        "bg": ("bg-muted", $btn-subtle-hover-bg),
+        "border-color": "transparent"
+      )
+    ),
+    "ghost": (
+      "base": (
+        "color": ("base", $btn-ghost-color),
+        "bg": "transparent",
+        "border-color": "transparent"
+      ),
+      "hover": (
+        "color": ("contrast", $btn-ghost-hover-color),
+        "bg": ("hover", $btn-ghost-hover-bg),
+        "border-color": ("hover", $btn-ghost-hover-bg)
+      ),
+      "active": (
+        "color": ("contrast", $btn-ghost-hover-color),
+        "bg": ("active", $btn-ghost-hover-bg),
+        "border-color": ("active", $btn-ghost-hover-bg)
+      )
+    )
   ),
-  $button-solid-tokens
+  $button-variants
 );
-// scss-docs-end btn-solid-tokens
-
-$button-outline-tokens: () !default;
-
-// scss-docs-start btn-outline-tokens
-$button-outline-tokens: defaults(
-  (
-    --#{$prefix}btn-color: var(--#{$prefix}theme-base, #{$btn-outline-color}),
-    --#{$prefix}btn-bg: transparent,
-    --#{$prefix}btn-border-color: var(--#{$prefix}theme-base, #{$btn-outline-border-color}),
-    --#{$prefix}btn-hover-color: var(--#{$prefix}theme-contrast, #{$btn-outline-hover-color}),
-    --#{$prefix}btn-hover-bg: var(--#{$prefix}theme-hover, #{$btn-outline-hover-bg}),
-    --#{$prefix}btn-hover-border-color: var(--#{$prefix}theme-hover, #{$btn-outline-border-color}),
-    --#{$prefix}btn-active-color: var(--#{$prefix}btn-hover-color),
-    --#{$prefix}btn-active-bg: var(--#{$prefix}theme-active, #{$btn-outline-hover-bg}),
-    --#{$prefix}btn-active-border-color: var(--#{$prefix}theme-active, #{$btn-outline-border-color}),
-    --#{$prefix}btn-disabled-color: var(--#{$prefix}btn-color),
-    --#{$prefix}btn-disabled-bg: transparent,
-    --#{$prefix}btn-disabled-border-color: var(--#{$prefix}btn-border-color)
-  ),
-  $button-outline-tokens
-);
-// scss-docs-end btn-outline-tokens
-
-$button-subtle-tokens: () !default;
-
-// scss-docs-start btn-subtle-tokens
-$button-subtle-tokens: defaults(
-  (
-    --#{$prefix}btn-color: var(--#{$prefix}theme-fg, #{$btn-subtle-color}),
-    --#{$prefix}btn-bg: var(--#{$prefix}theme-bg-subtle, #{$btn-subtle-bg}),
-    --#{$prefix}btn-border-color: transparent,
-    --#{$prefix}btn-hover-color: var(--#{$prefix}theme-fg-emphasis, #{$btn-subtle-color}),
-    --#{$prefix}btn-hover-bg: var(--#{$prefix}theme-bg-muted, #{$btn-subtle-hover-bg}),
-    --#{$prefix}btn-hover-border-color: transparent,
-    --#{$prefix}btn-active-color: var(--#{$prefix}btn-hover-color),
-    --#{$prefix}btn-active-bg: var(--#{$prefix}btn-hover-bg),
-    --#{$prefix}btn-active-border-color: transparent,
-    --#{$prefix}btn-disabled-color: var(--#{$prefix}btn-color),
-    --#{$prefix}btn-disabled-bg: var(--#{$prefix}btn-bg),
-    --#{$prefix}btn-disabled-border-color: transparent
-  ),
-  $button-subtle-tokens
-);
-// scss-docs-end btn-subtle-tokens
-
-$button-ghost-tokens: () !default;
-
-// scss-docs-start btn-ghost-tokens
-$button-ghost-tokens: defaults(
-  (
-    --#{$prefix}btn-color: var(--#{$prefix}theme-base, #{$btn-ghost-color}),
-    --#{$prefix}btn-bg: transparent,
-    --#{$prefix}btn-border-color: transparent,
-    --#{$prefix}btn-hover-color: var(--#{$prefix}theme-contrast, #{$btn-ghost-hover-color}),
-    --#{$prefix}btn-hover-bg: var(--#{$prefix}theme-hover, #{$btn-ghost-hover-bg}),
-    --#{$prefix}btn-hover-border-color: var(--#{$prefix}btn-hover-bg),
-    --#{$prefix}btn-active-color: var(--#{$prefix}btn-hover-color),
-    --#{$prefix}btn-active-bg: var(--#{$prefix}theme-active, #{$btn-ghost-hover-bg}),
-    --#{$prefix}btn-active-border-color: var(--#{$prefix}btn-active-bg),
-    --#{$prefix}btn-disabled-color: var(--#{$prefix}btn-color),
-    --#{$prefix}btn-disabled-bg: transparent,
-    --#{$prefix}btn-disabled-border-color: transparent
-  ),
-  $button-ghost-tokens
-);
-// scss-docs-end btn-ghost-tokens
+// scss-docs-end btn-variants
 
 $button-link-tokens: () !default;
 
@@ -203,22 +184,36 @@ $button-link-tokens: defaults(
 $button-sizes: ("xs", "sm", "lg") !default;
 // scss-docs-end btn-sizes
 
-// scss-docs-start btn-variants
-// The map drives both spellings of every variant: `.btn-{variant}` next to a
-// `.theme-*` class, and the `.btn-{variant}-{color}` class of its own.
-$button-variants: () !default;
-$button-variants: defaults(
-  (
-    "solid": $button-solid-tokens,
-    "outline": $button-outline-tokens,
-    "subtle": $button-subtle-tokens,
-    "ghost": $button-ghost-tokens
-  ),
-  $button-variants
-);
-// scss-docs-end btn-variants
-
 // stylelint-enable custom-property-no-missing-var-function, scss/dollar-variable-default
+
+// scss-docs-start btn-variant-mixin
+@function btn-variant-value($value) {
+  @if $value == "transparent" {
+    @return transparent;
+  }
+
+  @if meta.type-of($value) == "list" {
+    @return var(--#{$prefix}theme-#{list.nth($value, 1)}, #{list.nth($value, 2)});
+  }
+
+  @return var(--#{$prefix}theme-#{$value});
+}
+
+@mixin button-variant($variant) {
+  $config: map.get($button-variants, $variant);
+
+  @each $property, $value in map.get($config, "base") {
+    --#{$prefix}btn-#{$property}: #{btn-variant-value($value)};
+    --#{$prefix}btn-disabled-#{$property}: #{btn-variant-value($value)};
+  }
+
+  @each $state in ("hover", "active") {
+    @each $property, $value in map.get($config, $state) {
+      --#{$prefix}btn-#{$state}-#{$property}: #{btn-variant-value($value)};
+    }
+  }
+}
+// scss-docs-end btn-variant-mixin
 
 // scss-docs-start btn-variant-selectors
 $btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), string.unquote(".btn-icon")) !default;
@@ -269,7 +264,7 @@ $btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), st
     user-select: none;
     border: var(--#{$prefix}btn-border-width) solid var(--#{$prefix}btn-border-color);
     @include border-radius(var(--#{$prefix}btn-border-radius));
-    @include gradient-bg(var(--#{$prefix}btn-bg));
+    @include gradient-bg(var(--#{$prefix}btn-bg, #{$btn-bg}));
     @include box-shadow(var(--#{$prefix}btn-box-shadow));
     @include transition-props(
       var(--#{$prefix}btn-transition-property),
@@ -278,22 +273,22 @@ $btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), st
     );
 
     &:hover {
-      color: var(--#{$prefix}btn-hover-color);
+      color: var(--#{$prefix}btn-hover-color, #{$btn-color});
       // stylelint-disable-next-line scss/at-function-named-arguments
       text-decoration: if(sass($link-hover-decoration == underline): none);
-      background-color: var(--#{$prefix}btn-hover-bg);
+      background-color: var(--#{$prefix}btn-hover-bg, #{$btn-hover-bg});
       border-color: var(--#{$prefix}btn-hover-border-color);
     }
 
     &.btn-check:hover {
       color: var(--#{$prefix}btn-color);
-      background-color: var(--#{$prefix}btn-bg);
+      background-color: var(--#{$prefix}btn-bg, #{$btn-bg});
       border-color: var(--#{$prefix}btn-border-color);
     }
 
     &:focus-visible {
-      color: var(--#{$prefix}btn-hover-color);
-      @include gradient-bg(var(--#{$prefix}btn-hover-bg));
+      color: var(--#{$prefix}btn-hover-color, #{$btn-color});
+      @include gradient-bg(var(--#{$prefix}btn-hover-bg, #{$btn-hover-bg}));
       border-color: var(--#{$prefix}btn-hover-border-color);
       @include focus-ring(true);
     }
@@ -307,11 +302,11 @@ $btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), st
     &:active,
     &.active,
     &.show {
-      color: var(--#{$prefix}btn-active-color);
-      background-color: var(--#{$prefix}btn-active-bg);
+      color: var(--#{$prefix}btn-active-color, #{$btn-color});
+      background-color: var(--#{$prefix}btn-active-bg, #{$btn-hover-bg});
       // stylelint-disable-next-line scss/at-function-named-arguments
       background-image: if(sass($enable-gradients): none);
-      border-color: var(--#{$prefix}btn-active-border-color);
+      border-color: var(--#{$prefix}btn-active-border-color, transparent);
       @include box-shadow(var(--#{$prefix}btn-active-shadow));
 
       &:focus-visible {
@@ -326,12 +321,12 @@ $btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), st
     &:disabled,
     &.disabled,
     fieldset:disabled & {
-      color: var(--#{$prefix}btn-disabled-color);
+      color: var(--#{$prefix}btn-disabled-color, #{$btn-color});
       pointer-events: none;
-      background-color: var(--#{$prefix}btn-disabled-bg);
+      background-color: var(--#{$prefix}btn-disabled-bg, #{$btn-bg});
       // stylelint-disable-next-line scss/at-function-named-arguments
       background-image: if(sass($enable-gradients): none);
-      border-color: var(--#{$prefix}btn-disabled-border-color);
+      border-color: var(--#{$prefix}btn-disabled-border-color, transparent);
       opacity: var(--#{$prefix}btn-disabled-opacity);
       @include box-shadow(none);
     }
@@ -368,7 +363,7 @@ $btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), st
 
     + .btn:hover {
       color: var(--#{$prefix}btn-color);
-      background-color: var(--#{$prefix}btn-bg);
+      background-color: var(--#{$prefix}btn-bg, #{$btn-bg});
       border-color: var(--#{$prefix}btn-border-color);
     }
 
@@ -379,11 +374,11 @@ $btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), st
     }
 
     &:checked + .btn {
-      color: var(--#{$prefix}btn-active-color);
-      background-color: var(--#{$prefix}btn-active-bg);
+      color: var(--#{$prefix}btn-active-color, #{$btn-color});
+      background-color: var(--#{$prefix}btn-active-bg, #{$btn-hover-bg});
       // stylelint-disable-next-line scss/at-function-named-arguments
       background-image: if(sass($enable-gradients): none);
-      border-color: var(--#{$prefix}btn-active-border-color);
+      border-color: var(--#{$prefix}btn-active-border-color, transparent);
       @include box-shadow(var(--#{$prefix}btn-active-shadow));
     }
 
@@ -403,9 +398,9 @@ $btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), st
   //
 
   // scss-docs-start btn-variant-loops
-  @each $variant, $variant-tokens in $button-variants {
+  @each $variant, $config in $button-variants {
     #{btn-variant-selectors($variant)} {
-      @include tokens($variant-tokens);
+      @include button-variant($variant);
     }
   }
 

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -1,4 +1,6 @@
+@use "sass:list";
 @use "sass:map";
+@use "sass:string";
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
@@ -12,6 +14,9 @@
 // scss-docs-start btn-variables
 $btn-white-space:             null !default; // Set to `nowrap` to prevent text wrapping
 
+$btn-color:                   var(--#{$prefix}body-color) !default;
+$btn-bg:                      var(--#{$prefix}secondary-bg) !default;
+$btn-hover-bg:                light-dark(var(--#{$prefix}gray-300), var(--#{$prefix}gray-700)) !default;
 $btn-box-shadow:              inset 0 1px 0 color-mix(in srgb, var(--#{$prefix}white) 15%, transparent), 0 1px 1px color-mix(in srgb, var(--#{$prefix}black) 7.5%, transparent) !default;
 $btn-active-box-shadow:       inset 0 3px 5px color-mix(in srgb, var(--#{$prefix}black) 12.5%, transparent) !default;
 
@@ -19,32 +24,18 @@ $btn-link-color:              var(--#{$prefix}link-color) !default;
 $btn-link-hover-color:        var(--#{$prefix}link-hover-color) !default;
 $btn-link-disabled-color:     var(--#{$prefix}gray-600) !default;
 
-$btn-outline-color:                 var(--#{$prefix}secondary-color) !default;
-$btn-outline-border-color:          var(--#{$prefix}border-color) !default;
-$btn-outline-hover-color:           var(--#{$prefix}body-color) !default;
-$btn-outline-hover-bg:              var(--#{$prefix}tertiary-bg) !default;
-$btn-outline-hover-border-color:    var(--#{$prefix}border-color) !default;
-$btn-outline-active-color:          var(--#{$prefix}body-color) !default;
-$btn-outline-active-bg:             var(--#{$prefix}tertiary-bg) !default;
-$btn-outline-active-border-color:   var(--#{$prefix}border-color) !default;
-$btn-outline-disabled-color:        var(--#{$prefix}secondary-color) !default;
-$btn-outline-disabled-border-color: var(--#{$prefix}border-color) !default;
+$btn-outline-color:           var(--#{$prefix}secondary-color) !default;
+$btn-outline-border-color:    var(--#{$prefix}border-color) !default;
+$btn-outline-hover-color:     var(--#{$prefix}body-color) !default;
+$btn-outline-hover-bg:        var(--#{$prefix}tertiary-bg) !default;
+
+$btn-subtle-color:            var(--#{$prefix}body-color) !default;
+$btn-subtle-bg:               var(--#{$prefix}secondary-bg) !default;
+$btn-subtle-hover-bg:         var(--#{$prefix}tertiary-bg) !default;
 
 $btn-ghost-color:             var(--#{$prefix}secondary-color) !default;
 $btn-ghost-hover-color:       var(--#{$prefix}body-color) !default;
 $btn-ghost-hover-bg:          var(--#{$prefix}tertiary-bg) !default;
-$btn-ghost-active-color:      var(--#{$prefix}body-color) !default;
-$btn-ghost-active-bg:         var(--#{$prefix}tertiary-bg) !default;
-$btn-ghost-disabled-color:    var(--#{$prefix}secondary-color) !default;
-
-// Tuned to land near the shade-color() amounts compiled before the states moved into CSS.
-$btn-hover-lightness:         .85 !default;
-$btn-active-lightness:        .8 !default;
-
-// Dark theme colors sit too low to darken any further, so they brighten instead.
-$btn-lightness-overrides: (
-  "dark": ("hover": 1.48, "active": 1.62)
-) !default;
 // scss-docs-end btn-variables
 
 // The v6 spelling puts `.btn-check` on the `<label>` next to `.btn`, so the
@@ -66,13 +57,22 @@ $button-tokens: defaults(
     --#{$prefix}btn-font-size: var(--#{$prefix}btn-input-font-size),
     --#{$prefix}btn-font-weight: var(--#{$prefix}font-weight-normal),
     --#{$prefix}btn-line-height: var(--#{$prefix}btn-input-line-height),
-    --#{$prefix}btn-color: var(--#{$prefix}body-color),
-    --#{$prefix}btn-bg: transparent,
     --#{$prefix}btn-white-space: $btn-white-space,
+    --#{$prefix}btn-color: #{$btn-color},
+    --#{$prefix}btn-bg: #{$btn-bg},
     --#{$prefix}btn-border-width: var(--#{$prefix}btn-input-border-width),
     --#{$prefix}btn-border-color: transparent,
     --#{$prefix}btn-border-radius: var(--#{$prefix}border-radius),
+    --#{$prefix}btn-hover-color: #{$btn-color},
+    --#{$prefix}btn-hover-bg: #{$btn-hover-bg},
     --#{$prefix}btn-hover-border-color: transparent,
+    --#{$prefix}btn-active-color: #{$btn-color},
+    --#{$prefix}btn-active-bg: #{$btn-hover-bg},
+    --#{$prefix}btn-active-border-color: transparent,
+    --#{$prefix}btn-active-shadow: #{$btn-active-box-shadow},
+    --#{$prefix}btn-disabled-color: #{$btn-color},
+    --#{$prefix}btn-disabled-bg: #{$btn-bg},
+    --#{$prefix}btn-disabled-border-color: transparent,
     --#{$prefix}btn-box-shadow: #{$btn-box-shadow},
     --#{$prefix}btn-disabled-opacity: var(--#{$prefix}btn-input-disabled-opacity),
     --#{$prefix}btn-transition-property: var(--#{$prefix}btn-input-action-transition-property),
@@ -83,40 +83,92 @@ $button-tokens: defaults(
 );
 // scss-docs-end btn-tokens
 
+// Every variant reads the theme tokens and falls back to a neutral value, so
+// the class alone is a grey button and a theme colour — from `.theme-*`, from a
+// `.btn-*-{color}` class or from an ancestor — colours the whole variant.
+
+$button-solid-tokens: () !default;
+
+// scss-docs-start btn-solid-tokens
+$button-solid-tokens: defaults(
+  (
+    --#{$prefix}btn-color: var(--#{$prefix}theme-contrast, #{$btn-color}),
+    --#{$prefix}btn-bg: var(--#{$prefix}theme-base, #{$btn-bg}),
+    --#{$prefix}btn-border-color: var(--#{$prefix}theme-base, #{$btn-bg}),
+    --#{$prefix}btn-hover-color: var(--#{$prefix}theme-contrast, #{$btn-color}),
+    --#{$prefix}btn-hover-bg: var(--#{$prefix}theme-hover, #{$btn-hover-bg}),
+    --#{$prefix}btn-hover-border-color: var(--#{$prefix}theme-hover, #{$btn-hover-bg}),
+    --#{$prefix}btn-active-color: var(--#{$prefix}theme-contrast, #{$btn-color}),
+    --#{$prefix}btn-active-bg: var(--#{$prefix}theme-active, #{$btn-hover-bg}),
+    --#{$prefix}btn-active-border-color: var(--#{$prefix}theme-active, #{$btn-hover-bg}),
+    --#{$prefix}btn-disabled-color: var(--#{$prefix}theme-contrast, #{$btn-color}),
+    --#{$prefix}btn-disabled-bg: var(--#{$prefix}theme-base, #{$btn-bg}),
+    --#{$prefix}btn-disabled-border-color: var(--#{$prefix}theme-base, #{$btn-bg})
+  ),
+  $button-solid-tokens
+);
+// scss-docs-end btn-solid-tokens
+
 $button-outline-tokens: () !default;
 
 // scss-docs-start btn-outline-tokens
 $button-outline-tokens: defaults(
   (
-    --#{$prefix}btn-color: #{$btn-outline-color},
-    --#{$prefix}btn-border-color: #{$btn-outline-border-color},
-    --#{$prefix}btn-hover-color: #{$btn-outline-hover-color},
-    --#{$prefix}btn-hover-bg: #{$btn-outline-hover-bg},
-    --#{$prefix}btn-hover-border-color: #{$btn-outline-hover-border-color},
-    --#{$prefix}btn-active-color: #{$btn-outline-active-color},
-    --#{$prefix}btn-active-bg: #{$btn-outline-active-bg},
-    --#{$prefix}btn-active-border-color: #{$btn-outline-active-border-color},
-    --#{$prefix}btn-disabled-color: #{$btn-outline-disabled-color},
-    --#{$prefix}btn-disabled-border-color: #{$btn-outline-disabled-border-color}
+    --#{$prefix}btn-color: var(--#{$prefix}theme-base, #{$btn-outline-color}),
+    --#{$prefix}btn-bg: transparent,
+    --#{$prefix}btn-border-color: var(--#{$prefix}theme-base, #{$btn-outline-border-color}),
+    --#{$prefix}btn-hover-color: var(--#{$prefix}theme-contrast, #{$btn-outline-hover-color}),
+    --#{$prefix}btn-hover-bg: var(--#{$prefix}theme-hover, #{$btn-outline-hover-bg}),
+    --#{$prefix}btn-hover-border-color: var(--#{$prefix}theme-hover, #{$btn-outline-border-color}),
+    --#{$prefix}btn-active-color: var(--#{$prefix}theme-contrast, #{$btn-outline-hover-color}),
+    --#{$prefix}btn-active-bg: var(--#{$prefix}theme-active, #{$btn-outline-hover-bg}),
+    --#{$prefix}btn-active-border-color: var(--#{$prefix}theme-active, #{$btn-outline-border-color}),
+    --#{$prefix}btn-disabled-color: var(--#{$prefix}theme-base, #{$btn-outline-color}),
+    --#{$prefix}btn-disabled-bg: transparent,
+    --#{$prefix}btn-disabled-border-color: var(--#{$prefix}theme-base, #{$btn-outline-border-color})
   ),
   $button-outline-tokens
 );
 // scss-docs-end btn-outline-tokens
+
+$button-subtle-tokens: () !default;
+
+// scss-docs-start btn-subtle-tokens
+$button-subtle-tokens: defaults(
+  (
+    --#{$prefix}btn-color: var(--#{$prefix}theme-fg, #{$btn-subtle-color}),
+    --#{$prefix}btn-bg: var(--#{$prefix}theme-bg-subtle, #{$btn-subtle-bg}),
+    --#{$prefix}btn-border-color: transparent,
+    --#{$prefix}btn-hover-color: var(--#{$prefix}theme-fg-emphasis, #{$btn-subtle-color}),
+    --#{$prefix}btn-hover-bg: var(--#{$prefix}theme-bg-muted, #{$btn-subtle-hover-bg}),
+    --#{$prefix}btn-hover-border-color: transparent,
+    --#{$prefix}btn-active-color: var(--#{$prefix}theme-fg-emphasis, #{$btn-subtle-color}),
+    --#{$prefix}btn-active-bg: var(--#{$prefix}theme-bg-muted, #{$btn-subtle-hover-bg}),
+    --#{$prefix}btn-active-border-color: transparent,
+    --#{$prefix}btn-disabled-color: var(--#{$prefix}theme-fg, #{$btn-subtle-color}),
+    --#{$prefix}btn-disabled-bg: var(--#{$prefix}theme-bg-subtle, #{$btn-subtle-bg}),
+    --#{$prefix}btn-disabled-border-color: transparent
+  ),
+  $button-subtle-tokens
+);
+// scss-docs-end btn-subtle-tokens
 
 $button-ghost-tokens: () !default;
 
 // scss-docs-start btn-ghost-tokens
 $button-ghost-tokens: defaults(
   (
-    --#{$prefix}btn-color: #{$btn-ghost-color},
+    --#{$prefix}btn-color: var(--#{$prefix}theme-base, #{$btn-ghost-color}),
+    --#{$prefix}btn-bg: transparent,
     --#{$prefix}btn-border-color: transparent,
-    --#{$prefix}btn-hover-color: #{$btn-ghost-hover-color},
-    --#{$prefix}btn-hover-bg: #{$btn-ghost-hover-bg},
-    --#{$prefix}btn-hover-border-color: #{$btn-ghost-hover-bg},
-    --#{$prefix}btn-active-color: #{$btn-ghost-active-color},
-    --#{$prefix}btn-active-bg: #{$btn-ghost-active-bg},
-    --#{$prefix}btn-active-border-color: #{$btn-ghost-active-bg},
-    --#{$prefix}btn-disabled-color: #{$btn-ghost-disabled-color},
+    --#{$prefix}btn-hover-color: var(--#{$prefix}theme-contrast, #{$btn-ghost-hover-color}),
+    --#{$prefix}btn-hover-bg: var(--#{$prefix}theme-hover, #{$btn-ghost-hover-bg}),
+    --#{$prefix}btn-hover-border-color: var(--#{$prefix}theme-hover, #{$btn-ghost-hover-bg}),
+    --#{$prefix}btn-active-color: var(--#{$prefix}theme-contrast, #{$btn-ghost-hover-color}),
+    --#{$prefix}btn-active-bg: var(--#{$prefix}theme-active, #{$btn-ghost-hover-bg}),
+    --#{$prefix}btn-active-border-color: var(--#{$prefix}theme-active, #{$btn-ghost-hover-bg}),
+    --#{$prefix}btn-disabled-color: var(--#{$prefix}theme-base, #{$btn-ghost-color}),
+    --#{$prefix}btn-disabled-bg: transparent,
     --#{$prefix}btn-disabled-border-color: transparent
   ),
   $button-ghost-tokens
@@ -133,9 +185,13 @@ $button-link-tokens: defaults(
     --#{$prefix}btn-bg: transparent,
     --#{$prefix}btn-border-color: transparent,
     --#{$prefix}btn-hover-color: #{$btn-link-hover-color},
+    --#{$prefix}btn-hover-bg: transparent,
     --#{$prefix}btn-hover-border-color: transparent,
+    --#{$prefix}btn-active-color: #{$btn-link-hover-color},
+    --#{$prefix}btn-active-bg: transparent,
     --#{$prefix}btn-active-border-color: transparent,
     --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color},
+    --#{$prefix}btn-disabled-bg: transparent,
     --#{$prefix}btn-disabled-border-color: transparent,
     --#{$prefix}btn-box-shadow: none
   ),
@@ -144,28 +200,19 @@ $button-link-tokens: defaults(
 // scss-docs-end btn-link-tokens
 
 // scss-docs-start btn-sizes
-$button-sizes: ("sm", "lg") !default;
+$button-sizes: ("xs", "sm", "lg") !default;
 // scss-docs-end btn-sizes
 
 // scss-docs-start btn-variants
+// The map drives both spellings of every variant: `.btn-{variant}` next to a
+// `.theme-*` class, and the `.btn-{variant}-{color}` class of its own.
 $button-variants: () !default;
 $button-variants: defaults(
   (
-    "solid": (
-      "base": ("bg": "base", "color": "contrast", "border-color": "base"),
-      "hover": ("bg": "base", "color": "contrast", "border-color": "base"),
-      "active": ("bg": "base", "color": "contrast", "border-color": "base")
-    ),
-    "outline": (
-      "base": ("bg": "transparent", "color": "base", "border-color": "base"),
-      "hover": ("bg": "base", "color": "contrast", "border-color": "base"),
-      "active": ("bg": "base", "color": "contrast", "border-color": "base")
-    ),
-    "ghost": (
-      "base": ("bg": "transparent", "color": "base", "border-color": "transparent"),
-      "hover": ("bg": "base", "color": "contrast", "border-color": "base"),
-      "active": ("bg": "base", "color": "contrast", "border-color": "base")
-    )
+    "solid": $button-solid-tokens,
+    "outline": $button-outline-tokens,
+    "subtle": $button-subtle-tokens,
+    "ghost": $button-ghost-tokens
   ),
   $button-variants
 );
@@ -173,41 +220,33 @@ $button-variants: defaults(
 
 // stylelint-enable custom-property-no-missing-var-function, scss/dollar-variable-default
 
-// scss-docs-start btn-variant-mixin
-@mixin button-variant($variant, $hover-lightness: $btn-hover-lightness, $active-lightness: $btn-active-lightness) {
-  @each $property, $token in map.get($button-variants, $variant, "base") {
-    @if $token == "transparent" {
-      --#{$prefix}btn-#{$property}: transparent;
-      --#{$prefix}btn-disabled-#{$property}: transparent;
-    } @else {
-      --#{$prefix}btn-#{$property}: var(--#{$prefix}theme-#{$token});
-      --#{$prefix}btn-disabled-#{$property}: var(--#{$prefix}theme-#{$token});
-    }
-  }
-
-  @each $state, $shift in ("hover": $hover-lightness, "active": $active-lightness) {
-    @each $property, $token in map.get($button-variants, $variant, $state) {
-      @if $token == "transparent" {
-        --#{$prefix}btn-#{$state}-#{$property}: transparent;
-      } @else if $property == "color" {
-        --#{$prefix}btn-#{$state}-#{$property}: var(--#{$prefix}theme-#{$token});
-      } @else {
-        // stylelint-disable-next-line function-disallowed-list
-        --#{$prefix}btn-#{$state}-#{$property}: oklch(from var(--#{$prefix}theme-#{$token}) calc(l * #{$shift}) c h);
-      }
-    }
-  }
-
-  --#{$prefix}btn-active-shadow: #{$btn-active-box-shadow};
+// scss-docs-start btn-variant-selectors
+$btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), string.unquote(".btn-icon")) !default;
+@each $variant, $tokens in $button-variants {
+  $btn-variant-selectors: list.append($btn-variant-selectors, string.unquote(".btn-#{$variant}"), comma);
 }
-// scss-docs-end btn-variant-mixin
+// scss-docs-end btn-variant-selectors
+
+// The solid variant is the one a colour class spells without its variant name:
+// `.btn-primary`, not `.btn-solid-primary`.
+@function btn-variant-selectors($variant) {
+  // stylelint-disable-next-line scss/at-function-named-arguments
+  $infix: if(sass($variant == "solid"): ""; else: "#{$variant}-");
+  $selectors: (string.unquote(".btn-#{$variant}"));
+
+  @each $color in map.keys($theme-colors) {
+    $selectors: list.append($selectors, string.unquote(".btn-#{$infix}#{$color}"), comma);
+  }
+
+  @return $selectors;
+}
 
 @layer components {
   //
   // Base styles
   //
 
-  .btn {
+  #{$btn-variant-selectors} {
     @include tokens($button-tokens);
 
     display: inline-flex;
@@ -246,7 +285,6 @@ $button-variants: defaults(
       border-color: var(--#{$prefix}btn-hover-border-color);
     }
 
-    #{$btn-check-deprecated} + &:hover,
     &.btn-check:hover {
       color: var(--#{$prefix}btn-color);
       background-color: var(--#{$prefix}btn-bg);
@@ -260,16 +298,13 @@ $button-variants: defaults(
       @include focus-ring(true);
     }
 
-    #{$btn-check-deprecated}:focus-visible + &,
     &.btn-check:has(input:focus-visible) {
       border-color: var(--#{$prefix}btn-hover-border-color);
       @include focus-ring(true);
     }
 
-    #{$btn-check-deprecated}:checked + &,
     &.btn-check:has(input:checked),
-    :not(#{$btn-check-deprecated}) + &:active,
-    &:first-child:active,
+    &:active,
     &.active,
     &.show {
       color: var(--#{$prefix}btn-active-color);
@@ -284,7 +319,6 @@ $button-variants: defaults(
       }
     }
 
-    #{$btn-check-deprecated}:checked:focus-visible + &,
     &.btn-check:has(input:checked:focus-visible) {
       @include focus-ring(true);
     }
@@ -332,6 +366,27 @@ $button-variants: defaults(
     clip: rect(0, 0, 0, 0);
     pointer-events: none;
 
+    + .btn:hover {
+      color: var(--#{$prefix}btn-color);
+      background-color: var(--#{$prefix}btn-bg);
+      border-color: var(--#{$prefix}btn-border-color);
+    }
+
+    &:focus-visible + .btn,
+    &:checked:focus-visible + .btn {
+      border-color: var(--#{$prefix}btn-hover-border-color);
+      @include focus-ring(true);
+    }
+
+    &:checked + .btn {
+      color: var(--#{$prefix}btn-active-color);
+      background-color: var(--#{$prefix}btn-active-bg);
+      // stylelint-disable-next-line scss/at-function-named-arguments
+      background-image: if(sass($enable-gradients): none);
+      border-color: var(--#{$prefix}btn-active-border-color);
+      @include box-shadow(var(--#{$prefix}btn-active-shadow));
+    }
+
     &[disabled],
     &:disabled {
       + .btn {
@@ -343,42 +398,37 @@ $button-variants: defaults(
   }
 
 
-  .btn-ghost {
-    @include tokens($button-ghost-tokens);
+  //
+  // Variants
+  //
+
+  // scss-docs-start btn-variant-loops
+  @each $variant, $variant-tokens in $button-variants {
+    #{btn-variant-selectors($variant)} {
+      @include tokens($variant-tokens);
+    }
   }
 
-  .btn-outline {
-    @include tokens($button-outline-tokens);
+  @each $color in map.keys($theme-colors) {
+    $selectors: (string.unquote(".btn-#{$color}"));
+
+    @each $variant, $_ in $button-variants {
+      @if $variant != "solid" {
+        $selectors: list.append($selectors, string.unquote(".btn-#{$variant}-#{$color}"), comma);
+      }
+    }
+
+    #{$selectors} {
+      @include theme-tokens($color);
+    }
   }
+  // scss-docs-end btn-variant-loops
 
   .btn-transparent {
     --#{$prefix}btn-active-border-color: transparent;
     --#{$prefix}btn-disabled-border-color: transparent;
     --#{$prefix}btn-hover-border-color: transparent;
   }
-
-  // scss-docs-start btn-variant-loops
-  @each $color in map.keys($theme-colors) {
-    $overrides: map.get($btn-lightness-overrides, $color) or ();
-    $hover-l: map.get($overrides, "hover") or $btn-hover-lightness;
-    $active-l: map.get($overrides, "active") or $btn-active-lightness;
-
-    .btn-#{$color} {
-      @include theme-tokens($color);
-      @include button-variant("solid", $hover-l, $active-l);
-    }
-
-    .btn-outline-#{$color} {
-      @include theme-tokens($color);
-      @include button-variant("outline", $hover-l, $active-l);
-    }
-
-    .btn-ghost-#{$color} {
-      @include theme-tokens($color);
-      @include button-variant("ghost", $hover-l, $active-l);
-    }
-  }
-  // scss-docs-end btn-variant-loops
 
 
   //

--- a/scss/buttons/_close.scss
+++ b/scss/buttons/_close.scss
@@ -1,8 +1,9 @@
-@use "../mixins/mask-icon" as *;
 @use "../functions/defaults" as *;
 @use "../functions/escape-svg" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/color-mode" as *;
+@use "../mixins/focus-ring" as *;
+@use "../mixins/mask-icon" as *;
 @use "../mixins/tokens" as *;
 @use "../config" as *;
 
@@ -13,7 +14,6 @@ $btn-close-padding-x:        .25em !default;
 $btn-close-padding-y:        $btn-close-padding-x !default;
 $btn-close-color:            inherit !default;
 $btn-close-bg:               url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='black'><path d='M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414'/></svg>") !default;
-$btn-close-focus-shadow:     var(--#{$prefix}focus-ring) !default;
 $btn-close-opacity:          .5 !default;
 $btn-close-hover-opacity:    .75 !default;
 $btn-close-focus-opacity:    1 !default;
@@ -27,11 +27,14 @@ $close-tokens: () !default;
 // scss-docs-start close-css-vars
 $close-tokens: defaults(
   (
+    --#{$prefix}btn-close-width: #{$btn-close-width},
+    --#{$prefix}btn-close-height: #{$btn-close-height},
+    --#{$prefix}btn-close-padding-y: #{$btn-close-padding-y},
+    --#{$prefix}btn-close-padding-x: #{$btn-close-padding-x},
     --#{$prefix}btn-close-color: #{$btn-close-color},
     --#{$prefix}btn-close-bg: #{ escape-svg($btn-close-bg) },
     --#{$prefix}btn-close-opacity: #{$btn-close-opacity},
     --#{$prefix}btn-close-hover-opacity: #{$btn-close-hover-opacity},
-    --#{$prefix}btn-close-focus-shadow: #{$btn-close-focus-shadow},
     --#{$prefix}btn-close-focus-opacity: #{$btn-close-focus-opacity},
     --#{$prefix}btn-close-disabled-opacity: #{$btn-close-disabled-opacity},
   ),
@@ -52,14 +55,14 @@ $close-tokens: defaults(
     box-sizing: content-box;
     // Flex containers may shrink the button below its icon; a minimum keeps it
     // square and clickable.
-    width: $btn-close-width;
-    min-width: $btn-close-width;
-    height: $btn-close-height;
-    min-height: $btn-close-height;
-    padding: $btn-close-padding-y $btn-close-padding-x;
+    width: var(--#{$prefix}btn-close-width);
+    min-width: var(--#{$prefix}btn-close-width);
+    height: var(--#{$prefix}btn-close-height);
+    min-height: var(--#{$prefix}btn-close-height);
+    padding: var(--#{$prefix}btn-close-padding-y) var(--#{$prefix}btn-close-padding-x);
     color: var(--#{$prefix}btn-close-color);
     background-color: currentcolor;
-    @include mask-icon(var(--#{$prefix}btn-close-bg), $btn-close-width auto);
+    @include mask-icon(var(--#{$prefix}btn-close-bg), var(--#{$prefix}btn-close-width) auto);
     border: 0; // for button elements
     @include border-radius();
     opacity: var(--#{$prefix}btn-close-opacity);
@@ -72,9 +75,8 @@ $close-tokens: defaults(
     }
 
     &:focus-visible {
-      outline: 0;
-      box-shadow: var(--#{$prefix}btn-close-focus-shadow);
       opacity: var(--#{$prefix}btn-close-focus-opacity);
+      @include focus-ring();
     }
 
     &:disabled,

--- a/scss/buttons/_loading-button.scss
+++ b/scss/buttons/_loading-button.scss
@@ -3,6 +3,10 @@
 
 @layer components {
   .btn-loading {
+    // The spinner slides in on its own margins, so the button's gap would only
+    // add a fixed offset the animation cannot take back.
+    --#{$prefix}btn-gap: 0;
+
     position: relative;
     overflow: hidden;
   }

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -110,6 +110,7 @@ $input-group-tokens: defaults(
   .input-group-lg > .form-select,
   .input-group-lg > .input-group-text,
   .input-group-lg > .btn {
+    --#{$prefix}control-min-height: var(--#{$prefix}btn-input-lg-min-height);
     --#{$prefix}control-padding-y: var(--#{$prefix}btn-input-lg-padding-y);
     --#{$prefix}control-padding-x: var(--#{$prefix}btn-input-lg-padding-x);
     --#{$prefix}control-font-size: var(--#{$prefix}btn-input-lg-font-size);
@@ -124,6 +125,7 @@ $input-group-tokens: defaults(
   .input-group-sm > .form-select,
   .input-group-sm > .input-group-text,
   .input-group-sm > .btn {
+    --#{$prefix}control-min-height: var(--#{$prefix}btn-input-sm-min-height);
     --#{$prefix}control-padding-y: var(--#{$prefix}btn-input-sm-padding-y);
     --#{$prefix}control-padding-x: var(--#{$prefix}btn-input-sm-padding-x);
     --#{$prefix}control-font-size: var(--#{$prefix}btn-input-sm-font-size);


### PR DESCRIPTION
## A variant is a shape, the colour is a theme

`.btn-solid`, `.btn-outline`, `.btn-subtle` (new) and `.btn-ghost` each carry the base button styles and read their colour from `--cui-theme-*`, so a variant works on its own next to a `.theme-*` class — on the button or on any element above it — and `.btn` is no longer required beside it. Every variable falls back to a neutral value, which keeps a variant with no theme in reach rendering grey.

The colour classes are unchanged and stay the spelling the docs use: `.btn-primary` is `.btn-solid.theme-primary`, `.btn-outline-primary` is `.btn-outline.theme-primary`, `.btn-subtle-*` completes the set. They come from one rule per variant plus one rule per colour instead of a full token block per pair.

`button-variant()` and the `$button-variants` map of token names are gone; a variant is a `defaults()` token map (`$button-solid-tokens` and friends) naming the theme token each variable reads and the neutral value behind it.

The interaction shade moved to the theme: `.theme-*` emits `--cui-theme-hover` and `--cui-theme-active`, so any component wanting "this colour, one step darker" reads a token. `$btn-hover-lightness` / `$btn-active-lightness` / `$btn-lightness-overrides` become `$theme-*` in `scss/_theme.scss`; dark still brightens.

Not taken from upstream: `.btn-styled` (gradient + shadow depth).

## Layout and tokens

- `.btn` is an inline-flex row: `--cui-btn-gap` separates an icon from its label whether or not the markup leaves whitespace between them, `--cui-btn-min-height` keeps an icon-only button as tall as one holding text.
- `.btn-icon` (new): no padding, width follows height. `.btn-xs` (new): a fourth size.
- A bare `.btn` renders in the neutral surface colours instead of being invisible.
- Removes the `$btn-*` variables that only forwarded `var(--cui-btn-input-*)` — assigning to them never reached the rendered button. New tokens: `--cui-btn-gap`, `--cui-btn-min-height`, `--cui-btn-white-space`, `--cui-btn-transition-property` / `-duration` / `-timing`.
- Sizes are a loop over `$button-sizes`; `button-size()` is removed. The loop also covers `.input-group-{sm,lg} > .btn`, which had no effect before: those declarations sit in the forms layer and lose to `.btn` in components, so a button in a small input group rendered at full size and stretched the field to match it.
- Button group: the `-sm`/`-lg` `@extend` pairs and three `.dropdown-toggle-split` padding rules collapse into one reading `--cui-btn-padding-x`; eight `function-disallowed-list` disables go with them.
- `.btn-close` draws its focus ring as an `outline` — a box-shadow ring is clipped by the `overflow: hidden` of the modal, toast or drawer it sits in. Geometry is tokens now; `$btn-close-focus-shadow` is removed.

## Verification

Measured in Chromium against `v6-dev`: all 48 colour/variant/state combinations render identical computed values, `.btn-dark` included — which is what proves the theme-level shade matches the per-colour formula it replaces. Geometry: icon+label goes 81px → 83px and stops depending on markup whitespace (77px → 83px without a space), a `.dropdown-toggle` grows 2px, `.input-group-sm` drops 38px → 31px. Bare `.btn` is the only deliberate visual change.

Gates: stylelint, `fusv`, 3212 unit tests, 35 visual tests, `docs-build`. Budgets raised to 62.75/52.5 kB for `coreui.css`/`coreui.min.css` — two variants, a fourth size and two theme tokens on every theme class cost 0.7 kB gzip.