### PR TITLE
feat(Toast): theme a toast's parts, not just the whole toast

### DIFF
--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -355,9 +355,44 @@ myToastEl.addEventListener('hidden.coreui.toast', () => {
 
 ## Theming
 
-A [theme class](/customize/components/#theme-variants) tints the toast's border and header:
+A [theme class](/customize/components/#theme-variants) tints the toast's border and header. Add it to the toast to recolor the whole notification:
 
-<Example code={`<div class="toast theme-success show" role="alert" aria-live="assertive" aria-atomic="true">
+<Example class="d-flex flex-column gap-3" code={`<div class="toast theme-success show" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast-header">
+      <strong class="me-auto">Deployment</strong>
+      <small>11 mins ago</small>
+      <button type="button" class="btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>
+    </div>
+    <div class="toast-body">Build finished and deployed to production.</div>
+  </div>
+
+  <div class="toast theme-danger show" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast-header">
+      <strong class="me-auto">Deployment</strong>
+      <small>2 seconds ago</small>
+      <button type="button" class="btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>
+    </div>
+    <div class="toast-body">Build failed on step 4 of 9.</div>
+  </div>`} />
+
+The same classes work on a single part of a toast, so the body can stay neutral while the header carries the theme:
+
+<Example code={`<div class="toast show" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast-header theme-warning">
+      <strong class="me-auto">Certificate</strong>
+      <small>11 mins ago</small>
+      <button type="button" class="btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>
+    </div>
+    <div class="toast-body">The TLS certificate expires in 7 days.</div>
+  </div>`} />
+
+Theme classes also apply from an ancestor, so a themed container passes its colors to every toast inside it.
+
+### Dark toasts
+
+Set `data-coreui-theme="dark"` on a toast to render it dark whatever [color mode](/customize/color-modes/) the page is in:
+
+<Example code={`<div class="toast show" data-coreui-theme="dark" role="alert" aria-live="assertive" aria-atomic="true">
     <div class="toast-header">
       <strong class="me-auto">Deployment</strong>
       <small>11 mins ago</small>

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -11,7 +11,7 @@ $toast-max-width:                   350px !default;
 $toast-padding-x:                   .75rem !default;
 $toast-padding-y:                   .5rem !default;
 $toast-font-size:                   .875rem !default;
-$toast-color:                       null !default;
+$toast-color:                       var(--#{$prefix}body-color) !default;
 $toast-background-color:            var(--#{$prefix}body-bg) !default;
 $toast-border-width:                var(--#{$prefix}border-width) !default;
 $toast-border-color:                var(--#{$prefix}border-color-translucent) !default;
@@ -46,12 +46,12 @@ $toast-tokens: defaults(
     --#{$prefix}toast-color: #{$toast-color},
     --#{$prefix}toast-bg: #{$toast-background-color},
     --#{$prefix}toast-border-width: #{$toast-border-width},
-    --#{$prefix}toast-border-color: var(--#{$prefix}theme-border, #{$toast-border-color}),
+    --#{$prefix}toast-border-color: #{$toast-border-color},
     --#{$prefix}toast-border-radius: #{$toast-border-radius},
     --#{$prefix}toast-box-shadow: #{$toast-box-shadow},
-    --#{$prefix}toast-header-color: var(--#{$prefix}theme-fg-emphasis, #{$toast-header-color}),
-    --#{$prefix}toast-header-bg: var(--#{$prefix}theme-bg-subtle, #{$toast-header-background-color}),
-    --#{$prefix}toast-header-border-color: var(--#{$prefix}theme-border, #{$toast-header-border-color}),
+    --#{$prefix}toast-header-color: #{$toast-header-color},
+    --#{$prefix}toast-header-bg: #{$toast-header-background-color},
+    --#{$prefix}toast-header-border-color: #{$toast-header-border-color},
     --#{$prefix}toast-font-size: $toast-font-size,
     --#{$prefix}toast-transition-duration: #{$toast-transition-duration},
     --#{$prefix}toast-transition-timing: #{$toast-transition-timing},
@@ -73,7 +73,7 @@ $toast-tokens: defaults(
     pointer-events: auto;
     background-color: var(--#{$prefix}toast-bg);
     background-clip: padding-box;
-    border: var(--#{$prefix}toast-border-width) solid var(--#{$prefix}toast-border-color);
+    border: var(--#{$prefix}toast-border-width) solid var(--#{$prefix}theme-border, var(--#{$prefix}toast-border-color));
     box-shadow: var(--#{$prefix}toast-box-shadow);
     @include border-radius(var(--#{$prefix}toast-border-radius));
 
@@ -120,10 +120,10 @@ $toast-tokens: defaults(
     display: flex;
     align-items: center;
     padding: var(--#{$prefix}toast-padding-y) var(--#{$prefix}toast-padding-x);
-    color: var(--#{$prefix}toast-header-color);
-    background-color: var(--#{$prefix}toast-header-bg);
+    color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}toast-header-color));
+    background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}toast-header-bg));
     background-clip: padding-box;
-    border-bottom: var(--#{$prefix}toast-border-width) solid var(--#{$prefix}toast-header-border-color);
+    border-bottom: var(--#{$prefix}toast-border-width) solid var(--#{$prefix}theme-border, var(--#{$prefix}toast-header-border-color));
     @include border-top-radius(calc(var(--#{$prefix}toast-border-radius) - var(--#{$prefix}toast-border-width)));
 
     .btn-close {
@@ -141,7 +141,7 @@ $toast-tokens: defaults(
     backdrop-filter: $toast-translucent-backdrop-filter;
 
     .toast-header {
-      background-color: color-mix(in oklch, var(--#{$prefix}toast-header-bg) #{$toast-translucent-bg-opacity}, transparent);
+      background-color: color-mix(in oklch, var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}toast-header-bg)) #{$toast-translucent-bg-opacity}, transparent);
     }
   }
 }


### PR DESCRIPTION
Theme slots were baked into the token map, so `--cui-toast-header-bg` resolved on `.toast`. A `.theme-*` class on `.toast-header` was therefore never read — measured: the header stayed `rgb(255,255,255)` instead of picking up the tint.

- Each slot now sits where the property is set, so a theme class works on the toast, on an ancestor, **or on a single part**. `.card` and `.menu` already read them this way; the other components still declare them and are the follow-up.
- `.toast-translucent` mixes the themed value too, or a themed toast would lose its tint the moment it turned translucent.
- `--cui-toast-color` was `null`, which `defaults()` emits as an empty token, so `color: var(--cui-toast-color)` was invalid at computed-value time and the toast inherited its color from the page. `data-coreui-theme="dark"` therefore produced dark body text on a dark toast. It now resolves to `var(--cui-body-color)`, which follows the color mode set on the toast itself.
- Docs: both themed variants, a toast themed only on its header, and the dark toast that was unreadable.