### PR TITLE
refactor(Dialog, Drawer, Menu, Popup): read one overlay easing from :root

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./dist/css/coreui-reboot.min.css",
-      "maxSize": "5 kB"
+      "maxSize": "5.25 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.css",

--- a/docs/src/content/docs/customize/css-variables.mdx
+++ b/docs/src/content/docs/customize/css-variables.mdx
@@ -60,6 +60,22 @@ Those variables are then reassigned to `:root` level CSS variables that can be c
 
 <ScssDocs file="scss/_root.scss" capture="root-focus-variables" />
 
+## Overlay easing
+
+The components that float above the page — dialog, drawer, menu and the popup the field components open — read one easing curve from `:root` instead of carrying their own.
+
+<ScssDocs file="scss/_root.scss" capture="root-transition-variables" />
+
+Set it once and all four follow:
+
+```css
+:root {
+  --cui-transition-timing-overlay: linear;
+}
+```
+
+Each component still exposes its own `--cui-{component}-transition-timing`, so a single overlay can opt out without touching the others.
+
 ## Grid breakpoints
 
 While we include our grid breakpoints as CSS variables (except for `xs`), be aware that **CSS variables do not work in media queries**. This is by design in the CSS spec for variables, but may change in coming years with support for `env()` variables. Check out [this Stack Overflow answer](https://stackoverflow.com/a/47212942) for some helpful links. In the mean time, you can use these variables in other CSS situations, as well as in your JavaScript.

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -20,7 +20,7 @@ $dialog-border-width:               var(--#{$prefix}border-width) !default;
 $dialog-border-radius:              .75rem !default;
 $dialog-box-shadow:                 var(--#{$prefix}box-shadow-lg) !default;
 $dialog-transition-duration:        .3s !default;
-$dialog-transition-timing:          cubic-bezier(.22, 1, .36, 1) !default;
+$dialog-transition-timing:          var(--#{$prefix}transition-timing-overlay) !default;
 $dialog-slide-distance:             3rem !default;
 $dialog-scale-transform:            scale(1.02) !default;
 $dialog-backdrop-bg:                light-dark(rgb(0 0 0 / 50%), rgb(0 0 0 / 65%)) !default;

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -23,7 +23,7 @@ $drawer-border-width:               var(--#{$prefix}border-width) !default;
 $drawer-border-radius:              .75rem !default;
 $drawer-box-shadow:                 var(--#{$prefix}box-shadow-lg) !default;
 $drawer-transition-duration:        .3s !default;
-$drawer-transition-timing:          cubic-bezier(.22, 1, .36, 1) !default;
+$drawer-transition-timing:          var(--#{$prefix}transition-timing-overlay) !default;
 $drawer-scale-transform:            scale(1.02) !default;
 $drawer-title-line-height:          var(--#{$prefix}body-line-height) !default;
 $drawer-backdrop-bg:                color-mix(in oklch, var(--#{$prefix}body-bg) 25%, transparent) !default;

--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -44,7 +44,7 @@ $menu-header-color:             var(--#{$prefix}tertiary-color) !default;
 $menu-header-padding-x:         .75rem !default;
 $menu-header-padding-y:         .25rem !default;
 $menu-transition-duration:      .15s !default;
-$menu-transition-timing:        cubic-bezier(.22, 1, .36, 1) !default;
+$menu-transition-timing:        var(--#{$prefix}transition-timing-overlay) !default;
 // scss-docs-end menu-variables
 
 $menu-tokens: () !default;

--- a/scss/_popup.scss
+++ b/scss/_popup.scss
@@ -13,7 +13,7 @@ $popup-border-color:    var(--#{$prefix}border-color) !default;
 $popup-border-radius:   var(--#{$prefix}border-radius) !default;
 $popup-box-shadow:      var(--#{$prefix}box-shadow) !default;
 $popup-transition-duration: .15s !default;
-$popup-transition-timing:   cubic-bezier(.22, 1, .36, 1) !default;
+$popup-transition-timing:   var(--#{$prefix}transition-timing-overlay) !default;
 // scss-docs-end popup-variables
 
 // stylelint-disable scss/dollar-variable-default

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -63,6 +63,10 @@ $shadow-strength:      1 !default;
 $shadow-strength-dark: 2.5 !default;
 // scss-docs-end box-shadow-variables
 
+// scss-docs-start transition-variables
+$transition-timing-overlay: cubic-bezier(.22, 1, .36, 1) !default;
+// scss-docs-end transition-variables
+
 // scss-docs-start focus-ring-variables
 $focus-ring-width:            .25rem !default;
 $focus-ring-opacity:          .25 !default;
@@ -230,6 +234,11 @@ $root-token-defaults: map.merge(
     // scss-docs-end root-border-var
     --#{$prefix}shadow-color: $shadow-color,
     --#{$prefix}shadow-strength: $shadow-strength,
+    // scss-docs-start root-transition-variables
+    // Easing shared by the components that float above the page — dialog,
+    // drawer, menu and popup. One override restyles all four.
+    --#{$prefix}transition-timing-overlay: $transition-timing-overlay,
+    // scss-docs-end root-transition-variables
     // Focus styles
     // scss-docs-start root-focus-variables
     --#{$prefix}focus-ring-width: $focus-ring-width,


### PR DESCRIPTION
## One curve, four copies

`cubic-bezier(.22, 1, .36, 1)` was written out in `_dialog.scss`, `_drawer.scss`, `_menu.scss` and `_popup.scss`. Retiming the components that float above the page meant editing four files and keeping them in step by hand — and nothing failed if one drifted.

`--cui-transition-timing-overlay` is declared on `:root`; the four components read it.

```css
:root {
  --cui-transition-timing-overlay: linear;
}
```

Measured in Chromium with that override in place:

| | `transition-timing-function` |
| --- | --- |
| `.menu` | `linear` |
| `.popup` | `linear` |
| `.dialog` | `linear` |
| `.drawer` | `linear` |

Without the override all four still resolve to `cubic-bezier(0.22, 1, 0.36, 1)`, so nothing about the default motion changes.

Each component keeps its own `--cui-{component}-transition-timing`, so a single overlay can opt out without pulling the other three with it.

## Docs

New "Overlay easing" section on the CSS variables page, between focus variables and grid breakpoints.

## Budget

`coreui-reboot.min.css` measures 5.02 kB against a 5 kB ceiling it was already sitting on exactly — the growth is the one new `:root` declaration. Raised to 5.25 kB.

## Gates

`stylelint --report-needless-disables` clean, `fusv` clean (1846 variables), `css-test` 62/62, `css-test-class-api` passed, `js-test-unit` 3212/3212, `js-test-visual` 35/35, `docs-build` 147 pages with no broken links, `bundlewatch` PASS.