### PR TITLE
fix(Grid): declare the grid variables so a nested grid keeps its own layout

### DIFF
--- a/docs/src/content/docs/layout/css-grid.mdx
+++ b/docs/src/content/docs/layout/css-grid.mdx
@@ -41,7 +41,7 @@ Compared to the default grid system:
 
 - Inline and custom styles should be viewed as replacements for modifier classes (e.g., `style="--cui-columns: 3;"` vs `class="row-cols-3"`).
 
-- Nesting works similarly, but may require you to reset your column counts on each instance of a nested `.grid`. See the [nesting section](#nesting) for details.
+- Nesting works similarly, except every `.grid` starts from the defaults rather than picking up the grid around it. See the [nesting section](#nesting) for details.
 
 ## Examples
 
@@ -132,29 +132,29 @@ This behavior can be mixed with grid column classes.
 
 ## Nesting
 
-Similar to our default grid system, our CSS Grid allows for easy nesting of `.grid`s. However, unlike the default, this grid inherits changes in the rows, columns, and gaps. Consider the example below:
+Similar to our default grid system, our CSS Grid allows for easy nesting of `.grid`s. Every `.grid` declares its own rows, columns and gap, so a nested one starts from the defaults no matter what the grid around it is set to. Consider the example below:
 
-- We override the default number of columns with a local CSS variable: `--cui-columns: 3`.
-- In the first auto-column, the column count is inherited and each column is one-third of the available width.
-- In the second auto-column, we've reset the column count on the nested `.grid` to 12 (our default).
+- We set three columns on the outer grid with `--cui-columns: 3`.
+- The nested grid in the first auto-column takes the default twelve columns — the outer value does not reach it.
+- The nested grid in the second auto-column is set to three columns of its own, matching its parent.
 - The third auto-column has no nested content.
 
-In practice this allows for more complex and custom layouts when compared to our default grid system.
+That independence is the point: a component built on `.grid` keeps its own layout wherever you drop it, instead of silently taking the column count of whatever contains it.
 
 <Example class="docs-example-cssgrid" code={`<div class="grid text-center overflow-x-auto" style="--cui-columns: 3;">
     <div>
       First auto-column
       <div class="grid">
-        <div>Auto-column</div>
-        <div>Auto-column</div>
+        <div class="g-col-6">6 of 12</div>
+        <div class="g-col-4">4 of 12</div>
+        <div class="g-col-2">2 of 12</div>
       </div>
     </div>
     <div>
       Second auto-column
-      <div class="grid" style="--cui-columns: 12;">
-        <div class="g-col-6">6 of 12</div>
-        <div class="g-col-4">4 of 12</div>
-        <div class="g-col-2">2 of 12</div>
+      <div class="grid" style="--cui-columns: 3;">
+        <div>Auto-column</div>
+        <div>Auto-column</div>
       </div>
     </div>
     <div>Third auto-column</div>
@@ -164,13 +164,13 @@ In practice this allows for more complex and custom layouts when compared to our
 
 Customize the number of columns, the number of rows, and the width of the gaps with local CSS variables.
 
-| Variable | Fallback value | Description |
+| Variable | Default | Description |
 | --- | --- | --- |
 | `--cui-rows` | `1` | The number of rows in your grid template |
 | `--cui-columns` | `12` | The number of columns in your grid template |
 | `--cui-gap` | `1.5rem` | The size of the gap between columns (vertical and horizontal) |
 
-These CSS variables have no default value; instead, they apply fallback values that are used _until_ a local instance is provided. For example, we use `var(--cui-rows, 1)` for our CSS Grid rows, which ignores `--cui-rows` because that hasn't been set anywhere yet. Once it is, the `.grid` instance will use that value instead of the fallback value of `1`.
+Every `.grid` declares all three, so they show up in your browser's dev tools and each grid is self-contained. Set them on the `.grid` you want to change — inline, or in a stylesheet — and only that grid changes.
 
 ### No grid classes
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -2376,6 +2376,30 @@ for absolutely and fixed-positioned descendants: `position: fixed` inside a grid
 is positioned against the grid, not the viewport. Our own floating panels render
 through a portal and are unaffected; your own fixed markup has to live outside.
 
+#### The CSS Grid declares its variables, and nested grids no longer inherit
+
+<span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+
+`.grid` read `--cui-rows`, `--cui-columns` and `--cui-gap` through a `var()`
+fallback and declared none of them. Two consequences: the variables did not
+appear in dev tools, and — because a custom property that is never declared
+simply inherits — a nested `.grid` picked up the column count of the grid
+around it.
+
+All three are declared on `.grid` now, so every grid starts from twelve
+columns, one row and the standard gap regardless of its surroundings. A
+component built on `.grid` keeps its own layout wherever it is dropped.
+
+If you relied on a nested grid inheriting, set the variable on that grid too:
+
+```html
+<div class="grid" style="--cui-columns: 3;">
+  <div>
+    <div class="grid" style="--cui-columns: 3;">...</div>
+  </div>
+</div>
+```
+
 #### The `cq-*` grid is gone
 
 <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
@@ -2386,8 +2410,11 @@ with its own `$cq-grid-breakpoints` map that duplicated `$grid-breakpoints`
 value for value. It never shipped in the default build, and maintaining two
 grids to express one idea is what the CSS Grid above now does properly.
 
-The flag, the map, the classes and the `make-c-grid-columns()` mixin are all
-removed. If you had opted in: `.cq-row`/`.cq-col-*` map onto the CSS Grid
+The map, the classes and the `make-c-grid-columns()` mixin are removed.
+`$enable-container-queries` itself is still accepted and now does nothing —
+it stays until v7 because the shared docs engine passes it in its `with()`
+block for every edition, and an unknown variable there is a hard Sass error.
+If you had opted in: `.cq-row`/`.cq-col-*` map onto the CSS Grid
 (`.grid` + `.g-col-*`), which is container-based by default, or onto the flexbox
 grid (`.row`/`.col-*`) if you want viewport breakpoints. To keep the container
 behaviour on markup of your own, mark the element with

--- a/scss/layout/_grid.scss
+++ b/scss/layout/_grid.scss
@@ -30,15 +30,19 @@ $include-column-box-sizing: false !default;
 
   @if $enable-cssgrid {
     .grid {
+      --#{$prefix}rows: 1;
+      --#{$prefix}columns: #{$grid-columns};
+      --#{$prefix}gap: #{$grid-gutter-width};
+
       // The grid is its own query container, so `.g-col-*` responds to the width of
       // the grid rather than the viewport. `container-type` implies layout containment,
       // which makes the grid the containing block of any positioned descendant.
       @include set-container();
 
       display: grid;
-      grid-template-rows: repeat(var(--#{$prefix}rows, 1), 1fr);
-      grid-template-columns: repeat(var(--#{$prefix}columns, #{$grid-columns}), 1fr);
-      gap: var(--#{$prefix}gap, #{$grid-gutter-width});
+      grid-template-rows: repeat(var(--#{$prefix}rows), 1fr);
+      grid-template-columns: repeat(var(--#{$prefix}columns), 1fr);
+      gap: var(--#{$prefix}gap);
 
       @include make-cssgrid();
     }


### PR DESCRIPTION
Follows the `layout/` comparison. `.grid` now declares its variables instead of only reading them through a fallback, matching upstream v6.

## The behaviour that changes

`--cui-rows`, `--cui-columns` and `--cui-gap` were read as `var(--cui-columns, 12)` and declared nowhere. A custom property that is never declared inherits, so a nested `.grid` took the column count of the grid around it. Measured in Chromium, a `.grid` inside `<div class="grid" style="--cui-columns: 3">`:

| | outer | nested |
| --- | --- | --- |
| before (fallback only) | 3 | **3** |
| after (declared on `.grid`) | 3 | **12** |

Our own docs already worked around this: the nesting example set `--cui-columns: 12` on the nested grid to undo the inheritance it would otherwise get.

Declaring makes each grid self-contained — a component built on `.grid` keeps its layout wherever it is dropped — and puts the three variables in dev tools, where a fallback-only read never appears.

## Docs

The nesting section was written around the old behaviour and presented the inheritance as the feature, so it is rewritten against what the CSS does now, with the example flipped: the first nested grid shows the default twelve columns, the second sets three of its own to match the parent. The customizing table stops calling the values "fallback value", and there is a migration entry with the one-line fix for anyone who relied on inheritance.

Worth knowing: upstream declares these variables too, but their css-grid page still says "this grid inherits changes in the rows, columns, and gaps" and walks through a nested grid being "reset to 12". That text no longer matches their CSS — we take the behaviour, not the page.

## The `$enable-container-queries` flag

Correcting a claim, not changing code: the `cq-*` section said the flag was removed. It is not — it is accepted and ignored. It cannot be removed yet, because `@coreui/astro-docs` passes it in `@use ... with (...)` for **every** edition, and an unknown variable there is a hard Sass error (verified). The engine has to keep passing it while v5 exists: both v5 editions ship a `layout/container-queries-grid` page built on the `.cq-*` classes that flag generates. The wording now says so.

## Verification

`css-lint`, `docs-build` (no broken links) and bundlewatch pass; `coreui.css` 63.17 kB, `coreui-grid.css` unchanged at 7.4 kB.
