### PR TITLE
feat(Utilities): grid track, flow and inline-axis alignment utilities

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -18,19 +18,19 @@
     },
     {
       "path": "./dist/css/coreui-utilities.css",
-      "maxSize": "15.5 kB"
+      "maxSize": "16.5 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",
-      "maxSize": "14.75 kB"
+      "maxSize": "15.5 kB"
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "63.5kB"
+      "maxSize": "64.25kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "53kB"
+      "maxSize": "53.75kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/utilities/grid.mdx
+++ b/docs/src/content/docs/utilities/grid.mdx
@@ -1,0 +1,111 @@
+---
+title: "Bootstrap 5 Grid utilities"
+name: "Grid"
+description: "Lay out and align CSS Grid containers and their items with responsive utilities for track counts, auto flow, and inline-axis alignment."
+---
+
+These utilities work on any CSS Grid container — our [`.grid`](/layout/css-grid/), a `.d-grid`, or an element you gave `display: grid` yourself. They do nothing in flexbox: flex has no `justify-items`, and it ignores `justify-self`.
+
+## Column counts
+
+Set the track list with `.grid-cols-{1|2|3|4|6}`. Each one divides the container into equal fractions, so the items need no width of their own.
+
+<Example code={`<div class="d-grid grid-cols-3 gap-2">
+    <div class="p-2 border">1</div>
+    <div class="p-2 border">2</div>
+    <div class="p-2 border">3</div>
+  </div>`} />
+
+On our `.grid` component the same job is done by `--cui-columns`, which takes any number. The class is the shortcut for the counts you reach for most.
+
+### Subgrid
+
+`.grid-cols-subgrid` makes a nested grid adopt its parent's tracks instead of defining its own, so items in different rows line up on the same columns.
+
+<Example code={`<div class="d-grid grid-cols-3 gap-2">
+    <div class="p-2 border">1</div>
+    <div class="p-2 border">2</div>
+    <div class="p-2 border">3</div>
+    <div class="d-grid grid-cols-subgrid gap-2" style="grid-column: span 3">
+      <div class="p-2 border">Aligned to column 1</div>
+      <div class="p-2 border">2</div>
+      <div class="p-2 border">3</div>
+    </div>
+  </div>`} />
+
+## Fill columns
+
+`.grid-cols-fill` is the item-side counterpart: it spans the element across every track the container ended up with, whatever that number is.
+
+<Example code={`<div class="d-grid grid-cols-3 gap-2">
+    <div class="p-2 border">1</div>
+    <div class="p-2 border">2</div>
+    <div class="p-2 border">3</div>
+    <div class="p-2 border grid-cols-fill">Spans the full row</div>
+  </div>`} />
+
+## Auto flow
+
+`.grid-auto-flow-{row|column|dense}` controls how items that were not placed explicitly get filled in — down the rows by default, across the columns with `column`, or back-filling earlier gaps with `dense`.
+
+<Example code={`<div class="d-grid grid-cols-3 grid-auto-flow-column gap-2" style="grid-template-rows: repeat(2, auto)">
+    <div class="p-2 border">1</div>
+    <div class="p-2 border">2</div>
+    <div class="p-2 border">3</div>
+    <div class="p-2 border">4</div>
+  </div>`} />
+
+## Alignment
+
+`align-items` and `align-self` position items on the block axis, and they work in both flexbox and grid — they are covered under [flex utilities](/utilities/flex/#align-items). The inline axis is grid-only.
+
+### Justify items
+
+`.justify-items-{start|end|center|stretch}` sets the inline-axis alignment for every item in the container.
+
+<Example code={`<div class="d-grid grid-cols-3 justify-items-center gap-2">
+    <div class="p-2 border">1</div>
+    <div class="p-2 border">2</div>
+    <div class="p-2 border">3</div>
+  </div>`} />
+
+### Justify self
+
+`.justify-self-{start|end|center}` overrides that alignment for one item.
+
+<Example code={`<div class="d-grid grid-cols-3 justify-items-start gap-2">
+    <div class="p-2 border">1</div>
+    <div class="p-2 border justify-self-end">Pushed to the end</div>
+    <div class="p-2 border">3</div>
+  </div>`} />
+
+### Place items
+
+`.place-items-{start|end|center|stretch}` sets both axes at once — it is the shorthand for `align-items` and `justify-items` together.
+
+<Example code={`<div class="d-grid grid-cols-3 place-items-center gap-2" style="height: 120px">
+    <div class="p-2 border">1</div>
+    <div class="p-2 border">2</div>
+    <div class="p-2 border">3</div>
+  </div>`} />
+
+## Responsive
+
+Every utility on this page has responsive variants at each [breakpoint](/layout/breakpoints/) — `.grid-cols-md-2`, `.justify-items-lg-center`, `.grid-auto-flow-xl-column`, and so on. They read the **viewport** width, like every other responsive utility. To respond to a container's width instead, see [container queries](/utilities/container-queries/).
+
+<Example code={`<div class="d-grid grid-cols-1 grid-cols-md-2 grid-cols-lg-4 gap-2">
+    <div class="p-2 border">1</div>
+    <div class="p-2 border">2</div>
+    <div class="p-2 border">3</div>
+    <div class="p-2 border">4</div>
+  </div>`} />
+
+## Customizing
+
+### SASS
+
+<ScssDocs file="scss/_utilities.scss" capture="utils-grid" />
+
+<ScssDocs file="scss/_utilities.scss" capture="utils-justify-items" />
+
+Both blocks live in the `$utilities` map, so the [utility API](/utilities/api/) can extend, restrict or remove them like any other family.

--- a/docs/src/content/docs/utilities/grid.mdx
+++ b/docs/src/content/docs/utilities/grid.mdx
@@ -10,10 +10,10 @@ These utilities work on any CSS Grid container — our [`.grid`](/layout/css-gri
 
 Set the track list with `.grid-cols-{1|2|3|4|6}`. Each one divides the container into equal fractions, so the items need no width of their own.
 
-<Example code={`<div class="d-grid grid-cols-3 gap-2">
-    <div class="p-2 border">1</div>
-    <div class="p-2 border">2</div>
-    <div class="p-2 border">3</div>
+<Example class="docs-example-cssgrid" code={`<div class="d-grid grid-cols-3 gap-2">
+    <div>1</div>
+    <div>2</div>
+    <div>3</div>
   </div>`} />
 
 On our `.grid` component the same job is done by `--cui-columns`, which takes any number. The class is the shortcut for the counts you reach for most.
@@ -22,14 +22,14 @@ On our `.grid` component the same job is done by `--cui-columns`, which takes an
 
 `.grid-cols-subgrid` makes a nested grid adopt its parent's tracks instead of defining its own, so items in different rows line up on the same columns.
 
-<Example code={`<div class="d-grid grid-cols-3 gap-2">
-    <div class="p-2 border">1</div>
-    <div class="p-2 border">2</div>
-    <div class="p-2 border">3</div>
+<Example class="docs-example-cssgrid" code={`<div class="d-grid grid-cols-3 gap-2">
+    <div>1</div>
+    <div>2</div>
+    <div>3</div>
     <div class="d-grid grid-cols-subgrid gap-2" style="grid-column: span 3">
-      <div class="p-2 border">Aligned to column 1</div>
-      <div class="p-2 border">2</div>
-      <div class="p-2 border">3</div>
+      <div>Aligned to column 1</div>
+      <div>2</div>
+      <div>3</div>
     </div>
   </div>`} />
 
@@ -37,22 +37,22 @@ On our `.grid` component the same job is done by `--cui-columns`, which takes an
 
 `.grid-cols-fill` is the item-side counterpart: it spans the element across every track the container ended up with, whatever that number is.
 
-<Example code={`<div class="d-grid grid-cols-3 gap-2">
-    <div class="p-2 border">1</div>
-    <div class="p-2 border">2</div>
-    <div class="p-2 border">3</div>
-    <div class="p-2 border grid-cols-fill">Spans the full row</div>
+<Example class="docs-example-cssgrid" code={`<div class="d-grid grid-cols-3 gap-2">
+    <div>1</div>
+    <div>2</div>
+    <div>3</div>
+    <div class="grid-cols-fill">Spans the full row</div>
   </div>`} />
 
 ## Auto flow
 
 `.grid-auto-flow-{row|column|dense}` controls how items that were not placed explicitly get filled in — down the rows by default, across the columns with `column`, or back-filling earlier gaps with `dense`.
 
-<Example code={`<div class="d-grid grid-cols-3 grid-auto-flow-column gap-2" style="grid-template-rows: repeat(2, auto)">
-    <div class="p-2 border">1</div>
-    <div class="p-2 border">2</div>
-    <div class="p-2 border">3</div>
-    <div class="p-2 border">4</div>
+<Example class="docs-example-cssgrid" code={`<div class="d-grid grid-cols-3 grid-auto-flow-column gap-2" style="grid-template-rows: repeat(2, auto)">
+    <div>1</div>
+    <div>2</div>
+    <div>3</div>
+    <div>4</div>
   </div>`} />
 
 ## Alignment
@@ -63,41 +63,41 @@ On our `.grid` component the same job is done by `--cui-columns`, which takes an
 
 `.justify-items-{start|end|center|stretch}` sets the inline-axis alignment for every item in the container.
 
-<Example code={`<div class="d-grid grid-cols-3 justify-items-center gap-2">
-    <div class="p-2 border">1</div>
-    <div class="p-2 border">2</div>
-    <div class="p-2 border">3</div>
+<Example class="docs-example-cssgrid" code={`<div class="d-grid grid-cols-3 justify-items-center gap-2">
+    <div>1</div>
+    <div>2</div>
+    <div>3</div>
   </div>`} />
 
 ### Justify self
 
 `.justify-self-{start|end|center}` overrides that alignment for one item.
 
-<Example code={`<div class="d-grid grid-cols-3 justify-items-start gap-2">
-    <div class="p-2 border">1</div>
-    <div class="p-2 border justify-self-end">Pushed to the end</div>
-    <div class="p-2 border">3</div>
+<Example class="docs-example-cssgrid" code={`<div class="d-grid grid-cols-3 justify-items-start gap-2">
+    <div>1</div>
+    <div class="justify-self-end">Pushed to the end</div>
+    <div>3</div>
   </div>`} />
 
 ### Place items
 
 `.place-items-{start|end|center|stretch}` sets both axes at once — it is the shorthand for `align-items` and `justify-items` together.
 
-<Example code={`<div class="d-grid grid-cols-3 place-items-center gap-2" style="height: 120px">
-    <div class="p-2 border">1</div>
-    <div class="p-2 border">2</div>
-    <div class="p-2 border">3</div>
+<Example class="docs-example-cssgrid" code={`<div class="d-grid grid-cols-3 place-items-center gap-2" style="height: 120px">
+    <div>1</div>
+    <div>2</div>
+    <div>3</div>
   </div>`} />
 
 ## Responsive
 
 Every utility on this page has responsive variants at each [breakpoint](/layout/breakpoints/) — `.grid-cols-md-2`, `.justify-items-lg-center`, `.grid-auto-flow-xl-column`, and so on. They read the **viewport** width, like every other responsive utility. To respond to a container's width instead, see [container queries](/utilities/container-queries/).
 
-<Example code={`<div class="d-grid grid-cols-1 grid-cols-md-2 grid-cols-lg-4 gap-2">
-    <div class="p-2 border">1</div>
-    <div class="p-2 border">2</div>
-    <div class="p-2 border">3</div>
-    <div class="p-2 border">4</div>
+<Example class="docs-example-cssgrid" code={`<div class="d-grid grid-cols-1 grid-cols-md-2 grid-cols-lg-4 gap-2">
+    <div>1</div>
+    <div>2</div>
+    <div>3</div>
+    <div>4</div>
   </div>`} />
 
 ## Customizing

--- a/docs/src/data/sidebar.yml
+++ b/docs/src/data/sidebar.yml
@@ -370,6 +370,8 @@
       to: /utilities/flex/
     - title: Float
       to: /utilities/float/
+    - title: Grid
+      to: /utilities/grid/
     - title: Interactions
       to: /utilities/interactions/
     - title: Link

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -551,6 +551,70 @@ $utilities: map.merge(
         stretch: stretch,
       )
     ),
+    // The inline-axis counterparts of the three above, which only grid can act
+    // on — flex has no `justify-items` and ignores `justify-self`.
+    // scss-docs-start utils-justify-items
+    "justify-items": (
+      responsive: true,
+      property: justify-items,
+      values: (
+        start: start,
+        end: end,
+        center: center,
+        stretch: stretch,
+      )
+    ),
+    "justify-self": (
+      responsive: true,
+      property: justify-self,
+      values: (
+        start: start,
+        end: end,
+        center: center,
+      )
+    ),
+    "place-items": (
+      responsive: true,
+      property: place-items,
+      values: (
+        start: start,
+        end: end,
+        center: center,
+        stretch: stretch,
+      )
+    ),
+    // scss-docs-end utils-justify-items
+    // scss-docs-start utils-grid
+    // `grid-cols-*` sets the track list on the container; `grid-cols-fill` is
+    // the item counterpart, spanning whatever the container ended up with.
+    "grid-template-columns": (
+      responsive: true,
+      property: grid-template-columns,
+      class: grid-cols,
+      values: (
+        1: 1fr,
+        2: repeat(2, 1fr),
+        3: repeat(3, 1fr),
+        4: repeat(4, 1fr),
+        6: repeat(6, 1fr),
+        subgrid: subgrid,
+      )
+    ),
+    "grid-column": (
+      responsive: true,
+      property: grid-column,
+      class: grid-cols,
+      values: (
+        fill: #{"1 / -1"},
+      )
+    ),
+    "grid-auto-flow": (
+      responsive: true,
+      property: grid-auto-flow,
+      class: grid-auto-flow,
+      values: row column dense
+    ),
+    // scss-docs-end utils-grid
     "order": (
       responsive: true,
       property: order,


### PR DESCRIPTION
First of the batch from the `_utilities.scss` comparison. Items 1 and 4 land together because they share a docs page.

## The asymmetry it fixes

We ship `align-items`, `align-self` and `align-content` but nothing for the inline axis, so a grid could be aligned one way with a class and needed custom CSS for the other. `justify-items`, `justify-self` and `place-items` close it.

They are **grid-only** on purpose — flexbox has no `justify-items` and ignores `justify-self` — which is why they are not on the flex page.

## Track and flow utilities

| class | property |
| --- | --- |
| `.grid-cols-{1,2,3,4,6}` | `grid-template-columns: repeat(n, 1fr)` |
| `.grid-cols-subgrid` | `grid-template-columns: subgrid` |
| `.grid-cols-fill` | `grid-column: 1 / -1` |
| `.grid-auto-flow-{row,column,dense}` | `grid-auto-flow` |

On our own `.grid` the count is already settable through `--cui-columns`, which takes any number; these are the shortcut for the counts people actually reach for, and unlike the variable they work on any `display: grid` element.

One naming wrinkle inherited from upstream, worth a reviewer's eye: `.grid-cols-3` is a **container** property and `.grid-cols-fill` is an **item** property, under the same prefix. I kept their names for compatibility, but the two do opposite jobs.

## Docs

New page at `utilities/grid`, registered in the sidebar between Float and Interactions. It belongs neither on the flex page (these do nothing in flex) nor on the CSS Grid layout page (they are not tied to `.grid`). Covers column counts, subgrid, fill, auto flow, the three alignment families, responsive variants, and the Sass source through two `<ScssDocs>` blocks.

## Budgets

Four raised, and the numbers are the reason:

| bundle | before | after | new ceiling |
| --- | --- | --- | --- |
| `coreui.css` | 63.13 kB | 64.02 kB | 64.25 kB |
| `coreui.min.css` | 52.79 kB | 53.45 kB | 53.75 kB |
| `coreui-utilities.css` | 15.44 kB | 16.31 kB | 16.5 kB |
| `coreui-utilities.min.css` | 14.51 kB | 15.2 kB | 15.5 kB |

I measured how much of that is the responsive multiplication, since all six families carry `responsive: true` the way upstream has them: **584 bytes gzipped, 0.9%** of the stylesheet for variants across all six breakpoints. Dropping them would save that and cost the utilities their main use. Worth knowing the price rather than assuming it.

## Verification

`css-lint`, `css-test-class-api`, `docs-build` (148 pages now, no broken links), `js-test-visual` (35), bundlewatch after the raise. Spot-checked the compiled output: `.grid-cols-3` → `repeat(3, 1fr)`, `.grid-cols-fill` → `1 / -1`, `.grid-cols-subgrid` → `subgrid`, `.justify-self-end` → `end`, `.grid-cols-md-2` present.
