### PR TITLE
fix(Blockquote): make the source line readable and put the spacing on tokens

### DIFF
--- a/docs/src/content/docs/content/typography.mdx
+++ b/docs/src/content/docs/content/typography.mdx
@@ -232,7 +232,15 @@ Align terms and descriptions horizontally by using our grid system's predefined 
 
 Headings scale with the viewport: the larger sizes are written as `clamp()`, so they grow with the screen up to the size given as the ceiling and stop there.
 
-## Customization
+## Customizing
+
+### CSS variables
+
+Blockquotes carry their spacing, size and source colour as CSS variables, on the quote and on its footer separately — the footer is a sibling of the quote, not a child, so it cannot read anything declared on it.
+
+<ScssDocs file="scss/content/_blockquote.scss" capture="blockquote-css-vars" />
+
+<ScssDocs file="scss/content/_blockquote.scss" capture="blockquote-footer-css-vars" />
 
 ### SASS variables
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1302,6 +1302,23 @@ Multi Select's option indicators moved with it — they render as a decorative
   variant only has to set `--cui-table-color`, `--cui-table-bg` and
   `--cui-table-border-color`.
 
+#### Blockquote
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The source line reads `--cui-secondary-color`.** `.blockquote-footer` was
+  painted with `--cui-gray-600`, a fixed value that never flipped with the
+  colour mode: 4.15:1 on the light background and 3.65:1 on the dark one, both
+  under the 4.5:1 minimum. The secondary colour is defined per mode and clears
+  the threshold in both.
+- **The quote lays its children out with flex and `gap`.** Spacing inside a
+  multi-paragraph quote is `--cui-blockquote-gap` rather than each paragraph's
+  own bottom margin, and `.blockquote > :last-child { margin-bottom: 0 }` is
+  gone with the margins it existed to cancel.
+- **The footer no longer pulls itself up with a negative margin.** A quote
+  followed by `.blockquote-footer` drops its own bottom margin instead
+  (`:has()`), so the two spacings can be set independently:
+  `--cui-blockquote-margin-y` and `--cui-blockquote-footer-margin-y`.
+
 #### Toast
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/scss/content/_blockquote.scss
+++ b/scss/content/_blockquote.scss
@@ -1,27 +1,70 @@
+@use "../functions/defaults" as *;
+@use "../mixins/tokens" as *;
 @use "../config" as *;
 
 // scss-docs-start blockquote-variables
-$blockquote-margin-y:         $spacer !default;
-$blockquote-font-size:        calc(var(--#{$prefix}body-font-size) * 1.25) !default; // stylelint-disable-line function-disallowed-list
-$blockquote-footer-color:     var(--#{$prefix}gray-600) !default;
-$blockquote-footer-font-size: var(--#{$prefix}small-font-size) !default;
+$blockquote-margin-y:            var(--#{$prefix}spacer-3) !default;
+$blockquote-gap:                 var(--#{$prefix}spacer-3) !default;
+$blockquote-font-size:           calc(var(--#{$prefix}body-font-size) * 1.25) !default; // stylelint-disable-line function-disallowed-list
+$blockquote-footer-margin-y:     var(--#{$prefix}spacer-3) !default;
+$blockquote-footer-color:        var(--#{$prefix}secondary-color) !default;
+$blockquote-footer-font-size:    var(--#{$prefix}small-font-size) !default;
 // scss-docs-end blockquote-variables
+
+$blockquote-tokens: () !default;
+$blockquote-footer-tokens: () !default;
+
+// stylelint-disable scss/dollar-variable-default
+
+// scss-docs-start blockquote-css-vars
+$blockquote-tokens: defaults(
+  (
+    --#{$prefix}blockquote-margin-y: #{$blockquote-margin-y},
+    --#{$prefix}blockquote-gap: #{$blockquote-gap},
+    --#{$prefix}blockquote-font-size: #{$blockquote-font-size},
+  ),
+  $blockquote-tokens
+);
+// scss-docs-end blockquote-css-vars
+
+// scss-docs-start blockquote-footer-css-vars
+$blockquote-footer-tokens: defaults(
+  (
+    --#{$prefix}blockquote-footer-margin-y: #{$blockquote-footer-margin-y},
+    --#{$prefix}blockquote-footer-color: #{$blockquote-footer-color},
+    --#{$prefix}blockquote-footer-font-size: #{$blockquote-footer-font-size},
+  ),
+  $blockquote-footer-tokens
+);
+// scss-docs-end blockquote-footer-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 
 @layer content {
   .blockquote {
-    margin-bottom: $blockquote-margin-y;
-    font-size: $blockquote-font-size;
+    @include tokens($blockquote-tokens);
 
-    > :last-child {
+    display: flex;
+    flex-direction: column;
+    gap: var(--#{$prefix}blockquote-gap);
+    margin-bottom: var(--#{$prefix}blockquote-margin-y);
+    font-size: var(--#{$prefix}blockquote-font-size);
+
+    > * {
+      margin-block: 0;
+    }
+
+    &:has(+ .blockquote-footer) {
       margin-bottom: 0;
     }
   }
 
   .blockquote-footer {
-    margin-top: -$blockquote-margin-y;
-    margin-bottom: $blockquote-margin-y;
-    font-size: $blockquote-footer-font-size;
-    color: $blockquote-footer-color;
+    @include tokens($blockquote-footer-tokens);
+
+    margin-bottom: var(--#{$prefix}blockquote-footer-margin-y);
+    font-size: var(--#{$prefix}blockquote-footer-font-size);
+    color: var(--#{$prefix}blockquote-footer-color);
 
     &::before {
       content: "\2014\00A0"; // em dash, nbsp


### PR DESCRIPTION
Part of the `scss/content/` sweep.

## Contrast

`.blockquote-footer` was painted with `--cui-gray-600`, one fixed value with no `light-dark()` pair, so it never changed with the colour mode. Measured against a 4.5:1 minimum:

| | light | dark |
| --- | --- | --- |
| `--cui-gray-600` (before) | 4.15:1 | 3.65:1 |
| `--cui-secondary-color` (after) | 5.07:1 | 6.38:1 |

`.figure-caption` — the same kind of secondary label right next door — already used `--cui-secondary-color`.

## Spacing

The quote lays its children out with flex and `--cui-blockquote-gap`, which defaults to the paragraph margin it replaces, so multi-paragraph quotes render unchanged and the spacing becomes settable. `.blockquote > :last-child { margin-bottom: 0 }` goes with the margins it existed to cancel.

The footer no longer pulls itself up with a negative margin: a quote followed by a `.blockquote-footer` drops its own bottom margin instead. The two spacings were one value that had to be cancelled; now they are `--cui-blockquote-margin-y` and `--cui-blockquote-footer-margin-y` and neither has to know about the other.

The footer gets its own token block rather than reading the quote's — it is a **sibling** of `.blockquote`, not a child, so a custom property declared on the quote never reached it.

## Verification

Measured in Chromium before and after: quote-to-footer gap `0px`, spacing between quote paragraphs `16px`, standalone quote to next block `16px`, `<figure>` height `97px` — identical in both. The only computed difference is the footer's colour.

`css-lint`, `css-test-class-api`, `docs-build`, `js-test-unit` (3212), `js-test-visual` (35), bundlewatch all pass.
