### PR TITLE
fix(Images): declare the thumbnail and caption variables instead of only reading them

### DIFF
--- a/docs/src/content/docs/content/figures.mdx
+++ b/docs/src/content/docs/content/figures.mdx
@@ -20,7 +20,13 @@ Aligning the figure's caption is easy with our [text utilities](/utilities/text/
     <figcaption class="figure-caption text-end">A caption for the above image.</figcaption>
   </figure>`} />
 
-## Customization
+## Customizing
+
+### CSS variables
+
+The caption declares its own size and colour, so it works the same inside a `.figure` or on its own:
+
+<ScssDocs file="scss/content/_images.scss" capture="figure-css-vars" />
 
 ### SASS variables
 

--- a/docs/src/content/docs/content/images.mdx
+++ b/docs/src/content/docs/content/images.mdx
@@ -42,7 +42,17 @@ If you are using the `<picture>` element to specify multiple `<source />` elemen
 </picture>
 ```
 
-## Customization
+## Customizing
+
+### CSS variables
+
+`.img-thumbnail` declares its frame on the element, so a single thumbnail can be reframed without a modifier class:
+
+<ScssDocs file="scss/content/_images.scss" capture="thumbnail-css-vars" />
+
+```html
+<img src="..." class="img-thumbnail" style="--cui-thumbnail-padding: .5rem; --cui-thumbnail-border-color: var(--cui-primary);" alt="...">
+```
 
 ### SASS variables
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1269,6 +1269,14 @@ Multi Select's option indicators moved with it — they render as a decorative
   direction never switches. Plain `.hstack` and `.vstack` are unchanged, including
   `.hstack`'s vertical centring and its shrink-to-content width.
 
+#### Images and figures
+
+- **`--cui-thumbnail-*` and `--cui-figure-caption-*` are declared, not just
+  read.** They existed only as the fallback arm of a `var()` call, so nothing
+  reported them and an override had to guess the name. `.img-thumbnail` and
+  `.figure-caption` declare their full set on the element, padding, border width
+  and caption font size included.
+
 #### Reboot
 
 - **Links change color on hover.** `--cui-link-hover-color` was declared and

--- a/scss/content/_images.scss
+++ b/scss/content/_images.scss
@@ -1,6 +1,8 @@
+@use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
 @use "../mixins/image" as *;
+@use "../mixins/tokens" as *;
 @use "../config" as *;
 
 // scss-docs-start thumbnail-variables
@@ -13,9 +15,41 @@ $thumbnail-box-shadow:              var(--#{$prefix}box-shadow-sm) !default;
 // scss-docs-end thumbnail-variables
 
 // scss-docs-start figure-variables
+$figure-img-margin-bottom:          var(--#{$prefix}spacer-2) !default;
 $figure-caption-font-size:          var(--#{$prefix}small-font-size) !default;
 $figure-caption-color:              var(--#{$prefix}secondary-color) !default;
 // scss-docs-end figure-variables
+
+$thumbnail-tokens: () !default;
+$figure-caption-tokens: () !default;
+
+// stylelint-disable scss/dollar-variable-default
+
+// scss-docs-start thumbnail-css-vars
+$thumbnail-tokens: defaults(
+  (
+    --#{$prefix}thumbnail-padding: #{$thumbnail-padding},
+    --#{$prefix}thumbnail-bg: #{$thumbnail-bg},
+    --#{$prefix}thumbnail-border-width: #{$thumbnail-border-width},
+    --#{$prefix}thumbnail-border-color: #{$thumbnail-border-color},
+    --#{$prefix}thumbnail-border-radius: #{$thumbnail-border-radius},
+    --#{$prefix}thumbnail-box-shadow: #{$thumbnail-box-shadow},
+  ),
+  $thumbnail-tokens
+);
+// scss-docs-end thumbnail-css-vars
+
+// scss-docs-start figure-css-vars
+$figure-caption-tokens: defaults(
+  (
+    --#{$prefix}figure-caption-font-size: #{$figure-caption-font-size},
+    --#{$prefix}figure-caption-color: #{$figure-caption-color},
+  ),
+  $figure-caption-tokens
+);
+// scss-docs-end figure-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 
 @layer content {
   // Responsive images (ensure images don't scale beyond their parents)
@@ -32,11 +66,13 @@ $figure-caption-color:              var(--#{$prefix}secondary-color) !default;
 
   // Image thumbnails
   .img-thumbnail {
-    padding: $thumbnail-padding;
-    background-color: var(--#{$prefix}thumbnail-bg, $thumbnail-bg);
-    border: $thumbnail-border-width solid var(--#{$prefix}thumbnail-border-color, $thumbnail-border-color);
-    @include border-radius($thumbnail-border-radius);
-    @include box-shadow($thumbnail-box-shadow);
+    @include tokens($thumbnail-tokens);
+
+    padding: var(--#{$prefix}thumbnail-padding);
+    background-color: var(--#{$prefix}thumbnail-bg);
+    border: var(--#{$prefix}thumbnail-border-width) solid var(--#{$prefix}thumbnail-border-color);
+    @include border-radius(var(--#{$prefix}thumbnail-border-radius));
+    @include box-shadow(var(--#{$prefix}thumbnail-box-shadow));
 
     // Keep them at most 100% wide
     @include img-fluid();
@@ -48,12 +84,14 @@ $figure-caption-color:              var(--#{$prefix}secondary-color) !default;
   }
 
   .figure-img {
-    margin-bottom: var(--#{$prefix}spacer-2);
+    margin-bottom: $figure-img-margin-bottom;
     line-height: 1;
   }
 
   .figure-caption {
-    font-size: $figure-caption-font-size;
-    color: var(--#{$prefix}figure-caption-color, $figure-caption-color);
+    @include tokens($figure-caption-tokens);
+
+    font-size: var(--#{$prefix}figure-caption-font-size);
+    color: var(--#{$prefix}figure-caption-color);
   }
 }


### PR DESCRIPTION
Last part of the `scss/content/` sweep.

`--cui-thumbnail-bg`, `--cui-thumbnail-border-color` and `--cui-figure-caption-color` were never declared anywhere. They existed only as the fallback arm of a `var()` call:

```scss
background-color: var(--#{$prefix}thumbnail-bg, $thumbnail-bg);
```

That works if you already know the name, and is invisible otherwise — nothing lists it, no dev tool reports it, and the docs had no CSS-variables section to put it in. The padding, border width, radius, shadow and caption font size had no variable at all.

Both classes declare their full set on the element now, `.figure-caption` on itself rather than on `.figure`, so a caption used outside a figure keeps its own styling.

Docs: `images.mdx` and `figures.mdx` get a `### CSS variables` section, and both pages' `## Customization` heading is renamed to `## Customizing` to match the rest of the site.

## Verification

`css-lint`, `css-test-class-api`, `docs-build`, `js-test-unit` (3212), `js-test-visual` (35), bundlewatch all pass — no budget change needed.
