### PR TITLE
refactor(Reboot, Type): put the element styles on tokens and drop the @extend

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "63kB"
+      "maxSize": "63.5kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "52.75kB"
+      "maxSize": "53kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/content/reboot.mdx
+++ b/docs/src/content/docs/content/reboot.mdx
@@ -21,6 +21,14 @@ Here are our guidelines and reasons for choosing what to override in Reboot:
 
 With v4.1.0, we standardized our required `@import`s across all our CSS bundles (including `coreui.css`, `coreui-reboot.css`, and `coreui-grid.css` to include `_root.scss` . This adds `:root` level CSS variables to all bundles, regardless of how many of them are used in that bundle. Ultimately CoreUI will continue to see more CSS variables added over time.
 
+Reboot styles bare HTML, so its variables live on `:root` rather than on a class — set any of them there, or on a subtree, to restyle the elements underneath:
+
+<ScssDocs file="scss/content/_reboot.scss" capture="reboot-css-vars" />
+
+`<kbd>` carries its own, on the element:
+
+<ScssDocs file="scss/content/_reboot.scss" capture="kbd-css-vars" />
+
 ## Page defaults
 
 The `<html>` and `<body>` elements are updated to provide better page-wide defaults. More specifically:

--- a/docs/src/content/docs/content/typography.mdx
+++ b/docs/src/content/docs/content/typography.mdx
@@ -236,6 +236,10 @@ Headings scale with the viewport: the larger sizes are written as `clamp()`, so 
 
 ### CSS variables
 
+Headings, paragraphs, lists and the rest of the type Reboot styles read their spacing and weight from `:root`, so a subtree can be retyped without touching a single class:
+
+<ScssDocs file="scss/content/_reboot.scss" capture="reboot-css-vars" />
+
 Blockquotes carry their spacing, size and source colour as CSS variables, on the quote and on its footer separately — the footer is a sibling of the quote, not a child, so it cannot read anything declared on it.
 
 <ScssDocs file="scss/content/_blockquote.scss" capture="blockquote-css-vars" />

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1288,6 +1288,21 @@ Multi Select's option indicators moved with it — they render as a decorative
   `<html>` through the language rather than the attribute.
 - `pre` reserves scrollbar space (`scrollbar-gutter: stable`), so a horizontal
   scrollbar no longer covers the last line of a code block.
+- **Reboot's type and spacing are CSS variables on `:root`.** Heading margin,
+  family, style, weight and line height, paragraph margin, `hr`, `legend`, `dt`,
+  `sub`/`sup`, `mark` padding, the code font size and `--cui-list-padding-x` are
+  declared rather than compiled in, so a subtree can be retyped without a class.
+  `<kbd>` carries its own set on the element, `--cui-kbd-border-radius`
+  included.
+- **`.h1`–`.h6`, `.small`, `.mark` and `.initialism` are defined in Reboot**,
+  next to the elements they mirror, instead of `@extend`-ing them from
+  `_type.scss`. Only `.initialism` changes cascade layer (`content` → `reboot`);
+  the others were already emitted there, because `@extend` hoists a class to
+  wherever the extended selector is defined. `_type.scss` keeps `.lead` and
+  `.display-*` and no longer depends on the Reboot module.
+- **Hardcoded spacing in Reboot now reads the `--cui-spacer-*` scale**
+  (`address`, `ol`/`ul`/`dl`, `dd`, `blockquote`, `pre`, `figure`). Values are
+  unchanged.
 
 #### Tables
 

--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -1,36 +1,89 @@
+@use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
+@use "../mixins/tokens" as *;
 @use "../config" as *;
 
 // scss-docs-start reboot-type-variables
 $enable-smooth-scroll:        true !default;
-$paragraph-margin-bottom:     1rem !default;
+$paragraph-margin-bottom:     var(--#{$prefix}spacer-3) !default;
 $font-family-code:            var(--#{$prefix}font-monospace) !default;
 $headings-margin-bottom:      var(--#{$prefix}spacer-2) !default;
-$headings-font-family:        null !default;
-$headings-font-style:         null !default;
+$headings-font-family:        inherit !default;
+$headings-font-style:         inherit !default;
 $headings-font-weight:        500 !default;
 $sub-sup-font-size:           .75em !default;
-$hr-margin-y:                 $spacer !default;
+$hr-margin-y:                 var(--#{$prefix}spacer-3) !default;
 $hr-color:                    inherit !default;
 $hr-border-width:             var(--#{$prefix}border-width) !default;
 $hr-opacity:                  .25 !default;
-$legend-margin-bottom:        .5rem !default;
+$legend-margin-bottom:        var(--#{$prefix}spacer-2) !default;
 $legend-font-size:            clamp(1.275rem, 1.275rem + .3vw, 1.5rem) !default;
-$legend-font-weight:          null !default;
+$legend-font-weight:          inherit !default;
+$list-padding-x:              2rem !default;
 $dt-font-weight:              $font-weight-bold !default;
 $mark-padding:                .1875em !default;
+$initialism-font-size:        var(--#{$prefix}small-font-size) !default;
 $code-font-size:              var(--#{$prefix}small-font-size) !default;
+$pre-color:                   inherit !default;
 // scss-docs-end reboot-type-variables
 
 // scss-docs-start kbd-variables
-$kbd-padding-y:                     .1875rem !default;
-$kbd-padding-x:                     .375rem !default;
-$kbd-font-size:                     $code-font-size !default;
-$kbd-color:                         var(--#{$prefix}body-bg) !default;
-$kbd-bg:                            var(--#{$prefix}body-color) !default;
-
-$pre-color:                         null !default;
+$kbd-padding-y:               .1875rem !default;
+$kbd-padding-x:               .375rem !default;
+$kbd-font-size:               $code-font-size !default;
+$kbd-color:                   var(--#{$prefix}body-bg) !default;
+$kbd-bg:                      var(--#{$prefix}body-color) !default;
+$kbd-border-radius:           $border-radius-sm !default;
 // scss-docs-end kbd-variables
+
+$reboot-tokens: () !default;
+$reboot-kbd-tokens: () !default;
+
+// stylelint-disable scss/dollar-variable-default
+
+// scss-docs-start reboot-css-vars
+$reboot-tokens: defaults(
+  (
+    --#{$prefix}paragraph-margin-bottom: #{$paragraph-margin-bottom},
+    --#{$prefix}heading-margin-bottom: #{$headings-margin-bottom},
+    --#{$prefix}heading-font-family: #{$headings-font-family},
+    --#{$prefix}heading-font-style: #{$headings-font-style},
+    --#{$prefix}heading-font-weight: #{$headings-font-weight},
+    --#{$prefix}heading-line-height: #{$headings-line-height},
+    --#{$prefix}sub-sup-font-size: #{$sub-sup-font-size},
+    --#{$prefix}hr-margin-y: #{$hr-margin-y},
+    --#{$prefix}hr-color: #{$hr-color},
+    --#{$prefix}hr-border-width: #{$hr-border-width},
+    --#{$prefix}hr-opacity: #{$hr-opacity},
+    --#{$prefix}legend-margin-bottom: #{$legend-margin-bottom},
+    --#{$prefix}legend-font-size: #{$legend-font-size},
+    --#{$prefix}legend-font-weight: #{$legend-font-weight},
+    --#{$prefix}list-padding-x: #{$list-padding-x},
+    --#{$prefix}dt-font-weight: #{$dt-font-weight},
+    --#{$prefix}mark-padding: #{$mark-padding},
+    --#{$prefix}initialism-font-size: #{$initialism-font-size},
+    --#{$prefix}code-font-size: #{$code-font-size},
+    --#{$prefix}pre-color: #{$pre-color},
+  ),
+  $reboot-tokens
+);
+// scss-docs-end reboot-css-vars
+
+// scss-docs-start kbd-css-vars
+$reboot-kbd-tokens: defaults(
+  (
+    --#{$prefix}kbd-padding-y: #{$kbd-padding-y},
+    --#{$prefix}kbd-padding-x: #{$kbd-padding-x},
+    --#{$prefix}kbd-font-size: #{$kbd-font-size},
+    --#{$prefix}kbd-color: #{$kbd-color},
+    --#{$prefix}kbd-bg: #{$kbd-bg},
+    --#{$prefix}kbd-border-radius: #{$kbd-border-radius},
+  ),
+  $reboot-kbd-tokens
+);
+// scss-docs-end kbd-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 
 // stylelint-disable function-disallowed-list
 
@@ -72,6 +125,8 @@ $th-font-weight:       null !default;
   // null by default, thus nothing is generated.
 
   :root {
+    @include tokens($reboot-tokens);
+
     accent-color: var(--#{$prefix}primary);
 
     @if $font-size-root != null {
@@ -114,11 +169,11 @@ $th-font-weight:       null !default;
   // 1. Reset Firefox's gray color
 
   hr {
-    margin: $hr-margin-y 0;
-    color: $hr-color; // 1
+    margin: var(--#{$prefix}hr-margin-y) 0;
+    color: var(--#{$prefix}hr-color); // 1
     border: 0;
-    border-top: $hr-border-width solid var(--#{$prefix}hr-border-color);
-    opacity: $hr-opacity;
+    border-block-start: var(--#{$prefix}hr-border-width) solid var(--#{$prefix}hr-border-color);
+    opacity: var(--#{$prefix}hr-opacity);
   }
 
 
@@ -130,40 +185,46 @@ $th-font-weight:       null !default;
 
   %heading {
     margin-top: 0; // 1
-    margin-bottom: $headings-margin-bottom;
-    font-family: $headings-font-family;
-    font-style: $headings-font-style;
-    font-weight: $headings-font-weight;
-    line-height: $headings-line-height;
+    margin-bottom: var(--#{$prefix}heading-margin-bottom);
+    font-family: var(--#{$prefix}heading-font-family);
+    font-style: var(--#{$prefix}heading-font-style);
+    font-weight: var(--#{$prefix}heading-font-weight);
+    line-height: var(--#{$prefix}heading-line-height);
     color: var(--#{$prefix}heading-color);
   }
 
-  h1 {
+  h1,
+  .h1 {
     @extend %heading;
     font-size: var(--#{$prefix}font-size-4xl);
   }
 
-  h2 {
+  h2,
+  .h2 {
     @extend %heading;
     font-size: var(--#{$prefix}font-size-3xl);
   }
 
-  h3 {
+  h3,
+  .h3 {
     @extend %heading;
     font-size: var(--#{$prefix}font-size-2xl);
   }
 
-  h4 {
+  h4,
+  .h4 {
     @extend %heading;
     font-size: var(--#{$prefix}font-size-xl);
   }
 
-  h5 {
+  h5,
+  .h5 {
     @extend %heading;
     font-size: var(--#{$prefix}font-size-lg);
   }
 
-  h6 {
+  h6,
+  .h6 {
     @extend %heading;
     font-size: var(--#{$prefix}font-size-md);
   }
@@ -176,7 +237,7 @@ $th-font-weight:       null !default;
 
   p {
     margin-top: 0;
-    margin-bottom: $paragraph-margin-bottom;
+    margin-bottom: var(--#{$prefix}paragraph-margin-bottom);
   }
 
 
@@ -192,11 +253,17 @@ $th-font-weight:       null !default;
     text-decoration-skip-ink: none; // 3
   }
 
+  // Builds on `abbr`
+  .initialism {
+    font-size: var(--#{$prefix}initialism-font-size);
+    text-transform: uppercase;
+  }
+
 
   // Address
 
   address {
-    margin-bottom: 1rem;
+    margin-bottom: var(--#{$prefix}spacer-3);
     font-style: normal;
     line-height: inherit;
   }
@@ -206,14 +273,14 @@ $th-font-weight:       null !default;
 
   ol,
   ul {
-    padding-inline-start: 2rem;
+    padding-inline-start: var(--#{$prefix}list-padding-x);
   }
 
   ol,
   ul,
   dl {
     margin-top: 0;
-    margin-bottom: 1rem;
+    margin-bottom: var(--#{$prefix}spacer-3);
   }
 
   ol ol,
@@ -224,21 +291,21 @@ $th-font-weight:       null !default;
   }
 
   dt {
-    font-weight: $dt-font-weight;
+    font-weight: var(--#{$prefix}dt-font-weight);
   }
 
   // 1. Undo browser default
 
   dd {
     margin-inline-start: 0; // 1
-    margin-bottom: .5rem;
+    margin-bottom: var(--#{$prefix}spacer-2);
   }
 
 
   // Blockquote
 
   blockquote {
-    margin: 0 0 1rem;
+    margin: 0 0 var(--#{$prefix}spacer-3);
   }
 
 
@@ -256,15 +323,17 @@ $th-font-weight:       null !default;
   //
   // Add the correct font size in all browsers
 
-  small {
+  small,
+  .small {
     font-size: var(--#{$prefix}small-font-size);
   }
 
 
   // Mark
 
-  mark {
-    padding: $mark-padding;
+  mark,
+  .mark {
+    padding: var(--#{$prefix}mark-padding);
     color: var(--#{$prefix}highlight-color);
     background-color: var(--#{$prefix}highlight-bg);
   }
@@ -278,7 +347,7 @@ $th-font-weight:       null !default;
   sub,
   sup {
     position: relative;
-    font-size: $sub-sup-font-size;
+    font-size: var(--#{$prefix}sub-sup-font-size);
     line-height: 0;
     vertical-align: baseline;
   }
@@ -331,10 +400,10 @@ $th-font-weight:       null !default;
   pre {
     display: block;
     margin-top: 0; // 1
-    margin-bottom: 1rem; // 2
+    margin-bottom: var(--#{$prefix}spacer-3); // 2
     overflow: auto; // 3
-    font-size: $code-font-size;
-    color: var(--#{$prefix}pre-color, $pre-color);
+    font-size: var(--#{$prefix}code-font-size);
+    color: var(--#{$prefix}pre-color);
     scrollbar-gutter: stable; // 4
 
     // Account for some code outputs that place code tags in pre tags
@@ -346,7 +415,7 @@ $th-font-weight:       null !default;
   }
 
   code {
-    font-size: $code-font-size;
+    font-size: var(--#{$prefix}code-font-size);
     color: var(--#{$prefix}code-color);
     word-wrap: break-word;
 
@@ -357,11 +426,13 @@ $th-font-weight:       null !default;
   }
 
   kbd {
-    padding: $kbd-padding-y $kbd-padding-x;
-    font-size: $kbd-font-size;
-    color: var(--#{$prefix}kbd-color, $kbd-color);
-    background-color: var(--#{$prefix}kbd-bg, $kbd-bg);
-    @include border-radius($border-radius-sm);
+    @include tokens($reboot-kbd-tokens);
+
+    padding: var(--#{$prefix}kbd-padding-y) var(--#{$prefix}kbd-padding-x);
+    font-size: var(--#{$prefix}kbd-font-size);
+    color: var(--#{$prefix}kbd-color);
+    background-color: var(--#{$prefix}kbd-bg);
+    @include border-radius(var(--#{$prefix}kbd-border-radius));
 
     kbd {
       padding: 0;
@@ -375,7 +446,7 @@ $th-font-weight:       null !default;
   // Apply a consistent margin strategy (matches our type styles).
 
   figure {
-    margin: 0 0 1rem;
+    margin: 0 0 var(--#{$prefix}spacer-3);
   }
 
 
@@ -547,9 +618,9 @@ $th-font-weight:       null !default;
     float: inline-start; // 1
     width: 100%;
     padding: 0;
-    margin-bottom: $legend-margin-bottom;
-    font-size: $legend-font-size;
-    font-weight: $legend-font-weight;
+    margin-bottom: var(--#{$prefix}legend-margin-bottom);
+    font-size: var(--#{$prefix}legend-font-size);
+    font-weight: var(--#{$prefix}legend-font-weight);
     line-height: inherit;
 
     + * {

--- a/scss/content/_type.scss
+++ b/scss/content/_type.scss
@@ -1,11 +1,8 @@
-@use "../mixins/lists" as *;
-@use "reboot" as *;
 @use "../config" as *;
 
 // scss-docs-start type-variables
-$lead-font-size:                calc(var(--#{$prefix}body-font-size) * 1.25) !default; // stylelint-disable-line function-disallowed-list
-$lead-font-weight:              300 !default;
-$initialism-font-size:        var(--#{$prefix}small-font-size) !default;
+$lead-font-size:              calc(var(--#{$prefix}body-font-size) * 1.25) !default; // stylelint-disable-line function-disallowed-list
+$lead-font-weight:            300 !default;
 // scss-docs-end type-variables
 
 // scss-docs-start display-headings
@@ -25,30 +22,6 @@ $display-line-height: $headings-line-height !default;
 // scss-docs-end display-headings
 
 @layer content {
-  .h1 {
-    @extend h1;
-  }
-
-  .h2 {
-    @extend h2;
-  }
-
-  .h3 {
-    @extend h3;
-  }
-
-  .h4 {
-    @extend h4;
-  }
-
-  .h5 {
-    @extend h5;
-  }
-
-  .h6 {
-    @extend h6;
-  }
-
   .lead {
     font-size: $lead-font-size;
     font-weight: $lead-font-weight;
@@ -63,19 +36,5 @@ $display-line-height: $headings-line-height !default;
       font-weight: $display-font-weight;
       line-height: $display-line-height;
     }
-  }
-
-  .small {
-    @extend small;
-  }
-
-  .mark {
-    @extend mark;
-  }
-
-  // Builds on `abbr`
-  .initialism {
-    font-size: $initialism-font-size;
-    text-transform: uppercase;
   }
 }


### PR DESCRIPTION
Part of the `scss/content/` sweep.

## Tokens

Reboot styles bare HTML, so everything it decided was frozen at build time and unreachable from the browser: heading margin, family, style, weight and line height, paragraph margin, `hr`, `legend`, `dt`, `sub`/`sup`, `mark` padding, the code font size and the list indent. They are declared on `:root` now, and `<kbd>` gets its own set on the element — including `--cui-kbd-border-radius`, which was a hardcoded `$border-radius-sm`.

Two of them were reachable but not findable:

- `--cui-kbd-color` / `--cui-kbd-bg` were only ever read as `var(--cui-kbd-color, <sass fallback>)`. Overriding worked if you already knew the name and nothing reported it.
- `--cui-pre-color` resolved to `var(--cui-pre-color, )` — an empty fallback, which makes the whole declaration invalid at computed-value time. It defaults to `inherit` now, which is what the invalid declaration was effectively producing.

Spacing written as `1rem`, `.5rem` and `2rem` (`address`, `ol`/`ul`/`dl`, `dd`, `blockquote`, `pre`, `figure`) reads the `--cui-spacer-*` scale. Values unchanged.

## The `@extend`

`.h1`–`.h6`, `.small` and `.mark` were defined in `_type.scss` by `@extend`-ing the elements they mirror. That forced the module to `@use "reboot"` and — because `@extend` hoists a class to wherever the extended selector lives — emitted the classes inside Reboot's layer anyway. Defining them next to the elements removes the dependency and changes nothing in the output; verified in the compiled CSS, `h6, .h6, h5, .h5, …` sat in `@layer reboot` before this PR too.

`.initialism` joins `abbr`, which it builds on. It is the one class that actually changes layer (`content` → `reboot`).

`_type.scss` is left with what is genuinely its own: `.lead` and `.display-*`.

## Verification

`css-lint`, `css-test-class-api`, `docs-build`, `js-test-unit` (3212), `js-test-visual` (35) pass.

Bundlewatch: ~20 token declarations on `:root` and 6 on `kbd` put `coreui.css` at 63.12 kB and `coreui.min.css` at 52.75 kB, so the budgets go to 63.5 and 53 kB — the same headroom the file carried before.
