### PR TITLE
feat(Toast): make toasts opaque and add .toast-translucent

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "64.25kB"
+      "maxSize": "64.5kB"
     },
     {
       "path": "./dist/css/coreui.min.css",

--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -67,9 +67,9 @@ We use the following JavaScript to trigger our live toast demo:
 
 ### Translucent
 
-Toasts are slightly translucent to blend in with what's below them.
+Add `.toast-translucent` to let the background through the toast and blur it. The header thins out with it, so the whole toast reads as one surface.
 
-<Example class="bg-dark" code={`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+<Example class="bg-dark" code={`<div class="toast toast-translucent" role="alert" aria-live="assertive" aria-atomic="true">
     <div class="toast-header">
       <svg class="docs-placeholder-img rounded me-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
       <strong class="me-auto">CoreUI for Bootstrap</strong>
@@ -376,3 +376,7 @@ Toasts use local CSS variables on `.toast` for enhanced real-time customization.
 ### SASS variables
 
 <ScssDocs file="scss/_toasts.scss" capture="toast-variables" />
+
+The `.toast-translucent` mix amount and backdrop filter are build-time only — they are not tokens, so a toast does not carry two custom properties it will never read.
+
+<ScssDocs file="scss/_toasts.scss" capture="toast-translucent-variables" />

--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -29,7 +29,7 @@ To encourage extensible and predictable toasts, we recommend a header and body. 
 
 Bootstrap toasts are as flexible as you need and require very little markup. At a minimum, you should have a single element containing your “toasted” content, and it's strongly recommended to include a dismiss button.
 
-<Example class=" bg-body-tertiary" code={`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+<Example class=" bg-body-tertiary" code={`<div class="toast show" role="alert" aria-live="assertive" aria-atomic="true">
     <div class="toast-header">
       <svg class="docs-placeholder-img rounded me-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
       <strong class="me-auto">CoreUI for Bootstrap</strong>
@@ -69,7 +69,7 @@ We use the following JavaScript to trigger our live toast demo:
 
 Add `.toast-translucent` to let the background through the toast and blur it. The header thins out with it, so the whole toast reads as one surface.
 
-<Example class="bg-dark" code={`<div class="toast toast-translucent" role="alert" aria-live="assertive" aria-atomic="true">
+<Example class="bg-dark" code={`<div class="toast toast-translucent show" role="alert" aria-live="assertive" aria-atomic="true">
     <div class="toast-header">
       <svg class="docs-placeholder-img rounded me-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
       <strong class="me-auto">CoreUI for Bootstrap</strong>
@@ -86,7 +86,7 @@ Add `.toast-translucent` to let the background through the toast and blur it. Th
 Wrap toasts in a toast container to stack them, which adds vertical spacing.
 
 <Example class=" bg-body-tertiary" code={`<div class="toast-container position-static">
-    <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast show" role="alert" aria-live="assertive" aria-atomic="true">
       <div class="toast-header">
         <svg class="docs-placeholder-img rounded me-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
         <strong class="me-auto">CoreUI for Bootstrap</strong>
@@ -98,7 +98,7 @@ Wrap toasts in a toast container to stack them, which adds vertical spacing.
       </div>
     </div>
 
-    <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast show" role="alert" aria-live="assertive" aria-atomic="true">
       <div class="toast-header">
         <svg class="docs-placeholder-img rounded me-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
         <strong class="me-auto">CoreUI for Bootstrap</strong>
@@ -115,7 +115,7 @@ Wrap toasts in a toast container to stack them, which adds vertical spacing.
 
 Customize your toasts by removing sub-components, adjusting them with [utilities](/utilities/api/), or adding your own markup. In this example, we've made a simpler toast by removing the default `.toast-header`, incorporating a custom hide icon from [CoreUI Icons](https://coreui.io/icons/), and using [flexbox utilities](/utilities/flex/) to modify the layout.
 
-<Example class=" bg-body-tertiary" code={`<div class="toast align-items-center" role="alert" aria-live="assertive" aria-atomic="true">
+<Example class=" bg-body-tertiary" code={`<div class="toast align-items-center show" role="alert" aria-live="assertive" aria-atomic="true">
     <div class="d-flex">
       <div class="toast-body">
       Hello, world! This is a toast message.
@@ -126,7 +126,7 @@ Customize your toasts by removing sub-components, adjusting them with [utilities
 
 Alternatively, you can also add additional controls and components to toasts.
 
-<Example class=" bg-body-tertiary" code={`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+<Example class=" bg-body-tertiary" code={`<div class="toast show" role="alert" aria-live="assertive" aria-atomic="true">
     <div class="toast-body">
       Hello, world! This is a toast message.
       <div class="mt-2 pt-2 border-top">
@@ -142,7 +142,7 @@ Building on the previous example, you can design various toast color schemes usi
 
 Building on the previous example, you can design various toast color schemes using our [color](/utilities/colors/) and [background](/utilities/background/) utilities. We added `.text-bg-primary` to the `.toast`; the close button takes the colour it inherits, so it stays legible on its own. To achieve a clean edge, we remove the default border with `.border-0`.
 
-<Example class=" bg-body-tertiary" code={`<div class="toast align-items-center text-bg-primary border-0" role="alert" aria-live="assertive" aria-atomic="true">
+<Example class=" bg-body-tertiary" code={`<div class="toast align-items-center text-bg-primary border-0 show" role="alert" aria-live="assertive" aria-atomic="true">
     <div class="d-flex">
       <div class="toast-body">
         Hello, world! This is a toast message.
@@ -155,7 +155,7 @@ Building on the previous example, you can design various toast color schemes usi
 
 By default, toasts fade in and out. To disable the animation, add `.toast-instant` to the toast. The `show` and `hide` methods then finish immediately, so `shown.coreui.toast` and `hidden.coreui.toast` fire right away.
 
-<Example class=" bg-body-tertiary" code={`<div class="toast toast-instant" role="alert" aria-live="assertive" aria-atomic="true">
+<Example class=" bg-body-tertiary" code={`<div class="toast toast-instant show" role="alert" aria-live="assertive" aria-atomic="true">
     <div class="toast-header">
       <svg class="docs-placeholder-img rounded me-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
       <strong class="me-auto">CoreUI for Bootstrap</strong>
@@ -190,7 +190,7 @@ Place toasts with custom CSS where needed. The top right and top middle are comm
   </form>
   <div aria-live="polite" aria-atomic="true" class="bg-dark position-relative docs-example-toasts">
     <div class="toast-container position-absolute p-3" id="toastPlacement">
-      <div class="toast">
+      <div class="toast show">
         <div class="toast-header">
           <svg class="docs-placeholder-img rounded me-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
           <strong class="me-auto">CoreUI for Bootstrap</strong>
@@ -213,7 +213,7 @@ For systems that generate more notifications, consider using a wrapping element 
     <div class="toast-container top-0 end-0 p-3">
 
       <!-- Then put toasts within -->
-      <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+      <div class="toast show" role="alert" aria-live="assertive" aria-atomic="true">
         <div class="toast-header">
           <svg class="docs-placeholder-img rounded me-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
           <strong class="me-auto">CoreUI for Bootstrap</strong>
@@ -225,7 +225,7 @@ For systems that generate more notifications, consider using a wrapping element 
         </div>
       </div>
 
-      <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+      <div class="toast show" role="alert" aria-live="assertive" aria-atomic="true">
         <div class="toast-header">
           <svg class="docs-placeholder-img rounded me-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
           <strong class="me-auto">CoreUI for Bootstrap</strong>
@@ -245,7 +245,7 @@ You can also get fancy with flexbox utilities to align toasts horizontally and/o
   <div aria-live="polite" aria-atomic="true" class="d-flex justify-content-center align-items-center w-100">
 
     <!-- Then put toasts within -->
-    <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast show" role="alert" aria-live="assertive" aria-atomic="true">
       <div class="toast-header">
         <svg class="docs-placeholder-img rounded me-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
         <strong class="me-auto">CoreUI for Bootstrap</strong>
@@ -276,7 +276,7 @@ As the content changes, remember to update the [`delay` timeout](#options) so us
 
 When using `autohide: false`, you need to add a close button to let users dismiss the toast.
 
-<Example class=" bg-body-tertiary" code={`<div role="alert" aria-live="assertive" aria-atomic="true" class="toast" data-coreui-autohide="false">
+<Example class=" bg-body-tertiary" code={`<div role="alert" aria-live="assertive" aria-atomic="true" class="toast show" data-coreui-autohide="false">
     <div class="toast-header">
       <svg class="docs-placeholder-img rounded me-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
       <strong class="me-auto">CoreUI for Bootstrap</strong>

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1400,6 +1400,14 @@ Multi Select's option indicators moved with it — they render as a decorative
     `--cui-toast-transition-timing`.
   - `isShown()` returns `false` as soon as `hide()` is called, rather than when
     the fade-out ends.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **Toasts are opaque by default.** `--cui-toast-bg` and `--cui-toast-header-bg`
+  resolved to `color-mix(in srgb, var(--cui-body-bg) 85%, transparent)`, so every
+  toast let 15% of whatever sat behind it through — with no blur to settle it,
+  text underneath read straight through the message. Both now resolve to
+  `var(--cui-body-bg)`. Add `.toast-translucent` for the see-through look, which
+  puts `blur(5px) saturate(180%)` behind the toast and thins the header to match,
+  the same way `.card-translucent` and `.menu-translucent` work.
 
 #### Card
 

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -12,7 +12,7 @@ $toast-padding-x:                   .75rem !default;
 $toast-padding-y:                   .5rem !default;
 $toast-font-size:                   .875rem !default;
 $toast-color:                       null !default;
-$toast-background-color:            color-mix(in srgb, var(--#{$prefix}body-bg) 85%, transparent) !default;
+$toast-background-color:            var(--#{$prefix}body-bg) !default;
 $toast-border-width:                var(--#{$prefix}border-width) !default;
 $toast-border-color:                var(--#{$prefix}border-color-translucent) !default;
 $toast-border-radius:               var(--#{$prefix}border-radius) !default;
@@ -22,9 +22,14 @@ $toast-transition-duration:         .15s !default;
 $toast-transition-timing:           linear !default;
 
 $toast-header-color:                var(--#{$prefix}secondary-color) !default;
-$toast-header-background-color:     color-mix(in srgb, var(--#{$prefix}body-bg) 85%, transparent) !default;
+$toast-header-background-color:     $toast-background-color !default;
 $toast-header-border-color:         $toast-border-color !default;
 // scss-docs-end toast-variables
+
+// scss-docs-start toast-translucent-variables
+$toast-translucent-bg-opacity:      85% !default;
+$toast-translucent-backdrop-filter: blur(5px) saturate(180%) !default;
+// scss-docs-end toast-translucent-variables
 
 $toast-tokens: () !default;
 
@@ -129,5 +134,14 @@ $toast-tokens: defaults(
   .toast-body {
     padding: var(--#{$prefix}toast-padding-x);
     word-wrap: break-word;
+  }
+
+  .toast-translucent {
+    background-color: color-mix(in oklch, var(--#{$prefix}toast-bg) #{$toast-translucent-bg-opacity}, transparent);
+    backdrop-filter: $toast-translucent-backdrop-filter;
+
+    .toast-header {
+      background-color: color-mix(in oklch, var(--#{$prefix}toast-header-bg) #{$toast-translucent-bg-opacity}, transparent);
+    }
   }
 }


### PR DESCRIPTION
- `--cui-toast-bg` and `--cui-toast-header-bg` resolved to `color-mix(in srgb, var(--cui-body-bg) 85%, transparent)`, so every toast let 15% of the page through with no backdrop filter behind it — content underneath read through the message instead of being frosted out. Both now resolve to `var(--cui-body-bg)`.
- Add `.toast-translucent` for the see-through look: `blur(5px) saturate(180%)` behind the toast, header thinned to the same 85% mix, so the toast reads as one surface. This puts Toast in the same family as `.card-translucent` and `.menu-translucent`, which already share that filter.
- `$toast-translucent-bg-opacity` and `$toast-translucent-backdrop-filter` are build-time Sass only — a toast that never uses the modifier does not carry two custom properties it will never read, matching how Card handles it.
- Fix the docs page: since the fade moved to CSS, `.toast` is `display: none` until `.show` lands, so every static example rendered as an empty box — only the theming one carried the class. Twelve examples get `.show`; `#liveToast` and the `delay` markup snippet stay hidden on purpose.
- Document the two Sass variables under Customizing and add a migration entry for the changed default.
- Raise the `coreui.css` ceiling to 64.5 kB: the modifier left 82 bytes of headroom, which would fire the tripwire on whatever landed next rather than on a real regression.