### PR TITLE
fix(Tooltip, Popover): follow the body font set at runtime

### DIFF
--- a/scss/mixins/_reset-text.scss
+++ b/scss/mixins/_reset-text.scss
@@ -1,10 +1,10 @@
 @use "../config" as *;
 
 @mixin reset-text {
-  font-family: $font-family-base;
+  font-family: var(--#{$prefix}body-font-family);
   // We deliberately do NOT reset font-size or overflow-wrap / word-wrap.
   font-style: normal;
-  font-weight: $font-weight-normal;
+  font-weight: var(--#{$prefix}body-font-weight);
   line-height: var(--#{$prefix}body-line-height);
   text-align: start;
   text-decoration: none;


### PR DESCRIPTION
From the `scss/mixins/` comparison.

`reset-text()` set the family and weight from Sass:

```scss
font-family: $font-family-base;
font-weight: $font-weight-normal;
```

so both were frozen at build time. Its only two callers are `_tooltip.scss` and `_popover.scss`, which means a page theming its typography at runtime restyled everything **except** the tooltip and the popover — the two things most likely to sit on top of that content.

With `:root { --cui-body-font-family: Georgia, serif; --cui-body-font-weight: 600 }`:

| | before | after |
| --- | --- | --- |
| body paragraph | Georgia, serif / 600 | Georgia, serif / 600 |
| tooltip | **system-ui … / 400** | **Georgia, serif / 600** |

The two tokens are the same ones Reboot already sets `body` from, so nothing changes without an override — the compiled default goes from `var(--cui-font-sans-serif)` / `400` to `var(--cui-body-font-family)` / `var(--cui-body-font-weight)`, which resolve to those values.

`line-height` in the same mixin was already a token; this brings the other two in line, and matches upstream, whose `reset-text` reads all three from custom properties.

`css-lint` (stylelint + fusv) clean.