### PR TITLE
fix(Layout): logical properties on the container, and two smaller cleanups

### DIFF
--- a/scss/layout/_breakpoints.scss
+++ b/scss/layout/_breakpoints.scss
@@ -21,7 +21,7 @@
 @function breakpoint-next($name, $breakpoints: $grid-breakpoints, $breakpoint-names: map.keys($breakpoints)) {
   $n: list.index($breakpoint-names, $name);
   @if not $n {
-    @error "breakpoint `#{$name}` not found in `#{$breakpoints}`";
+    @error "breakpoint `#{$name}` not found in `#{$breakpoint-names}`";
   }
   // Use @if/@else because list.nth would error if evaluated when $n equals list length
   @if $n < list.length($breakpoint-names) {

--- a/scss/layout/_containers.scss
+++ b/scss/layout/_containers.scss
@@ -1,4 +1,4 @@
-@use "../layout/breakpoints" as *;
+@use "breakpoints" as *;
 @use "../mixins/container" as *;
 @use "../config" as *;
 

--- a/scss/mixins/_container.scss
+++ b/scss/mixins/_container.scss
@@ -6,8 +6,6 @@
   --#{$prefix}gutter-x: #{$gutter};
   --#{$prefix}gutter-y: 0;
   width: 100%;
-  padding-right: calc(var(--#{$prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
-  padding-left: calc(var(--#{$prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
-  margin-right: auto;
-  margin-left: auto;
+  padding-inline: calc(var(--#{$prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
+  margin-inline: auto;
 }


### PR DESCRIPTION
The remainder of the `scss/layout/` comparison — three things with no effect on how anything renders today.

**`make-container()` used physical properties.** Four declarations for the gutter and the centring, where the rest of v6 has moved to logical:

```scss
padding-right: calc(var(--cui-gutter-x) * .5);
padding-left:  calc(var(--cui-gutter-x) * .5);
margin-right: auto;
margin-left: auto;
```

become `padding-inline` and `margin-inline`. Identical in horizontal writing, correct in vertical — where the gutter was previously landing across the block axis.

**`breakpoint-next()` printed the wrong thing on error.** It interpolated `$breakpoints`, the whole map, so a typo produced a wall of `(xs: 0, sm: 576px, md: 768px, …)` rather than the names you can pick from. The function already takes `$breakpoint-names`; the message uses it.

**`_containers.scss` reached its sibling as `../layout/breakpoints`** while `_grid.scss` beside it writes `breakpoints`. Same module either way.

## Verification

Measured in Chromium before and after, `.container` at 1400px wide, in `dir="ltr"` and inside `dir="rtl"`:

| | padding | margin | width |
| --- | --- | --- | --- |
| before | 12px / 12px | 40px / 40px | 1320 |
| after | 12px / 12px | 40px / 40px | 1320 |

Identical in all four cells. `coreui.scss` and `coreui-grid.scss` both compile; stylelint (with `--report-needless-disables`) and fusv clean.