### PR TITLE
docs(Tables): restore the sixteen demos lost in the Astro migration

### DIFF
--- a/docs/src/content/docs/content/tables.mdx
+++ b/docs/src/content/docs/content/tables.mdx
@@ -8,11 +8,45 @@ otherFrameworks:
 
 import { getData } from '@coreui/astro-docs/data'
 
+export const rows = `  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">First</th>
+      <th scope="col">Last</th>
+      <th scope="col">Handle</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">1</th>
+      <td>Mark</td>
+      <td>Otto</td>
+      <td>@mdo</td>
+    </tr>
+    <tr>
+      <th scope="row">2</th>
+      <td>Jacob</td>
+      <td>Thornton</td>
+      <td>@fat</td>
+    </tr>
+    <tr>
+      <th scope="row">3</th>
+      <td colspan="2">Larry the Bird</td>
+      <td>@twitter</td>
+    </tr>
+  </tbody>`
+
+export const demo = (classes) => `<table class="${classes}">\n${rows}\n</table>`
+
+export const snippet = (classes) => `<table class="${classes}">\n  ...\n</table>`
+
 ## Overview
 
 Due to the widespread use of `<table>` elements across third-party widgets like calendars and date pickers, CoreUI for Bootstrap's tables are **opt-in**. Add the base class `.table` to any `<table>`, then extend with our optional modifier classes or custom styles. All table styles are not inherited in Bootstrap, meaning any nested tables can be styled independent from the parent.
 
 Using the most basic table markup, here's how `.table`-based tables look in Bootstrap.
+
+<Example code={demo('table')} />
 
 ## Variants
 
@@ -79,17 +113,35 @@ Relying on color to convey meaning creates a visual cue that assistive technolog
 
 Use `.table-striped` to add zebra-striping to any table row within the `<tbody>`.
 
+<Example html={demo('table table-striped')} code={snippet('table table-striped')} />
+
 ### Striped columns
 
 Use `.table-striped-columns` to add zebra-striping to any table column.
 
+<Example html={demo('table table-striped-columns')} code={snippet('table table-striped-columns')} />
+
 These classes can also be added to table variants:
+
+<Example html={demo('table table-dark table-striped')} code={snippet('table table-dark table-striped')} />
+
+<Example html={demo('table table-dark table-striped-columns')} code={snippet('table table-dark table-striped-columns')} />
+
+<Example html={demo('table table-success table-striped')} code={snippet('table table-success table-striped')} />
+
+<Example html={demo('table table-success table-striped-columns')} code={snippet('table table-success table-striped-columns')} />
 
 ### Hoverable rows
 
 Add `.table-hover` to enable a hover state on table rows within a `<tbody>`.
 
+<Example html={demo('table table-hover')} code={snippet('table table-hover')} />
+
+<Example html={demo('table table-dark table-hover')} code={snippet('table table-dark table-hover')} />
+
 These hoverable rows can also be combined with the striped rows variant:
+
+<Example html={demo('table table-striped table-hover')} code={snippet('table table-striped table-hover')} />
 
 ### Active tables
 
@@ -161,15 +213,27 @@ Behind the scenes it looks like this:
 
 Add `.table-bordered` for borders on all sides of the table and cells.
 
+<Example html={demo('table table-bordered')} code={snippet('table table-bordered')} />
+
 [Border color utilities](/utilities/borders/#border-color) can be added to change colors:
+
+<Example html={demo('table table-bordered border-primary')} code={snippet('table table-bordered border-primary')} />
 
 ### Tables without borders
 
 Add `.table-borderless` for a table without borders.
 
+<Example html={demo('table table-borderless')} code={snippet('table table-borderless')} />
+
+<Example html={demo('table table-dark table-borderless')} code={snippet('table table-dark table-borderless')} />
+
 ## Small tables
 
 Add `.table-sm` to make any `.table` more compact by cutting all cell `padding` in half.
+
+<Example html={demo('table table-sm')} code={snippet('table table-sm')} />
+
+<Example html={demo('table table-dark table-sm')} code={snippet('table table-dark table-sm')} />
 
 ## Table group dividers
 


### PR DESCRIPTION
The tables page has been describing demos that aren't there. Seven sections, sixteen missing examples — and this one is on the **live site**, since production docs build from this repo.

## What happened

Hugo had a `{{< table class="…" >}}` shortcode: it rendered a demo table from `partials/table-content.html` and printed an abbreviated snippet under it. The Astro engine has no equivalent — there is no `Table.astro` in `@coreui/astro-docs` — so the migration (#578) dropped every call site and left the prose standing.

Counted across the pre-migration tree, the damage is contained to this one page:

| shortcode | before | after |
| --- | --- | --- |
| `{{< table class=… >}}` | 16, all on `content/tables.md` | **0** |
| `{{< example >}}` | 754 | migrated 1:1 |
| `{{< callout >}}` / `{{< scss-docs >}}` / `{{< js-docs >}}` / `{{< partial >}}` | 456 | migrated 1:1 |

Three sections end mid-sentence because of it:

- "These classes can also be added to table variants:" — then nothing
- "These hoverable rows can also be combined with the striped rows variant:" — then nothing
- "[Border color utilities] can be added to change colors:" — then nothing

And Overview promises "here's how `.table`-based tables look" above an empty gap.

## The fix

No engine change needed. `<Example>` already takes the rendered demo (`html`) and the shown source (`code`) as separate props, which is exactly the shortcode's split — the full table renders, the snippet stays one line plus `...`. The rows live in a single `export const` the way they lived in a single Hugo partial, so each demo costs one line instead of a screenful.

Restored: Overview, striped rows, striped columns plus the four variant combinations, hoverable rows and the striped-hover pair, bordered, bordered with a border-color utility, borderless, and small. Sixteen, matching what was removed.

## Verification

`docs-build` passes with no broken links. Verified in the built HTML that all sixteen tables render with their intended classes — `table-striped`, `table-dark table-striped-columns`, `table-bordered border-primary`, `table-dark table-sm` and the rest.

Same change on the v5 line: coreui/coreui#1164 (free) and coreui/coreui-pro#818 (pro), where it is live on the site today.
