### PR TITLE
feat(Card, ListGroup): switch the responsive layouts to container queries

### DIFF
--- a/docs/src/content/docs/components/card.mdx
+++ b/docs/src/content/docs/components/card.mdx
@@ -432,9 +432,11 @@ In addition to styling the content within cards, Bootstrap includes a few option
 
 ### Card groups
 
-Use card groups to render cards as a single, attached element with equal width and height columns. Card groups start off stacked and use `display: flex;` to become attached with uniform dimensions starting at the `sm` breakpoint.
+Use card groups to render cards as a single, attached element with equal width and height columns. Card groups start off stacked and become attached with uniform dimensions from the `sm` breakpoint up.
 
-<Example code={`<div class="card-group">
+That breakpoint is measured on the nearest [query container](/utilities/container-queries/), not the viewport, so a group in a narrow column stays stacked while the same markup in a wide one attaches. Mark an ancestor with `.contains-inline` — without one the query has nothing to read and the cards never attach.
+
+<Example class="contains-inline" code={`<div class="card-group">
     <div class="card">
       <svg class="docs-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Image cap" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Image cap</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
       <div class="card-body">
@@ -463,7 +465,7 @@ Use card groups to render cards as a single, attached element with equal width a
 
 When using card groups with footers, their content will automatically line up.
 
-<Example code={`<div class="card-group">
+<Example class="contains-inline" code={`<div class="card-group">
     <div class="card">
       <svg class="docs-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Image cap" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Image cap</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
       <div class="card-body">

--- a/docs/src/content/docs/components/list-group.mdx
+++ b/docs/src/content/docs/components/list-group.mdx
@@ -124,11 +124,13 @@ These work great with custom content as well.
 
 ## Horizontal
 
-Add `.list-group-horizontal` to change the layout of list group items from vertical to horizontal across all breakpoints. Alternatively, choose a responsive variant `.list-group-horizontal-{sm|md|lg|xl|xxl}` to make a list group horizontal starting at that breakpoint's `min-width`. Currently **horizontal list groups cannot be combined with flush list groups.**
+Add `.list-group-horizontal` to change the layout of list group items from vertical to horizontal across all breakpoints. Alternatively, choose a responsive variant `.list-group-horizontal-{sm|md|lg|xl|xxl}` to turn horizontal from that breakpoint up. Currently **horizontal list groups cannot be combined with flush list groups.**
+
+The responsive variants measure the nearest [query container](/utilities/container-queries/), not the viewport, so a list group in a narrow column stays stacked while the same class in a wide one goes horizontal. Mark an ancestor with `.contains-inline` — without one the query has nothing to read and the direction never switches. Plain `.list-group-horizontal` needs no container.
 
 **ProTip:** Want equal-width list group items when horizontal? Add `.flex-fill` to each list group item.
 
-<Example code={getData('breakpoints').map((b) => `<ul class="list-group list-group-horizontal${b.abbr}">
+<Example class="contains-inline" code={getData('breakpoints').map((b) => `<ul class="list-group list-group-horizontal${b.abbr}">
     <li class="list-group-item">An item</li>
     <li class="list-group-item">A second item</li>
     <li class="list-group-item">A third item</li>

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1356,6 +1356,22 @@ Multi Select's option indicators moved with it — they render as a decorative
 - **Two adjacent `.card-body` blocks now have a rule between them.** Every
   section draws a bottom edge unless it is last or a footer follows, so a card
   split into two bodies reads as two sections rather than one run of padding.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`.card-group` attaches its cards from a container query, not a media
+  query.** The `sm` breakpoint is now the width of the nearest query container,
+  which is what a group inside a column actually has to fit — the viewport
+  being wide never meant the group was. Mark an ancestor with
+  [`.contains-inline`](/utilities/container-queries/); without a container the
+  query has nothing to read and the cards stay stacked at every width.
+
+#### List group
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`.list-group-horizontal-{sm|md|lg|xl|xxl}` turns horizontal from a
+  container query.** Same change and same fix as `.card-group`: put
+  [`.contains-inline`](/utilities/container-queries/) on an ancestor, or the
+  list stays vertical. Plain `.list-group-horizontal` is unconditional and
+  needs no container.
 
 ### Sass architecture & design tokens
 

--- a/docs/src/content/docs/utilities/container-queries.mdx
+++ b/docs/src/content/docs/utilities/container-queries.mdx
@@ -34,6 +34,13 @@ Apply `.contains-inline` to query on inline size (width in horizontal writing mo
 
 Our [CSS Grid](/layout/css-grid/) uses this: every `.grid` is a query container, which is what makes `.g-col-md-*` respond to the width of the grid instead of the browser window.
 
+Several components read a query container rather than the viewport, and need one on an ancestor to switch at all:
+
+- [`.card-group`](/components/card/#card-groups) attaches its cards from `sm` up
+- [`.list-group-horizontal-*`](/components/list-group/#horizontal) turns horizontal from its breakpoint up
+- [`.hstack-*` and `.vstack-*`](/helpers/stacks/) switch direction at their breakpoint
+- [`.table-responsive*`](/content/tables/#responsive-tables) is itself a query container, so content inside it can respond to its width
+
 ## Sass
 
 ### Mixins

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -291,6 +291,9 @@ $card-tokens: defaults(
   // Card groups
   //
 
+  // A group lays its cards out in a row from a container query, so the width it
+  // reads is the nearest query container's — put `.contains-inline` on an
+  // ancestor, or the query has nothing to measure and the cards stay stacked.
   .card-group {
     // The child selector allows nested `.card` within `.card-group`
     // to display properly.
@@ -298,7 +301,7 @@ $card-tokens: defaults(
       margin-bottom: var(--#{$prefix}card-group-margin);
     }
 
-    @include media-breakpoint-up(sm) {
+    @include container-breakpoint-up(sm) {
       display: flex;
       flex-flow: row wrap;
       // The child selector allows nested `.card` within `.card-group`

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -165,12 +165,15 @@ $list-group-tokens: defaults(
   // Horizontal
   //
   // Change the layout of list group items from vertical (default) to horizontal.
+  // The responsive variants read the width of the nearest query container — put
+  // `.contains-inline` on an ancestor, or the query has nothing to measure and
+  // the direction never switches.
 
   @each $breakpoint in map.keys($grid-breakpoints) {
-    @include media-breakpoint-up($breakpoint) {
-      $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
-      .list-group-horizontal#{$infix} {
+    .list-group-horizontal#{$infix} {
+      @include container-breakpoint-up($breakpoint) {
         flex-direction: row;
 
         > .list-group-item {


### PR DESCRIPTION
Stacked on #807, which is stacked on #805. Merge in that order.

A card group inside a column, and a horizontal list group inside one, asked the viewport whether they had room. The viewport being wide never meant they were — a group in a 300px column attached its cards the moment the browser window passed 576px and then overflowed. `.card-group` and `.list-group-horizontal-{sm|md|lg|xl|xxl}` read the nearest query container now, which is the width they actually have to fit.

The cost is that a query needs a container to read: mark an ancestor with [`.contains-inline`](https://coreui.io/bootstrap/docs/utilities/container-queries/), or the cards stay stacked and the list stays vertical at every width. Plain `.list-group-horizontal` is unconditional and unaffected. Both docs pages and the migration guide say so.

Stacks and the CSS grid already worked this way, so the container-queries page now lists every component that reads a container instead of leaving each page to say it separately.

Measured: a `.card-group` and a `.list-group-horizontal-sm` in a 700px `.contains-inline` go to `flex-direction: row`; the same markup with no container stays `display: block` / `column`; and inside a 400px container the group stays stacked while the 1200px viewport would previously have attached it.

`coreui.css` unchanged at 62.77 kB.