### PR TITLE
fix(Reboot): repair the datetime resets, LTR inputs and link hover

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "52.5kB"
+      "maxSize": "52.75kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/content/reboot.mdx
+++ b/docs/src/content/docs/content/reboot.mdx
@@ -29,6 +29,16 @@ The `<html>` and `<body>` elements are updated to provide better page-wide defau
   - No base `font-size` is declared on the `<html>`, but `16px` is assumed (the browser default). `font-size: 1rem` is applied on the `<body>` for easy responsive type-scaling via media queries while respecting user preferences and ensuring a more accessible approach. This browser default can be overridden by modifying the `$font-size-root` variable.
 - The `<body>` also sets a global `font-family`, `font-weight`, `line-height`, and `color`. This is inherited later by some form elements to prevent font inconsistencies.
 - For safety, the `<body>` has a declared `background-color`, defaulting to `#fff`.
+- `accent-color` is set to `--cui-primary` on the root, so native controls that we do not restyle — a bare checkbox, radio, range or `<progress>` — are drawn in your brand color instead of the browser's blue.
+
+## Links
+
+Links take `--cui-link-color` and switch to `--cui-link-hover-color` on hover. Inside anything that sets a theme, both follow it: the link reads `--cui-theme-fg` and hovers to `--cui-theme-fg-emphasis`, so a link on a colored surface stays part of that surface.
+
+Placeholder links — an `<a>` with neither `href` nor a class — keep the surrounding text color and get no underline, so an anchor waiting for its URL doesn't read as a working link.
+
+<Example code={`<p><a href="#">This is a link</a></p>
+  <p><a>This is a placeholder link</a></p>`} />
 
 ## Native font stack
 
