### PR TITLE
feat(Mixins): let `transition-props()` emit `transition-behavior`

### DIFF
--- a/scss/mixins/_transition.scss
+++ b/scss/mixins/_transition.scss
@@ -1,28 +1,9 @@
-// stylelint-disable property-disallowed-list
 @use "sass:list";
 @use "../config" as *;
 
 $transition-base: all .2s ease-in-out !default;
 
-// Sets the `transition-*` properties one by one. In the shorthand a trailing
-// duration binds to the last property only, so `color, box-shadow .15s` leaves
-// `color` at `0s`. Set apart, one duration and easing cover every property.
-@mixin transition-props($property, $duration, $timing) {
-  @if $enable-transitions {
-    @if $enable-reduced-motion {
-      @media (prefers-reduced-motion: no-preference) {
-        transition-timing-function: $timing;
-        transition-duration: $duration;
-        transition-property: $property;
-      }
-    } @else {
-      transition-timing-function: $timing;
-      transition-duration: $duration;
-      transition-property: $property;
-    }
-  }
-}
-
+// stylelint-disable property-disallowed-list
 @mixin transition($transition...) {
   @if list.length($transition) == 0 {
     $transition: $transition-base;
@@ -40,7 +21,7 @@ $transition-base: all .2s ease-in-out !default;
     $first: list.nth($transition, 1);
 
     @if $first != null {
-      // `none` disables motion on purpose, so it must reach every reader. It
+      // `none` force-disables a transition, so it must reach every reader. It
       // arrives bare or as `none !important`, hence the list test.
       @if $enable-reduced-motion and not list.index($first, none) {
         @media (prefers-reduced-motion: no-preference) {
@@ -50,5 +31,37 @@ $transition-base: all .2s ease-in-out !default;
         transition: $transition;
       }
     }
+  }
+}
+
+// Set the `transition-*` properties one by one. In the shorthand a trailing
+// duration binds to the last property only, so `color, box-shadow .15s` leaves
+// `color` at `0s`. Set apart, one duration and easing cover every property.
+//
+// This also keeps the property list in a custom property. A single token then
+// adds a property to the animation, where the shorthand would need the whole
+// declaration again.
+//
+// Pass `$behavior: allow-discrete` for a list that animates a discrete
+// property, such as `display` or `content-visibility`.
+@mixin transition-props($property, $duration, $timing, $behavior: null) {
+  @if $enable-transitions {
+    @if $enable-reduced-motion {
+      @media (prefers-reduced-motion: no-preference) {
+        @include transition-longhands($property, $duration, $timing, $behavior);
+      }
+    } @else {
+      @include transition-longhands($property, $duration, $timing, $behavior);
+    }
+  }
+}
+
+@mixin transition-longhands($property, $duration, $timing, $behavior) {
+  transition-timing-function: $timing;
+  transition-duration: $duration;
+  transition-property: $property;
+
+  @if $behavior {
+    transition-behavior: $behavior;
   }
 }


### PR DESCRIPTION
`_transition.scss` is now **byte-identical to upstream's**. Nothing in the file was a CoreUI decision — no prefixed tokens, no bidi, no divergent naming — so there was nothing to preserve. The diff is the `$behavior` parameter, the `transition-longhands()` helper it delegates to, upstream's ordering of the two mixins and their comments.

## What it is for

`display`, `content-visibility` and `overlay` are **discrete** properties — they jump rather than animate, and only take part in a transition when `transition-behavior: allow-discrete` says so. That is what lets an element stay laid out until its fade-out finishes, instead of vanishing on frame one, and it is half of the `@starting-style` recipe for animating something in from `display: none`.

We already do this in five places — `_menu.scss`, `_popup.scss`, `_toasts.scss`, `_accordion.scss` and `_transitions.scss` — but all of them through the `transition` shorthand, because the longhand mixin could not emit the declaration:

```scss
@include transition(
  opacity var(--cui-menu-transition-duration) var(--cui-menu-transition-timing),
  transform var(--cui-menu-transition-duration) var(--cui-menu-transition-timing),
  display var(--cui-menu-transition-duration) allow-discrete
);
```

The real cost is what the shorthand gives up. The longhand form keeps the property list in a custom property, so a consumer adds a property to the animation by extending one token; with the shorthand they have to restate the whole declaration. `_accordion.scss` already has the token shape (`--cui-accordion-transition-property`) and uses the longhand; menu, popup and toast do not.

## Scope

**Compiled CSS is unchanged** — I diffed `coreui.css` before and after and it is empty. No caller passes `$behavior` yet, which means this adds an unused parameter, the same shape I flagged on `$backdrop-blur` in #827.

Cashing it in is the follow-up: give menu, popup and toast a `--cui-*-transition-property` token and switch those three to `transition-props(…, allow-discrete)`. Five call sites, three new public tokens, a docs entry each. Say the word and I will do it as its own PR — I did not fold it in here because it changes the components' token surface, not just a mixin.

`css-lint` (stylelint with `--report-needless-disables`, plus fusv) clean.