### PR TITLE
fix(Table): declare every value it draws with as a CSS variable

### DIFF
--- a/docs/src/content/docs/content/tables.mdx
+++ b/docs/src/content/docs/content/tables.mdx
@@ -501,7 +501,27 @@ Two things are required: a `.table-responsive*` ancestor, because that is the qu
 Because the breakpoint is read from the `.table-responsive*` wrapper rather than the window, a stacked table inside a narrow column stacks there while the same markup in the main content area stays a table.
 </Callout>
 
-## Customization
+## Customizing
+
+### CSS variables
+
+<ScssDocs file="scss/content/_tables.scss" capture="table-css-vars" />
+
+Every value the table draws with is on the table element, so a one-off table is a style attribute away:
+
+```html
+<table class="table" style="--cui-table-cell-padding-y: 1rem; --cui-table-border-color: var(--cui-primary);">
+  ...
+</table>
+```
+
+The striped, active and hover backgrounds are mixed from `--cui-table-color`, so a variant that changes the text color carries them along. To make the zebra stripes stronger or fainter without touching the color, change the factor:
+
+```html
+<table class="table table-striped" style="--cui-table-striped-bg-factor: 12%;">
+  ...
+</table>
+```
 
 ### SASS variables
 
@@ -510,8 +530,3 @@ Because the breakpoint is read from the `.table-responsive*` wrapper rather than
 ### SASS loop
 
 <ScssDocs file="scss/content/_tables.scss" capture="table-loop" />
