### PR TITLE
chore(Mixins): modern `:not()` and `math.max()`

### DIFF
--- a/scss/mixins/_border-radius.scss
+++ b/scss/mixins/_border-radius.scss
@@ -1,5 +1,6 @@
 // stylelint-disable property-disallowed-list
 @use "sass:list";
+@use "sass:math";
 @use "sass:meta";
 @use "../config" as *;
 
@@ -10,7 +11,7 @@
   $return: ();
   @each $value in $radius {
     @if meta.type-of($value) == number {
-      $return: list.append($return, max($value, 0));
+      $return: list.append($return, math.max($value, 0));
     } @else {
       $return: list.append($return, $value);
     }

--- a/scss/mixins/_visually-hidden.scss
+++ b/scss/mixins/_visually-hidden.scss
@@ -32,7 +32,7 @@
 // Useful for "Skip to main content" links; see https://www.w3.org/WAI/WCAG22/Techniques/general/G1.html
 
 @mixin visually-hidden-focusable() {
-  &:not(:focus):not(:focus-within) {
+  &:not(:focus, :focus-within) {
     @include visually-hidden();
   }
 }


### PR DESCRIPTION
The two smallest items from the `scss/mixins/` comparison. **Compiled CSS is byte-identical** — I diffed `coreui.css` before and after and it is empty.

**`visually-hidden-focusable()`** chained `&:not(:focus):not(:focus-within)`; upstream and the rest of our v6 use `:not(a, b)`. Worth knowing why the output does not move: `helpers/_visually-hidden.scss` writes

```scss
.visually-hidden,
.visually-hidden-focusable:not(:focus, :focus-within) {
  @include visually-hidden();
}
```

with the modern form spelled out, and nothing calls `visually-hidden-focusable()`. The old syntax only ever reached a consumer invoking the mixin in their own stylesheet.

**`valid-radius()`** used the global `max()`. Sass is retiring the global built-ins for the `sass:math` module, and the docs engine sets `silenceDeprecations: ['global-builtin']` for the whole library — so this particular warning could not be seen from here. On numbers the two are the same function, hence no output change.

`css-lint` (stylelint + fusv) clean.