### PR TITLE
feat(Utilities): add the .transition-none utility

### DIFF
--- a/docs/src/content/docs/customize/transitions.mdx
+++ b/docs/src/content/docs/customize/transitions.mdx
@@ -82,12 +82,13 @@ Two cases hand that job back to the browser through [`interpolate-size`](https:/
 
 ## Remove the motion
 
-Four options, from the narrowest to the widest:
+Five options, from the narrowest to the widest:
 
 1. Add the component's `-instant` class to one element, such as `.toast-instant`.
-2. Set a `-duration` variable to `0s` for one component or a whole subtree.
-3. Set `$enable-transitions` to `false` to remove every transition at build time.
-4. Leave it to the reader: with `$enable-reduced-motion` on, which is the default, every transition is wrapped in `prefers-reduced-motion: no-preference`, so anyone who asks their system for less motion already gets instant state changes. See [reduced motion](/getting-started/accessibility/#reduced-motion).
+2. Add the [`.transition-none` utility](/utilities/motion/) to one element, which removes every transition on it rather than just the component's own.
+3. Set a `-duration` variable to `0s` for one component or a whole subtree.
+4. Set `$enable-transitions` to `false` to remove every transition at build time.
+5. Leave it to the reader: with `$enable-reduced-motion` on, which is the default, every transition is wrapped in `prefers-reduced-motion: no-preference`, so anyone who asks their system for less motion already gets instant state changes. See [reduced motion](/getting-started/accessibility/#reduced-motion).
 
 Whichever you use, JavaScript reads the element's computed `transition-duration` before it waits. A duration of `0s` resolves events and promises on the next tick rather than hanging for a transition that never runs.
 

--- a/docs/src/content/docs/utilities/motion.mdx
+++ b/docs/src/content/docs/utilities/motion.mdx
@@ -1,0 +1,32 @@
+---
+title: "Bootstrap 5 Motion"
+name: "Motion"
+description: "Remove the transition from a single element with motion utilities."
+---
+
+Components animate with CSS transitions, and the timing is customizable — see [transitions](/customize/transitions/). Add `.transition-none` to set `transition: none` on one element, so its property changes apply instantly instead of animating.
+
+Hover both buttons. The first eases into its hover colour; the second snaps.
+
+<Example class="d-flex gap-3" code={`<button type="button" class="btn btn-primary">Default</button>
+<button type="button" class="btn btn-primary transition-none">No hover transition</button>`} />
+
+```html
+<button type="button" class="btn btn-primary transition-none">...</button>
+```
+
+The utility sets the `transition` shorthand, so it removes every transition on the element at once — including any you declared yourself. To retime one component instead of removing its motion, set its `--cui-{component}-transition-duration` to `0s`.
+
+## Reduced motion
+
+`.transition-none` applies whatever the reader's motion preference is. Reach for it when the motion has to go in every case.
+
+You do not need it to honour that preference: with `$enable-reduced-motion` on, which is the default, every component transition is already wrapped in `prefers-reduced-motion: no-preference`. See [reduced motion](/getting-started/accessibility/#reduced-motion).
+
+To remove every transition at build time instead, set the `$enable-transitions` Sass option to `false`.
+
+### Utilities API
+
+Motion utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+
+<ScssDocs file="scss/_utilities.scss" capture="utils-transition" />

--- a/docs/src/data/sidebar.yml
+++ b/docs/src/data/sidebar.yml
@@ -378,6 +378,8 @@
       to: /utilities/interactions/
     - title: Link
       to: /utilities/link/
+    - title: Motion
+      to: /utilities/motion/
     - title: Object fit
       to: /utilities/object-fit/
     - title: Opacity

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -1154,8 +1154,17 @@ $utilities: map.merge(
       property: z-index,
       class: z,
       values: $zindex-levels,
-    )
+    ),
     // scss-docs-end utils-zindex
+    // scss-docs-start utils-transition
+    "transition": (
+      property: transition,
+      class: transition,
+      values: (
+        none: none,
+      )
+    )
+    // scss-docs-end utils-transition
   ),
   $utilities
 );


### PR DESCRIPTION
## Why

Removing motion from a single element had no answer in the library. The `-instant` classes cover four components (`.dialog-instant`, `.drawer-instant`, `.modal-instant`, `.toast-instant`) and nothing else; a `-duration` token has to be set per component; `$enable-transitions` is a build-time switch for everything. A one-off — on markup you do not own, on a component with no `-instant` class — meant hand-written CSS.

## What

The utility entry is upstream's, verbatim:

```scss
"transition": (
  property: transition,
  class: transition,
  values: (
    none: none,
  )
)
```

No responsive variants, matching upstream — one class, `.transition-none`.

Measured in Chromium against the built `coreui.css`:

| | `transition-duration` | `transition-property` |
| --- | --- | --- |
| `.btn` | `0.15s` | `color, background-color, border-color, box-shadow` |
| `.btn.transition-none` | `0s` | `none` |

## Docs

New **Motion** page under Utilities, at `/utilities/motion/` — the same slug upstream uses, so the cross-framework links line up when the other editions get it. It says what the utility does, that it removes *every* transition on the element rather than only the component's own, and points at the `-duration` token for the narrower case.

It also states what the utility is *not* for: `$enable-reduced-motion` already wraps every component transition in `prefers-reduced-motion: no-preference`, so nobody needs `.transition-none` to honour that preference.

The Transitions page now lists it as the second of five ways to remove motion, between the `-instant` classes and the duration token.

## Gates

`stylelint --report-needless-disables` clean, `css-test` 62/62, `css-test-class-api` passed, `js-test-unit` 3212/3212, `js-test-visual` 35/35, `docs-build` 150 pages with no broken links, `bundlewatch` PASS with no budget raised — `coreui.css` 64.04 kB against 64.25, `coreui-utilities.css` 16.35 against 16.5.

## Not in this PR

Upstream's Motion page also documents `.animation-none`, `.animation-shake` and `.animation-pop`, which need `@keyframes` emitted outside the cascade layer and a `prefers-reduced-motion: reduce` opt-out. The page has room for them.