### PR TITLE
fix(Check, Radio, Switch): keep the themed border on focus, and document the slot rule

### DIFF
--- a/docs/src/content/docs/customize/components.mdx
+++ b/docs/src/content/docs/customize/components.mdx
@@ -62,6 +62,36 @@ Because the theme tokens are plain CSS variables, you can also scope a theme to 
 
 The classic color classes — `.btn-primary`, `.alert-success`, `.badge` color spellings from v5 — keep working: they are generated from the same theme tokens, so both APIs stay pixel-identical.
 
+### Building a themeable component
+
+A component reads a theme token **inside its own token's default**, never around that token at the property. Both forms below render identically until something overrides the token — and then the position of the slot decides who wins:
+
+```scss
+// Do this: the slot is the token's default, so the token stays the override point
+--cui-badge-bg: var(--cui-theme-base, #{$badge-bg}),
+// …
+background-color: var(--cui-badge-bg);
+
+// Not this: the slot wraps the token, so the token can no longer win
+--cui-badge-bg: #{$badge-bg},
+// …
+background-color: var(--cui-theme-base, var(--cui-badge-bg));
+```
+
+With the slot inside, setting `--cui-badge-bg` on a themed element beats the theme. With the slot outside, the theme always wins and the token is dead — and that takes every structural variant with it, because a variant is a rule that redeclares the component token. `.badge-subtle` and `.badge-outline` both collapse into the solid theme color.
+
+The rule holds one level down too. Where a state remaps a token, the slot belongs to the default being remapped from, not around it:
+
+```scss
+--cui-stepper-step-indicator-complete-color: var(--cui-theme-contrast, #{$stepper-step-indicator-complete-color}),
+// …
+.stepper-step-button.complete {
+  --cui-stepper-step-indicator-color: var(--cui-stepper-step-indicator-complete-color);
+}
+```
+
+One consequence to design around: a `var()` resolves where the property is declared, so a token declared on the component root cannot see a theme class placed on one of its parts. Declare the token on the part that should carry the theme.
+
 ## Responsive
 
 These Sass loops aren't limited to color maps, either. You can also generate responsive variations of your components. Take for example our responsive alignment of the dropdowns where we mix an `@each` loop for the `$grid-breakpoints` Sass map with a media query include.

--- a/scss/forms/_check.scss
+++ b/scss/forms/_check.scss
@@ -43,7 +43,6 @@ $check-tokens: defaults(
     --#{$prefix}check-indeterminate-border-color: var(--#{$prefix}control-indeterminate-border-color),
     --#{$prefix}check-disabled-opacity: var(--#{$prefix}control-disabled-opacity),
     --#{$prefix}check-margin-top: calc((var(--#{$prefix}body-line-height) * 1em - var(--#{$prefix}check-size)) * .5),
-    --#{$prefix}check-focus-border: var(--#{$prefix}control-focus-border-color),
     --#{$prefix}check-active-filter: var(--#{$prefix}control-active-filter),
     --#{$prefix}check-label-disabled-opacity: var(--#{$prefix}control-label-disabled-opacity),
   ),
@@ -109,7 +108,6 @@ $check-selector: if(sass($enable-deprecated-form-check): ".check, .form-check-in
     }
 
     &:focus-visible {
-      border-color: var(--#{$prefix}check-focus-border);
       @include focus-ring(true);
     }
 

--- a/scss/forms/_radio.scss
+++ b/scss/forms/_radio.scss
@@ -35,7 +35,6 @@ $radio-tokens: defaults(
     --#{$prefix}radio-mark: #{escape-svg($radio-mark)},
     --#{$prefix}radio-disabled-opacity: var(--#{$prefix}control-disabled-opacity),
     --#{$prefix}radio-margin-top: calc((var(--#{$prefix}body-line-height) * 1em - var(--#{$prefix}radio-size)) * .5),
-    --#{$prefix}radio-focus-border: var(--#{$prefix}control-focus-border-color),
     --#{$prefix}radio-active-filter: var(--#{$prefix}control-active-filter),
     --#{$prefix}radio-label-disabled-opacity: var(--#{$prefix}control-label-disabled-opacity),
   ),
@@ -89,7 +88,6 @@ $radio-selector: if(sass($enable-deprecated-form-check): ".radio, .form-check-in
     }
 
     &:focus-visible {
-      border-color: var(--#{$prefix}radio-focus-border);
       @include focus-ring(true);
     }
 

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -61,7 +61,6 @@ $switch-tokens: defaults(
     --#{$prefix}switch-disabled-thumb-bg: #{$switch-disabled-thumb-bg},
     --#{$prefix}switch-disabled-opacity: var(--#{$prefix}control-disabled-opacity),
     --#{$prefix}switch-margin-top: calc((var(--#{$prefix}body-line-height) * 1em - var(--#{$prefix}switch-height)) * .5),
-    --#{$prefix}switch-focus-border: var(--#{$prefix}control-focus-border-color),
     --#{$prefix}switch-active-filter: var(--#{$prefix}control-active-filter),
     --#{$prefix}switch-label-disabled-opacity: var(--#{$prefix}control-label-disabled-opacity),
   ),
@@ -118,7 +117,6 @@ $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch
     }
 
     &:focus-visible {
-      border-color: var(--#{$prefix}switch-focus-border);
       @include focus-ring(true);
     }
 


### PR DESCRIPTION
Two results of the same investigation into how `.theme-*` reaches a component.

### The themed border no longer dies on focus

`:focus-visible` on check, radio and switch overwrote `border-color` with `--cui-*-focus-border`, which resolves to the primary focus border and carries no theme slot. A themed control dropped its color the moment it took keyboard focus.

| | border on focus |
| --- | --- |
| `.theme-success` checked, before | `color(srgb .67 .67 .92)` — primary, while its focus ring stayed green |
| `.theme-success` checked, after | `rgb(27, 158, 62)` — the theme |
| plain unchecked, before | primary |
| plain unchecked, after | `rgb(219, 223, 230)` — neutral, the ring marks focus |

The focus ring already marks focus, so the override goes and the border keeps whatever the state set. The three `--cui-*-focus-border` tokens existed only to feed it and are removed with it.

**Visual change to flag:** an unthemed check, radio or switch no longer gains a primary border on focus. The 4px ring is unchanged.

### The rule that made that a bug is now written down

The theme-variants page showed how badge consumes theme tokens but never said that the position of the slot is load-bearing, so anyone adding a themeable component had to infer it. Reading a slot **around** a component token instead of **inside** its default inverts precedence:

```scss
--cui-badge-bg: var(--cui-theme-base, #{$badge-bg}),   // token stays the override point
--cui-badge-bg: #{$badge-bg},                          // + var(--cui-theme-base, var(--cui-badge-bg)) at the property
                                                       //   → the theme always wins, the token is dead
```

The second form takes every structural variant with it, because a variant is a rule that redeclares the component token — `.badge-subtle` and `.badge-outline` both collapse into the solid theme color. Measured, not assumed.

A new `### Building a themeable component` section covers both forms, how the rule applies one level down where a state remaps a token (stepper), and the consequence that a token declared on the component root cannot see a theme class placed on one of its parts.