### PR TITLE
fix(Caret): mirror the dropdown arrow in RTL

### DIFF
--- a/scss/mixins/_caret.scss
+++ b/scss/mixins/_caret.scss
@@ -8,30 +8,30 @@ $caret-spacing:               $caret-width * .85 !default;
 
 // scss-docs-start caret-mixins
 @mixin caret-down($width: $caret-width) {
-  border-top: $width solid;
-  border-right: $width solid transparent;
-  border-bottom: 0;
-  border-left: $width solid transparent;
+  border-block-start: $width solid;
+  border-block-end: 0;
+  border-inline-start: $width solid transparent;
+  border-inline-end: $width solid transparent;
 }
 
 @mixin caret-up($width: $caret-width) {
-  border-top: 0;
-  border-right: $width solid transparent;
-  border-bottom: $width solid;
-  border-left: $width solid transparent;
+  border-block-start: 0;
+  border-block-end: $width solid;
+  border-inline-start: $width solid transparent;
+  border-inline-end: $width solid transparent;
 }
 
 @mixin caret-end($width: $caret-width) {
-  border-top: $width solid transparent;
-  border-right: 0;
-  border-bottom: $width solid transparent;
-  border-left: $width solid;
+  border-block-start: $width solid transparent;
+  border-block-end: $width solid transparent;
+  border-inline-start: $width solid;
+  border-inline-end: 0;
 }
 
 @mixin caret-start($width: $caret-width) {
-  border-top: $width solid transparent;
-  border-right: $width solid;
-  border-bottom: $width solid transparent;
+  border-block-start: $width solid transparent;
+  border-block-end: $width solid transparent;
+  border-inline-end: $width solid;
 }
 
 @mixin caret(


### PR DESCRIPTION
From the `scss/mixins/` comparison.

`.dropend` and `.dropstart` place their panel with logical properties — `inset-inline-start`, `inset-inline-end`, `margin-inline-*` — so the menu already flips with the document direction. The arrow did not: `_caret.scss` drew it with `border-left` / `border-right`. In RTL the menu opened to the left while the triangle kept pointing right.

Measured on the toggle's pseudo-element (border widths, left/right/top/bottom):

| | before | after |
| --- | --- | --- |
| `.dropend` LTR | 4/0/4/4 | 4/0/4/4 |
| `.dropend` **RTL** | **4/0/4/4** | **0/4/4/4** |
| `.dropstart` LTR | 0/4/4/4 | 0/4/4/4 |
| `.dropstart` **RTL** | **0/4/4/4** | **4/0/4/4** |
| `.dropdown` LTR / RTL | 4/4/4/0 | 4/4/4/0 |

LTR is untouched everywhere, and `caret-down` / `caret-up` are symmetric on the inline axis so they render the same either way.

This is one of the places our bidi model does not cover by itself: we emit both directions into one stylesheet through `ltr-rtl()` rather than building a separate `.rtl.css`, so a physical property is only mirrored where the call site asks for it. The caret never did. Logical properties need no call-site help.

Upstream's `_caret.scss` is already logical, but theirs is dead code — v6 replaced Dropdown with Menu and nothing calls `caret()` there any more. Ours is live, from `_dropdown.scss` lines 139, 223, 237 and 254.

`css-lint` (stylelint + fusv) clean.