### PR TITLE
fix(Sidebar): size the backdrop by the viewport, not by vw units

### DIFF
--- a/scss/mixins/_backdrop.scss
+++ b/scss/mixins/_backdrop.scss
@@ -1,14 +1,16 @@
 @use "../config" as *;
 
-// Shared between modals and offcanvases
-@mixin overlay-backdrop($zindex, $backdrop-bg, $backdrop-opacity) {
+// The full-viewport scrim behind an overlay. Used by the sidebar; exported for
+// anything else that needs the same surface.
+@mixin overlay-backdrop($zindex, $backdrop-bg, $backdrop-opacity, $backdrop-blur: null) {
   position: fixed;
-  top: 0;
-  left: 0;
+  inset: 0;
   z-index: $zindex;
-  width: 100vw;
-  height: 100vh;
   background-color: $backdrop-bg;
+
+  @if $backdrop-blur {
+    backdrop-filter: blur($backdrop-blur);
+  }
 
   // Fade for backdrop
   &.fade { opacity: 0; }


### PR DESCRIPTION
From the `scss/mixins/` comparison.

`overlay-backdrop()` built the scrim from `top`/`left` plus `width: 100vw` / `height: 100vh`. Both units are wrong for this job:

- `100vw` is the viewport width **including** a classic scrollbar, so wherever the scrollbar takes layout space — Windows, Linux, macOS with "always show scrollbars" — the scrim is wider than the visible area.
- `100vh` keeps the **largest** viewport height on mobile, i.e. the height with the browser chrome retracted, so the scrim overruns while the chrome is showing.

`inset: 0` on a fixed element sizes to the actual containing block and has neither problem. Four declarations become one; upstream's mixin does the same.

**Honest note on verification:** I could not reproduce the `100vw` overshoot as a number here — headless Chromium on macOS uses overlay scrollbars, where the scrollbar takes no layout space and `100vw` equals `clientWidth`, so the measurement reads 0 either way. The behaviour is per spec (`vw` resolves against the viewport including the classic scrollbar) rather than something I can demonstrate on this machine. The compiled diff is the whole change:

```diff
   .sidebar-backdrop {
     position: fixed;
-    top: 0;
-    left: 0;
+    inset: 0;
     z-index: var(--cui-backdrop-zindex);
-    width: 100vw;
-    height: 100vh;
     background-color: var(--cui-backdrop-bg);
```

Two smaller things in the same file:

- The mixin now takes an optional `$backdrop-blur`, matching upstream. **No first-party caller passes it** — it emits nothing by default and exists because the mixin is public API through `mixins/index.scss`. Say the word and I will drop it.
- Its comment said "Shared between modals and offcanvases". Both moved to the native `<dialog>`; the sidebar is the only caller left.

I did **not** take upstream's version wholesale: theirs accepts `$backdrop-bg` and `$backdrop-opacity` and then ignores them, reading `var(--drawer-backdrop-bg)` and `var(--drawer-backdrop-opacity)` on its own — a modal built on it would get the drawer's scrim.

`css-lint` (stylelint + fusv) clean.