@@ -308,6 +318,11 @@ These changes, and more, are demonstrated below.
 
 Keep in mind date inputs are [not fully supported](https://caniuse.com/input-datetime) by all browsers, namely Safari.
 </Callout>
+
+Two more form resets worth knowing about:
+
+- Every segment of a date or time input — including seconds, milliseconds, the week number and the AM/PM field — has its browser padding removed, so a `<input type="time" step="1">` is the same height as a text input.
+- `tel`, `url`, `email` and `number` inputs stay left-to-right whatever the document direction is, because their content is not language text.
 
 ### Pointers on buttons
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1269,6 +1269,26 @@ Multi Select's option indicators moved with it — they render as a decorative
   direction never switches. Plain `.hstack` and `.vstack` are unchanged, including
   `.hstack`'s vertical centring and its shrink-to-content width.
 
+#### Reboot
+
+- **Links change color on hover.** `--cui-link-hover-color` was declared and
+  read by navs and pagination, but a plain `<a>` only ever changed its underline.
+  It now switches color as well, and inside a themed surface it hovers to
+  `--cui-theme-fg-emphasis`.
+- **`accent-color: var(--cui-primary)` on `:root`.** Native controls we don't
+  restyle — a bare checkbox, radio, range or `<progress>` — follow the brand
+  color instead of the browser's blue.
+- **Every segment of a date or time input gets its padding removed.** The list
+  covered five pseudo-elements and one of them (`::-webkit-datetime-edit-minute`)
+  had been renamed by browsers years ago; seconds, milliseconds, the week number
+  and the AM/PM field were never in it. `<input type="time" step="1">` no longer
+  renders taller than a text input.
+- **`tel`, `url`, `email` and `number` inputs stay LTR everywhere.** The rule was
+  scoped to `[dir="rtl"]` elements, so it missed pages that set the direction on
+  `<html>` through the language rather than the attribute.
+- `pre` reserves scrollbar space (`scrollbar-gutter: stable`), so a horizontal
+  scrollbar no longer covers the last line of a code block.
+
 #### Tables
 
 - **`.table-responsive*` is a query container.** It still scrolls horizontally

--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -72,6 +72,8 @@ $th-font-weight:       null !default;
   // null by default, thus nothing is generated.
 
   :root {
+    accent-color: var(--#{$prefix}primary);
+
     @if $font-size-root != null {
       font-size: var(--#{$prefix}root-font-size);
     }
@@ -292,15 +294,17 @@ $th-font-weight:       null !default;
     text-decoration: $link-decoration;
 
     &:hover {
+      color: color-mix(in srgb, var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}link-hover-color)) calc(var(--#{$prefix}link-opacity, 1) * 100%), transparent);
       text-decoration: $link-hover-decoration;
     }
   }
+
   // And undo these styles for placeholder links/named anchors (without href).
   // It would be more straightforward to just use a[href] in previous block, but that
   // causes specificity issues in many other styles that are too complex to fix.
   // See https://github.com/twbs/bootstrap/issues/19402
 
-  a:not([href]):not([class]) {
+  a:not([href], [class]) {
     &,
     &:hover {
       color: inherit;
@@ -322,6 +326,7 @@ $th-font-weight:       null !default;
   // 1. Remove browser default top margin
   // 2. Reset browser default of `1em` to use `rem`s
   // 3. Don't allow content to break outside
+  // 4. Reserve room for the scrollbar so it cannot sit on top of the last line
 
   pre {
     display: block;
@@ -330,6 +335,7 @@ $th-font-weight:       null !default;
     overflow: auto; // 3
     font-size: $code-font-size;
     color: var(--#{$prefix}pre-color, $pre-color);
+    scrollbar-gutter: stable; // 4
 
     // Account for some code outputs that place code tags in pre tags
     code {
@@ -483,7 +489,7 @@ $th-font-weight:       null !default;
   // Remove the dropdown arrow only from text type inputs built with datalists in Chrome.
   // See https://stackoverflow.com/a/54997118
 
-  [list]:not([type="date"]):not([type="datetime-local"]):not([type="month"]):not([type="week"]):not([type="time"])::-webkit-calendar-picker-indicator {
+  [list]:not([type="date"], [type="datetime-local"], [type="month"], [type="week"], [type="time"])::-webkit-calendar-picker-indicator {
     display: none !important;
   }
 
@@ -532,7 +538,7 @@ $th-font-weight:       null !default;
     border: 0; // 2
   }
 
-  // 1. By using `float: left`, the legend will behave like a block element.
+  // 1. By using `float: inline-start`, the legend will behave like a block element.
   //    This way the border of a fieldset wraps around the legend if present.
   // 2. Fix wrapping bug.
   //    See https://github.com/twbs/bootstrap/issues/29712
@@ -547,7 +553,7 @@ $th-font-weight:       null !default;
     line-height: inherit;
 
     + * {
-      clear: left; // 2
+      clear: inline-start; // 2
     }
   }
 
@@ -556,15 +562,21 @@ $th-font-weight:       null !default;
 
   ::-webkit-datetime-edit-fields-wrapper,
   ::-webkit-datetime-edit-text,
-  ::-webkit-datetime-edit-minute,
+  ::-webkit-datetime-edit-millisecond-field,
+  ::-webkit-datetime-edit-second-field,
+  ::-webkit-datetime-edit-minute-field,
   ::-webkit-datetime-edit-hour-field,
+  ::-webkit-datetime-edit-meridiem-field, // WebKit
+  ::-webkit-datetime-edit-ampm-field, // Chromium
   ::-webkit-datetime-edit-day-field,
+  ::-webkit-datetime-edit-week-field,
   ::-webkit-datetime-edit-month-field,
   ::-webkit-datetime-edit-year-field {
     padding: 0;
   }
 
-  ::-webkit-inner-spin-button {
+  ::-webkit-inner-spin-button,
+  ::-webkit-outer-spin-button {
     height: auto;
   }
 
@@ -585,16 +597,14 @@ $th-font-weight:       null !default;
     }
   }
 
-  // 1. A few input types should stay LTR
+  // A few input types should stay LTR regardless of document direction
   // See https://rtlstyling.com/posts/rtl-styling#form-inputs
 
-  *[dir="rtl"] {
-    [type="tel"],
-    [type="url"],
-    [type="email"],
-    [type="number"] {
-      direction: ltr;
-    }
+  [type="tel"],
+  [type="url"],
+  [type="email"],
+  [type="number"] {
+    direction: ltr;
   }
 
 


### PR DESCRIPTION
Part of the `scss/content/` sweep. Four things Reboot got wrong, plus two small additions.

## Datetime segments

The `::-webkit-datetime-edit-*` list still names `::-webkit-datetime-edit-minute`, which browsers renamed to `-minute-field` — so the minute segment has been keeping its browser padding. Seconds, milliseconds, the week number and the AM/PM field were never in the list at all. A `<input type="time" step="1">` therefore rendered taller than the text input beside it. `::-webkit-outer-spin-button` joins its inner twin for the same reason.

This matters more for us than for upstream: our date, time and datetime pickers are built on these fields.

## LTR input types

`tel`, `url`, `email` and `number` were only forced left-to-right under an element carrying `[dir="rtl"]`. A page that sets its direction on `<html>` through the language got none of it and rendered phone numbers reversed. Those types are direction-independent by nature, so the rule is unconditional now.

## Link hover

`--cui-link-hover-color` is declared on `:root` and consumed by navs and pagination, but a plain `<a>` never read it — hovering a link in body copy only changed the underline. It now changes colour too, and follows `--cui-theme-fg-emphasis` where a theme is set.

## Additions

- `accent-color: var(--cui-primary)` on `:root`, so native controls we don't restyle (bare checkbox, radio, range, `<progress>`) follow the brand instead of the browser's blue.
- `pre { scrollbar-gutter: stable }` — the scrollbar can no longer sit on the last line of a code block.
- The placeholder-link and datalist selectors move to the modern `:not(a, b)` form, and `clear: left` next to `float: inline-start` becomes `clear: inline-start`.

## Verification

`css-lint`, `css-test-class-api`, `docs-build`, `js-test-unit` (3212), `js-test-visual` (35) pass.

Bundlewatch: `coreui.min.css` lands at 52.54 kB against a 52.5 kB ceiling, so the budget goes to 52.75 kB. The growth is the longer selector list and the hover rule.
