### PR TITLE
docs: run the library JS from js/src in docs dev

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 
 import { defineConfig } from 'astro/config'
 import mdx from '@astrojs/mdx'
@@ -37,7 +38,26 @@ export default defineConfig({
     // lz-string (used by the engine's sandbox script) is a UMD/CJS package with no ESM
     // entry, and Vite's dep scanner doesn't reach the lazily-loaded sandbox script, so it
     // gets served raw and `import { compressToBase64 }` fails in dev. Force pre-bundling.
-    optimizeDeps: { include: ['lz-string'] }
+    optimizeDeps: { include: ['lz-string'] },
+    plugins: [
+      // Dev runs the library JS from js/src instead of the dist/js/coreui.esm.js
+      // the engine aliases. dist only changes on `npm run js`, so the dev server
+      // could pair stale JS with live-compiled SCSS — invisible in Chromium
+      // (`interpolate-size` animates in CSS) and indistinguishable from a
+      // Firefox-only bug. With the source alias a js/src edit reloads the page
+      // the same way an scss edit does. `astro build` keeps the dist alias, so
+      // the built docs still exercise the shipped artifact. A plugin `config`
+      // result is merged over the engine's alias (Vite prepends it), which is
+      // what lets this override win.
+      {
+        name: 'coreui-docs-dev-js-from-source',
+        config(_, { command }) {
+          return command === 'serve'
+            ? { resolve: { alias: { '@coreui-docs-js': fileURLToPath(new URL('../js/src/index.ts', import.meta.url)) } } }
+            : undefined
+        }
+      }
+    ]
   },
   integrations: [...coreuiDocs({ libraryConfig: 'src/styles/_library-config.scss' }), mdx()],
 })


### PR DESCRIPTION
In dev the docs paired live-compiled SCSS with the built `dist/js/coreui.esm.js`, which only changes on `npm run js` — so a dev server could serve stale component JS. Chromium hides the mismatch (`interpolate-size` animates in CSS), so it surfaces as what looks like a Firefox-only component bug (accordion not animating, collapse not opening).

A dev-only Vite plugin re-aliases `@coreui-docs-js` to `js/src/index.ts`, so a `js/src` edit reloads the docs page the same way an `scss` edit does — no `npm run js`, no dev-server restart. `astro build` keeps the engine's dist alias, so the built docs still exercise the shipped artifact.

Verified on a running dev server: the alias resolves to `js/src/index.ts`, `./x.js`-suffixed TS imports resolve, a source touch invalidates the module graph immediately, and the accordion page runs with no console errors (exclusive open/close works).