### PR TITLE
fix(Layout): put the breakpoint tokens in the root layer

### DIFF
--- a/scss/layout/_grid.scss
+++ b/scss/layout/_grid.scss
@@ -5,14 +5,6 @@
 $include-column-box-sizing: false !default;
 
 @layer layout {
-  :root {
-    @each $name, $value in $grid-breakpoints {
-      --#{$prefix}breakpoint-#{$name}: #{$value};
-    }
-
-    --#{$prefix}mobile-breakpoint: #{$mobile-breakpoint};
-  }
-
   @if $enable-grid-classes {
     .row {
       @include make-row();

--- a/scss/layout/_tokens.scss
+++ b/scss/layout/_tokens.scss
@@ -1,0 +1,16 @@
+@use "../config" as *;
+
+// The breakpoint scale as custom properties, for consumers reading it at runtime.
+// It lives with layout rather than in _root.scss because coreui-grid.scss ships
+// layout without root, and it is forwarded ahead of the layout partials so the
+// root layer registers before the layout one in that bundle too.
+
+@layer root {
+  :root {
+    @each $name, $value in $grid-breakpoints {
+      --#{$prefix}breakpoint-#{$name}: #{$value};
+    }
+
+    --#{$prefix}mobile-breakpoint: #{$mobile-breakpoint};
+  }
+}

--- a/scss/layout/index.scss
+++ b/scss/layout/index.scss
@@ -1,3 +1,4 @@
 @forward "breakpoints";
+@forward "tokens";
 @forward "containers";
 @forward "grid";


### PR DESCRIPTION
`--cui-breakpoint-*` and `--cui-mobile-breakpoint` are an export — the breakpoint scale for whoever reads it at runtime — but they were the only `:root` tokens in the library emitted from `@layer layout` instead of `@layer root`.

## Why they don't just move to `_root.scss`

`coreui-grid.scss` forwards `config` and `layout` and **not** `root`, so moving them there drops them from `coreui-grid.css` entirely. Upstream solves that by emitting the tokens twice — once in `_root.scss`, once in `bootstrap-grid.scss` — which is two places to keep in step. They stay in `layout/` here, in a partial of their own.

## The part that made this more than a one-line change

Emitting the block from `_grid.scss` produced this in `coreui-grid.css`:

```
@layer layout   ← containers
@layer root     ← the tokens
@layer utilities
```

That bundle carries **no** `@layer …;` order declaration — it lives in `_root.scss`, which the grid bundle doesn't include — so registration order *is* the order, and `root` ended up outranking `layout`. Nothing collides today (the root layer holds only custom properties there), but it is the trap the workspace notes describe: a layer used before the order is declared registers first and silently reorders the cascade.

Forwarding the tokens ahead of the layout partials fixes it. `coreui-grid.css` now reads:

```
@layer root
@layer layout
@layer utilities
```

a correct subsequence of the canonical order. The main bundle is unaffected either way — `_root.scss` declares the full order on line 7, before the first `@layer x {` on line 8.

## Verification

- Both bundles still emit all six `--cui-breakpoint-*` plus `--cui-mobile-breakpoint`.
- Diff of `coreui.css` is the block moving from a `layout` wrapper to a `root` one, nothing else.
- `css-lint` (stylelint + fusv), `docs-build` (147 pages, no broken links), `js-test-visual` (35) and bundlewatch pass. `coreui-grid.css` 7.41 kB.

Worth recording separately: nothing in our SCSS or JS reads either token, and `--cui-mobile-breakpoint: lg` emits a **name**, not a length, so it cannot be used in `calc()` or a media query. Both are inherited from v5 and left alone here.