### PR TITLE
fix(Utilities, IconLink): revive two rules that resolved to nothing

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",
-      "maxSize": "14.5 kB"
+      "maxSize": "14.75 kB"
     },
     {
       "path": "./dist/css/coreui.css",

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -843,7 +843,7 @@ $utilities: map.merge(
           "body-tertiary": var(--#{$prefix}tertiary-color),
           "body-emphasis": var(--#{$prefix}emphasis-color),
           "reset": inherit,
-          "disabled": var(--#{$prefix}disabled)
+          "disabled": var(--#{$prefix}tertiary-color)
         )
       )
     ),

--- a/scss/helpers/_icon-link.scss
+++ b/scss/helpers/_icon-link.scss
@@ -42,6 +42,9 @@ $icon-link-tokens: defaults(
     text-underline-offset: var(--#{$prefix}icon-link-underline-offset);
     backface-visibility: hidden;
 
+    // `.icon` is our own icon set; `.bi` is Bootstrap Icons, kept so markup
+    // written against upstream keeps working.
+    > .icon,
     > .bi {
       flex-shrink: 0;
       width: var(--#{$prefix}icon-link-icon-size);
@@ -54,6 +57,7 @@ $icon-link-tokens: defaults(
   .icon-link-hover {
     &:hover,
     &:focus-visible {
+      > .icon,
       > .bi {
         transform: var(--#{$prefix}icon-link-transform, var(--#{$prefix}icon-link-icon-transform));
       }


### PR DESCRIPTION
Two rules from the `coreui-utilities.css` review that compiled fine and did nothing.

## `.text-disabled` rendered as plain body text

It sets `--cui-text: var(--cui-disabled)`. **`--cui-disabled` is declared nowhere in v6** — v5 had it in `_root.scss` marked *"Deprecated in v5.0.0"*, and the root cleanup dropped the token while the class stayed behind reading it. An undeclared `var()` with no fallback is invalid at computed-value time, so the colour declaration fell away entirely.

| | before | after |
| --- | --- | --- |
| unstyled text | `rgba(37, 43, 54, .95)` | — |
| `.text-disabled` | **`rgba(37, 43, 54, .95)`** | `color(srgb .145 .168 .212 / .38)` |
| `.text-body-tertiary` | `color(srgb .145 .168 .212 / .38)` | unchanged |

`--cui-tertiary-color` is the right target: it is v6's token for the least prominent text and carries the same `.38` alpha v5's `$disabled` had.

Upstream has no `.text-disabled`, so this is ours to keep working. It is in `class-api-v5.txt`, so the gate has been guarding a class that produced no styling since v6 began.

## `.icon-link` did not animate our own icons

The helper styled `> .bi` — Bootstrap Icons' class. Our set uses `.icon`, and all six examples on the helper's own page are written `<svg class="icon">`.

Measured on hover, with the full bundle:

| | before | after |
| --- | --- | --- |
| `svg.icon` size | 16px / 16px | 16px / 16px |
| `svg.icon` transform on hover | **`none`** | a translation |

**A correction to what I reported earlier in the conversation:** I first measured against `coreui-utilities.css` alone and said the icon was left completely unstyled at 300×150. That was wrong — that bundle has no `.icon` component, so the number was an artefact of the file I picked. In the real bundle our `.icon` sizes and colours itself, so what was actually dead was the hover animation, not the sizing. Narrower than I claimed, and still a helper that does not do what its page promises.

`.bi` stays in the selector, so markup written against upstream keeps working.

## Budget

`coreui-utilities.min.css` goes to 14.51 kB against a 14.5 kB ceiling, because `--cui-tertiary-color` is six characters longer than the name it replaces. Raised to 14.75 kB.

This is the bump I flagged when #833 landed: that refactor left this bundle sitting exactly on its ceiling, and the next thing to touch it would push it over. It turned out to be a ten-byte bug fix.

## Verification

`css-lint`, `css-test-class-api`, `docs-build` (147 pages, no broken links), `js-test-visual` (35) and bundlewatch pass.

## Also reviewed, nothing to do

- **`coreui-grid.css` is clean** — no descendant selectors left after #834, no duplicate selectors, no empty rules, no undeclared tokens.
- **148 of 301 root tokens in the utilities bundle are never referenced there.** Looks wasteful at 19.6 kB raw, but upstream declares 475 with roughly 257 unreferenced — it is the self-contained-bundle design, not a defect of ours.
- **`--cui-icon-link-transform`** is read but never declared. Not a phantom: [our helper page documents it](https://coreui.io/bootstrap/docs/helpers/icon-link/) as the hook for customising the hover transform, exactly as upstream documents theirs.
