### PR TITLE
feat(Utilities API): validate the keys of a `$utilities` entry

### DIFF
--- a/docs/src/content/docs/utilities/api.mdx
+++ b/docs/src/content/docs/utilities/api.mdx
@@ -18,6 +18,9 @@ The `$utilities` map contains all our utilities and is later merged with your cu
 | [`responsive`](#responsive) | Optional | `false` | Boolean indicating if responsive classes should be generated. |
 | [`print`](#print) | Optional | `false` | Boolean indicating if print classes need to be generated. |
 | `at-property` | Optional | `true` | Set to `false` to keep the utility's custom properties inheriting (see [property map](#property-map)). |
+| [`enabled`](#remove-utilities) | Optional | `true` | Set to `false` to skip the utility without removing its definition. |
+
+Every key is checked while the utility is generated: `property` and `values` are required, a boolean option given a non-boolean errors, and a key outside this table is reported as a warning rather than ignored — a misspelled `responsiv` used to cost you the responsive classes with nothing said about it.
 
 ## API explained
 
@@ -603,6 +606,17 @@ Remove any of the default utilities with the [`map-remove()` Sass function](http
 $utilities: map-remove($utilities, "width", "float");
 
 @import "@coreui/coreui/scss/utilities/api";
+```
+
+To switch one off while keeping its definition around — so you can read it, or turn it back on later — set `enabled: false` instead:
+
+```scss
+$utilities: map-merge(
+  $utilities,
+  (
+    "width": map-merge(map-get($utilities, "width"), (enabled: false))
+  )
+);
 ```
 
 You can also use the [`map-merge()` Sass function](https://sass-lang.com/documentation/modules/map/#merge) and set the group key to `null` to remove the utility.

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -334,26 +334,22 @@ $utilities: map.merge(
     "border-top-color": (
       property: border-top-color,
       class: border-top,
-      values: map.merge(map-slot($theme-colors, "base"), ("white": var(--#{$prefix}white))),
-      vars: true
+      values: map.merge(map-slot($theme-colors, "base"), ("white": var(--#{$prefix}white)))
     ),
     "border-end-color": (
       property: border-inline-end-color,
       class: border-end,
-      values: map.merge(map-slot($theme-colors, "base"), ("white": var(--#{$prefix}white))),
-      vars: true,
+      values: map.merge(map-slot($theme-colors, "base"), ("white": var(--#{$prefix}white)))
     ),
     "border-bottom-color": (
       property: border-bottom-color,
       class: border-bottom,
-      values: map.merge(map-slot($theme-colors, "base"), ("white": var(--#{$prefix}white))),
-      vars: true
+      values: map.merge(map-slot($theme-colors, "base"), ("white": var(--#{$prefix}white)))
     ),
     "border-start-color": (
       property: border-inline-start-color,
       class: border-start,
-      values: map.merge(map-slot($theme-colors, "base"), ("white": var(--#{$prefix}white))),
-      vars: true,
+      values: map.merge(map-slot($theme-colors, "base"), ("white": var(--#{$prefix}white)))
     ),
     "border-width": (
       property: border-width,

--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -36,7 +36,7 @@
   $names: ();
 
   @each $key, $utility in $utilities {
-    @if meta.type-of($utility) == "map" and map.get($utility, at-property) != false {
+    @if meta.type-of($utility) == "map" and map.get($utility, enabled) != false and map.get($utility, at-property) != false {
       $properties: map.get($utility, property);
 
       @if meta.type-of($properties) == "map" {
@@ -93,6 +93,33 @@
 // Utility generator
 // Used to generate utilities & print utilities
 @mixin generate-utility($utility, $infix: "") {
+  // Every key `$utilities` understands. A key outside this list is read by
+  // nothing, so it fails silently — which is how `vars: true` sat on four
+  // border utilities across two majors doing nothing at all.
+  $utility-keys: at-property, child-selector, class, enabled, print, property, responsive, selector, state, values;
+
+  // Named by its `class` where it has one — a map interpolates as "isn't a
+  // valid CSS value", which says nothing about which utility is at fault.
+  @if not map.has-key($utility, property) {
+    @error "Utility `#{map.get($utility, class)}` is missing the required `property` key; keys present: #{map.keys($utility)}.";
+  }
+
+  @if not map.has-key($utility, values) {
+    @error "Utility `#{map.get($utility, class)}` is missing the required `values` key; keys present: #{map.keys($utility)}.";
+  }
+
+  @each $key in map.keys($utility) {
+    @if not list.index($utility-keys, $key) {
+      @warn "Unknown utility key `#{$key}`. Valid keys are: #{$utility-keys}.";
+    }
+  }
+
+  @each $flag in (at-property, enabled, print, responsive) {
+    @if map.has-key($utility, $flag) and meta.type-of(map.get($utility, $flag)) != "bool" {
+      @error "Utility key `#{$flag}` takes a boolean, got `#{map.get($utility, $flag)}`.";
+    }
+  }
+
   $values: map.get($utility, values);
 
   // If the values are a list or string, convert it into a map

--- a/scss/utilities/_api.scss
+++ b/scss/utilities/_api.scss
@@ -6,6 +6,8 @@
 @use "../mixins/utilities" as *;
 @use "../config" as *;
 
+// Outside the cascade layer on purpose: `@property` registration is global and
+// layers do not apply to it.
 @include generate-utility-at-properties($utilities);
 
 @layer utilities {
@@ -18,9 +20,10 @@
 
       // Loop over each utility property
       @each $key, $utility in $utilities {
-        // The utility can be disabled with `false`, thus check if the utility is a map first
+        // The utility can be disabled by replacing it with `false` or by setting
+        // `enabled: false`, thus check if the utility is a map first.
         // Only proceed if responsive media queries are enabled or if it's the base media query
-        @if meta.type-of($utility) == "map" and (map.get($utility, responsive) or $infix == "") {
+        @if meta.type-of($utility) == "map" and map.get($utility, enabled) != false and (map.get($utility, responsive) or $infix == "") {
           @include generate-utility($utility, $infix);
         }
       }
@@ -53,7 +56,7 @@
     @each $key, $utility in $utilities {
       // The utility can be disabled with `false`, thus check if the utility is a map first
       // Then check if the utility needs print styles
-      @if meta.type-of($utility) == "map" and map.get($utility, print) == true {
+      @if meta.type-of($utility) == "map" and map.get($utility, enabled) != false and map.get($utility, print) == true {
         @include generate-utility($utility, "-print");
       }
     }


### PR DESCRIPTION
From the `utilities/_api.scss` comparison. The plan already listed this as worth taking (`plans/scss-token-architecture.md`: *"Possibly worth taking: upstream's key validation… which helps anyone extending `$utilities`"*).

## It found a real one immediately

`vars: true` sits on the four directional border-colour utilities — `border-top-color`, `border-end-color`, `border-bottom-color`, `border-start-color`. **Nothing reads it.** Not in v6, and not in v5 either, where the generator reads `local-vars`, never `vars`. It has been inert across two majors, and the only reason it surfaced now is that I wrote the check.

That is the whole argument: an unknown key is not rejected, it is *ignored*. A misspelled `responsiv` silently costs you every responsive class of that utility.

## What is checked

`generate-utility()` now validates, before it reads anything:

- `@error` on a missing `property` or `values`
- `@warn` on a key outside the supported set
- `@error` when `at-property`, `enabled`, `print` or `responsive` is given a non-boolean

Verified by compiling deliberately broken utilities:

```
WARNING: Unknown utility key `responsiv`. Valid keys are: at-property, child-selector,
         class, enabled, print, property, responsive, selector, state, values.
Error: "Utility `op` is missing the required `property` key; keys present: class, values."
Error: "Utility key `responsive` takes a boolean, got `yes`."
```

The first message is why the error names the utility by its `class`: interpolating the map itself gives `Error: (class: op, values: (0: 0)) isn't a valid CSS value`, which tells you nothing about which entry is broken. Upstream interpolates the map and has that problem.

Our key list is **not** upstream's — the APIs diverged. Ours adds `at-property` (the `@property` registration from #635/#636); theirs has `variables`, `important` and `dark`, which we express differently, globally, and deliberately not at all.

## `enabled: false`

Skips a utility without deleting its definition — clearer than replacing the entry with a non-map, and the definition stays there to switch back on. Honoured by the responsive loop, the print loop and the `@property` registration.

Proved end to end by setting it on `"opacity"` and compiling: `.opacity-50` drops to **0** occurrences, `.d-none` is untouched, and reverting brings it back.

## Scope

**Compiled CSS is byte-identical** — diffed against `v6-dev`, empty. Removing the four dead `vars` keys changes nothing, which is the proof they were dead.

Docs: the options table gains `enabled` and a line about the validation, and "Remove utilities" shows the `enabled: false` form.

Gates: `css-lint` (stylelint + fusv), `css-test-class-api` ("Class API check passed"), `docs-build` (147 pages, no broken links), bundlewatch. All five entry points — `coreui`, `coreui-grid`, `coreui-reboot`, `coreui-utilities` and the Bootstrap theme — compile with no warnings, i.e. our own `$utilities` map is clean under the new rules.