### PR TITLE
fix(Collapse): animate the find-in-page reveal, and name the animated property in a token

### DIFF
--- a/docs/src/content/docs/components/collapse.mdx
+++ b/docs/src/content/docs/components/collapse.mdx
@@ -198,7 +198,9 @@ myCollapsible.addEventListener('hidden.coreui.collapse', event => {
 
 ### CSS variables
 
-The transition is declared on `.collapsing`, so overriding these on an ancestor retimes every collapse below it.
+The three variables are declared on both `.collapse` and `.collapsing`, so overriding them on an ancestor retimes every collapse below it.
+
+`--cui-transition-collapse-property` names what animates. Adding to the animation is one declaration instead of a whole new `transition` — that is how `.collapse-horizontal` switches from `height` to `width`, and how the findable option adds `content-visibility`.
 
 <ScssDocs file="scss/_transitions.scss" capture="collapse-css-vars" />
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1047,10 +1047,11 @@ adornment in the library — so the button needs no icon markup at all:
   in two.** `$transition-collapse` and `$transition-collapse-width` were
   shorthands carrying the property, the duration and the easing at once, which
   meant retiming a collapse required restating the property. They are replaced
-  by `$transition-collapse-duration` and `$transition-collapse-timing`, emitted
-  as `--cui-transition-collapse-duration` / `-timing` on `.collapsing`, so the
-  timing can also be changed per instance at runtime. `$transition-fade` splits
-  the same way into `$transition-fade-duration` / `$transition-fade-timing`.
+  by `$transition-collapse-property`, `$transition-collapse-duration` and
+  `$transition-collapse-timing`, emitted as `--cui-transition-collapse-property`
+  / `-duration` / `-timing` on `.collapse` and `.collapsing`, so all three can
+  also be changed per instance at runtime. `$transition-fade` splits the same
+  way into `$transition-fade-duration` / `$transition-fade-timing`.
 
 #### Button
 

--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -9,6 +9,7 @@ $transition-fade-timing:      linear !default;
 // scss-docs-end fade-transition
 
 // scss-docs-start collapse-transition
+$transition-collapse-property: height !default;
 $transition-collapse-duration: .35s !default;
 $transition-collapse-timing:   ease !default;
 // scss-docs-end collapse-transition
@@ -30,11 +31,12 @@ $fade-tokens: defaults(
 
 // stylelint-enable scss/dollar-variable-default
 
-// stylelint-disable scss/dollar-variable-default
+// stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
 
 // scss-docs-start collapse-css-vars
 $collapse-tokens: defaults(
   (
+    --#{$prefix}transition-collapse-property: #{$transition-collapse-property},
     --#{$prefix}transition-collapse-duration: #{$transition-collapse-duration},
     --#{$prefix}transition-collapse-timing: #{$transition-collapse-timing},
   ),
@@ -42,7 +44,7 @@ $collapse-tokens: defaults(
 );
 // scss-docs-end collapse-css-vars
 
-// stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function, scss/dollar-variable-default
 
 @layer components {
   .fade {
@@ -55,6 +57,14 @@ $collapse-tokens: defaults(
   }
 
   // scss-docs-start collapse-classes
+  // Both classes carry the tokens: JavaScript swaps `.collapse` for
+  // `.collapsing` while the size animates, and find-in-page reveals the content
+  // without either swap happening.
+  .collapse,
+  .collapsing {
+    @include tokens($collapse-tokens);
+  }
+
   .collapse {
     // `until-found` content is hidden by the browser instead, which keeps it
     // laid out so find-in-page can reach it. `display: none` would take it back
@@ -65,16 +75,19 @@ $collapse-tokens: defaults(
   }
 
   .collapsing {
-    @include tokens($collapse-tokens);
-
     height: 0;
     overflow: hidden;
-    @include transition(height var(--#{$prefix}transition-collapse-duration) var(--#{$prefix}transition-collapse-timing));
+    @include transition-props(
+      var(--#{$prefix}transition-collapse-property),
+      var(--#{$prefix}transition-collapse-duration),
+      var(--#{$prefix}transition-collapse-timing)
+    );
 
     &.collapse-horizontal {
+      --#{$prefix}transition-collapse-property: width;
+
       width: 0;
       height: auto;
-      @include transition(width var(--#{$prefix}transition-collapse-duration) var(--#{$prefix}transition-collapse-timing));
     }
   }
   // scss-docs-end collapse-classes
@@ -87,11 +100,15 @@ $collapse-tokens: defaults(
     // Not scoped to `.collapse`: during the transition the element carries
     // `.collapsing` instead, and the declaration has to survive that swap.
     [data-coreui-hidden-until-found="true"] {
+      --#{$prefix}transition-collapse-property: height, content-visibility;
+
       interpolate-size: allow-keywords;
       overflow: hidden;
-      @include transition(
-        height var(--#{$prefix}transition-collapse-duration) var(--#{$prefix}transition-collapse-timing),
-        content-visibility var(--#{$prefix}transition-collapse-duration) allow-discrete
+      @include transition-props(
+        var(--#{$prefix}transition-collapse-property),
+        var(--#{$prefix}transition-collapse-duration),
+        var(--#{$prefix}transition-collapse-timing),
+        allow-discrete
       );
     }
 


### PR DESCRIPTION
## Findable collapses opened without animating

The three collapse transition variables were declared on `.collapsing` only. Find-in-page reveals a `data-coreui-hidden-until-found` area on its own — `beforematch` fires, the browser drops the `hidden` attribute, and `Collapse` adds `.show` — so `.collapsing` is never applied on that path. The `@supports (interpolate-size: allow-keywords)` rule read variables that nothing declared, which is invalid at computed-value time, so both longhands fell back to their initial values.

Measured in Chromium on `.collapse[data-coreui-hidden-until-found="true"]`:

| | before | after |
| --- | --- | --- |
| `transition-duration` | `0s` | `0.35s` |
| `transition-property` | `all` | `height, content-visibility` |
| `transition-behavior` | `normal` | `allow-discrete` |

The panel jumped to full height in one frame. The tokens are declared on `.collapse` as well now — both classes need them, because JavaScript removes `.collapse` for the duration of a scripted toggle.

## The animated property is a variable

`$transition-collapse-property` and `--cui-transition-collapse-property` are new, alongside the existing duration and timing.

`.collapse-horizontal` and the findable option each restated the entire `transition` just to change which property animates. They override the one variable now, and the two duplicate declarations are gone. Anyone animating something extra on a collapse writes one declaration instead of copying the rule.

`.collapsing.collapse-horizontal` is unchanged where it matters: `0.35s` / `width`, same as before.

## Gates

`stylelint --report-needless-disables` clean, `fusv` clean (1846 variables), `css-test` 62/62, `css-test-class-api` passed, `js-test-unit` 3212/3212, `js-test-visual` 35/35, `docs-build` 147 pages with no broken links, `bundlewatch` PASS on every bundle with no budget raised (`coreui.css` 63.16 kB against a 63.5 kB ceiling).

The map needs `stylelint-disable custom-property-no-missing-var-function`: the rule reads the map key as a value because the same custom property is also declared in a rule below. Same disable upstream carries on its collapse map.