### PR TITLE
feat(Collapse)!: CSS owns the animation, JavaScript measures only as a fallback

### DIFF
--- a/docs/src/content/docs/components/collapse.mdx
+++ b/docs/src/content/docs/components/collapse.mdx
@@ -8,7 +8,7 @@ otherFrameworks:
 
 ## How it works
 
-The collapse JavaScript plugin is used to show and hide content. Buttons or anchors are used as triggers that are mapped to specific elements you toggle. Collapsing an element will animate the `height` from its current value to `0`. Given how CSS handles animations, you cannot use `padding` on a `.collapse` element. Instead, use the class as an independent wrapping element.
+The collapse JavaScript plugin is used to show and hide content. Buttons or anchors are used as triggers that are mapped to specific elements you toggle. Collapsing an element animates its `height` between `0` and the natural size of the content — the browser interpolates the size itself through [`interpolate-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size), and where that is not supported JavaScript measures the two sizes and the stylesheet still times the move. Given how CSS handles animations, you cannot use `padding` on a `.collapse` element. Instead, use the class as an independent wrapping element.
 
 <Callout color="info">
 This component's animation effect relies on the `prefers-reduced-motion` media query. For more information, refer to the [reduced motion section of our accessibility documentation](/getting-started/accessibility/#reduced-motion).
@@ -18,9 +18,9 @@ This component's animation effect relies on the `prefers-reduced-motion` media q
 
 Click the buttons below to show and hide another element via class changes:
 
-- `.collapse` hides content
-- `.collapsing` is applied during transitions
-- `.collapse.show` shows content
+- `.collapse` stays on the element at all times; without `.show` the content is hidden
+- `.show` lands at the start of the opening transition and leaves at the start of the closing one
+- `.collapsing` is applied while either transition runs
 
 You can use a link with the `href` attribute, or a button with the `data-coreui-target` attribute. In both samples, the `data-coreui-toggle="collapse""` is required.
 
@@ -116,9 +116,9 @@ Note that CoreUI for Bootstrap's current implementation does not cover the vario
 
 The collapse plugin utilizes a few classes to handle the heavy lifting:
 
-- `.collapse` hides the content
-- `.collapse.show` shows the content
-- `.collapsing` is added when the transition starts, and removed when it finishes
+- `.collapse` marks the element and never leaves it; without `.show` the content is hidden
+- `.collapse.show` shows the content — the class is added when the opening transition starts and removed when the closing one starts
+- `.collapsing` is added when either transition starts, and removed when it finishes
 
 These classes can be found in `_transitions.scss`.
 
@@ -200,7 +200,7 @@ myCollapsible.addEventListener('hidden.coreui.collapse', event => {
 
 The three variables are declared on both `.collapse` and `.collapsing`, so overriding them on an ancestor retimes every collapse below it.
 
-`--cui-transition-collapse-property` names what animates. Adding to the animation is one declaration instead of a whole new `transition` — that is how `.collapse-horizontal` switches from `height` to `width`, and how the findable option adds `content-visibility`.
+`--cui-transition-collapse-property` names what animates. Adding to the animation is one declaration instead of a whole new `transition` — that is how `.collapse-horizontal` switches from `height` to `width`, and how the findable option adds `content-visibility`. Keep `display` in the list: it is what holds the element in the layout until the closing transition ends.
 
 <ScssDocs file="scss/_transitions.scss" capture="collapse-css-vars" />
 

--- a/docs/src/content/docs/customize/transitions.mdx
+++ b/docs/src/content/docs/customize/transitions.mdx
@@ -5,7 +5,7 @@ description: "How CoreUI components animate, which state classes drive them, and
 
 ## How it works
 
-CSS owns every component transition. JavaScript toggles a state class and then waits for the transition to finish before it fires an event or resolves a promise. It never writes a `transition` and, apart from the collapse height it has to measure, never writes a style at all.
+CSS owns every component transition. JavaScript toggles a state class and then waits for the transition to finish before it fires an event or resolves a promise. It never writes a `transition` and, apart from the sizes it measures for browsers without `interpolate-size`, never writes a style at all.
 
 That split is what makes the motion customizable: restyle it in CSS and the component follows, with no need to reimplement anything.
 
@@ -74,11 +74,11 @@ Each of them still has its own `--cui-{component}-transition-timing`, so one ove
 
 ### Size animations
 
-Collapse and accordion animate a size rather than an opacity. The collapse measures its content in JavaScript, because `0` cannot interpolate to `auto` on its own.
+Collapse and accordion animate a size rather than an opacity. `0` cannot interpolate to `auto` on its own, so both let the browser do it through [`interpolate-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size): the stylesheet owns the whole animation and JavaScript only toggles the state class. Where `interpolate-size` is missing, JavaScript measures the two sizes and the stylesheet still times the move between them — the motion is the same everywhere, only who measures differs.
 
 <ScssDocs file="scss/_transitions.scss" capture="collapse-transition" />
 
-Two cases hand that job back to the browser through [`interpolate-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size): the accordion, which is built on the native disclosure element, and a collapse with [`data-coreui-hidden-until-found`](/components/collapse/#findable-when-collapsed) set. Where `interpolate-size` is missing the collapse falls back to the measured animation, so the motion is the same everywhere.
+The collapse's `display` transitions discretely with `allow-discrete`, which is what keeps the closing element in the layout until its size reaches `0`.
 
 ## Remove the motion
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1053,6 +1053,27 @@ adornment in the library — so the button needs no icon markup at all:
   also be changed per instance at runtime. `$transition-fade` splits the same
   way into `$transition-fade-duration` / `$transition-fade-timing`.
 
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **CSS owns the collapse animation, and the class choreography follows.**
+  Where `interpolate-size: allow-keywords` is supported the stylesheet
+  interpolates the size to the `auto` of the open state on its own; elsewhere
+  JavaScript measures the two sizes and the stylesheet still times the move.
+  Three observable changes come with that:
+
+  - **`.collapse` never leaves the element.** It used to be swapped out for
+    `.collapsing` while the transition ran; now `.collapsing` is added
+    alongside it, so `.collapse.collapsing` matches during a run and a selector
+    keying on the *absence* of `.collapse` no longer fires mid-animation.
+  - **`.show` toggles at the start of both directions.** It used to land at
+    the end of the opening transition. A rule styling `.collapse.show` applies
+    for the whole expansion now, and its absence marks the whole closing run.
+  - **An open `.collapse-horizontal` is `fit-content` wide, not as wide as its
+    container** — the open size is the animation's target, and a target of
+    `auto` would spend most of the run growing an empty box past the content.
+    This also removes the end-of-animation jump to full container width the
+    measured animation used to make. Style the child, as the docs always
+    showed, and nothing changes.
+
 #### Button
 
 - **A toggle button always exposes `aria-pressed` now.** The attribute has no

--- a/js/src/accordion.ts
+++ b/js/src/accordion.ts
@@ -8,7 +8,8 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { defineJQueryPlugin, reflow } from './util/index.js'
+import { defineJQueryPlugin } from './util/index.js'
+import { startSizeTransition, supportsInterpolateSize } from './util/size-transition.js'
 
 /**
  * Constants
@@ -31,14 +32,6 @@ const SELECTOR_ACCORDION = '.accordion'
 const SELECTOR_HEADER = '.accordion-header'
 const SELECTOR_INTERACTIVE = 'a, button, input, select, textarea'
 const SELECTOR_ITEM = 'details.accordion-item'
-
-// Chromium animates `block-size: 0 -> auto` on its own through `interpolate-size`,
-// so this component only exists for the browsers that cannot. It is safe to drop
-// once Firefox and WebKit ship `calc-size()`.
-const supportsNativeAnimation = (): boolean =>
-  typeof CSS !== 'undefined' &&
-  typeof CSS.supports === 'function' &&
-  CSS.supports('interpolate-size', 'allow-keywords')
 
 /**
  * Class definition
@@ -184,28 +177,17 @@ class Accordion extends BaseComponent {
     }
   }
 
-  // Sets the two sizes and lets the stylesheet time the move between them, so
-  // the duration, the easing and the reduced-motion decision are read from one
-  // place by both paths and this file needs no token names.
   async _animate(details: HTMLDetailsElement, from: number, to: number, onFinish?: () => void): Promise<void> {
     // Where the panel is animated by CSS, running this one too would drive the
     // same expansion from both ends.
-    if (supportsNativeAnimation()) {
+    if (supportsInterpolateSize()) {
       onFinish?.()
       return
     }
 
     details.setAttribute(ATTRIBUTE_ANIMATING, '')
 
-    // The starting size has to land unanimated, or the transition the attribute
-    // just enabled would run towards it and the real move would cancel it.
-    details.style.transition = 'none'
-    details.style.blockSize = `${from}px`
-
-    reflow(details)
-
-    details.style.transition = ''
-    details.style.blockSize = `${to}px`
+    startSizeTransition(details, 'blockSize', from, to)
 
     await this._queueCallback(() => {
       onFinish?.()
@@ -250,7 +232,7 @@ EventHandler.on(document, EVENT_TOGGLE_DATA_API, SELECTOR_ITEM, function (this: 
 // natively.
 EventHandler.on(document, EVENT_CLICK_DATA_API, (event: Event) => {
   // Where CSS can animate the panel, the element is left to toggle itself.
-  if (supportsNativeAnimation() || event.defaultPrevented) {
+  if (supportsInterpolateSize() || event.defaultPrevented) {
     return
   }
 

--- a/js/src/base-component.ts
+++ b/js/src/base-component.ts
@@ -57,7 +57,7 @@ class BaseComponent extends Config {
   // Runs `callback` once the transition on `element` ends, and resolves afterwards.
   // Lifecycle methods return this promise, so `await instance.show()` continues at the
   // same moment a `shown.coreui.*` listener would run.
-  _queueCallback(callback: () => void, element: Element, isAnimated = true): Promise<void> {
+  _queueCallback(callback: () => void, element: Element, isAnimated = true, transitionProperty?: string): Promise<void> {
     return new Promise(resolve => {
       executeAfterTransition(() => {
         // Don't run the completion callback if the instance was disposed mid-transition.
@@ -67,7 +67,7 @@ class BaseComponent extends Config {
         }
 
         resolve()
-      }, element, isAnimated)
+      }, element, isAnimated, transitionProperty)
     })
   }
 

--- a/js/src/collapse.ts
+++ b/js/src/collapse.ts
@@ -15,9 +15,9 @@ import SelectorEngine from './dom/selector-engine.js'
 import {
   defineJQueryPlugin,
   getElement,
-  reflow,
   setAriaAttribute
 } from './util/index.js'
+import { startSizeTransition, supportsInterpolateSize } from './util/size-transition.js'
 
 /**
  * Constants
@@ -48,7 +48,9 @@ const HEIGHT = 'height'
 const ATTRIBUTE_HIDDEN = 'hidden'
 const VALUE_UNTIL_FOUND = 'until-found'
 
-const SELECTOR_ACTIVES = '.collapse.show, .collapse.collapsing'
+// `.show` lands at the start of both directions, so on its own it means
+// "open or opening" and leaves a closing sibling alone.
+const SELECTOR_ACTIVES = '.collapse.show'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="collapse"]'
 const SELECTOR_HIDDEN_UNTIL_FOUND = '.collapse[data-coreui-hidden-until-found="true"]'
 
@@ -76,13 +78,6 @@ type CollapseConfig = {
 // with `!important` — so an area carrying a display utility would show.
 const supportsUntilFound = (): boolean =>
   typeof document !== 'undefined' && 'onbeforematch' in document.documentElement
-
-// Where `auto` can be interpolated, a `hidden="until-found"` area is animated by
-// the stylesheet: it stays in the layout, so its height needs no measuring.
-const usesInterpolatedHeight = (): boolean =>
-  typeof CSS !== 'undefined' &&
-  typeof CSS.supports === 'function' &&
-  CSS.supports('interpolate-size', 'allow-keywords')
 
 /**
  * Class definition
@@ -154,7 +149,7 @@ class Collapse extends BaseComponent {
     // find active children
     if (this._config.parent) {
       activeChildren = this._getFirstLevelChildren(SELECTOR_ACTIVES)
-        .filter(element => element !== this._element)
+        .filter(element => element !== this._element && !this._sharesTrigger(element))
         .map(element => Collapse.getOrCreateInstance(element))
     }
 
@@ -172,45 +167,37 @@ class Collapse extends BaseComponent {
     }
 
     const dimension = this._getDimension()
-    const interpolated = this._usesInterpolatedHeight()
 
     this._setHiddenUntilFound(false)
 
-    this._element.classList.remove(CLASS_NAME_COLLAPSE)
-    this._element.classList.add(CLASS_NAME_COLLAPSING)
-
-    if (!interpolated) {
-      this._element.style[dimension] = '0'
-    }
+    // `.show` lands at the start on both paths: the stylesheet reads it as the
+    // open state and animates towards it, while `.collapsing` marks the run.
+    this._element.classList.add(CLASS_NAME_COLLAPSING, CLASS_NAME_SHOW)
 
     this._setAriaExpanded(this._triggerArray, true)
     this._isTransitioning = true
 
     const complete = () => {
       this._isTransitioning = false
-
       this._element.classList.remove(CLASS_NAME_COLLAPSING)
-      this._element.classList.add(CLASS_NAME_COLLAPSE, CLASS_NAME_SHOW)
-
       this._element.style[dimension] = ''
 
       EventHandler.trigger(this._element, EVENT_SHOWN)
     }
 
-    if (interpolated) {
-      await this._queueCallback(complete, this._element, true)
+    // Where the stylesheet interpolates the size itself, the class toggle is
+    // the whole show; driving the size from here too would run the same
+    // expansion from both ends.
+    if (supportsInterpolateSize()) {
+      await this._queueCallback(complete, this._element, true, dimension)
       return
     }
 
     const capitalizedDimension = dimension[0].toUpperCase() + dimension.slice(1)
     const scrollSize = `scroll${capitalizedDimension}` as 'scrollWidth' | 'scrollHeight'
 
-    // Register the completion callback first, then set the target size to start the
-    // transition. Awaiting here instead would stop the size from ever being applied.
-    const transition = this._queueCallback(complete, this._element, true)
-    this._element.style[dimension] = `${this._element[scrollSize]}px`
-
-    await transition
+    startSizeTransition(this._element, dimension, 0, this._element[scrollSize])
+    await this._queueCallback(complete, this._element, true, dimension)
   }
 
   async hide(): Promise<void> {
@@ -223,22 +210,20 @@ class Collapse extends BaseComponent {
       return
     }
 
+    const cssPath = supportsInterpolateSize()
     const dimension = this._getDimension()
-    const interpolated = this._usesInterpolatedHeight()
+    const size = cssPath ? 0 : this._element.getBoundingClientRect()[dimension]
 
-    if (interpolated) {
+    this._element.classList.add(CLASS_NAME_COLLAPSING)
+
+    if (cssPath) {
       // The attribute is what the stylesheet animates towards, so it goes on
       // now rather than at the end; `content-visibility` is transitioned with
       // `allow-discrete`, which keeps the content on screen until it finishes.
       this._setHiddenUntilFound(true)
-    } else {
-      this._element.style[dimension] = `${this._element.getBoundingClientRect()[dimension]}px`
-
-      reflow(this._element)
     }
 
-    this._element.classList.add(CLASS_NAME_COLLAPSING)
-    this._element.classList.remove(CLASS_NAME_COLLAPSE, CLASS_NAME_SHOW)
+    this._element.classList.remove(CLASS_NAME_SHOW)
 
     for (const trigger of this._triggerArray) {
       const element = SelectorEngine.getElementFromSelector(trigger)
@@ -253,18 +238,25 @@ class Collapse extends BaseComponent {
     const complete = () => {
       this._isTransitioning = false
       this._element.classList.remove(CLASS_NAME_COLLAPSING)
-      this._element.classList.add(CLASS_NAME_COLLAPSE)
+      this._element.style[dimension] = ''
 
-      if (!interpolated) {
+      // A fallback browser gets the attribute only once the area is fully
+      // collapsed; mid-animation it would hide the content on the spot.
+      if (!cssPath) {
         this._setHiddenUntilFound(true)
       }
 
       EventHandler.trigger(this._element, EVENT_HIDDEN)
     }
 
-    this._element.style[dimension] = ''
+    if (!cssPath) {
+      startSizeTransition(this._element, dimension, size, 0)
+    }
 
-    await this._queueCallback(complete, this._element, true)
+    // The wait is pinned to the size property: `display` and
+    // `content-visibility` fire their own `transitionend`, and a leftover one
+    // from the previous run would settle this one on the spot.
+    await this._queueCallback(complete, this._element, true, dimension)
   }
 
   // Private
@@ -279,6 +271,14 @@ class Collapse extends BaseComponent {
 
   _getDimension(): 'width' | 'height' {
     return this._element.classList.contains(CLASS_NAME_HORIZONTAL) ? WIDTH : HEIGHT
+  }
+
+  // One trigger can target more than one collapse. Those collapses open
+  // together, so a shared parent must not close them against each other.
+  _sharesTrigger(element: HTMLElement): boolean {
+    return this._triggerArray.some(
+      trigger => SelectorEngine.getMultipleElementsFromSelector(trigger).includes(element)
+    )
   }
 
   _initializeChildren(): void {
@@ -301,10 +301,6 @@ class Collapse extends BaseComponent {
     const children = SelectorEngine.find(CLASS_NAME_DEEPER_CHILDREN, this._config.parent as ParentNode)
     // remove children if greater depth
     return SelectorEngine.find(selector, this._config.parent as ParentNode).filter(element => !children.includes(element))
-  }
-
-  _usesInterpolatedHeight(): boolean {
-    return this._config.hiddenUntilFound && supportsUntilFound() && usesInterpolatedHeight()
   }
 
   _setHiddenUntilFound(hidden: boolean): void {

--- a/js/src/util/index.ts
+++ b/js/src/util/index.ts
@@ -254,7 +254,12 @@ const execute = <T = any>(possibleCallback: T | ((...functionArgs: any[]) => T),
   return typeof possibleCallback === 'function' ? (possibleCallback as (...functionArgs: any[]) => T).call(...args as [any, ...any[]]) : defaultValue as T
 }
 
-const executeAfterTransition = (callback: () => void, transitionElement: Element, waitForTransition = true): void => {
+// `transitionProperty` narrows the wait to that property's own `transitionend`.
+// A multi-property transition fires one event per property, and the events of a
+// run that just finished can land after the next run has started waiting — an
+// unfiltered waiter picks such a leftover up and settles a whole animation
+// early. The emulated event carries no `propertyName` and always passes.
+const executeAfterTransition = (callback: () => void, transitionElement: Element, waitForTransition = true, transitionProperty?: string): void => {
   if (!waitForTransition) {
     execute(callback)
     return
@@ -265,8 +270,13 @@ const executeAfterTransition = (callback: () => void, transitionElement: Element
 
   let called = false
 
-  const handler = ({ target }: Event): void => {
-    if (target !== transitionElement) {
+  const handler = (event: Event): void => {
+    if (event.target !== transitionElement) {
+      return
+    }
+
+    const { propertyName } = event as TransitionEvent
+    if (transitionProperty && propertyName && propertyName !== transitionProperty) {
       return
     }
 

--- a/js/src/util/size-transition.ts
+++ b/js/src/util/size-transition.ts
@@ -1,0 +1,37 @@
+/**
+ * --------------------------------------------------------------------------
+ * CoreUI util/size-transition.ts
+ * Licensed under MIT (https://github.com/coreui/coreui/blob/main/LICENSE)
+ * --------------------------------------------------------------------------
+ */
+
+import { reflow } from './index.js'
+
+// Chromium interpolates a size to the `auto` of the open state on its own
+// through `interpolate-size`; the choreography below only exists for the
+// browsers that cannot. It is safe to drop once Firefox and WebKit ship
+// `calc-size()`.
+const supportsInterpolateSize = (): boolean =>
+  typeof CSS !== 'undefined' &&
+  typeof CSS.supports === 'function' &&
+  CSS.supports('interpolate-size', 'allow-keywords')
+
+type SizeProperty = 'blockSize' | 'height' | 'width'
+
+// Sets the two sizes and lets the stylesheet time the move between them, so the
+// duration, the easing and the reduced-motion decision are read from one place
+// by every caller and this file needs no token names. The caller owns waiting
+// for the transition and clearing the inline size afterwards.
+const startSizeTransition = (element: HTMLElement, property: SizeProperty, from: number, to: number): void => {
+  // The starting size has to land unanimated, or the transition would run
+  // towards it and the real move would cancel it.
+  element.style.transition = 'none'
+  element.style[property] = `${from}px`
+
+  reflow(element)
+
+  element.style.transition = ''
+  element.style[property] = `${to}px`
+}
+
+export { startSizeTransition, supportsInterpolateSize }

--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -9,7 +9,7 @@ $transition-fade-timing:      linear !default;
 // scss-docs-end fade-transition
 
 // scss-docs-start collapse-transition
-$transition-collapse-property: height !default;
+$transition-collapse-property: "height, display" !default;
 $transition-collapse-duration: .35s !default;
 $transition-collapse-timing:   ease !default;
 // scss-docs-end collapse-transition
@@ -57,37 +57,97 @@ $collapse-tokens: defaults(
   }
 
   // scss-docs-start collapse-classes
-  // Both classes carry the tokens: JavaScript swaps `.collapse` for
-  // `.collapsing` while the size animates, and find-in-page reveals the content
-  // without either swap happening.
+  // Both classes carry the tokens: `.collapsing` marks a running transition on
+  // either path, and find-in-page reveals the content with neither toggle
+  // happening.
   .collapse,
   .collapsing {
     @include tokens($collapse-tokens);
   }
 
-  .collapse {
-    // `until-found` content is hidden by the browser instead, which keeps it
-    // laid out so find-in-page can reach it. `display: none` would take it back
-    // out of the layout and undo that.
-    &:not(.show, [hidden="until-found"]) {
-      display: none;
+  // As wide as its content, not as wide as its container: the open size is the
+  // animation's target, and a target of `auto` would spend most of the run
+  // growing an empty box past the content.
+  .collapse-horizontal {
+    width: fit-content;
+  }
+
+  // The browser animates the size itself: `interpolate-size` lets the `0` of
+  // the closed state interpolate to the `auto` of the open one, and `display`
+  // transitions discretely, so the element stays laid out until the size
+  // reaches `0`.
+  @supports (interpolate-size: allow-keywords) {
+    .collapse {
+      interpolate-size: allow-keywords;
+      @include transition-props(
+        var(--#{$prefix}transition-collapse-property),
+        var(--#{$prefix}transition-collapse-duration),
+        var(--#{$prefix}transition-collapse-timing),
+        allow-discrete
+      );
+
+      // `until-found` content is hidden by the browser instead, which keeps it
+      // laid out so find-in-page can reach it. `display: none` would take it
+      // back out of the layout and undo that.
+      &:not(.show, [hidden="until-found"]) {
+        display: none;
+        height: 0;
+      }
+
+      // The box is clipped only while the move runs, so a dropdown inside an
+      // open collapse can still spill out of it.
+      &.collapsing {
+        overflow: hidden;
+      }
+
+      // A hidden collapse is not rendered, so the opening side needs a start
+      // value of its own — but only when JavaScript marks the run: a collapse
+      // that loads already open must not play an entrance.
+      &.show.collapsing {
+        @starting-style {
+          height: 0;
+        }
+      }
+
+      &.collapse-horizontal {
+        --#{$prefix}transition-collapse-property: width, display;
+
+        &:not(.show, [hidden="until-found"]) {
+          width: 0;
+          height: auto;
+        }
+
+        &.show.collapsing {
+          @starting-style {
+            width: 0;
+          }
+        }
+      }
     }
   }
 
-  .collapsing {
-    height: 0;
-    overflow: hidden;
-    @include transition-props(
-      var(--#{$prefix}transition-collapse-property),
-      var(--#{$prefix}transition-collapse-duration),
-      var(--#{$prefix}transition-collapse-timing)
-    );
+  // Everywhere else JavaScript measures the two sizes and the stylesheet still
+  // times the move between them.
+  @supports not (interpolate-size: allow-keywords) {
+    .collapse:not(.show, .collapsing, [hidden="until-found"]) {
+      display: none;
+    }
 
-    &.collapse-horizontal {
-      --#{$prefix}transition-collapse-property: width;
+    .collapsing {
+      height: 0;
+      overflow: hidden;
+      @include transition-props(
+        var(--#{$prefix}transition-collapse-property),
+        var(--#{$prefix}transition-collapse-duration),
+        var(--#{$prefix}transition-collapse-timing)
+      );
 
-      width: 0;
-      height: auto;
+      &.collapse-horizontal {
+        --#{$prefix}transition-collapse-property: width;
+
+        width: 0;
+        height: auto;
+      }
     }
   }
   // scss-docs-end collapse-classes
@@ -97,25 +157,12 @@ $collapse-tokens: defaults(
   // JavaScript. Scoped to the option rather than to `[hidden]`, because that
   // attribute comes and goes while the opt-in does not.
   @supports (interpolate-size: allow-keywords) {
-    // Not scoped to `.collapse`: during the transition the element carries
-    // `.collapsing` instead, and the declaration has to survive that swap.
     [data-coreui-hidden-until-found="true"] {
       --#{$prefix}transition-collapse-property: height, content-visibility;
 
-      interpolate-size: allow-keywords;
+      // Clipped at all times, not only under `.collapsing`: find-in-page
+      // reveals the panel with no class toggle happening.
       overflow: hidden;
-      @include transition-props(
-        var(--#{$prefix}transition-collapse-property),
-        var(--#{$prefix}transition-collapse-duration),
-        var(--#{$prefix}transition-collapse-timing),
-        allow-discrete
-      );
-    }
-
-    // `.collapsing` still marks the transition for anyone styling it, but its
-    // own height would clamp the one being interpolated.
-    .collapsing[data-coreui-hidden-until-found="true"] {
-      height: auto;
     }
 
     [data-coreui-hidden-until-found="true"][hidden="until-found"] {


### PR DESCRIPTION
## What this is

The collapse follows the accordion's model (#739): where `interpolate-size: allow-keywords` is supported the stylesheet animates the size to the `auto` of the open state itself — `display` transitions discretely with `allow-discrete`, `@starting-style` supplies the enter-from size, JavaScript only toggles classes. Everywhere else (`interpolate-size` sits at 67.5% coverage — no Firefox, no Safali/iOS) JavaScript measures the two sizes and the stylesheet still times the move, so **the animation exists everywhere; only who measures differs**. This is deliberately not upstream's shape, which ships the CSS path alone and lets ~32% of users get a snap.

The probe and the measured-size choreography were already written for the accordion — first commit extracts them unchanged into `js/src/util/size-transition.ts` and rewires the accordion against its untouched 29-spec suite.

## Class choreography — now identical on both paths

| | before | after |
| --- | --- | --- |
| `.collapse` | removed for the duration of a run | never leaves the element |
| `.show` | end of the opening transition | start of both directions |
| `.collapsing` | replaces `.collapse` mid-run | added alongside, both paths |

`.collapsing` survives as a functional part, not just compat: it carries the `overflow` clip, so a dropdown inside an open collapse can still spill out — which is why this doesn't adopt upstream's permanent `overflow-y: clip`. The `@starting-style` block is scoped to `.show.collapsing`, so a collapse that loads already open plays no entrance (verified: zero animations on load, upstream's unscoped variant would animate every initially-open panel).

## Two defects this surfaced — both fixed here

**1. `SELECTOR_ACTIVES` had a dead arm that came alive.** `.collapse.collapsing` could never match under the old choreography (`.collapse` was removed mid-run). With both classes present it started matching and an accordion parent refused to open the second panel of a multi-target trigger — caught by the existing suite. The arm is gone (`.collapse.show` now means exactly "open or opening"), and panels sharing a trigger are filtered out of the actives via `_sharesTrigger`, so a shared parent no longer closes them against each other.

**2. A leftover `transitionend` settled the next run instantly.** A multi-property transition fires one event per property; hide's waiter consumed `display`'s event and `height`'s landed a task later — right into an immediately-following show. Measured: hide→show back-to-back resolved in **350 ms instead of 700**, with `shown` firing before anything moved. `executeAfterTransition` takes an optional property name (additive, default = old behaviour) and the collapse pins its wait to the size property. Re-measured: 698 ms, and the same fix covers the until-found path, which already had this race on today's `v6-dev` (height + content-visibility).

## Horizontal: `fit-content`

An open `.collapse-horizontal` box is `fit-content` wide, not container-wide. The open size is the animation's target — a target of `auto` spent ~77% of the run growing an empty box past the 300 px content (measured: mid-animation width 1026 px in a 1280 px viewport). This also removes the end-of-animation jump to container width the measured path made in v5/v6 alike. Both paths now end at the same 300 px.

## Verified in real browsers, both paths

**Chromium (CSS path):** mid-show height 150/200 interpolating with `height` in `getAnimations()`; mid-hide content laid out (`display: block`) and 45/200; `display: none` only at the end; overflow clipped only while `.collapsing`; static `.collapse.show` at load: zero animations; findable panel keeps content visible to the end of the hide, ends `height: 0` + `content-visibility: hidden`, never `display: none`; reduced motion resolves in 7 ms.

**Firefox (fallback, real Gecko via Playwright — no `interpolate-size`):** show mid 159/200 on the measured inline size, hide mid 44/200, inline style cleared at the end, horizontal ends at the same 300 px as Chromium, rapid toggle 701 ms, `shown` at 357 ms.

## Breaking changes (migration guide updated)

- `.collapse` no longer removed during transitions; `.show` timing moves to the start of both directions — anyone styling `.collapse.show` or keying on the absence of `.collapse` mid-run sees the new choreography.
- Open horizontal collapse is `fit-content` wide.
- `$transition-collapse-property` default is now `"height, display"` (the `display` entry is inert without `allow-discrete`, so the fallback world reads the same token).

## Follow-ups, not in this PR

- Framework ports: React Pro's `CCollapse.spec.tsx` asserts the class choreography in five places — the parity wave goes per the standard workflow once this lands.
- `.collapsing[data-coreui-hidden-until-found]` height-clamp override became dead under the new scoping and is removed.

## Gates

3212 unit (incl. the multi-target accordion spec that caught defect 1), 62 css-test, 35 visual, class-api, fusv, stylelint `--report-needless-disables`, docs-build 150 pages no broken links, `js-typecheck`. bundlewatch PASS with **no budget raised**: `coreui.css` 64.12 against 64.25, `coreui.min.css` 53.16, JS bundle +0.02 kB. Push went through the full extended pre-push gate including `docs-vnu`.