### PR TITLE
docs(Accordion): the find-in-page behaviour was undocumented

### DIFF
--- a/docs/src/content/docs/components/accordion.mdx
+++ b/docs/src/content/docs/components/accordion.mdx
@@ -164,6 +164,23 @@ Both return a promise that settles once the items have finished moving.
 
 <Code code={accordionToggleAll} lang="js" />
 
+## Findable when collapsed
+
+Nothing to enable here: a closed `<details>` keeps its content searchable, and the browser expands the item on a find-in-page match — the capability the [collapse opts into](/components/collapse/#findable-when-collapsed) with `data-coreui-hidden-until-found` is built into the disclosure element the accordion stands on.
+
+<Example code={`<div class="accordion">
+    <details class="accordion-item" name="accordionFindable" open>
+      <summary class="accordion-header">Accordion Item #1</summary>
+      <div class="accordion-body">This item starts open. The interesting one is below it.</div>
+    </details>
+    <details class="accordion-item" name="accordionFindable">
+      <summary class="accordion-header">Accordion Item #2</summary>
+      <div class="accordion-body">Search this page for <strong>axolotl</strong> with your browser's find-in-page and this closed item opens on its own.</div>
+    </details>
+  </div>`} />
+
+Everything composes with it: in an exclusive accordion the browser closes the previously open item as it reveals the match, `shown.coreui.accordion` fires the way it does for a click, and `<summary>` exposes the new state to assistive technology on its own. In browsers that do not search closed disclosure content the item simply is not found while collapsed — the same degradation the collapse option has.
+
 ## Headings
 
 `<summary>` accepts heading content, so wrap the label in a heading to keep the sections reachable by heading navigation. The heading inherits the summary's typography, so it does not change how the accordion looks.


### PR DESCRIPTION
The collapse page has a whole [Findable when collapsed](https://coreui.io/bootstrap/docs/components/collapse/#findable-when-collapsed) section for the opt-in attribute, while the accordion page said nothing about find-in-page at all. That invites exactly the wrong conclusion — that the accordion cannot do it — when the truth is the reverse: the capability the collapse opts into with `data-coreui-hidden-until-found` is built into the disclosure element the accordion stands on. A closed `<details>` keeps its content searchable, and the browser expands the item on a match.

## What the section says

- **Nothing to enable** — with a link to the collapse's opt-in for the contrast.
- A runnable example: two-item exclusive accordion, the searchable keyword sits in the closed item.
- **What composes with it**: in a `name` group the browser closes the previously open item as it reveals the match; `shown.coreui.accordion` fires through the native `toggle` bridge exactly as for a click; `<summary>` exposes the new state to assistive technology on its own.
- The degradation note is deliberately version-free: which browsers search closed disclosure content is UA behaviour, not ours to pin — where they don't, the item simply is not found while collapsed, the same degradation the collapse option has.

Verified in the repo before writing: nothing on our side interferes — the closed panel is `::details-content { block-size: 0; overflow-y: clip }`, never `display: none`, so the UA's `content-visibility` searchability stays intact, and the `toggle` listener covers the reveal path with no extra code.

Placed between "Expand & collapse all" and "Headings". `docs-build` 150 pages, no broken links.