### PR TITLE
docs(Reboot, Typography): document the iframe reset, nested quotes and the font scale

### DIFF
--- a/docs/src/content/docs/content/reboot.mdx
+++ b/docs/src/content/docs/content/reboot.mdx
@@ -29,6 +29,18 @@ Reboot styles bare HTML, so its variables live on `:root` rather than on a class
 
 <ScssDocs file="scss/content/_reboot.scss" capture="kbd-css-vars" />
 
+The `<body>` rules show how a variable is consumed:
+
+<ScssDocs file="scss/content/_reboot.scss" capture="reboot-body-rules" />
+
+Which means the page can be restyled from the markup, with no recompile:
+
+```html
+<body style="--cui-body-color: #333; --cui-paragraph-margin-bottom: 1.5rem;">
+  <!-- ... -->
+</body>
+```
+
 ## Page defaults
 
 The `<html>` and `<body>` elements are updated to provide better page-wide defaults. More specifically:
@@ -379,3 +391,31 @@ HTML5 adds [a new global attribute named `[hidden]`](https://developer.mozilla.o
 </Callout>
 
 To merely toggle the visibility of an element, meaning its `display` is not modified and the element can still affect the flow of the document, use [the `.invisible` class](/utilities/visibility/) instead.
+
+## iframe color-scheme
+
+`<iframe>` is set to `color-scheme: light dark`, and its border is removed.
+
+The reason is a browser safeguard rather than a style preference. When an embedded document's color scheme differs from the iframe element's, the browser paints an opaque canvas behind the frame — on a dark page, a white box. An embedded document cannot see your `data-coreui-theme` attribute; it follows the system preference. Pinning the iframe to the system preference too keeps the embed transparent, including on a page where you force a theme.
+
+<Example class="p-3" code={`<div data-coreui-theme="dark" class="bg-body text-body p-3">
+    <iframe class="w-100 border-0" style="color-scheme: unset" title="Default iframe" src="data:text/html,<!DOCTYPE html><html><meta name='color-scheme' content='light dark'><body style='background-color:transparent;color:gray;'><h4>Default iframe</h4></body></html>"></iframe>
+    <iframe class="w-100 border-0" title="iframe with color-scheme" src="data:text/html,<!DOCTYPE html><html><meta name='color-scheme' content='light dark'><body style='background-color:transparent;color:gray;'><h4>iframe with color-scheme: light dark</h4></body></html>"></iframe>
+    <iframe class="w-100 border-0" title="Embed that declares no color scheme" src="data:text/html,<!DOCTYPE html><html><body style='background-color:transparent;color:gray;'><h4>Embed that declares no color scheme</h4></body></html>"></iframe>
+  </div>`} />
+
+The first two embeds declare `<meta name="color-scheme" content="light dark">`, so they follow the system preference and stay transparent. The third declares nothing, which is what most third-party embeds do — set your system to dark mode and the browser paints a white box behind it.
+
+### Third-party embeds with no dark mode
+
+Payment buttons, comment widgets and review widgets often ship light-only. The white background the browser paints behind them in dark mode is deliberate: it keeps the embed's own light content readable, and no stylesheet of ours can remove it.
+
+Pin that one frame to light instead, so the browser has no mismatch to guard against:
+
+```html
+<iframe style="color-scheme: light" src="..."></iframe>
+```
+
+<Callout color="warning">
+Use this only for an embed that has no dark mode. Safari and Firefox pass the value into the embedded document, so an embed that *does* have a dark mode will be forced into its light one.
+</Callout>

--- a/docs/src/content/docs/content/typography.mdx
+++ b/docs/src/content/docs/content/typography.mdx
@@ -146,6 +146,17 @@ The HTML spec requires that blockquote attribution be placed outside the `<block
     </figcaption>
   </figure>`} />
 