-
-### Customizing
-
-- The factor variables (`$table-striped-bg-factor`, `$table-active-bg-factor` & `$table-hover-bg-factor`) are used to determine the contrast in table variants.
-- Apart from the light & dark table variants, theme colors are lightened by the `$table-bg-scale` variable.

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1279,6 +1279,28 @@ Multi Select's option indicators moved with it — they render as a decorative
   Give every `<td>` past the first a `data-cell` attribute for its label; the
   header is hidden visually and kept in the accessibility tree. See
   [Stacked tables](/content/tables/#stacked-tables).
+- **Cell padding, vertical alignment and the border width are CSS variables
+  now.** `--cui-table-cell-padding-y`, `--cui-table-cell-padding-x`,
+  `--cui-table-cell-vertical-align`, `--cui-table-border-width` and
+  `--cui-table-group-separator-color` are declared on `.table` instead of being
+  compiled into the cell rule. This also fixes stacked tables, which read
+  `--cui-table-cell-padding-*` and `--cui-table-border-width` while nothing
+  declared them, so their rows collapsed to zero padding and lost the separating
+  line.
+- **`.table-sm` sets the padding variables** on the table instead of overriding
+  the padding on every cell. Anything that raised specificity to beat
+  `.table-sm > :not(caption) > * > *` can set `--cui-table-cell-padding-y`/`-x`
+  instead.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The contrast factors are percentages.** `$table-striped-bg-factor`,
+  `$table-active-bg-factor` and `$table-hover-bg-factor` changed from unit-less
+  fractions (`.05`) to percentages (`5%`), because they now ship as the
+  `--cui-table-*-bg-factor` variables that `color-mix()` reads at runtime.
+- **The state colours follow `--cui-table-color`.** `--cui-table-striped-color`,
+  `--cui-table-active-color` and `--cui-table-hover-color` default to
+  `var(--cui-table-color)`, and the matching backgrounds are mixed from it, so a
+  variant only has to set `--cui-table-color`, `--cui-table-bg` and
+  `--cui-table-border-color`.
 
 #### Toast
 

--- a/scss/content/_tables.scss
+++ b/scss/content/_tables.scss
@@ -1,7 +1,7 @@
 @use "sass:map";
-@use "sass:math";
-@use "../functions/color" as *;
+@use "../functions/defaults" as *;
 @use "../layout/breakpoints" as *;
+@use "../mixins/tokens" as *;
 @use "../mixins/visually-hidden" as *;
 @use "../theme" as *;
 @use "../config" as *;
@@ -18,18 +18,17 @@ $table-color:                 var(--#{$prefix}emphasis-color) !default;
 $table-bg:                    var(--#{$prefix}body-bg) !default;
 $table-accent-bg:             transparent !default;
 
+$table-striped-color:         var(--#{$prefix}table-color) !default;
+$table-striped-bg-factor:     5% !default;
+$table-striped-bg:            color-mix(in srgb, var(--#{$prefix}table-color) var(--#{$prefix}table-striped-bg-factor), transparent) !default;
 
-$table-striped-color:         $table-color !default;
-$table-striped-bg-factor:     .05 !default;
-$table-striped-bg:            color-mix(in srgb, var(--#{$prefix}emphasis-color) math.percentage($table-striped-bg-factor), transparent) !default;
+$table-active-color:          var(--#{$prefix}table-color) !default;
+$table-active-bg-factor:      10% !default;
+$table-active-bg:             color-mix(in srgb, var(--#{$prefix}table-color) var(--#{$prefix}table-active-bg-factor), transparent) !default;
 
-$table-active-color:          $table-color !default;
-$table-active-bg-factor:      .1 !default;
-$table-active-bg:             color-mix(in srgb, var(--#{$prefix}emphasis-color) math.percentage($table-active-bg-factor), transparent) !default;
-
-$table-hover-color:           $table-color !default;
-$table-hover-bg-factor:       .075 !default;
-$table-hover-bg:              color-mix(in srgb, var(--#{$prefix}emphasis-color) math.percentage($table-hover-bg-factor), transparent) !default;
+$table-hover-color:           var(--#{$prefix}table-color) !default;
+$table-hover-bg-factor:       7.5% !default;
+$table-hover-bg:              color-mix(in srgb, var(--#{$prefix}table-color) var(--#{$prefix}table-hover-bg-factor), transparent) !default;
 
 $table-border-width:          var(--#{$prefix}border-width) !default;
 $table-border-color:          var(--#{$prefix}border-color) !default;
@@ -38,9 +37,39 @@ $table-striped-order:         odd !default;
 $table-striped-columns-order: even !default;
 
 $table-group-separator-color: currentcolor !default;
-
-
 // scss-docs-end table-variables
+
+$table-tokens: () !default;
+
+// stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
+
+// scss-docs-start table-css-vars
+$table-tokens: defaults(
+  (
+    --#{$prefix}table-cell-padding-y: #{$table-cell-padding-y},
+    --#{$prefix}table-cell-padding-x: #{$table-cell-padding-x},
+    --#{$prefix}table-cell-vertical-align: #{$table-cell-vertical-align},
+    --#{$prefix}table-color: #{$table-color},
+    --#{$prefix}table-bg: #{$table-bg},
+    --#{$prefix}table-accent-bg: #{$table-accent-bg},
+    --#{$prefix}table-border-width: #{$table-border-width},
+    --#{$prefix}table-border-color: #{$table-border-color},
+    --#{$prefix}table-group-separator-color: #{$table-group-separator-color},
+    --#{$prefix}table-striped-color: #{$table-striped-color},
+    --#{$prefix}table-striped-bg-factor: #{$table-striped-bg-factor},
+    --#{$prefix}table-striped-bg: #{$table-striped-bg},
+    --#{$prefix}table-active-color: #{$table-active-color},
+    --#{$prefix}table-active-bg-factor: #{$table-active-bg-factor},
+    --#{$prefix}table-active-bg: #{$table-active-bg},
+    --#{$prefix}table-hover-color: #{$table-hover-color},
+    --#{$prefix}table-hover-bg-factor: #{$table-hover-bg-factor},
+    --#{$prefix}table-hover-bg: #{$table-hover-bg},
+  ),
+  $table-tokens
+);
+// scss-docs-end table-css-vars
+
+// stylelint-enable custom-property-no-missing-var-function, scss/dollar-variable-default
 
 // scss-docs-start table-loop
 // Which theme colours get a .table-* variant. The values come from the theme
@@ -59,12 +88,6 @@ $table-variants: map.keys($theme-colors) !default;
     --#{$prefix}table-color: var(--#{$prefix}theme-fg-emphasis);
     --#{$prefix}table-bg: var(--#{$prefix}theme-bg-subtle);
     --#{$prefix}table-border-color: var(--#{$prefix}theme-border);
-    --#{$prefix}table-striped-color: var(--#{$prefix}theme-fg-emphasis);
-    --#{$prefix}table-striped-bg: color-mix(in srgb, var(--#{$prefix}theme-fg-emphasis) #{math.percentage($table-striped-bg-factor)}, transparent);
-    --#{$prefix}table-active-color: var(--#{$prefix}theme-fg-emphasis);
-    --#{$prefix}table-active-bg: color-mix(in srgb, var(--#{$prefix}theme-fg-emphasis) #{math.percentage($table-active-bg-factor)}, transparent);
-    --#{$prefix}table-hover-color: var(--#{$prefix}theme-fg-emphasis);
-    --#{$prefix}table-hover-bg: color-mix(in srgb, var(--#{$prefix}theme-fg-emphasis) #{math.percentage($table-hover-bg-factor)}, transparent);
 
     color: var(--#{$prefix}table-color);
     border-color: var(--#{$prefix}table-border-color);
@@ -74,26 +97,18 @@ $table-variants: map.keys($theme-colors) !default;
 
 @layer content {
   .table {
+    @include tokens($table-tokens);
+
     // Reset needed for nesting tables
     --#{$prefix}table-color-type: initial;
     --#{$prefix}table-bg-type: initial;
     --#{$prefix}table-color-state: initial;
     --#{$prefix}table-bg-state: initial;
     // End of reset
-    --#{$prefix}table-color: #{$table-color};
-    --#{$prefix}table-bg: #{$table-bg};
-    --#{$prefix}table-border-color: #{$table-border-color};
-    --#{$prefix}table-accent-bg: #{$table-accent-bg};
-    --#{$prefix}table-striped-color: #{$table-striped-color};
-    --#{$prefix}table-striped-bg: #{$table-striped-bg};
-    --#{$prefix}table-active-color: #{$table-active-color};
-    --#{$prefix}table-active-bg: #{$table-active-bg};
-    --#{$prefix}table-hover-color: #{$table-hover-color};
-    --#{$prefix}table-hover-bg: #{$table-hover-bg};
 
     width: 100%;
     margin-bottom: var(--#{$prefix}spacer-3);
-    vertical-align: $table-cell-vertical-align;
+    vertical-align: var(--#{$prefix}table-cell-vertical-align);
     border-color: var(--#{$prefix}table-border-color);
 
     // Target th & td
@@ -102,11 +117,11 @@ $table-variants: map.keys($theme-colors) !default;
     // Another advantage is that this generates less code and makes the selector less specific making it easier to override.
     // stylelint-disable-next-line selector-max-universal
     > :not(caption) > * > * {
-      padding: $table-cell-padding-y $table-cell-padding-x;
+      padding: var(--#{$prefix}table-cell-padding-y) var(--#{$prefix}table-cell-padding-x);
       // Following the precept of cascades: https://codepen.io/miriamsuzanne/full/vYNgodb
       color: var(--#{$prefix}table-color-state, var(--#{$prefix}table-color-type, var(--#{$prefix}table-color)));
       background-color: var(--#{$prefix}table-bg);
-      border-bottom-width: $table-border-width;
+      border-block-end-width: var(--#{$prefix}table-border-width);
       box-shadow: inset 0 0 0 9999px var(--#{$prefix}table-bg-state, var(--#{$prefix}table-bg-type, var(--#{$prefix}table-accent-bg)));
     }
 
@@ -120,7 +135,7 @@ $table-variants: map.keys($theme-colors) !default;
   }
 
   .table-group-divider {
-    border-top: calc(#{$table-border-width} * 2) solid $table-group-separator-color; // stylelint-disable-line function-disallowed-list
+    border-block-start: calc(var(--#{$prefix}table-border-width) * 2) solid var(--#{$prefix}table-group-separator-color); // stylelint-disable-line function-disallowed-list
   }
 
   //
@@ -137,10 +152,8 @@ $table-variants: map.keys($theme-colors) !default;
   //
 
   .table-sm {
-    // stylelint-disable-next-line selector-max-universal
-    > :not(caption) > * > * {
-      padding: $table-cell-padding-y-sm $table-cell-padding-x-sm;
-    }
+    --#{$prefix}table-cell-padding-y: #{$table-cell-padding-y-sm};
+    --#{$prefix}table-cell-padding-x: #{$table-cell-padding-x-sm};
   }
 
 
@@ -155,11 +168,13 @@ $table-variants: map.keys($theme-colors) !default;
 
   .table-bordered {
     > :not(caption) > * {
-      border-width: $table-border-width 0;
+      border-block-width: var(--#{$prefix}table-border-width);
+      border-inline-width: 0;
 
       // stylelint-disable-next-line selector-max-universal
       > * {
-        border-width: 0 $table-border-width;
+        border-block-width: 0;
+        border-inline-width: var(--#{$prefix}table-border-width);
       }
     }
   }
@@ -167,11 +182,11 @@ $table-variants: map.keys($theme-colors) !default;
   .table-borderless {
     // stylelint-disable-next-line selector-max-universal
     > :not(caption) > * > * {
-      border-bottom-width: 0;
+      border-block-end-width: 0;
     }
 
     > :not(:first-child) {
-      border-top-width: 0;
+      border-block-start-width: 0;
     }
   }
 


### PR DESCRIPTION
Part of the `scss/content/` sweep. Everything `.table` draws with is a CSS variable now, which also fixes stacked tables.

## The bug

`.table-stacked*` reads `--cui-table-cell-padding-y`, `--cui-table-cell-padding-x` and `--cui-table-border-width`. None of the three was declared anywhere — cell padding and the border width were compiled straight into the rules, so every one of those reads was invalid at computed-value time. Measured in Chromium, before and after:

| | before | after |
| --- | --- | --- |
| stacked `<tr>` padding-block | `0px` | `8px` |
| stacked `<td>` padding | `0px 0px` | `2px 16px` |
| line between stacked rows | none | `1px` |

Everything else measures identically: plain cell padding `8px`, `.table-sm` `4px`, bordered row/cell widths, and the striped background resolves to the same `color(srgb 0.031 0.039 0.047 / 0.05)` on both the base table and `.table-primary`.

## What changed

- The full set ships through `defaults()` + `tokens()` on `.table`, including `--cui-table-cell-vertical-align` and `--cui-table-group-separator-color`, which had no variable at all.
- The striped, active and hover backgrounds are mixed from `--cui-table-color` and a `--cui-table-*-bg-factor` variable, so their strength is adjustable without redefining the colour. `table-variant()` drops six declarations per variant as a result — setting colour, background and border colour is enough for the states to follow.
- `.table-sm` sets the padding variables on the table instead of overriding the padding of every cell, so it reaches stacked rows too.
- Borders use logical properties.

Sass note: `$table-striped-bg-factor` and friends are percentages (`5%`) rather than fractions (`.05`) — they are the token values now. Migration guide updated.

## Verification

`css-lint` (stylelint + fusv), `css-test-class-api`, `docs-build`, `js-test-unit` (3212), `js-test-visual` (35), bundlewatch all pass. `coreui.min.css` comes out 0.02 kB **smaller** than `v6-dev` — the variant loop shrinks more than the token map grows.
