### PR TITLE
chore(Stylelint): stop disallowing `calc()`

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -126,7 +126,7 @@ $accordion-tokens: defaults(
     }
 
     &:not(:first-of-type) {
-      margin-block-start: calc(-1 * var(--#{$prefix}accordion-border-width)); // stylelint-disable-line function-disallowed-list
+      margin-block-start: calc(-1 * var(--#{$prefix}accordion-border-width));
     }
 
     &:last-of-type {
@@ -152,7 +152,7 @@ $accordion-tokens: defaults(
       > .accordion-header {
         color: var(--#{$prefix}accordion-active-color);
         background-color: var(--#{$prefix}accordion-active-bg);
-        box-shadow: inset 0 calc(-1 * var(--#{$prefix}accordion-border-width)) 0 var(--#{$prefix}accordion-active-border-color); // stylelint-disable-line function-disallowed-list
+        box-shadow: inset 0 calc(-1 * var(--#{$prefix}accordion-border-width)) 0 var(--#{$prefix}accordion-active-border-color);
 
         &::after {
           mask-image: var(--#{$prefix}accordion-btn-active-icon);

--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -73,7 +73,7 @@ $avatar-variants: (
     height: var(--#{$prefix}avatar-size);
     // Declared as a fallback rather than a token, so the derived size is the
     // default and an explicit one still wins.
-    font-size: var(--#{$prefix}avatar-font-size, calc(var(--#{$prefix}avatar-size) * #{$avatar-font-size-ratio})); // stylelint-disable-line function-disallowed-list
+    font-size: var(--#{$prefix}avatar-font-size, calc(var(--#{$prefix}avatar-size) * #{$avatar-font-size-ratio}));
     color: var(--#{$prefix}avatar-color);
     vertical-align: middle;
     background-color: var(--#{$prefix}avatar-bg);
@@ -123,7 +123,7 @@ $avatar-variants: (
     display: flex;
 
     .avatar {
-      margin-inline-end: calc(-.4 * var(--#{$prefix}avatar-size)); // stylelint-disable-line function-disallowed-list
+      margin-inline-end: calc(-.4 * var(--#{$prefix}avatar-size));
 
       // Lifted rather than pulled apart: changing the margin here moves every
       // avatar after this one.

--- a/scss/_calendar.scss
+++ b/scss/_calendar.scss
@@ -115,7 +115,7 @@ $calendar-tokens: defaults(
     font-weight: initial;
 
     table {
-      width: calc(var(--#{$prefix}calendar-table-cell-size) * 7); // stylelint-disable-line function-disallowed-list
+      width: calc(var(--#{$prefix}calendar-table-cell-size) * 7);
       margin: var(--#{$prefix}calendar-table-margin);
 
       th,
@@ -137,7 +137,7 @@ $calendar-tokens: defaults(
   }
 
   .show-week-numbers table {
-    width: calc(var(--#{$prefix}calendar-table-cell-size) * 8); // stylelint-disable-line function-disallowed-list
+    width: calc(var(--#{$prefix}calendar-table-cell-size) * 8);
   }
 
   .calendars {

--- a/scss/_callout.scss
+++ b/scss/_callout.scss
@@ -12,7 +12,7 @@ $callout-margin-x:                  0 !default;
 $callout-border-radius:             var(--#{$prefix}border-radius) !default;
 $callout-border-width:              var(--#{$prefix}border-width) !default;
 $callout-border-color:              var(--#{$prefix}border-color) !default;
-$callout-border-left-width:         calc(#{$callout-border-width} * 4) !default; // stylelint-disable-line function-disallowed-list
+$callout-border-left-width:         calc(#{$callout-border-width} * 4) !default;
 
 $callout-variants: (
   "primary":    var(--#{$prefix}primary),

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -8,15 +8,15 @@
 // scss-docs-start card-variables
 $card-spacer-y:                     var(--#{$prefix}spacer-3) !default;
 $card-spacer-x:                     var(--#{$prefix}spacer-3) !default;
-$card-body-gap:                     calc(#{$card-spacer-y} * .5) !default; // stylelint-disable-line function-disallowed-list
+$card-body-gap:                     calc(#{$card-spacer-y} * .5) !default;
 $card-title-color:                  inherit !default;
 $card-subtitle-color:               inherit !default;
 $card-border-width:                 var(--#{$prefix}border-width) !default;
 $card-border-color:                 var(--#{$prefix}border-color-translucent) !default;
 $card-border-radius:                var(--#{$prefix}border-radius) !default;
 $card-box-shadow:                   none !default;
-$card-inner-border-radius:          calc(#{$card-border-radius} - #{$card-border-width}) !default; // stylelint-disable-line function-disallowed-list
-$card-cap-padding-y:                calc(#{$card-spacer-y} * .5) !default; // stylelint-disable-line function-disallowed-list
+$card-inner-border-radius:          calc(#{$card-border-radius} - #{$card-border-width}) !default;
+$card-cap-padding-y:                calc(#{$card-spacer-y} * .5) !default;
 $card-cap-padding-x:                $card-spacer-x !default;
 $card-cap-bg:                       color-mix(in srgb, var(--#{$prefix}body-color) 3%, transparent) !default;
 $card-cap-color:                    inherit !default;
@@ -138,7 +138,7 @@ $card-tokens: defaults(
   }
 
   .card-subtitle {
-    margin-block-start: calc(-.5 * var(--#{$prefix}card-body-gap)); // stylelint-disable-line function-disallowed-list
+    margin-block-start: calc(-.5 * var(--#{$prefix}card-body-gap));
     color: var(--#{$prefix}card-subtitle-color);
   }
 
@@ -197,8 +197,8 @@ $card-tokens: defaults(
   //
 
   .card-header-tabs {
-    margin-inline: calc(-.5 * var(--#{$prefix}card-cap-padding-x)); // stylelint-disable-line function-disallowed-list
-    margin-bottom: calc(-1 * var(--#{$prefix}card-cap-padding-y)); // stylelint-disable-line function-disallowed-list
+    margin-inline: calc(-.5 * var(--#{$prefix}card-cap-padding-x));
+    margin-bottom: calc(-1 * var(--#{$prefix}card-cap-padding-y));
     border-bottom: 0;
 
     .nav-link.active {

--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -8,7 +8,6 @@
 @use "theme" as *;
 @use "config" as *;
 
-// stylelint-disable function-disallowed-list
 
 // scss-docs-start chip-variables
 $chip-font-size:             .875rem !default;

--- a/scss/_combobox.scss
+++ b/scss/_combobox.scss
@@ -232,7 +232,7 @@ $combobox-tokens: defaults(
   .combobox-option-with-checkbox,
   .combobox-optgroup-label-with-checkbox {
     position: relative;
-    padding-inline-start: calc(var(--#{$prefix}combobox-option-padding-x) + var(--#{$prefix}combobox-option-indicator-width)); // stylelint-disable-line function-disallowed-list
+    padding-inline-start: calc(var(--#{$prefix}combobox-option-padding-x) + var(--#{$prefix}combobox-option-indicator-width));
   }
 
   // The indicator is a decorative `.check` (a span, so it never matches
@@ -240,7 +240,7 @@ $combobox-tokens: defaults(
   // the mark's opacity is set here rather than by the control's own state rules.
   .combobox-option-indicator {
     position: absolute;
-    inset-inline-start: calc(var(--#{$prefix}combobox-option-padding-x) * .5); // stylelint-disable-line function-disallowed-list
+    inset-inline-start: calc(var(--#{$prefix}combobox-option-padding-x) * .5);
     top: 50%;
     width: var(--#{$prefix}combobox-option-indicator-width);
     height: var(--#{$prefix}combobox-option-indicator-width);

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -130,7 +130,6 @@ $border-radius-pill:          50rem !default;
 // `--#{$prefix}shadow-tint` and `--#{$prefix}shadow-opacity` are written by the
 // `.shadow-{color}` and `.shadow-opacity-*` utilities and registered as
 // non-inheriting, so neither leaks into a nested `.shadow-*`.
-// stylelint-disable function-disallowed-list
 
 // scss-docs-start box-shadow-variables
 
@@ -142,7 +141,6 @@ $shadows: (
 ) !default;
 // scss-docs-end box-shadow-variables
 
-// stylelint-enable function-disallowed-list
 
 // Font, line-height, and color for body text, headings, and more.
 
@@ -153,8 +151,8 @@ $font-family-base:            var(--#{$prefix}font-sans-serif) !default;
 // $font-size-base affects the font size of the body text
 $font-size-root:              null !default;
 $font-size-base:              1rem !default; // Assumes the browser default, typically `16px`
-$font-size-sm:                calc(var(--#{$prefix}body-font-size) * .875) !default; // stylelint-disable-line function-disallowed-list
-$font-size-lg:                calc(var(--#{$prefix}body-font-size) * 1.25) !default; // stylelint-disable-line function-disallowed-list
+$font-size-sm:                calc(var(--#{$prefix}body-font-size) * .875) !default;
+$font-size-lg:                calc(var(--#{$prefix}body-font-size) * 1.25) !default;
 
 $font-weight-lighter:         lighter !default;
 $font-weight-light:           300 !default;
@@ -204,7 +202,7 @@ $headings-color:              inherit !default;
 
 // scss-docs-start font-sizes
 $font-sizes: (
-  "xs":  ("font-size": calc(var(--#{$prefix}body-font-size) * .75), "line-height": var(--#{$prefix}body-line-height)), // stylelint-disable-line function-disallowed-list
+  "xs":  ("font-size": calc(var(--#{$prefix}body-font-size) * .75), "line-height": var(--#{$prefix}body-line-height)),
   "sm":  ("font-size": $font-size-sm,         "line-height": var(--#{$prefix}body-line-height)),
   "md":  ("font-size": $h6-font-size,         "line-height": var(--#{$prefix}body-line-height)),
   "lg":  ("font-size": $h5-font-size,         "line-height": $headings-line-height),

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -7,7 +7,7 @@
 @use "mixins/transition" as *;
 @use "config" as *;
 
-// stylelint-disable custom-property-no-missing-var-function, function-disallowed-list
+// stylelint-disable custom-property-no-missing-var-function
 
 // scss-docs-start dialog-variables
 $dialog-padding:                    var(--#{$prefix}spacer-3) !default;

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -8,7 +8,7 @@
 @use "mixins/transition" as *;
 @use "config" as *;
 
-// stylelint-disable custom-property-no-missing-var-function, function-disallowed-list
+// stylelint-disable custom-property-no-missing-var-function
 
 // scss-docs-start drawer-variables
 $drawer-inset:                      var(--#{$prefix}spacer-3) !default;

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -19,7 +19,7 @@ $dropdown-bg:                       var(--#{$prefix}body-bg) !default;
 $dropdown-border-color:             var(--#{$prefix}border-color-translucent) !default;
 $dropdown-border-radius:            var(--#{$prefix}border-radius) !default;
 $dropdown-border-width:             var(--#{$prefix}border-width) !default;
-$dropdown-inner-border-radius:      calc(#{$dropdown-border-radius} - #{$dropdown-border-width}) !default; // stylelint-disable-line function-disallowed-list
+$dropdown-inner-border-radius:      calc(#{$dropdown-border-radius} - #{$dropdown-border-width}) !default;
 $dropdown-divider-bg:               $dropdown-border-color !default;
 $dropdown-divider-margin-y:         var(--#{$prefix}spacer-2) !default;
 $dropdown-box-shadow:               var(--#{$prefix}box-shadow) !default;

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -27,8 +27,8 @@ $header-disabled-color:         color-mix(in srgb, var(--#{$prefix}emphasis-colo
 $header-transition:             box-shadow .15s ease-in-out !default;
 
 // Compute the header-brand padding-y so the header-brand will have the same height as header-text and nav-link
-$header-brand-height:           calc(#{$header-brand-font-size} * var(--#{$prefix}body-line-height)) !default; // stylelint-disable-line function-disallowed-list
-$header-brand-padding-y:        calc((#{$nav-link-height} - #{$header-brand-height}) * .5) !default; // stylelint-disable-line function-disallowed-list
+$header-brand-height:           calc(#{$header-brand-font-size} * var(--#{$prefix}body-line-height)) !default;
+$header-brand-padding-y:        calc((#{$nav-link-height} - #{$header-brand-height}) * .5) !default;
 $header-brand-margin-end:       1rem !default;
 $header-brand-font-size:        var(--#{$prefix}font-size-lg) !default;
 $header-brand-color:            var(--#{$prefix}gray-900) !default;
@@ -131,9 +131,9 @@ $header-tokens: defaults(
   }
 
   .header-divider {
-    flex-basis: calc(100% + (2 * var(--#{$prefix}header-padding-x))); // stylelint-disable-line function-disallowed-list
+    flex-basis: calc(100% + (2 * var(--#{$prefix}header-padding-x)));
     height: 0;
-    margin: var(--#{$prefix}header-padding-y) calc(-1 * var(--#{$prefix}header-padding-x)); // stylelint-disable-line function-disallowed-list
+    margin: var(--#{$prefix}header-padding-y) calc(-1 * var(--#{$prefix}header-padding-x));
     border-top: var(--#{$prefix}header-divider-border);
   }
 
@@ -238,7 +238,7 @@ $header-tokens: defaults(
 
   .header-toggler-icon {
     display: block;
-    height: calc(#{$header-toggler-font-size} * 1.25); // stylelint-disable-line function-disallowed-list
+    height: calc(#{$header-toggler-font-size} * 1.25);
     background-color: currentcolor;
     @include mask-icon(var(--#{$prefix}header-toggler-icon-bg), 100% 100%);
   }

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -1,10 +1,10 @@
 @use "mixins/icon" as *;
 @use "config" as *;
 
-$icon-size-sm:    calc(var(--#{$prefix}icon-size-base) * .875) !default; // stylelint-disable-line function-disallowed-list
-$icon-size-lg:    calc(var(--#{$prefix}icon-size-base) * 1.25) !default; // stylelint-disable-line function-disallowed-list
-$icon-size-xl:    calc(var(--#{$prefix}icon-size-base) * 1.5) !default; // stylelint-disable-line function-disallowed-list
-$icon-size-xxl:   calc(var(--#{$prefix}icon-size-base) * 2) !default; // stylelint-disable-line function-disallowed-list
+$icon-size-sm:    calc(var(--#{$prefix}icon-size-base) * .875) !default;
+$icon-size-lg:    calc(var(--#{$prefix}icon-size-base) * 1.25) !default;
+$icon-size-xl:    calc(var(--#{$prefix}icon-size-base) * 1.5) !default;
+$icon-size-xxl:   calc(var(--#{$prefix}icon-size-base) * 2) !default;
 
 
 @layer components {

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -129,7 +129,7 @@ $list-group-tokens: defaults(
       border-top-width: 0;
 
       &.active {
-        margin-top: calc(-1 * var(--#{$prefix}list-group-border-width)); // stylelint-disable-line function-disallowed-list
+        margin-top: calc(-1 * var(--#{$prefix}list-group-border-width));
         border-top-width: var(--#{$prefix}list-group-border-width);
       }
     }
@@ -196,7 +196,7 @@ $list-group-tokens: defaults(
             border-top-width: var(--#{$prefix}list-group-border-width);
 
             &.active {
-              margin-inline-start: calc(-1 * var(--#{$prefix}list-group-border-width)); // stylelint-disable-line function-disallowed-list
+              margin-inline-start: calc(-1 * var(--#{$prefix}list-group-border-width));
               border-inline-start-width: var(--#{$prefix}list-group-border-width);
             }
           }

--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -38,7 +38,7 @@ $menu-item-padding-x:           .75rem !default;
 $menu-item-padding-y:           .25rem !default;
 $menu-item-border-radius:       $border-radius-sm !default;
 $menu-icon-size:                1rem !default;
-$menu-description-font-size:    calc(var(--#{$prefix}body-font-size) * .75) !default; // stylelint-disable-line function-disallowed-list
+$menu-description-font-size:    calc(var(--#{$prefix}body-font-size) * .75) !default;
 $menu-check-color:              currentcolor !default;
 $menu-header-color:             var(--#{$prefix}tertiary-color) !default;
 $menu-header-padding-x:         .75rem !default;
@@ -298,7 +298,7 @@ $menu-tokens: defaults(
 
     > .menu {
       top: 0;
-      margin-top: calc(-1 * var(--#{$prefix}menu-padding-y)); // stylelint-disable-line function-disallowed-list
+      margin-top: calc(-1 * var(--#{$prefix}menu-padding-y));
     }
 
     &:hover > .menu-item,

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -7,7 +7,7 @@
 @use "mixins/transition" as *;
 @use "config" as *;
 
-// stylelint-disable custom-property-no-missing-var-function, function-disallowed-list
+// stylelint-disable custom-property-no-missing-var-function
 
 // scss-docs-start modal-variables
 $modal-inner-padding:               var(--#{$prefix}spacer-3) !default;

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -206,7 +206,7 @@ $nav-underline-border-tokens: defaults(
     border-bottom: var(--#{$prefix}nav-tabs-border-width) solid var(--#{$prefix}nav-tabs-border-color);
 
     .nav-link {
-      margin-bottom: calc(-1 * var(--#{$prefix}nav-tabs-border-width)); // stylelint-disable-line function-disallowed-list
+      margin-bottom: calc(-1 * var(--#{$prefix}nav-tabs-border-width));
       border: var(--#{$prefix}nav-tabs-border-width) solid transparent;
       @include border-top-radius(var(--#{$prefix}nav-tabs-border-radius));
 
@@ -227,7 +227,7 @@ $nav-underline-border-tokens: defaults(
 
     .dropdown-menu {
       // Make dropdown border overlap tab border
-      margin-top: calc(-1 * var(--#{$prefix}nav-tabs-border-width)); // stylelint-disable-line function-disallowed-list
+      margin-top: calc(-1 * var(--#{$prefix}nav-tabs-border-width));
       // Remove the top rounded corners here since there is a hard edge above the menu
       @include border-top-radius(0);
     }
@@ -293,7 +293,7 @@ $nav-underline-border-tokens: defaults(
 
     .nav-link {
       padding: var(--#{$prefix}nav-underline-border-link-padding-y) var(--#{$prefix}nav-underline-border-link-padding-x);
-      margin-bottom: calc(-1 * var(--#{$prefix}nav-underline-border-border-width)); // stylelint-disable-line function-disallowed-list
+      margin-bottom: calc(-1 * var(--#{$prefix}nav-underline-border-border-width));
       border-bottom: var(--#{$prefix}nav-underline-border-border-width) solid transparent;
 
       &:hover,
@@ -331,7 +331,7 @@ $nav-underline-border-tokens: defaults(
     @include border-radius(var(--#{$prefix}nav-enclosed-border-radius));
 
     .nav-link {
-      padding: calc(var(--#{$prefix}nav-enclosed-link-padding-y) - var(--#{$prefix}nav-enclosed-link-border-width)) calc(var(--#{$prefix}nav-enclosed-link-padding-x) - var(--#{$prefix}nav-enclosed-link-border-width)); // stylelint-disable-line function-disallowed-list
+      padding: calc(var(--#{$prefix}nav-enclosed-link-padding-y) - var(--#{$prefix}nav-enclosed-link-border-width)) calc(var(--#{$prefix}nav-enclosed-link-padding-x) - var(--#{$prefix}nav-enclosed-link-border-width));
       color: var(--#{$prefix}nav-enclosed-link-color);
       border: var(--#{$prefix}nav-enclosed-link-border-width) solid transparent;
       @include border-radius(calc(var(--#{$prefix}nav-enclosed-border-radius) - var(--#{$prefix}nav-enclosed-padding)));

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -24,9 +24,9 @@ $navbar-nav-link-padding-x:         .5rem !default;
 
 $navbar-brand-font-size:            var(--#{$prefix}font-size-lg) !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
-$nav-link-height:                   calc(var(--#{$prefix}body-font-size) * var(--#{$prefix}body-line-height) + #{$nav-link-padding-y} * 2) !default; // stylelint-disable-line function-disallowed-list
-$navbar-brand-height:               calc(#{$navbar-brand-font-size} * var(--#{$prefix}body-line-height)) !default; // stylelint-disable-line function-disallowed-list
-$navbar-brand-padding-y:            calc((#{$nav-link-height} - #{$navbar-brand-height}) * .5) !default; // stylelint-disable-line function-disallowed-list
+$nav-link-height:                   calc(var(--#{$prefix}body-font-size) * var(--#{$prefix}body-line-height) + #{$nav-link-padding-y} * 2) !default;
+$navbar-brand-height:               calc(#{$navbar-brand-font-size} * var(--#{$prefix}body-line-height)) !default;
+$navbar-brand-padding-y:            calc((#{$nav-link-height} - #{$navbar-brand-height}) * .5) !default;
 $navbar-brand-margin-end:           1rem !default;
 
 $navbar-toggler-padding-y:          .25rem !default;

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -8,7 +8,7 @@
 @use "modal" as *;
 @use "config" as *;
 
-// stylelint-disable custom-property-no-missing-var-function, function-disallowed-list
+// stylelint-disable custom-property-no-missing-var-function
 
 // scss-docs-start offcanvas-variables
 $offcanvas-padding-y:               $modal-inner-padding !default;

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -22,7 +22,7 @@ $pagination-color:                  var(--#{$prefix}link-color) !default;
 $pagination-bg:                     var(--#{$prefix}body-bg) !default;
 $pagination-border-radius:          var(--#{$prefix}border-radius) !default;
 $pagination-border-width:           var(--#{$prefix}border-width) !default;
-$pagination-margin-start:           calc(-1 * #{$pagination-border-width}) !default; // stylelint-disable-line function-disallowed-list
+$pagination-margin-start:           calc(-1 * #{$pagination-border-width}) !default;
 $pagination-border-color:           var(--#{$prefix}border-color) !default;
 
 $pagination-focus-color:            var(--#{$prefix}link-hover-color) !default;

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -12,7 +12,7 @@ $popover-max-width:                 276px !default;
 $popover-border-width:              var(--#{$prefix}border-width) !default;
 $popover-border-color:              var(--#{$prefix}border-color-translucent) !default;
 $popover-border-radius:             var(--#{$prefix}border-radius-lg) !default;
-$popover-inner-border-radius:       calc(#{$popover-border-radius} - #{$popover-border-width}) !default; // stylelint-disable-line function-disallowed-list
+$popover-inner-border-radius:       calc(#{$popover-border-radius} - #{$popover-border-width}) !default;
 $popover-box-shadow:                var(--#{$prefix}box-shadow) !default;
 
 $popover-header-font-size:          var(--#{$prefix}body-font-size) !default;
@@ -106,11 +106,11 @@ $popover-tokens: defaults(
 
   .bs-popover-top {
     > .popover-arrow {
-      bottom: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+      bottom: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width));
 
       &::before,
       &::after {
-        border-width: var(--#{$prefix}popover-arrow-height) calc(var(--#{$prefix}popover-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
+        border-width: var(--#{$prefix}popover-arrow-height) calc(var(--#{$prefix}popover-arrow-width) * .5) 0;
       }
 
       &::before {
@@ -128,13 +128,13 @@ $popover-tokens: defaults(
   /* rtl:begin:ignore */
   .bs-popover-end {
     > .popover-arrow {
-      left: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+      left: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width));
       width: var(--#{$prefix}popover-arrow-height);
       height: var(--#{$prefix}popover-arrow-width);
 
       &::before,
       &::after {
-        border-width: calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height) calc(var(--#{$prefix}popover-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
+        border-width: calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height) calc(var(--#{$prefix}popover-arrow-width) * .5) 0;
       }
 
       &::before {
@@ -153,11 +153,11 @@ $popover-tokens: defaults(
 
   .bs-popover-bottom {
     > .popover-arrow {
-      top: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+      top: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width));
 
       &::before,
       &::after {
-        border-width: 0 calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height); // stylelint-disable-line function-disallowed-list
+        border-width: 0 calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height);
       }
 
       &::before {
@@ -178,7 +178,7 @@ $popover-tokens: defaults(
       left: 50%;
       display: block;
       width: var(--#{$prefix}popover-arrow-width);
-      margin-left: calc(-.5 * var(--#{$prefix}popover-arrow-width)); // stylelint-disable-line function-disallowed-list
+      margin-left: calc(-.5 * var(--#{$prefix}popover-arrow-width));
       content: "";
       border-bottom: var(--#{$prefix}popover-border-width) solid var(--#{$prefix}popover-header-bg);
     }
@@ -187,13 +187,13 @@ $popover-tokens: defaults(
   /* rtl:begin:ignore */
   .bs-popover-start {
     > .popover-arrow {
-      right: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+      right: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width));
       width: var(--#{$prefix}popover-arrow-height);
       height: var(--#{$prefix}popover-arrow-width);
 
       &::before,
       &::after {
-        border-width: calc(var(--#{$prefix}popover-arrow-width) * .5) 0 calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height); // stylelint-disable-line function-disallowed-list
+        border-width: calc(var(--#{$prefix}popover-arrow-width) * .5) 0 calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height);
       }
 
       &::before {

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -8,7 +8,7 @@
 
 // scss-docs-start progress-variables
 $progress-height:                   1rem !default;
-$progress-font-size:                calc(var(--#{$prefix}body-font-size) * .75) !default; // stylelint-disable-line function-disallowed-list
+$progress-font-size:                calc(var(--#{$prefix}body-font-size) * .75) !default;
 $progress-bg:                       var(--#{$prefix}secondary-bg) !default;
 $progress-border-radius:            var(--#{$prefix}border-radius) !default;
 $progress-box-shadow:               var(--#{$prefix}box-shadow-inset) !default;

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -272,7 +272,6 @@ $range-slider-vertical-tokens: defaults(
     // Deliberately outside `$prefix`: the plugin writes this name, so a
     // configurable one would let the two sides disagree.
     position: absolute;
-    // stylelint-disable-next-line function-disallowed-list
     inset-inline-start: calc(var(--#{$prefix}range-slider-thumb-width) * .5 + var(--cui-range-slider-tooltip-position, 0) * (100% - var(--#{$prefix}range-slider-thumb-width)));
     z-index: var(--#{$prefix}range-slider-tooltip-zindex);
     display: flex;
@@ -320,11 +319,11 @@ $range-slider-vertical-tokens: defaults(
     }
 
     .range-slider-labels-container {
-      width: calc(var(--#{$prefix}range-slider-track-width) - var(--#{$prefix}range-slider-thumb-width)); // stylelint-disable-line function-disallowed-list
+      width: calc(var(--#{$prefix}range-slider-track-width) - var(--#{$prefix}range-slider-thumb-width));
     }
 
     .range-slider-tooltip {
-      bottom: calc(var(--#{$prefix}range-slider-tooltip-margin-bottom) + var(--#{$prefix}range-slider-thumb-height)); // stylelint-disable-line function-disallowed-list
+      bottom: calc(var(--#{$prefix}range-slider-tooltip-margin-bottom) + var(--#{$prefix}range-slider-thumb-height));
     }
 
     .range-slider-tooltip-arrow {
@@ -332,7 +331,7 @@ $range-slider-vertical-tokens: defaults(
       height: var(--#{$prefix}range-slider-tooltip-arrow-height);
 
       &::before {
-        border-width: var(--#{$prefix}range-slider-tooltip-arrow-height) calc(var(--#{$prefix}range-slider-tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
+        border-width: var(--#{$prefix}range-slider-tooltip-arrow-height) calc(var(--#{$prefix}range-slider-tooltip-arrow-width) * .5) 0;
         border-top-color: var(--#{$prefix}range-slider-tooltip-bg);
       }
     }
@@ -365,8 +364,7 @@ $range-slider-vertical-tokens: defaults(
 
     .range-slider-tooltip {
       inset-inline-start: auto;
-      inset-inline-end: calc(var(--#{$prefix}range-slider-tooltip-margin-end) + var(--#{$prefix}range-slider-thumb-width)); // stylelint-disable-line function-disallowed-list
-      // stylelint-disable-next-line function-disallowed-list
+      inset-inline-end: calc(var(--#{$prefix}range-slider-tooltip-margin-end) + var(--#{$prefix}range-slider-thumb-width));
       bottom: calc(var(--#{$prefix}range-slider-thumb-height) * .5 + var(--cui-range-slider-tooltip-position, 0) * (100% - var(--#{$prefix}range-slider-thumb-height)));
       flex-direction: row;
       transform: translateY(50%);
@@ -378,15 +376,15 @@ $range-slider-vertical-tokens: defaults(
 
       &::before {
         border-inline-start-color: var(--#{$prefix}range-slider-tooltip-bg);
-        border-inline-width: calc(var(--#{$prefix}range-slider-tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
-        border-top-width: calc(var(--#{$prefix}range-slider-tooltip-arrow-width) * .5); // stylelint-disable-line function-disallowed-list
-        border-bottom-width: calc(var(--#{$prefix}range-slider-tooltip-arrow-width) * .5); // stylelint-disable-line function-disallowed-list
+        border-inline-width: calc(var(--#{$prefix}range-slider-tooltip-arrow-width) * .5) 0;
+        border-top-width: calc(var(--#{$prefix}range-slider-tooltip-arrow-width) * .5);
+        border-bottom-width: calc(var(--#{$prefix}range-slider-tooltip-arrow-width) * .5);
       }
     }
 
     .range-slider-labels-container {
       flex-shrink: 0;
-      height: calc(var(--#{$prefix}range-slider-vertical-track-height) - var(--#{$prefix}range-slider-thumb-height)); // stylelint-disable-line function-disallowed-list
+      height: calc(var(--#{$prefix}range-slider-vertical-track-height) - var(--#{$prefix}range-slider-thumb-height));
     }
 
     .range-slider-label {

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -283,28 +283,28 @@ $code-color: light-dark($pink, tint-color($pink, 40%)) !default;
     --#{$prefix}btn-input-focus-color: var(--#{$prefix}btn-input-color);
     --#{$prefix}btn-input-focus-bg: var(--#{$prefix}btn-input-bg);
     --#{$prefix}btn-input-focus-border-color: color-mix(in srgb, var(--#{$prefix}primary) 50%, var(--#{$prefix}white));
-    --#{$prefix}btn-input-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2); // stylelint-disable-line function-disallowed-list
+    --#{$prefix}btn-input-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2);
 
     --#{$prefix}btn-input-xs-gap: #{$input-btn-gap-xs};
     --#{$prefix}btn-input-xs-padding-y: #{$input-btn-padding-y-xs};
     --#{$prefix}btn-input-xs-padding-x: #{$input-btn-padding-x-xs};
     --#{$prefix}btn-input-xs-font-size: #{$input-btn-font-size-xs};
     --#{$prefix}btn-input-xs-border-radius: var(--#{$prefix}border-radius-sm);
-    --#{$prefix}btn-input-xs-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-xs-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2); // stylelint-disable-line function-disallowed-list
+    --#{$prefix}btn-input-xs-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-xs-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2);
 
     --#{$prefix}btn-input-sm-gap: #{$input-btn-gap-sm};
     --#{$prefix}btn-input-sm-padding-y: #{$input-btn-padding-y-sm};
     --#{$prefix}btn-input-sm-padding-x: #{$input-btn-padding-x-sm};
     --#{$prefix}btn-input-sm-font-size: #{$input-btn-font-size-sm};
     --#{$prefix}btn-input-sm-border-radius: var(--#{$prefix}border-radius-sm);
-    --#{$prefix}btn-input-sm-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-sm-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2); // stylelint-disable-line function-disallowed-list
+    --#{$prefix}btn-input-sm-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-sm-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2);
 
     --#{$prefix}btn-input-lg-gap: #{$input-btn-gap-lg};
     --#{$prefix}btn-input-lg-padding-y: #{$input-btn-padding-y-lg};
     --#{$prefix}btn-input-lg-padding-x: #{$input-btn-padding-x-lg};
     --#{$prefix}btn-input-lg-font-size: #{$input-btn-font-size-lg};
     --#{$prefix}btn-input-lg-border-radius: var(--#{$prefix}border-radius-lg);
-    --#{$prefix}btn-input-lg-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-lg-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2); // stylelint-disable-line function-disallowed-list
+    --#{$prefix}btn-input-lg-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-lg-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2);
     // scss-docs-end root-btn-input-variables
 
     // scss-docs-start root-control-variables

--- a/scss/_stepper.scss
+++ b/scss/_stepper.scss
@@ -130,9 +130,9 @@ $stepper-tokens: defaults(
 
       .stepper-step-connector {
         position: absolute;
-        inset-inline-start: calc((var(--#{$prefix}stepper-step-button-width) / 2) + (var(--#{$prefix}stepper-step-indicator-width) / 2) + var(--#{$prefix}stepper-steps-gap)); // stylelint-disable-line function-disallowed-list
-        top: calc(var(--#{$prefix}stepper-step-indicator-height) / 2); // stylelint-disable-line function-disallowed-list
-        width: calc(100% - var(--#{$prefix}stepper-step-indicator-width) + var(--#{$prefix}stepper-steps-gap) - (var(--#{$prefix}stepper-steps-gap) * 2)); // stylelint-disable-line function-disallowed-list
+        inset-inline-start: calc((var(--#{$prefix}stepper-step-button-width) / 2) + (var(--#{$prefix}stepper-step-indicator-width) / 2) + var(--#{$prefix}stepper-steps-gap));
+        top: calc(var(--#{$prefix}stepper-step-indicator-height) / 2);
+        width: calc(100% - var(--#{$prefix}stepper-step-indicator-width) + var(--#{$prefix}stepper-steps-gap) - (var(--#{$prefix}stepper-steps-gap) * 2));
         transform: translateY(-50%);
       }
     }
@@ -234,21 +234,21 @@ $stepper-tokens: defaults(
       position: relative;
       display: block;
       &:not(:last-child) {
-        min-height: calc(var(--#{$prefix}stepper-step-indicator-height) * 2); // stylelint-disable-line function-disallowed-list
+        min-height: calc(var(--#{$prefix}stepper-step-indicator-height) * 2);
       }
     }
 
     .stepper-step-connector {
       position: absolute;
-      inset-inline-start: calc(var(--#{$prefix}stepper-step-indicator-width) / 2); // stylelint-disable-line function-disallowed-list
-      top: calc(var(--#{$prefix}stepper-step-indicator-height) + var(--#{$prefix}stepper-steps-gap)); // stylelint-disable-line function-disallowed-list
+      inset-inline-start: calc(var(--#{$prefix}stepper-step-indicator-width) / 2);
+      top: calc(var(--#{$prefix}stepper-step-indicator-height) + var(--#{$prefix}stepper-steps-gap));
       width: var(--#{$prefix}stepper-step-connector-height);
-      height: calc(100% - var(--#{$prefix}stepper-step-indicator-height) - var(--#{$prefix}stepper-step-connector-gap)); // stylelint-disable-line function-disallowed-list
+      height: calc(100% - var(--#{$prefix}stepper-step-indicator-height) - var(--#{$prefix}stepper-step-connector-gap));
       transform: translateX(-50%);
     }
 
     .stepper-step-content {
-      padding-inline-start: calc(var(--#{$prefix}stepper-step-indicator-width) + var(--#{$prefix}stepper-step-connector-gap) / 2); // stylelint-disable-line function-disallowed-list
+      padding-inline-start: calc(var(--#{$prefix}stepper-step-indicator-width) + var(--#{$prefix}stepper-step-connector-gap) / 2);
       @include transition(var(--#{$prefix}stepper-step-content-transition));
     }
 

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -16,7 +16,6 @@ $dark:          $gray-900 !default;
 
 $link-color:    $primary !default;
 
-// stylelint-disable function-disallowed-list
 
 // scss-docs-start theme-colors-map
 $theme-colors: (
@@ -103,7 +102,6 @@ $theme-colors: (
 ) !default;
 // scss-docs-end theme-colors-map
 
-// stylelint-enable function-disallowed-list
 
 // Color scales
 //
@@ -204,7 +202,6 @@ $theme-lightness-overrides: (
 
   @each $token, $lightness in ("hover": $theme-hover-lightness, "active": $theme-active-lightness) {
     $shift: map.get($overrides, $token) or $lightness;
-    // stylelint-disable-next-line function-disallowed-list
     --#{$prefix}theme-#{$token}: oklch(from var(--#{$prefix}#{$state}) calc(l * #{$shift}) c h);
   }
 }

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -21,7 +21,7 @@ $time-picker-roll-cell-hover-bg:              var(--#{$prefix}tertiary-bg) !defa
 $time-picker-roll-cell-selected-color:        var(--#{$prefix}white) !default;
 $time-picker-roll-cell-selected-bg:           var(--#{$prefix}primary) !default;
 $time-picker-roll-cell-selected-hover-color:  var(--#{$prefix}white) !default;
-$time-picker-roll-cell-selected-hover-bg:     oklch(from var(--#{$prefix}primary) calc(l * .85) c h) !default; // stylelint-disable-line function-disallowed-list
+$time-picker-roll-cell-selected-hover-bg:     oklch(from var(--#{$prefix}primary) calc(l * .85) c h) !default;
 
 $time-picker-inline-select-font-size:       var(--#{$prefix}btn-input-sm-font-size) !default;
 $time-picker-inline-select-color:           var(--#{$prefix}btn-input-color) !default;
@@ -131,7 +131,7 @@ $time-picker-tokens: defaults(
   }
 
   .time-picker-roll-col {
-    height: calc(8 * var(--#{$prefix}time-picker-roll-cell-height)); // stylelint-disable-line
+    height: calc(8 * var(--#{$prefix}time-picker-roll-cell-height));
     overflow: scroll;
 
     -ms-overflow-style: none;  /* Internet Explorer 10+ */
@@ -177,7 +177,7 @@ $time-picker-tokens: defaults(
     }
 
     &:last-child {
-      margin-bottom: calc(7 * var(--#{$prefix}time-picker-roll-cell-height)); // stylelint-disable-line
+      margin-bottom: calc(7 * var(--#{$prefix}time-picker-roll-cell-height));
     }
   }
 

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -122,7 +122,7 @@ $toast-tokens: defaults(
     @include border-top-radius(calc(var(--#{$prefix}toast-border-radius) - var(--#{$prefix}toast-border-width)));
 
     .btn-close {
-      margin-inline: var(--#{$prefix}toast-padding-x) calc(-.5 * var(--#{$prefix}toast-padding-x)); // stylelint-disable-line function-disallowed-list
+      margin-inline: var(--#{$prefix}toast-padding-x) calc(-.5 * var(--#{$prefix}toast-padding-x));
     }
   }
 

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -52,7 +52,7 @@ $tooltip-tokens: defaults(
     // Fold `--#{$prefix}tooltip-opacity` into the surface colour instead of the
     // element: element-level opacity also faded the label text, compositing it
     // below the WCAG 1.4.3 contrast minimum.
-    --#{$prefix}tooltip-surface-bg: color-mix(in srgb, var(--#{$prefix}tooltip-bg) calc(var(--#{$prefix}tooltip-opacity) * 100%), transparent); // stylelint-disable-line function-disallowed-list
+    --#{$prefix}tooltip-surface-bg: color-mix(in srgb, var(--#{$prefix}tooltip-bg) calc(var(--#{$prefix}tooltip-opacity) * 100%), transparent);
 
     z-index: var(--#{$prefix}tooltip-zindex);
     display: block;
@@ -83,24 +83,24 @@ $tooltip-tokens: defaults(
   }
 
   .bs-tooltip-top .tooltip-arrow {
-    bottom: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
+    bottom: calc(-1 * var(--#{$prefix}tooltip-arrow-height));
 
     &::before {
       top: -1px;
-      border-width: var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
+      border-width: var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0;
       border-top-color: var(--#{$prefix}tooltip-surface-bg);
     }
   }
 
   /* rtl:begin:ignore */
   .bs-tooltip-end .tooltip-arrow {
-    left: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
+    left: calc(-1 * var(--#{$prefix}tooltip-arrow-height));
     width: var(--#{$prefix}tooltip-arrow-height);
     height: var(--#{$prefix}tooltip-arrow-width);
 
     &::before {
       right: -1px;
-      border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
+      border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0;
       border-right-color: var(--#{$prefix}tooltip-surface-bg);
     }
   }
@@ -108,24 +108,24 @@ $tooltip-tokens: defaults(
   /* rtl:end:ignore */
 
   .bs-tooltip-bottom .tooltip-arrow {
-    top: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
+    top: calc(-1 * var(--#{$prefix}tooltip-arrow-height));
 
     &::before {
       bottom: -1px;
-      border-width: 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
+      border-width: 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height);
       border-bottom-color: var(--#{$prefix}tooltip-surface-bg);
     }
   }
 
   /* rtl:begin:ignore */
   .bs-tooltip-start .tooltip-arrow {
-    right: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
+    right: calc(-1 * var(--#{$prefix}tooltip-arrow-height));
     width: var(--#{$prefix}tooltip-arrow-height);
     height: var(--#{$prefix}tooltip-arrow-width);
 
     &::before {
       left: -1px;
-      border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
+      border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height);
       border-left-color: var(--#{$prefix}tooltip-surface-bg);
     }
   }

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -121,7 +121,6 @@ $position-values: (
 // scss-docs-end position-map
 
 
-// stylelint-disable function-disallowed-list
 // The opacity utilities scale a runtime var, so calc() is unavoidable here.
 
 // Utilities

--- a/scss/buttons/_button-group.scss
+++ b/scss/buttons/_button-group.scss
@@ -47,7 +47,7 @@
     // Prevent double borders when buttons are next to each other
     > :not(#{$btn-check-deprecated}:first-child) + .btn,
     > .btn-group:not(:first-child) {
-      margin-inline-start: calc(-1 * var(--#{$prefix}btn-border-width)); // stylelint-disable-line function-disallowed-list
+      margin-inline-start: calc(-1 * var(--#{$prefix}btn-border-width));
     }
 
     // Reset rounded corners
@@ -70,7 +70,7 @@
   }
 
   .dropdown-toggle-split {
-    padding-inline: calc(var(--#{$prefix}btn-padding-x) * .75); // stylelint-disable-line function-disallowed-list
+    padding-inline: calc(var(--#{$prefix}btn-padding-x) * .75);
   }
 
 
@@ -102,7 +102,7 @@
 
     > .btn:not(:first-child),
     > .btn-group:not(:first-child) {
-      margin-top: calc(-1 * var(--#{$prefix}btn-border-width)); // stylelint-disable-line function-disallowed-list
+      margin-top: calc(-1 * var(--#{$prefix}btn-border-width));
     }
 
     // Reset rounded corners

--- a/scss/content/_blockquote.scss
+++ b/scss/content/_blockquote.scss
@@ -5,7 +5,7 @@
 // scss-docs-start blockquote-variables
 $blockquote-margin-y:            var(--#{$prefix}spacer-3) !default;
 $blockquote-gap:                 var(--#{$prefix}spacer-3) !default;
-$blockquote-font-size:           calc(var(--#{$prefix}body-font-size) * 1.25) !default; // stylelint-disable-line function-disallowed-list
+$blockquote-font-size:           calc(var(--#{$prefix}body-font-size) * 1.25) !default;
 $blockquote-footer-margin-y:     var(--#{$prefix}spacer-3) !default;
 $blockquote-footer-color:        var(--#{$prefix}secondary-color) !default;
 $blockquote-footer-font-size:    var(--#{$prefix}small-font-size) !default;

--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -85,7 +85,6 @@ $reboot-kbd-tokens: defaults(
 
 // stylelint-enable scss/dollar-variable-default
 
-// stylelint-disable function-disallowed-list
 
 // scss-docs-start reboot-table-variables
 // Reboot styles the raw HTML elements, so it owns these rather than borrowing

--- a/scss/content/_tables.scss
+++ b/scss/content/_tables.scss
@@ -135,7 +135,7 @@ $table-variants: map.keys($theme-colors) !default;
   }
 
   .table-group-divider {
-    border-block-start: calc(var(--#{$prefix}table-border-width) * 2) solid var(--#{$prefix}table-group-separator-color); // stylelint-disable-line function-disallowed-list
+    border-block-start: calc(var(--#{$prefix}table-border-width) * 2) solid var(--#{$prefix}table-group-separator-color);
   }
 
   //
@@ -284,7 +284,7 @@ $table-variants: map.keys($theme-colors) !default;
 
           > td {
             display: block;
-            padding: calc(var(--#{$prefix}table-cell-padding-y) * .25) calc(var(--#{$prefix}table-cell-padding-x) * 2); // stylelint-disable-line function-disallowed-list
+            padding: calc(var(--#{$prefix}table-cell-padding-y) * .25) calc(var(--#{$prefix}table-cell-padding-x) * 2);
             border: 0;
 
             &:first-child {

--- a/scss/content/_type.scss
+++ b/scss/content/_type.scss
@@ -1,7 +1,7 @@
 @use "../config" as *;
 
 // scss-docs-start type-variables
-$lead-font-size:              calc(var(--#{$prefix}body-font-size) * 1.25) !default; // stylelint-disable-line function-disallowed-list
+$lead-font-size:              calc(var(--#{$prefix}body-font-size) * 1.25) !default;
 $lead-font-weight:            300 !default;
 // scss-docs-end type-variables
 

--- a/scss/forms/_check.scss
+++ b/scss/forms/_check.scss
@@ -25,7 +25,7 @@ $check-sizes: (
 
 $check-tokens: () !default;
 
-// stylelint-disable custom-property-no-missing-var-function, function-disallowed-list, scss/dollar-variable-default
+// stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
 
 // scss-docs-start check-css-vars
 $check-tokens: defaults(
@@ -51,7 +51,7 @@ $check-tokens: defaults(
 );
 // scss-docs-end check-css-vars
 
-// stylelint-enable scss/dollar-variable-default, custom-property-no-missing-var-function, function-disallowed-list
+// stylelint-enable scss/dollar-variable-default, custom-property-no-missing-var-function
 
 // A v5 switch input is a checkbox too: without the `:not()` it would collect
 // the check mark on top of the switch thumb.

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -4,7 +4,6 @@
 @use "../mixins/transition" as *;
 @use "../config" as *;
 
-// stylelint-disable function-disallowed-list
 
 // scss-docs-start form-floating-variables
 $form-floating-height:                  calc(3.5rem + var(--#{$prefix}btn-input-border-width) * 2) !default;

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -3,7 +3,7 @@
 @use "../config" as *;
 
 // scss-docs-start form-check-wrapper-variables
-$form-check-min-height:                   calc(var(--#{$prefix}body-font-size) * var(--#{$prefix}body-line-height)) !default; // stylelint-disable-line function-disallowed-list
+$form-check-min-height:                   calc(var(--#{$prefix}body-font-size) * var(--#{$prefix}body-line-height)) !default;
 $form-check-margin-bottom:                .125rem !default;
 $form-check-inline-margin-end:            1rem !default;
 

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -95,8 +95,8 @@ $form-control-select-indicator-color:      $gray-800 !default;
 $form-control-select-indicator:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$form-control-select-indicator-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/></svg>") !default;
 $form-control-select-bg-position:          right var(--#{$prefix}control-padding-x) center !default;
 $form-control-select-bg-size:              16px 12px !default; // In pixels because image dimensions
-$form-control-select-padding-end:          calc(var(--#{$prefix}control-padding-x) * 3) !default; // stylelint-disable-line function-disallowed-list
-$form-control-select-feedback-icon-padding-end: calc(var(--#{$prefix}control-padding-x) * 2.5 + var(--#{$prefix}control-select-padding-end)) !default; // stylelint-disable-line function-disallowed-list
+$form-control-select-padding-end:          calc(var(--#{$prefix}control-padding-x) * 3) !default;
+$form-control-select-feedback-icon-padding-end: calc(var(--#{$prefix}control-padding-x) * 2.5 + var(--#{$prefix}control-select-padding-end)) !default;
 $form-control-select-feedback-icon-position: center right var(--#{$prefix}control-select-padding-end) !default;
 $form-control-select-feedback-icon-size:   $input-height-inner-half $input-height-inner-half !default;
 // scss-docs-end form-control-select-variables
@@ -161,7 +161,7 @@ $form-control-select-tokens: defaults(
       // Add some height to date inputs on iOS
       // https://github.com/twbs/bootstrap/issues/23307
       // TODO: we can remove this workaround once https://bugs.webkit.org/show_bug.cgi?id=198959 is resolved
-      height: calc(var(--#{$prefix}btn-input-line-height) * 1em); // stylelint-disable-line function-disallowed-list
+      height: calc(var(--#{$prefix}btn-input-line-height) * 1em);
 
       // Android Chrome type="date" is taller than the other inputs
       // because of "margin: 1px 24px 1px 4px" inside the shadow DOM
@@ -199,7 +199,6 @@ $form-control-select-tokens: defaults(
     // File input buttons theming
     &::file-selector-button {
       padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
-      // stylelint-disable-next-line function-disallowed-list
       margin: calc(var(--#{$prefix}control-padding-y) * -1) calc(var(--#{$prefix}control-padding-x) * -1);
       margin-inline-end: var(--#{$prefix}control-padding-x);
       color: var(--#{$prefix}control-action-color);
@@ -278,7 +277,6 @@ $form-control-select-tokens: defaults(
 
     &::file-selector-button {
       padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
-      // stylelint-disable-next-line function-disallowed-list
       margin: calc(var(--#{$prefix}control-padding-y) * -1) calc(var(--#{$prefix}control-padding-x) * -1);
       margin-inline-end: var(--#{$prefix}control-padding-x);
     }
@@ -299,7 +297,6 @@ $form-control-select-tokens: defaults(
 
     &::file-selector-button {
       padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
-      // stylelint-disable-next-line function-disallowed-list
       margin: calc(var(--#{$prefix}control-padding-y) * -1) calc(var(--#{$prefix}control-padding-x) * -1);
       margin-inline-end: var(--#{$prefix}control-padding-x);
     }

--- a/scss/forms/_form-multi-select.scss
+++ b/scss/forms/_form-multi-select.scss
@@ -71,7 +71,6 @@ $form-multi-select-tokens: defaults(
   .form-multi-select-selection-tags {
     gap: var(--#{$prefix}form-multi-select-selection-tags-gap);
     align-content: center;
-    // stylelint-disable-next-line function-disallowed-list
     margin: calc(var(--#{$prefix}form-multi-select-selection-tags-padding-y) * -1) 0;
   }
 
@@ -98,7 +97,7 @@ $form-multi-select-tokens: defaults(
     }
 
     .form-multi-select-selection-tags & {
-      padding-inline-start: calc(var(--#{$prefix}control-padding-x) - .25rem); // stylelint-disable-line function-disallowed-list
+      padding-inline-start: calc(var(--#{$prefix}control-padding-x) - .25rem);
     }
   }
 
@@ -106,7 +105,7 @@ $form-multi-select-tokens: defaults(
     color: var(--#{$prefix}control-placeholder-color);
 
     .form-multi-select-selection-tags & {
-      padding: calc(var(--#{$prefix}control-padding-y) - .25rem) calc(var(--#{$prefix}control-padding-x) - .25rem); // stylelint-disable-line function-disallowed-list
+      padding: calc(var(--#{$prefix}control-padding-y) - .25rem) calc(var(--#{$prefix}control-padding-x) - .25rem);
     }
   }
 

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -97,7 +97,7 @@ $form-range-tokens: defaults(
     @include tokens($form-range-tokens);
 
     width: 100%;
-    height: calc(var(--#{$prefix}range-thumb-height) + #{$form-range-thumb-focus-ring-width} * 2); // stylelint-disable-line function-disallowed-list
+    height: calc(var(--#{$prefix}range-thumb-height) + #{$form-range-thumb-focus-ring-width} * 2);
     padding: 0; // Need to reset padding
     appearance: none;
     background-color: transparent;
@@ -114,7 +114,7 @@ $form-range-tokens: defaults(
     }
 
     &::-webkit-slider-thumb {
-      margin-top: calc((var(--#{$prefix}range-track-height) - var(--#{$prefix}range-thumb-height)) * .5); // stylelint-disable-line function-disallowed-list
+      margin-top: calc((var(--#{$prefix}range-track-height) - var(--#{$prefix}range-thumb-height)) * .5);
       @include form-range-thumb();
     }
 

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -127,7 +127,6 @@ $input-group-tokens: defaults(
 
   .input-group-lg > .form-select,
   .input-group-sm > .form-select {
-    // stylelint-disable-next-line function-disallowed-list
     padding-inline-end: calc(var(--#{$prefix}control-padding-x) + var(--#{$prefix}control-select-padding-end));
   }
 
@@ -163,7 +162,7 @@ $input-group-tokens: defaults(
     }
 
     > :not(:first-child):not(.dropdown-menu)#{$validation-messages} {
-      margin-inline-start: calc(-1 * var(--#{$prefix}btn-input-border-width)); // stylelint-disable-line function-disallowed-list
+      margin-inline-start: calc(-1 * var(--#{$prefix}btn-input-border-width));
       @include border-start-radius(0);
     }
 

--- a/scss/forms/_labels.scss
+++ b/scss/forms/_labels.scss
@@ -47,7 +47,7 @@ $form-label-tokens: defaults(
   // For use with horizontal and inline forms, when you need the label (or legend)
   // text to align with the form controls.
   .col-form-label {
-    --#{$prefix}label-padding-y: calc(var(--#{$prefix}btn-input-padding-y) + var(--#{$prefix}btn-input-border-width)); // stylelint-disable-line function-disallowed-list
+    --#{$prefix}label-padding-y: calc(var(--#{$prefix}btn-input-padding-y) + var(--#{$prefix}btn-input-border-width));
     --#{$prefix}label-line-height: var(--#{$prefix}btn-input-line-height);
 
     padding-top: var(--#{$prefix}label-padding-y);
@@ -57,12 +57,12 @@ $form-label-tokens: defaults(
   }
 
   .col-form-label-lg {
-    --#{$prefix}label-padding-y: calc(var(--#{$prefix}btn-input-lg-padding-y) + var(--#{$prefix}btn-input-border-width)); // stylelint-disable-line function-disallowed-list
+    --#{$prefix}label-padding-y: calc(var(--#{$prefix}btn-input-lg-padding-y) + var(--#{$prefix}btn-input-border-width));
     --#{$prefix}label-font-size: var(--#{$prefix}btn-input-lg-font-size);
   }
 
   .col-form-label-sm {
-    --#{$prefix}label-padding-y: calc(var(--#{$prefix}btn-input-sm-padding-y) + var(--#{$prefix}btn-input-border-width)); // stylelint-disable-line function-disallowed-list
+    --#{$prefix}label-padding-y: calc(var(--#{$prefix}btn-input-sm-padding-y) + var(--#{$prefix}btn-input-border-width));
     --#{$prefix}label-font-size: var(--#{$prefix}btn-input-sm-font-size);
   }
 }

--- a/scss/forms/_radio.scss
+++ b/scss/forms/_radio.scss
@@ -20,7 +20,7 @@ $radio-mark:              url("data:image/svg+xml,<svg xmlns='http://www.w3.org/
 
 $radio-tokens: () !default;
 
-// stylelint-disable custom-property-no-missing-var-function, function-disallowed-list, scss/dollar-variable-default
+// stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
 
 // scss-docs-start radio-css-vars
 $radio-tokens: defaults(
@@ -43,7 +43,7 @@ $radio-tokens: defaults(
 );
 // scss-docs-end radio-css-vars
 
-// stylelint-enable scss/dollar-variable-default, custom-property-no-missing-var-function, function-disallowed-list
+// stylelint-enable scss/dollar-variable-default, custom-property-no-missing-var-function
 
 // stylelint-disable-next-line scss/at-function-named-arguments
 $radio-selector: if(sass($enable-deprecated-form-check): ".radio, .form-check-input[type=radio]"; else: ".radio") !default;

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -36,7 +36,7 @@ $form-switch-sizes: ("lg", "xl") !default;
 
 $switch-tokens: () !default;
 
-// stylelint-disable custom-property-no-missing-var-function, function-disallowed-list, scss/dollar-variable-default
+// stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
 
 // scss-docs-start switch-css-vars
 $switch-tokens: defaults(
@@ -69,7 +69,7 @@ $switch-tokens: defaults(
 );
 // scss-docs-end switch-css-vars
 
-// stylelint-enable custom-property-no-missing-var-function, function-disallowed-list, scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function, scss/dollar-variable-default
 
 // stylelint-disable-next-line scss/at-function-named-arguments
 $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch .form-check-input"; else: ".switch") !default;
@@ -112,7 +112,6 @@ $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch
       border-color: var(--#{$prefix}switch-checked-border-color);
 
       &::before {
-        // stylelint-disable-next-line function-disallowed-list
         inset-inline-start: calc(100% - var(--#{$prefix}switch-thumb-size) - var(--#{$prefix}switch-padding));
         background-color: var(--#{$prefix}switch-checked-thumb-bg);
       }
@@ -168,7 +167,6 @@ $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch
         min-height: var(--#{$prefix}switch-height);
 
         .form-check-label {
-          // stylelint-disable-next-line function-disallowed-list
           padding-top: calc((var(--#{$prefix}switch-height) - var(--#{$prefix}body-font-size)) * .5);
         }
       }

--- a/scss/helpers/_color-bg.scss
+++ b/scss/helpers/_color-bg.scss
@@ -2,7 +2,6 @@
 @use "../theme" as *;
 @use "../config" as *;
 
-// stylelint-disable function-disallowed-list
 // The opacity utilities scale a runtime var, so calc() is unavoidable here.
 
 @layer helpers {

--- a/scss/helpers/_colored-links.scss
+++ b/scss/helpers/_colored-links.scss
@@ -9,7 +9,6 @@
 $link-shade-percentage:                   20% !default;
 
 
-// stylelint-disable function-disallowed-list
 // The opacity utilities scale a runtime var, so calc() is unavoidable here.
 
 @layer helpers {

--- a/scss/helpers/_icon-link.scss
+++ b/scss/helpers/_icon-link.scss
@@ -3,7 +3,6 @@
 @use "../mixins/transition" as *;
 @use "../config" as *;
 
-// stylelint-disable function-disallowed-list
 
 // scss-docs-start icon-link-variables
 $icon-link-gap:               .375rem !default;

--- a/scss/helpers/_ratio.scss
+++ b/scss/helpers/_ratio.scss
@@ -1,6 +1,5 @@
 @use "../config" as *;
 
-// stylelint-disable function-disallowed-list
 // scss-docs-start aspect-ratios
 $aspect-ratios: (
   "1x1": 100%,
@@ -9,7 +8,6 @@ $aspect-ratios: (
   "21x9": calc(9 / 21 * 100%)
 ) !default;
 // scss-docs-end aspect-ratios
-// stylelint-enable function-disallowed-list
 
 @layer helpers {
   // Credit: Nicolas Gallagher and SUIT CSS.

--- a/scss/mixins/_container.scss
+++ b/scss/mixins/_container.scss
@@ -6,6 +6,6 @@
   --#{$prefix}gutter-x: #{$gutter};
   --#{$prefix}gutter-y: 0;
   width: 100%;
-  padding-inline: calc(var(--#{$prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
+  padding-inline: calc(var(--#{$prefix}gutter-x) * .5);
   margin-inline: auto;
 }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -39,11 +39,9 @@ $form-validation-states: (
 
 // Geometry of the validation icon painted into the field: the room it needs and
 // where it sits. Derived from the frame, so it follows a retuned control.
-// stylelint-disable function-disallowed-list
 $input-height-inner:                    calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2) !default;
 $input-height-inner-half:               calc(var(--#{$prefix}btn-input-line-height) * .5em + var(--#{$prefix}btn-input-padding-y)) !default;
 $input-height-inner-quarter:            calc(var(--#{$prefix}btn-input-line-height) * .25em + var(--#{$prefix}btn-input-padding-y) * .5) !default;
-// stylelint-enable function-disallowed-list
 
 // scss-docs-start tooltip-feedback-variables
 $form-feedback-tooltip-padding-y:     var(--#{$prefix}spacer-1) !default;
@@ -236,7 +234,7 @@ $validated-controls: if(sass($enable-deprecated-form-check): ".check, .radio, .s
   .form-control-color {
     @include form-validation-state-selector($state) {
       @if $enable-validation-icons {
-        width: calc(var(--#{$prefix}control-color-width) + #{$input-height-inner}); // stylelint-disable-line function-disallowed-list
+        width: calc(var(--#{$prefix}control-color-width) + #{$input-height-inner});
       }
     }
   }

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -18,9 +18,9 @@ $grid-row-columns:            6 !default;
   display: flex;
   flex-wrap: wrap;
   // TODO: Revisit calc order after https://github.com/react-bootstrap/react-bootstrap/issues/6039 is fixed
-  margin-top: calc(-1 * var(--#{$prefix}gutter-y)); // stylelint-disable-line function-disallowed-list
-  margin-right: calc(-.5 * var(--#{$prefix}gutter-x)); // stylelint-disable-line function-disallowed-list
-  margin-left: calc(-.5 * var(--#{$prefix}gutter-x)); // stylelint-disable-line function-disallowed-list
+  margin-top: calc(-1 * var(--#{$prefix}gutter-y));
+  margin-right: calc(-.5 * var(--#{$prefix}gutter-x));
+  margin-left: calc(-.5 * var(--#{$prefix}gutter-x));
 }
 
 @mixin make-col-ready($include-column-box-sizing: false) {
@@ -33,8 +33,8 @@ $grid-row-columns:            6 !default;
   flex-shrink: 0;
   width: 100%;
   max-width: 100%; // Prevent `.col-auto`, `.col` (& responsive variants) from breaking out the grid
-  padding-right: calc(var(--#{$prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
-  padding-left: calc(var(--#{$prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
+  padding-right: calc(var(--#{$prefix}gutter-x) * .5);
+  padding-left: calc(var(--#{$prefix}gutter-x) * .5);
   margin-top: var(--#{$prefix}gutter-y);
 }
 

--- a/scss/sidebar/_sidebar-narrow.scss
+++ b/scss/sidebar/_sidebar-narrow.scss
@@ -32,7 +32,7 @@
       }
 
       .nav-icon {
-        flex: 0 0 calc(var(--#{$prefix}sidebar-narrow-width) - (var(--#{$prefix}sidebar-nav-padding-x) * 2) - (var(--#{$prefix}sidebar-nav-link-padding-x) * 2)); // stylelint-disable-line function-disallowed-list
+        flex: 0 0 calc(var(--#{$prefix}sidebar-narrow-width) - (var(--#{$prefix}sidebar-nav-padding-x) * 2) - (var(--#{$prefix}sidebar-nav-link-padding-x) * 2));
       }
 
       .nav-label,

--- a/scss/sidebar/_sidebar-nav.scss
+++ b/scss/sidebar/_sidebar-nav.scss
@@ -7,8 +7,8 @@
 // Sidebar navigation
 
 // scss-docs-start sidebar-nav-variables
-$sidebar-nav-padding-y:                       calc(#{$sidebar-padding-y} * .5) !default; // stylelint-disable-line function-disallowed-list
-$sidebar-nav-padding-x:                       calc(#{$sidebar-padding-x} * .5) !default; // stylelint-disable-line function-disallowed-list
+$sidebar-nav-padding-y:                       calc(#{$sidebar-padding-y} * .5) !default;
+$sidebar-nav-padding-x:                       calc(#{$sidebar-padding-x} * .5) !default;
 $sidebar-nav-gap:                             1px !default;
 
 $sidebar-nav-title-padding-y:                 .75rem !default;
@@ -325,11 +325,11 @@ $sidebar-nav-tree-link-active-icon-bullet-bg:  var(--#{$prefix}border-color) !de
       @include transition($sidebar-nav-group-items-transition);
 
       .nav-link {
-        padding-inline-start: calc(var(--#{$prefix}sidebar-nav-link-padding-x) + var(--#{$prefix}sidebar-nav-link-icon-width) + var(--#{$prefix}sidebar-nav-link-icon-margin)); // stylelint-disable-line function-disallowed-list
+        padding-inline-start: calc(var(--#{$prefix}sidebar-nav-link-padding-x) + var(--#{$prefix}sidebar-nav-link-icon-width) + var(--#{$prefix}sidebar-nav-link-icon-margin));
       }
 
       .nav-icon {
-        margin-inline-start: calc(-1 * (var(--#{$prefix}sidebar-nav-link-icon-width) + var(--#{$prefix}sidebar-nav-link-icon-margin))); // stylelint-disable-line function-disallowed-list
+        margin-inline-start: calc(-1 * (var(--#{$prefix}sidebar-nav-link-icon-width) + var(--#{$prefix}sidebar-nav-link-icon-margin)));
       }
     }
 
@@ -349,7 +349,7 @@ $sidebar-nav-tree-link-active-icon-bullet-bg:  var(--#{$prefix}border-color) !de
       // scss-docs-end sidebar-nav-tree-css-vars
 
       .nav-group .nav-group-items {
-        $indent: calc((var(--#{$prefix}sidebar-nav-link-padding-x) + var(--#{$prefix}sidebar-nav-link-icon-width) + var(--#{$prefix}sidebar-nav-link-icon-margin)) / 2); // stylelint-disable-line function-disallowed-list
+        $indent: calc((var(--#{$prefix}sidebar-nav-link-padding-x) + var(--#{$prefix}sidebar-nav-link-icon-width) + var(--#{$prefix}sidebar-nav-link-icon-margin)) / 2);
 
         position: relative;
         z-index: 0;
@@ -357,7 +357,7 @@ $sidebar-nav-tree-link-active-icon-bullet-bg:  var(--#{$prefix}border-color) !de
 
         &::before {
           position: absolute;
-          inset-inline-start: calc($indent + 1.5px); // stylelint-disable-line function-disallowed-list
+          inset-inline-start: calc($indent + 1.5px);
           top: 0;
           z-index: -1;
           height: 100%;
@@ -367,7 +367,7 @@ $sidebar-nav-tree-link-active-icon-bullet-bg:  var(--#{$prefix}border-color) !de
 
         // stylelint-disable-next-line selector-max-class
         .nav-link {
-          margin-inline-start: calc(-1 * $indent); // stylelint-disable-line function-disallowed-list
+          margin-inline-start: calc(-1 * $indent);
         }
       }
     }

--- a/scss/sidebar/_sidebar.scss
+++ b/scss/sidebar/_sidebar.scss
@@ -1,4 +1,3 @@
-// stylelint-disable function-disallowed-list
 @use "../functions/escape-svg" as *;
 @use "../mixins/backdrop" as *;
 @use "../mixins/border-radius" as *;

--- a/scss/tests/mixins/_utilities.test.scss
+++ b/scss/tests/mixins/_utilities.test.scss
@@ -238,7 +238,6 @@
           .bg-blue {
             --cui-bg: var(--cui-blue);
             --cui-bg-opacity: 1;
-            // stylelint-disable-next-line function-disallowed-list
             background-color: color-mix(in srgb, var(--cui-bg) calc(var(--cui-bg-opacity) * 100%), transparent);
           }
         }

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -24,7 +24,6 @@ export default {
           outline: 'none'
         },
         'function-disallowed-list': [
-          'calc',
           'lighten',
           'darken'
         ],


### PR DESCRIPTION
> **Stacked on #831** — based on `chore/stylelint-align-with-upstream-v6`, because that PR is what moves the config into `stylelint.config.mjs`. Merge #831 first; GitHub will retarget this to `v6-dev` automatically.

Settles the open question in `plans/scss-token-architecture.md` (*"Do rozstrzygnięcia, czy nie wyrzucić `calc` z listy"*). Upstream's `function-disallowed-list` is `['lighten', 'darken']` — they dropped `calc`.

## Why the rule stopped making sense

It is inherited from Bootstrap 5, where it pushed you towards `add()` and `subtract()` so an expression could stay a Sass expression and fold at build time. v6 inverted that premise: a derived value is supposed to be computed **in the browser**, so `calc()` is how you write one. The rule now forbids the house style.

The evidence is the disable count. It was 123 when the note went into `CLAUDE.md` in August; today it is **148 comments across 56 files**, and it grows with every token that derives from another. Two of them were bare `// stylelint-disable-line` with no rule named — silencing *every* rule on the line to hide this one:

```scss
height: calc(8 * var(--cui-time-picker-roll-cell-height)); // stylelint-disable-line
```

## Shape of the diff

`reportNeedlessDisables` is on, so the rule and the comments have to go together — leaving them would fail the lint. 57 files, and it is mechanical:

- 116 trailing `// stylelint-disable-line function-disallowed-list` stripped from the end of a declaration
- 27 whole comment lines removed (`disable` / `disable-next-line` / `enable` where it was the only rule named)
- 10 multi-rule comments narrowed — e.g. `// stylelint-disable custom-property-no-missing-var-function, function-disallowed-list` keeps the first rule
- 2 bare `// stylelint-disable-line` removed

## Verification

**Compiled `coreui.css` is byte-identical** to the parent branch — `diff -q` reports no difference, which is the point: nothing but comments changed.

`css-lint` clean with `reportNeedlessDisables` still on (that is what proves every removal was needed), `css-test-class-api` passes, and the pre-push gate ran lint, build, tests and bundlewatch.