+### Nested
+
+A quote inside a quote keeps the same spacing, because the outer quote lays its children out with `--cui-blockquote-gap` rather than each child's own margin.
+
+<Example code={`<blockquote class="blockquote">
+    <p>A well-known quote, contained in a blockquote element.</p>
+    <blockquote class="blockquote">
+      <p>A quote inside the quote above.</p>
+    </blockquote>
+  </blockquote>`} />
+
 ### Alignment
 
 Use text utilities as needed to change the alignment of your blockquote.
@@ -232,6 +243,8 @@ Align terms and descriptions horizontally by using our grid system's predefined 
 
 Headings scale with the viewport: the larger sizes are written as `clamp()`, so they grow with the screen up to the size given as the ceiling and stop there.
 
+The same sizes are on `:root` as `--cui-font-size-*` tokens, one per stop of the `$font-sizes` scale, and reachable as [font size utilities](/utilities/text/#font-size) — `.fs-xs` through `.fs-4xl`, or `.text-*` for the size plus the leading that belongs to it. Use them to give a non-heading element a heading's size without also giving it a heading's weight.
+
 ## Customizing
 
 ### CSS variables
@@ -256,7 +269,6 @@ Headings have some dedicated variables for sizing and spacing.
 
 Miscellaneous typography elements covered here and in [Reboot](/content/reboot/) also have dedicated variables.
 
-<ScssDocs file="scss/_config.scss" capture="type-variables" />
 <ScssDocs file="scss/_root.scss" capture="type-variables" />
 
 <ScssDocs file="scss/content/_type.scss" capture="type-variables" />

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -220,10 +220,6 @@ $font-sizes: (
 ) !default;
 // scss-docs-end font-sizes
 
-// scss-docs-start type-variables
-
-// scss-docs-end type-variables
-
 // Icons
 
 // Customizes the `.table` component with basic values, each used across all table variations.


### PR DESCRIPTION
Follow-up to the `scss/content/` sweep (#812–#816): things upstream's content docs cover and ours didn't.

## `## iframe color-scheme`

Reboot pins every `<iframe>` to `color-scheme: light dark` and removes its border. Nothing documented it, and it is not a cosmetic rule: a browser paints an opaque canvas behind a frame whose colour scheme differs from the page's — on a dark page, a white box. An embedded document cannot see `data-coreui-theme`, so it follows the system preference, and the frame has to be pinned to the same thing.

The example shows all three cases (embed declaring `light dark` with the reset off, with it on, and an embed declaring nothing), and a subsection covers the case we cannot fix from a stylesheet: a light-only third-party embed. Upstream sends readers to a `.color-scheme-light` utility there; we don't ship one, so the workaround is an inline `style="color-scheme: light"` on that single frame, with the same warning about Safari and Firefox passing the value into the embedded document.

## Smaller gaps

- **CSS variables** section listed the variables but never showed one being consumed. It now cites the `<body>` rules and an inline `<body style="--cui-body-color: …">` override.
- **Nested blockquotes** — upstream has the example, we didn't. It is also the case where `--cui-blockquote-gap` from #813 does visible work.
- **Responsive font sizes** stopped at one sentence about `clamp()`. It now points at the `--cui-font-size-*` scale and the `.fs-*` / `.text-*` utilities that expose it. The ladder itself stays where it is documented properly, on [Text utilities](https://coreui.io/bootstrap/docs/utilities/text/#font-size) — no reason to duplicate it here.

## One bug

`_config.scss` carried an empty `// scss-docs-start type-variables` block, and `typography.mdx` cited it — so the page has been rendering an empty code block. The variables moved out of that block a while ago. Both are gone.

## Not taken

Upstream's `## Global font sizes`, `### Sass maps` and `### Sass loops` on the typography page duplicate what our [Text utilities](https://coreui.io/bootstrap/docs/utilities/text/) page already covers, `$font-sizes` map and `root-font-size-loop` included.

`.prose` is still an open question — a whole new component, not a docs gap.

## Verification

`docs-build` passes with no broken links; verified in the built HTML that the three iframes, the nested quote and the `<body>` rules render, and that no empty code block is left on the typography page. `css-lint` clean.
