### PR TITLE
refactor(scss): read theme slots where the property is set

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -69,9 +69,9 @@ $accordion-tokens: defaults(
     --#{$prefix}accordion-btn-active-icon-color: #{$accordion-icon-active-color},
     --#{$prefix}accordion-btn-icon-transform: #{$accordion-icon-transform},
     --#{$prefix}accordion-btn-icon-transition: #{$accordion-icon-transition},
-    --#{$prefix}accordion-active-color: var(--#{$prefix}theme-fg-emphasis, #{$accordion-button-active-color}),
-    --#{$prefix}accordion-active-bg: var(--#{$prefix}theme-bg-subtle, #{$accordion-button-active-bg}),
-    --#{$prefix}accordion-active-border-color: var(--#{$prefix}theme-border, #{$accordion-active-border-color}),
+    --#{$prefix}accordion-active-color: #{$accordion-button-active-color},
+    --#{$prefix}accordion-active-bg: #{$accordion-button-active-bg},
+    --#{$prefix}accordion-active-border-color: #{$accordion-active-border-color},
     --#{$prefix}accordion-content-duration: #{$accordion-content-duration},
     --#{$prefix}accordion-content-easing: #{$accordion-content-easing},
   ),
@@ -143,16 +143,16 @@ $accordion-tokens: defaults(
 
     &[open] {
       z-index: 2;
-      border-color: var(--#{$prefix}accordion-active-border-color);
+      border-color: var(--#{$prefix}theme-border, var(--#{$prefix}accordion-active-border-color));
 
       &::details-content {
         block-size: auto;
       }
 
       > .accordion-header {
-        color: var(--#{$prefix}accordion-active-color);
-        background-color: var(--#{$prefix}accordion-active-bg);
-        box-shadow: inset 0 calc(-1 * var(--#{$prefix}accordion-border-width)) 0 var(--#{$prefix}accordion-active-border-color);
+        color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}accordion-active-color));
+        background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}accordion-active-bg));
+        box-shadow: inset 0 calc(-1 * var(--#{$prefix}accordion-border-width)) 0 var(--#{$prefix}theme-border, var(--#{$prefix}accordion-active-border-color));
 
         &::after {
           mask-image: var(--#{$prefix}accordion-btn-active-icon);

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -22,14 +22,14 @@ $alert-tokens: () !default;
 // scss-docs-start alert-css-vars
 $alert-tokens: defaults(
   (
-    --#{$prefix}alert-bg: var(--#{$prefix}theme-bg-subtle, transparent),
+    --#{$prefix}alert-bg: transparent,
     --#{$prefix}alert-padding-x: #{$alert-padding-x},
     --#{$prefix}alert-padding-y: #{$alert-padding-y},
     --#{$prefix}alert-gap: #{$alert-gap},
     --#{$prefix}alert-margin-bottom: #{$alert-margin-bottom},
-    --#{$prefix}alert-color: var(--#{$prefix}theme-fg-emphasis, inherit),
-    --#{$prefix}alert-border-color: var(--#{$prefix}theme-border, transparent),
-    --#{$prefix}alert-border: #{$alert-border-width} solid var(--#{$prefix}alert-border-color),
+    --#{$prefix}alert-color: inherit,
+    --#{$prefix}alert-border-color: transparent,
+    --#{$prefix}alert-border: #{$alert-border-width} solid var(--#{$prefix}theme-border, var(--#{$prefix}alert-border-color)),
     --#{$prefix}alert-border-radius: #{$alert-border-radius},
     --#{$prefix}alert-link-color: inherit,
     --#{$prefix}hr-border-color: var(--#{$prefix}theme-border, var(--#{$prefix}border-color)),
@@ -59,8 +59,8 @@ $alert-variants: (
     align-items: start;
     padding: var(--#{$prefix}alert-padding-y) var(--#{$prefix}alert-padding-x);
     margin-bottom: var(--#{$prefix}alert-margin-bottom);
-    color: var(--#{$prefix}alert-color);
-    background-color: var(--#{$prefix}alert-bg);
+    color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}alert-color));
+    background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}alert-bg));
     border: var(--#{$prefix}alert-border);
     @include border-radius(var(--#{$prefix}alert-border-radius));
   }

--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -39,8 +39,8 @@ $avatar-tokens: () !default;
 $avatar-tokens: defaults(
   (
     --#{$prefix}avatar-size: #{$avatar-size},
-    --#{$prefix}avatar-color: var(--#{$prefix}theme-contrast, #{$avatar-color}),
-    --#{$prefix}avatar-bg: var(--#{$prefix}theme-base, #{$avatar-bg}),
+    --#{$prefix}avatar-color: #{$avatar-color},
+    --#{$prefix}avatar-bg: #{$avatar-bg},
     --#{$prefix}avatar-border-radius: #{$avatar-border-radius},
     --#{$prefix}avatar-status-size: #{$avatar-status-size},
     --#{$prefix}avatar-status-border-radius: #{$avatar-status-border-radius},
@@ -74,9 +74,9 @@ $avatar-variants: (
     // Declared as a fallback rather than a token, so the derived size is the
     // default and an explicit one still wins.
     font-size: var(--#{$prefix}avatar-font-size, calc(var(--#{$prefix}avatar-size) * #{$avatar-font-size-ratio}));
-    color: var(--#{$prefix}avatar-color);
+    color: var(--#{$prefix}theme-contrast, var(--#{$prefix}avatar-color));
     vertical-align: middle;
-    background-color: var(--#{$prefix}avatar-bg);
+    background-color: var(--#{$prefix}theme-base, var(--#{$prefix}avatar-bg));
     @include border-radius(var(--#{$prefix}avatar-border-radius));
     @include transition($avatar-transition);
   }

--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -41,8 +41,8 @@ $badge-tokens: defaults(
     --#{$prefix}badge-padding-y: #{$badge-padding-y},
     --#{$prefix}badge-font-size: clamp(#{$badge-font-size-floor}, #{$badge-font-size}, #{$badge-font-size}),
     --#{$prefix}badge-font-weight: #{$badge-font-weight},
-    --#{$prefix}badge-color: var(--#{$prefix}theme-contrast, #{$badge-color}),
-    --#{$prefix}badge-bg: var(--#{$prefix}theme-base, #{$badge-bg}),
+    --#{$prefix}badge-color: #{$badge-color},
+    --#{$prefix}badge-bg: #{$badge-bg},
     --#{$prefix}badge-border-width: #{$badge-border-width},
     --#{$prefix}badge-border-color: #{$badge-border-color},
     --#{$prefix}badge-border-radius: #{$badge-border-radius},
@@ -81,14 +81,14 @@ $badge-variants: (
     font-size: var(--#{$prefix}badge-font-size);
     font-weight: var(--#{$prefix}badge-font-weight);
     line-height: 1;
-    color: var(--#{$prefix}badge-color);
+    color: var(--#{$prefix}theme-contrast, var(--#{$prefix}badge-color));
     text-align: center;
     text-decoration: none;
     white-space: nowrap;
     vertical-align: baseline;
     border: var(--#{$prefix}badge-border-width) solid var(--#{$prefix}badge-border-color);
     border-radius: var(--#{$prefix}badge-border-radius, 0); // stylelint-disable-line property-disallowed-list
-    @include gradient-bg(var(--#{$prefix}badge-bg));
+    @include gradient-bg(var(--#{$prefix}theme-base, var(--#{$prefix}badge-bg)));
 
     // Empty badges collapse automatically
     &:empty {

--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -78,10 +78,10 @@ $chip-tokens: defaults(
     --#{$prefix}chip-bg: var(--#{$prefix}theme-bg-subtle, #{$chip-bg}),
     --#{$prefix}chip-border-width: #{$chip-border-width},
     --#{$prefix}chip-border-color: #{$chip-border-color},
-    --#{$prefix}chip-active-color: var(--#{$prefix}theme-contrast, #{$chip-active-color}),
-    --#{$prefix}chip-active-bg: var(--#{$prefix}theme-base, #{$chip-active-bg}),
+    --#{$prefix}chip-active-color: #{$chip-active-color},
+    --#{$prefix}chip-active-bg: #{$chip-active-bg},
     --#{$prefix}chip-active-border-color: #{$chip-active-border-color},
-    --#{$prefix}chip-hover-color: var(--#{$prefix}theme-fg-emphasis, #{$chip-hover-color}),
+    --#{$prefix}chip-hover-color: #{$chip-hover-color},
     --#{$prefix}chip-hover-bg: var(--#{$prefix}theme-bg-muted, #{$chip-hover-bg}),
     --#{$prefix}chip-hover-border-color: #{$chip-hover-border-color},
   ),
@@ -102,10 +102,10 @@ $chip-outline-tokens: defaults(
     --#{$prefix}chip-bg: transparent,
     --#{$prefix}chip-border-color: var(--#{$prefix}theme-base, var(--#{$prefix}border-color)),
     --#{$prefix}chip-hover-bg: var(--#{$prefix}theme-bg-subtle, #{$chip-hover-bg}),
-    --#{$prefix}chip-hover-color: var(--#{$prefix}theme-fg-emphasis, #{$chip-color}),
+    --#{$prefix}chip-hover-color: #{$chip-color},
     --#{$prefix}chip-hover-border-color: var(--#{$prefix}theme-base, var(--#{$prefix}border-color)),
-    --#{$prefix}chip-active-bg: var(--#{$prefix}theme-base, #{$chip-active-bg}),
-    --#{$prefix}chip-active-color: var(--#{$prefix}theme-contrast, #{$chip-active-color}),
+    --#{$prefix}chip-active-bg: #{$chip-active-bg},
+    --#{$prefix}chip-active-color: #{$chip-active-color},
   ),
   $chip-outline-tokens
 );
@@ -133,8 +133,8 @@ $chip-outline-tokens: defaults(
     @include transition(var(--#{$prefix}chip-transition));
 
     &.active {
-      color: var(--#{$prefix}chip-active-color);
-      background-color: var(--#{$prefix}chip-active-bg);
+      color: var(--#{$prefix}theme-contrast, var(--#{$prefix}chip-active-color));
+      background-color: var(--#{$prefix}theme-base, var(--#{$prefix}chip-active-bg));
       border-color: var(--#{$prefix}chip-active-border-color);
     }
 
@@ -167,14 +167,14 @@ $chip-outline-tokens: defaults(
     cursor: pointer;
 
     &:hover {
-      color: var(--#{$prefix}chip-hover-color);
+      color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}chip-hover-color));
       background-color: var(--#{$prefix}chip-hover-bg);
       border-color: var(--#{$prefix}chip-hover-border-color);
     }
 
     &.active:hover {
-      color: var(--#{$prefix}chip-active-color);
-      background-color: var(--#{$prefix}chip-active-bg);
+      color: var(--#{$prefix}theme-contrast, var(--#{$prefix}chip-active-color));
+      background-color: var(--#{$prefix}theme-base, var(--#{$prefix}chip-active-bg));
       opacity: .9;
     }
   }

--- a/scss/_combobox.scss
+++ b/scss/_combobox.scss
@@ -250,8 +250,8 @@ $combobox-tokens: defaults(
   }
 
   .selected > .combobox-option-indicator {
-    background-color: var(--#{$prefix}check-checked-bg);
-    border-color: var(--#{$prefix}check-checked-border-color);
+    background-color: var(--#{$prefix}theme-base, var(--#{$prefix}check-checked-bg));
+    border-color: var(--#{$prefix}theme-base, var(--#{$prefix}check-checked-border-color));
 
     &::before {
       opacity: 1;

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -41,23 +41,23 @@ $list-group-tokens: () !default;
 // scss-docs-start list-group-css-vars
 $list-group-tokens: defaults(
   (
-    --#{$prefix}list-group-color: var(--#{$prefix}theme-fg-emphasis, #{$list-group-color}),
-    --#{$prefix}list-group-bg: var(--#{$prefix}theme-bg-subtle, #{$list-group-bg}),
-    --#{$prefix}list-group-border-color: var(--#{$prefix}theme-border, #{$list-group-border-color}),
+    --#{$prefix}list-group-color: #{$list-group-color},
+    --#{$prefix}list-group-bg: #{$list-group-bg},
+    --#{$prefix}list-group-border-color: #{$list-group-border-color},
     --#{$prefix}list-group-border-width: #{$list-group-border-width},
     --#{$prefix}list-group-border-radius: #{$list-group-border-radius},
     --#{$prefix}list-group-item-padding-x: #{$list-group-item-padding-x},
     --#{$prefix}list-group-item-padding-y: #{$list-group-item-padding-y},
     --#{$prefix}list-group-action-color: #{$list-group-action-color},
     --#{$prefix}list-group-action-hover-color: #{$list-group-action-hover-color},
-    --#{$prefix}list-group-action-hover-bg: var(--#{$prefix}theme-border, #{$list-group-hover-bg}),
+    --#{$prefix}list-group-action-hover-bg: #{$list-group-hover-bg},
     --#{$prefix}list-group-action-active-color: #{$list-group-action-active-color},
-    --#{$prefix}list-group-action-active-bg: var(--#{$prefix}theme-border, #{$list-group-action-active-bg}),
+    --#{$prefix}list-group-action-active-bg: #{$list-group-action-active-bg},
     --#{$prefix}list-group-disabled-color: #{$list-group-disabled-color},
     --#{$prefix}list-group-disabled-bg: #{$list-group-disabled-bg},
-    --#{$prefix}list-group-active-color: var(--#{$prefix}theme-bg-subtle, #{$list-group-active-color}),
-    --#{$prefix}list-group-active-bg: var(--#{$prefix}theme-fg-emphasis, #{$list-group-active-bg}),
-    --#{$prefix}list-group-active-border-color: var(--#{$prefix}theme-fg-emphasis, #{$list-group-active-border-color}),
+    --#{$prefix}list-group-active-color: #{$list-group-active-color},
+    --#{$prefix}list-group-active-bg: #{$list-group-active-bg},
+    --#{$prefix}list-group-active-border-color: #{$list-group-active-border-color},
   ),
   $list-group-tokens
 );
@@ -96,10 +96,10 @@ $list-group-tokens: defaults(
     position: relative;
     display: block;
     padding: var(--#{$prefix}list-group-item-padding-y) var(--#{$prefix}list-group-item-padding-x);
-    color: var(--#{$prefix}list-group-color);
+    color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}list-group-color));
     text-decoration: if(not sass($link-decoration == none): none);
-    background-color: var(--#{$prefix}list-group-bg);
-    border: var(--#{$prefix}list-group-border-width) solid var(--#{$prefix}list-group-border-color);
+    background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}list-group-bg));
+    border: var(--#{$prefix}list-group-border-width) solid var(--#{$prefix}theme-border, var(--#{$prefix}list-group-border-color));
 
     &:first-child {
       @include border-top-radius(inherit);
@@ -119,9 +119,9 @@ $list-group-tokens: defaults(
     // Include both here for `<a>`s and `<button>`s
     &.active {
       z-index: 2; // Place active items above their siblings for proper border styling
-      color: var(--#{$prefix}list-group-active-color);
-      background-color: var(--#{$prefix}list-group-active-bg);
-      border-color: var(--#{$prefix}list-group-active-border-color);
+      color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}list-group-active-color));
+      background-color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}list-group-active-bg));
+      border-color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}list-group-active-border-color));
     }
 
     // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
@@ -152,12 +152,12 @@ $list-group-tokens: defaults(
         z-index: 1; // Place hover/focus items above their siblings for proper border styling
         color: var(--#{$prefix}list-group-action-hover-color);
         text-decoration: none;
-        background-color: var(--#{$prefix}list-group-action-hover-bg);
+        background-color: var(--#{$prefix}theme-border, var(--#{$prefix}list-group-action-hover-bg));
       }
 
       &:active {
         color: var(--#{$prefix}list-group-action-active-color);
-        background-color: var(--#{$prefix}list-group-action-active-bg);
+        background-color: var(--#{$prefix}theme-border, var(--#{$prefix}list-group-action-active-bg));
       }
     }
   }

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -107,8 +107,8 @@ $nav-pills-tokens: () !default;
 $nav-pills-tokens: defaults(
   (
     --#{$prefix}nav-pills-border-radius: #{$nav-pills-border-radius},
-    --#{$prefix}nav-pills-link-active-color: var(--#{$prefix}theme-contrast, #{$nav-pills-link-active-color}),
-    --#{$prefix}nav-pills-link-active-bg: var(--#{$prefix}theme-base, #{$nav-pills-link-active-bg}),
+    --#{$prefix}nav-pills-link-active-color: #{$nav-pills-link-active-color},
+    --#{$prefix}nav-pills-link-active-bg: #{$nav-pills-link-active-bg},
   ),
   $nav-pills-tokens
 );
@@ -125,7 +125,7 @@ $nav-underline-tokens: defaults(
   (
     --#{$prefix}nav-underline-gap: #{$nav-underline-gap},
     --#{$prefix}nav-underline-border-width: #{$nav-underline-border-width},
-    --#{$prefix}nav-underline-link-active-color: var(--#{$prefix}theme-fg, #{$nav-underline-link-active-color}),
+    --#{$prefix}nav-underline-link-active-color: #{$nav-underline-link-active-color},
   ),
   $nav-underline-tokens
 );
@@ -146,7 +146,7 @@ $nav-underline-border-tokens: defaults(
     --#{$prefix}nav-underline-border-link-padding-x: #{$nav-underline-border-link-padding-x},
     --#{$prefix}nav-underline-border-link-padding-y: #{$nav-underline-border-link-padding-y},
     --#{$prefix}nav-underline-border-link-color: #{$nav-underline-border-link-color},
-    --#{$prefix}nav-underline-border-link-active-color: var(--#{$prefix}theme-base, #{$nav-underline-border-link-active-color}),
+    --#{$prefix}nav-underline-border-link-active-color: #{$nav-underline-border-link-active-color},
     --#{$prefix}nav-underline-border-link-disabled-color: #{$nav-underline-border-link-disabled-color},
   ),
   $nav-underline-border-tokens
@@ -247,8 +247,8 @@ $nav-underline-border-tokens: defaults(
 
     .nav-link.active,
     .show > .nav-link {
-      color: var(--#{$prefix}nav-pills-link-active-color);
-      @include gradient-bg(var(--#{$prefix}nav-pills-link-active-bg));
+      color: var(--#{$prefix}theme-contrast, var(--#{$prefix}nav-pills-link-active-color));
+      @include gradient-bg(var(--#{$prefix}theme-base, var(--#{$prefix}nav-pills-link-active-bg)));
     }
   }
 
@@ -276,7 +276,7 @@ $nav-underline-border-tokens: defaults(
     .nav-link.active,
     .show > .nav-link {
       font-weight: var(--#{$prefix}font-weight-bold);
-      color: var(--#{$prefix}nav-underline-link-active-color);
+      color: var(--#{$prefix}theme-fg, var(--#{$prefix}nav-underline-link-active-color));
       border-bottom-color: currentcolor;
     }
   }
@@ -305,7 +305,7 @@ $nav-underline-border-tokens: defaults(
     .nav-link.active,
     .show > .nav-link {
       font-weight: var(--#{$prefix}font-weight-bold);
-      color: var(--#{$prefix}nav-underline-border-link-active-color);
+      color: var(--#{$prefix}theme-base, var(--#{$prefix}nav-underline-border-link-active-color));
       border-bottom-color: currentcolor;
     }
   }

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -68,12 +68,12 @@ $navbar-tokens: defaults(
     --#{$prefix}navbar-color: #{$navbar-light-color},
     --#{$prefix}navbar-hover-color: #{$navbar-light-hover-color},
     --#{$prefix}navbar-disabled-color: #{$navbar-light-disabled-color},
-    --#{$prefix}navbar-active-color: var(--#{$prefix}theme-fg, #{$navbar-light-active-color}),
+    --#{$prefix}navbar-active-color: #{$navbar-light-active-color},
     --#{$prefix}navbar-brand-padding-y: #{$navbar-brand-padding-y},
     --#{$prefix}navbar-brand-margin-end: #{$navbar-brand-margin-end},
     --#{$prefix}navbar-brand-font-size: #{$navbar-brand-font-size},
-    --#{$prefix}navbar-brand-color: var(--#{$prefix}theme-fg, #{$navbar-light-brand-color}),
-    --#{$prefix}navbar-brand-hover-color: var(--#{$prefix}theme-fg-emphasis, #{$navbar-light-brand-hover-color}),
+    --#{$prefix}navbar-brand-color: #{$navbar-light-brand-color},
+    --#{$prefix}navbar-brand-hover-color: #{$navbar-light-brand-hover-color},
     --#{$prefix}navbar-nav-link-padding-x: #{$navbar-nav-link-padding-x},
     --#{$prefix}navbar-toggler-padding-y: #{$navbar-toggler-padding-y},
     --#{$prefix}navbar-toggler-padding-x: #{$navbar-toggler-padding-x},
@@ -121,9 +121,9 @@ $navbar-dark-tokens: defaults(
     --#{$prefix}navbar-color: #{$navbar-dark-color},
     --#{$prefix}navbar-hover-color: #{$navbar-dark-hover-color},
     --#{$prefix}navbar-disabled-color: #{$navbar-dark-disabled-color},
-    --#{$prefix}navbar-active-color: var(--#{$prefix}theme-fg, #{$navbar-dark-active-color}),
-    --#{$prefix}navbar-brand-color: var(--#{$prefix}theme-fg, #{$navbar-dark-brand-color}),
-    --#{$prefix}navbar-brand-hover-color: var(--#{$prefix}theme-fg-emphasis, #{$navbar-dark-brand-hover-color}),
+    --#{$prefix}navbar-active-color: #{$navbar-dark-active-color},
+    --#{$prefix}navbar-brand-color: #{$navbar-dark-brand-color},
+    --#{$prefix}navbar-brand-hover-color: #{$navbar-dark-brand-hover-color},
     --#{$prefix}navbar-toggler-border-color: #{$navbar-dark-toggler-border-color},
   ),
   $navbar-dark-tokens
@@ -195,13 +195,13 @@ $navbar-dark-tokens: defaults(
     padding-bottom: var(--#{$prefix}navbar-brand-padding-y);
     margin-inline-end: var(--#{$prefix}navbar-brand-margin-end);
     font-size: var(--#{$prefix}navbar-brand-font-size);
-    color: var(--#{$prefix}navbar-brand-color);
+    color: var(--#{$prefix}theme-fg, var(--#{$prefix}navbar-brand-color));
     text-decoration: if(not sass($link-decoration == none): none);
     white-space: nowrap;
 
     &:hover,
     &:focus {
-      color: var(--#{$prefix}navbar-brand-hover-color);
+      color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}navbar-brand-hover-color));
       // stylelint-disable-next-line scss/at-function-named-arguments
       text-decoration: if(sass($link-hover-decoration == underline): none);
     }
@@ -224,7 +224,7 @@ $navbar-dark-tokens: defaults(
     .nav-link {
       &.active,
       &.show {
-        color: var(--#{$prefix}navbar-active-color);
+        color: var(--#{$prefix}theme-fg, var(--#{$prefix}navbar-active-color));
       }
     }
 
@@ -246,7 +246,7 @@ $navbar-dark-tokens: defaults(
     a,
     a:hover,
     a:focus  {
-      color: var(--#{$prefix}navbar-active-color);
+      color: var(--#{$prefix}theme-fg, var(--#{$prefix}navbar-active-color));
     }
   }
 

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -55,19 +55,19 @@ $pagination-tokens: defaults(
   (
     --#{$prefix}pagination-padding-x: #{$pagination-padding-x},
     --#{$prefix}pagination-padding-y: #{$pagination-padding-y},
-    --#{$prefix}pagination-color: var(--#{$prefix}theme-fg, #{$pagination-color}),
+    --#{$prefix}pagination-color: #{$pagination-color},
     --#{$prefix}pagination-bg: #{$pagination-bg},
     --#{$prefix}pagination-border-width: #{$pagination-border-width},
     --#{$prefix}pagination-border-color: #{$pagination-border-color},
     --#{$prefix}pagination-border-radius: #{$pagination-border-radius},
-    --#{$prefix}pagination-hover-color: var(--#{$prefix}theme-fg-emphasis, #{$pagination-hover-color}),
-    --#{$prefix}pagination-hover-bg: var(--#{$prefix}theme-bg-subtle, #{$pagination-hover-bg}),
-    --#{$prefix}pagination-hover-border-color: var(--#{$prefix}theme-border, #{$pagination-hover-border-color}),
+    --#{$prefix}pagination-hover-color: #{$pagination-hover-color},
+    --#{$prefix}pagination-hover-bg: #{$pagination-hover-bg},
+    --#{$prefix}pagination-hover-border-color: #{$pagination-hover-border-color},
     --#{$prefix}pagination-focus-color: #{$pagination-focus-color},
     --#{$prefix}pagination-focus-bg: #{$pagination-focus-bg},
-    --#{$prefix}pagination-active-color: var(--#{$prefix}theme-contrast, #{$pagination-active-color}),
-    --#{$prefix}pagination-active-bg: var(--#{$prefix}theme-base, #{$pagination-active-bg}),
-    --#{$prefix}pagination-active-border-color: var(--#{$prefix}theme-base, #{$pagination-active-border-color}),
+    --#{$prefix}pagination-active-color: #{$pagination-active-color},
+    --#{$prefix}pagination-active-bg: #{$pagination-active-bg},
+    --#{$prefix}pagination-active-border-color: #{$pagination-active-border-color},
     --#{$prefix}pagination-disabled-color: #{$pagination-disabled-color},
     --#{$prefix}pagination-disabled-bg: #{$pagination-disabled-bg},
     --#{$prefix}pagination-disabled-border-color: #{$pagination-disabled-border-color},
@@ -91,7 +91,7 @@ $pagination-tokens: defaults(
     display: block;
     padding: var(--#{$prefix}pagination-padding-y) var(--#{$prefix}pagination-padding-x);
     font-size: var(--#{$prefix}pagination-font-size);
-    color: var(--#{$prefix}pagination-color);
+    color: var(--#{$prefix}theme-fg, var(--#{$prefix}pagination-color));
     text-decoration: if(not sass($link-decoration == none): none);
     background-color: var(--#{$prefix}pagination-bg);
     border: var(--#{$prefix}pagination-border-width) solid var(--#{$prefix}pagination-border-color);
@@ -99,11 +99,11 @@ $pagination-tokens: defaults(
 
     &:hover {
       z-index: 2;
-      color: var(--#{$prefix}pagination-hover-color);
+      color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}pagination-hover-color));
       // stylelint-disable-next-line scss/at-function-named-arguments
       text-decoration: if(sass($link-hover-decoration == underline): none);
-      background-color: var(--#{$prefix}pagination-hover-bg);
-      border-color: var(--#{$prefix}pagination-hover-border-color);
+      background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}pagination-hover-bg));
+      border-color: var(--#{$prefix}theme-border, var(--#{$prefix}pagination-hover-border-color));
     }
 
     &:focus-visible {
@@ -116,9 +116,9 @@ $pagination-tokens: defaults(
     &.active,
     .active > & {
       z-index: 3;
-      color: var(--#{$prefix}pagination-active-color);
-      @include gradient-bg(var(--#{$prefix}pagination-active-bg));
-      border-color: var(--#{$prefix}pagination-active-border-color);
+      color: var(--#{$prefix}theme-contrast, var(--#{$prefix}pagination-active-color));
+      @include gradient-bg(var(--#{$prefix}theme-base, var(--#{$prefix}pagination-active-bg)));
+      border-color: var(--#{$prefix}theme-base, var(--#{$prefix}pagination-active-border-color));
     }
 
     &.disabled,

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -33,8 +33,8 @@ $progress-tokens: defaults(
     --#{$prefix}progress-bg: #{$progress-bg},
     --#{$prefix}progress-border-radius: #{$progress-border-radius},
     --#{$prefix}progress-box-shadow: #{$progress-box-shadow},
-    --#{$prefix}progress-bar-color: var(--#{$prefix}theme-contrast, #{$progress-bar-color}),
-    --#{$prefix}progress-bar-bg: var(--#{$prefix}theme-base, #{$progress-bar-bg}),
+    --#{$prefix}progress-bar-color: #{$progress-bar-color},
+    --#{$prefix}progress-bar-bg: #{$progress-bar-bg},
     --#{$prefix}progress-bar-transition: #{$progress-bar-transition},
     --#{$prefix}progress-font-size: $progress-font-size,
   ),
@@ -72,10 +72,10 @@ $progress-tokens: defaults(
     flex-direction: column;
     justify-content: center;
     overflow: hidden;
-    color: var(--#{$prefix}progress-bar-color);
+    color: var(--#{$prefix}theme-contrast, var(--#{$prefix}progress-bar-color));
     text-align: center;
     white-space: nowrap;
-    background-color: var(--#{$prefix}progress-bar-bg);
+    background-color: var(--#{$prefix}theme-base, var(--#{$prefix}progress-bar-bg));
     @include transition(var(--#{$prefix}progress-bar-transition));
   }
 

--- a/scss/_stepper.scss
+++ b/scss/_stepper.scss
@@ -66,12 +66,12 @@ $stepper-tokens: defaults(
     --#{$prefix}stepper-step-indicator-border-width: #{$stepper-step-indicator-border-width},
     --#{$prefix}stepper-step-indicator-border-color: #{$stepper-step-indicator-border-color},
     --#{$prefix}stepper-step-indicator-transition: #{$stepper-step-indicator-transition},
-    --#{$prefix}stepper-step-indicator-active-color: var(--#{$prefix}theme-base, #{$stepper-step-indicator-active-color}),
+    --#{$prefix}stepper-step-indicator-active-color: #{$stepper-step-indicator-active-color},
     --#{$prefix}stepper-step-indicator-active-bg: #{$stepper-step-indicator-active-bg},
-    --#{$prefix}stepper-step-indicator-active-border-color: var(--#{$prefix}theme-base, #{$stepper-step-indicator-active-border-color}),
-    --#{$prefix}stepper-step-indicator-complete-color: var(--#{$prefix}theme-contrast, #{$stepper-step-indicator-complete-color}),
-    --#{$prefix}stepper-step-indicator-complete-bg: var(--#{$prefix}theme-base, #{$stepper-step-indicator-complete-bg}),
-    --#{$prefix}stepper-step-indicator-complete-border-color: var(--#{$prefix}theme-base, #{$stepper-step-indicator-complete-border-color}),
+    --#{$prefix}stepper-step-indicator-active-border-color: #{$stepper-step-indicator-active-border-color},
+    --#{$prefix}stepper-step-indicator-complete-color: #{$stepper-step-indicator-complete-color},
+    --#{$prefix}stepper-step-indicator-complete-bg: #{$stepper-step-indicator-complete-bg},
+    --#{$prefix}stepper-step-indicator-complete-border-color: #{$stepper-step-indicator-complete-border-color},
     --#{$prefix}stepper-step-indicator-disabled-color: #{$stepper-step-indicator-disabled-color},
     --#{$prefix}stepper-step-indicator-disabled-bg: #{$stepper-step-indicator-disabled-bg},
     --#{$prefix}stepper-step-indicator-disabled-border-color: #{$stepper-step-indicator-disabled-border-color},
@@ -81,7 +81,7 @@ $stepper-tokens: defaults(
     --#{$prefix}stepper-step-connector-height: #{$stepper-step-connector-height},
     --#{$prefix}stepper-step-connector-gap: #{$stepper-step-connector-gap},
     --#{$prefix}stepper-step-connector-bg: #{$stepper-step-connector-bg},
-    --#{$prefix}stepper-step-connector-complete-bg: var(--#{$prefix}theme-base, #{$stepper-step-connector-complete-bg}),
+    --#{$prefix}stepper-step-connector-complete-bg: #{$stepper-step-connector-complete-bg},
     --#{$prefix}stepper-step-connector-transition: #{$stepper-step-connector-transition},
     --#{$prefix}stepper-step-content-transition: #{$stepper-step-content-transition},
   ),
@@ -149,9 +149,9 @@ $stepper-tokens: defaults(
 
     &.active {
       --#{$prefix}stepper-step-button-color: var(--#{$prefix}stepper-step-button-active-color);
-      --#{$prefix}stepper-step-indicator-color: var(--#{$prefix}stepper-step-indicator-active-color);
+      --#{$prefix}stepper-step-indicator-color: var(--#{$prefix}theme-base, var(--#{$prefix}stepper-step-indicator-active-color));
       --#{$prefix}stepper-step-indicator-bg: var(--#{$prefix}stepper-step-indicator-active-bg);
-      --#{$prefix}stepper-step-indicator-border-color: var(--#{$prefix}stepper-step-indicator-active-border-color);
+      --#{$prefix}stepper-step-indicator-border-color: var(--#{$prefix}theme-base, var(--#{$prefix}stepper-step-indicator-active-border-color));
     }
 
     &:disabled {
@@ -163,16 +163,16 @@ $stepper-tokens: defaults(
 
     &.complete {
       --#{$prefix}stepper-step-button-color: var(--#{$prefix}stepper-step-button-complete-color);
-      --#{$prefix}stepper-step-indicator-color: var(--#{$prefix}stepper-step-indicator-complete-color);
-      --#{$prefix}stepper-step-indicator-bg: var(--#{$prefix}stepper-step-indicator-complete-bg);
-      --#{$prefix}stepper-step-indicator-border-color: var(--#{$prefix}stepper-step-indicator-complete-border-color);
+      --#{$prefix}stepper-step-indicator-color: var(--#{$prefix}theme-contrast, var(--#{$prefix}stepper-step-indicator-complete-color));
+      --#{$prefix}stepper-step-indicator-bg: var(--#{$prefix}theme-base, var(--#{$prefix}stepper-step-indicator-complete-bg));
+      --#{$prefix}stepper-step-indicator-border-color: var(--#{$prefix}theme-base, var(--#{$prefix}stepper-step-indicator-complete-border-color));
 
       .stepper-step-indicator-text {
         display: none;
       }
 
       ~ .stepper-step-connector {
-        --#{$prefix}stepper-step-connector-bg: var(--#{$prefix}stepper-step-connector-complete-bg);
+        --#{$prefix}stepper-step-connector-bg: var(--#{$prefix}theme-base, var(--#{$prefix}stepper-step-connector-complete-bg));
       }
     }
 

--- a/scss/forms/_check.scss
+++ b/scss/forms/_check.scss
@@ -43,7 +43,6 @@ $check-tokens: defaults(
     --#{$prefix}check-indeterminate-border-color: var(--#{$prefix}control-indeterminate-border-color),
     --#{$prefix}check-disabled-opacity: var(--#{$prefix}control-disabled-opacity),
     --#{$prefix}check-margin-top: calc((var(--#{$prefix}body-line-height) * 1em - var(--#{$prefix}check-size)) * .5),
-    --#{$prefix}check-focus-border: var(--#{$prefix}control-focus-border-color),
     --#{$prefix}check-active-filter: var(--#{$prefix}control-active-filter),
     --#{$prefix}check-label-disabled-opacity: var(--#{$prefix}control-label-disabled-opacity),
   ),
@@ -109,7 +108,6 @@ $check-selector: if(sass($enable-deprecated-form-check): ".check, .form-check-in
     }
 
     &:focus-visible {
-      border-color: var(--#{$prefix}check-focus-border);
       @include focus-ring(true);
     }
 

--- a/scss/forms/_check.scss
+++ b/scss/forms/_check.scss
@@ -37,8 +37,8 @@ $check-tokens: defaults(
     --#{$prefix}check-mark-color: #{$check-mark-color},
     --#{$prefix}check-mark-checked: #{escape-svg($check-mark-checked)},
     --#{$prefix}check-mark-indeterminate: #{escape-svg($check-mark-indeterminate)},
-    --#{$prefix}check-checked-bg: var(--#{$prefix}theme-base, var(--#{$prefix}control-checked-bg)),
-    --#{$prefix}check-checked-border-color: var(--#{$prefix}theme-base, var(--#{$prefix}control-checked-border-color)),
+    --#{$prefix}check-checked-bg: var(--#{$prefix}control-checked-bg),
+    --#{$prefix}check-checked-border-color: var(--#{$prefix}control-checked-border-color),
     --#{$prefix}check-indeterminate-bg: var(--#{$prefix}control-indeterminate-bg),
     --#{$prefix}check-indeterminate-border-color: var(--#{$prefix}control-indeterminate-border-color),
     --#{$prefix}check-disabled-opacity: var(--#{$prefix}control-disabled-opacity),
@@ -88,8 +88,8 @@ $check-selector: if(sass($enable-deprecated-form-check): ".check, .form-check-in
     }
 
     &:checked {
-      background-color: var(--#{$prefix}check-checked-bg);
-      border-color: var(--#{$prefix}check-checked-border-color);
+      background-color: var(--#{$prefix}theme-base, var(--#{$prefix}check-checked-bg));
+      border-color: var(--#{$prefix}theme-base, var(--#{$prefix}check-checked-border-color));
 
       &::before {
         opacity: 1;

--- a/scss/forms/_radio.scss
+++ b/scss/forms/_radio.scss
@@ -29,8 +29,8 @@ $radio-tokens: defaults(
     --#{$prefix}radio-bg: #{$radio-bg},
     --#{$prefix}radio-border: #{$radio-border},
     --#{$prefix}radio-border-radius: #{$radio-border-radius},
-    --#{$prefix}radio-checked-bg: var(--#{$prefix}theme-base, var(--#{$prefix}control-checked-bg)),
-    --#{$prefix}radio-checked-border-color: var(--#{$prefix}theme-base, var(--#{$prefix}control-checked-border-color)),
+    --#{$prefix}radio-checked-bg: var(--#{$prefix}control-checked-bg),
+    --#{$prefix}radio-checked-border-color: var(--#{$prefix}control-checked-border-color),
     --#{$prefix}radio-mark-color: #{$radio-mark-color},
     --#{$prefix}radio-mark: #{escape-svg($radio-mark)},
     --#{$prefix}radio-disabled-opacity: var(--#{$prefix}control-disabled-opacity),
@@ -79,8 +79,8 @@ $radio-selector: if(sass($enable-deprecated-form-check): ".radio, .form-check-in
     }
 
     &:checked {
-      background-color: var(--#{$prefix}radio-checked-bg);
-      border-color: var(--#{$prefix}radio-checked-border-color);
+      background-color: var(--#{$prefix}theme-base, var(--#{$prefix}radio-checked-bg));
+      border-color: var(--#{$prefix}theme-base, var(--#{$prefix}radio-checked-border-color));
 
       &::before {
         opacity: 1;

--- a/scss/forms/_radio.scss
+++ b/scss/forms/_radio.scss
@@ -35,7 +35,6 @@ $radio-tokens: defaults(
     --#{$prefix}radio-mark: #{escape-svg($radio-mark)},
     --#{$prefix}radio-disabled-opacity: var(--#{$prefix}control-disabled-opacity),
     --#{$prefix}radio-margin-top: calc((var(--#{$prefix}body-line-height) * 1em - var(--#{$prefix}radio-size)) * .5),
-    --#{$prefix}radio-focus-border: var(--#{$prefix}control-focus-border-color),
     --#{$prefix}radio-active-filter: var(--#{$prefix}control-active-filter),
     --#{$prefix}radio-label-disabled-opacity: var(--#{$prefix}control-label-disabled-opacity),
   ),
@@ -89,7 +88,6 @@ $radio-selector: if(sass($enable-deprecated-form-check): ".radio, .form-check-in
     }
 
     &:focus-visible {
-      border-color: var(--#{$prefix}radio-focus-border);
       @include focus-ring(true);
     }
 

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -54,8 +54,8 @@ $switch-tokens: defaults(
     --#{$prefix}switch-thumb-bg: #{$switch-thumb-bg},
     --#{$prefix}switch-thumb-size: calc(var(--#{$prefix}switch-height) - var(--#{$prefix}switch-padding) * 2 - var(--#{$prefix}switch-border-width) * 2),
     --#{$prefix}switch-thumb-shadow: #{$switch-thumb-shadow},
-    --#{$prefix}switch-checked-bg: var(--#{$prefix}theme-base, var(--#{$prefix}control-checked-bg)),
-    --#{$prefix}switch-checked-border-color: var(--#{$prefix}theme-base, var(--#{$prefix}control-checked-border-color)),
+    --#{$prefix}switch-checked-bg: var(--#{$prefix}control-checked-bg),
+    --#{$prefix}switch-checked-border-color: var(--#{$prefix}control-checked-border-color),
     --#{$prefix}switch-checked-thumb-bg: #{$switch-checked-thumb-bg},
     --#{$prefix}switch-disabled-bg: #{$switch-disabled-bg},
     --#{$prefix}switch-disabled-thumb-bg: #{$switch-disabled-thumb-bg},
@@ -108,8 +108,8 @@ $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch
     }
 
     &:checked {
-      background-color: var(--#{$prefix}switch-checked-bg);
-      border-color: var(--#{$prefix}switch-checked-border-color);
+      background-color: var(--#{$prefix}theme-base, var(--#{$prefix}switch-checked-bg));
+      border-color: var(--#{$prefix}theme-base, var(--#{$prefix}switch-checked-border-color));
 
       &::before {
         inset-inline-start: calc(100% - var(--#{$prefix}switch-thumb-size) - var(--#{$prefix}switch-padding));

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -61,7 +61,6 @@ $switch-tokens: defaults(
     --#{$prefix}switch-disabled-thumb-bg: #{$switch-disabled-thumb-bg},
     --#{$prefix}switch-disabled-opacity: var(--#{$prefix}control-disabled-opacity),
     --#{$prefix}switch-margin-top: calc((var(--#{$prefix}body-line-height) * 1em - var(--#{$prefix}switch-height)) * .5),
-    --#{$prefix}switch-focus-border: var(--#{$prefix}control-focus-border-color),
     --#{$prefix}switch-active-filter: var(--#{$prefix}control-active-filter),
     --#{$prefix}switch-label-disabled-opacity: var(--#{$prefix}control-label-disabled-opacity),
   ),
@@ -118,7 +117,6 @@ $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch
     }
 
     &:focus-visible {
-      border-color: var(--#{$prefix}switch-focus-border);
       @include focus-ring(true);
     }
 


### PR DESCRIPTION
Theme slots sat in the token maps, so `--cui-list-group-color` resolved on `.list-group` and a `.theme-*` class on `.list-group-item` was never read. Measured across the compiled stylesheet: **44 of 58 themed tokens** were declared on a parent and read on a child, so this was the rule, not an exception.

Each slot now sits at the read site, which is where the theme class can land. Verified in Chromium against a build of `v6-dev`, comparing computed `color`/`background-color`/`border-color`:

| probe | before | after |
| --- | --- | --- |
| `.theme-success` on the component root (list-group, pagination, nav, progress, accordion, navbar, stepper, badge, alert, chip, table, check, switch) | — | identical, no regression |
| `.list-group-item.theme-success` | default color | themed |
| `.page-link.theme-success` | default color | themed |
| `.progress-bar.theme-success` | default | themed |
| `.accordion-item.theme-success` | default | themed |
| `.navbar-brand.theme-success` | default | themed |
| `.list-group-item-danger` with no theme class | — | identical |

**Twelve tokens deliberately keep their slot in the declaration**, because the same token carries a different slot — or none — in different variants, and hoisting would apply a theme where the variant never had one. Both cases showed up as real regressions on the first pass and are what the rule now prevents:

- the chip family — `--cui-chip-border-color` is plain `transparent` on `.chip` but themed on `.chip-outline`, so hoisting gave a plain themed chip a border it never had;
- `--cui-alert-border-color` is read inside another token (`--cui-alert-border`), on the same element, so hoisting only dropped the slot and lost the themed border;
- the table variants, `--cui-nav-link-color` / `--cui-nav-link-hover-color` (redeclared by navbar), `--cui-hr-border-color` (the alert overrides a global token for a descendant `hr`) and `--cui-control-focus-ring` (declared and read on the same element, so nothing to gain).

Consequence worth knowing: where a slot moved, a theme class now beats a user-set component token, because the theme is the outer `var()`. Combining a variant class with a theme class (`.list-group-item-danger.theme-success`) resolves to the theme.

Size is neutral — the slot leaves many variant maps and lands on few read sites: `coreui.css` 64.17 → 64.16 kB gzip.

---

### Also here: the themed border no longer dies on focus

`:focus-visible` on check, radio and switch overwrote `border-color` with `--cui-*-focus-border`, which resolves to the primary focus border and carries no theme slot. A themed control dropped its color the moment it took keyboard focus:

| | border on focus |
| --- | --- |
| `.theme-success` checked, before | `color(srgb .67 .67 .92)` — primary |
| `.theme-success` checked, after | `rgb(27, 158, 62)` — the theme |
| plain unchecked, before | primary |
| plain unchecked, after | `rgb(219, 223, 230)` — neutral, the ring marks focus |

The focus ring already marks focus, so the override is gone and the border keeps whatever the state set. The three `--cui-*-focus-border` tokens existed only to feed it and are removed with it. **Visual change to flag:** an unthemed control no longer gains a primary border on focus.