### PR TITLE
chore(Layout): remove `--cui-mobile-breakpoint`

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1961,6 +1961,25 @@ tintable and lets dark mode deepen every shadow at once.
   written in `$theme-colors-contrast`. `.text-bg-*` reads the token instead of
   calling `color-contrast()`.
 
+#### `--cui-mobile-breakpoint` removed
+
+<span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+
+The token carried the **name** of the sidebar's breakpoint (`lg`), not a length,
+so it could not be used in a media query or in `calc()`, and nothing in the
+library read it. Read `--cui-breakpoint-lg` for the value.
+
+It also sat one letter away from a mechanism that does work and looks similar.
+The sidebar tells its plugin about the mobile layout with `--cui-is-mobile`,
+which is declared **inside** the media query, so it is `"true"` below the
+breakpoint and empty above — the plugin only tests whether it is set. The
+removed token was declared on `:root` unconditionally, so the same
+`Boolean(getPropertyValue(…))` test against it answered "mobile" at every
+width.
+
+The Sass variable `$mobile-breakpoint` is unchanged; the sidebar's own media
+queries are built on it.
+
 #### Colour scales, and `_variables-dark.scss` removed
 
 <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/scss/layout/_tokens.scss
+++ b/scss/layout/_tokens.scss
@@ -10,7 +10,5 @@
     @each $name, $value in $grid-breakpoints {
       --#{$prefix}breakpoint-#{$name}: #{$value};
     }
-
-    --#{$prefix}mobile-breakpoint: #{$mobile-breakpoint};
   }
 }


### PR DESCRIPTION
The token carried the **name** of the sidebar's breakpoint (`lg`), not a length — unusable in a media query or a `calc()` — and an exhaustive search of `scss/`, `js/src/` and `docs/src/` finds exactly one occurrence: the line declaring it. `--cui-breakpoint-lg` already publishes the value.

## Why removing beats fixing

It sits one letter from a mechanism that works and looks the same. The sidebar signals its mobile layout with `--cui-is-mobile`, declared **inside** the media query:

```scss
@include media-breakpoint-down($mobile-breakpoint) {
  --cui-is-mobile: true;
```

and the plugin tests only whether it is set:

```ts
return Boolean(window.getComputedStyle(this._element, null).getPropertyValue('--cui-is-mobile'))
```

Measured on `.sidebar` at two widths:

| viewport | `--cui-is-mobile` | `--cui-mobile-breakpoint` |
| --- | --- | --- |
| 1400px | `""` → Boolean **false** | `"lg"` → Boolean **true** |
| 800px | `"true"` → Boolean **true** | `"lg"` → Boolean **true** |

So code written on the sidebar's pattern but reaching for the other name would report "mobile" at every width, silently. Keeping a token nobody reads is cheap; keeping one that is a plausible-looking trap is not.

`$mobile-breakpoint` (Sass) is untouched — the sidebar's eight media queries are built on it, and `fusv` confirms it is still used.

## Verification

- Diff of `coreui.css` is one line. `--cui-is-mobile` untouched.
- `css-lint` (stylelint + fusv), `docs-build` (147 pages, no broken links), `js-test-unit` (3212) and bundlewatch pass.
- Migration guide records the removal, the replacement, and the `--cui-is-mobile` distinction.