### PR TITLE
feat(scss): let a theme class work on a component's parts

### DIFF
--- a/docs/src/content/docs/customize/components.mdx
+++ b/docs/src/content/docs/customize/components.mdx
@@ -23,7 +23,7 @@ Here are two examples of how we loop over the `$theme-colors` map to generate mo
 
 ## Theme variants
 
-Themeable components also support a single family of composable `.theme-*` classes that recolor a component without a per-component color class. A themeable component reads a shared set of generic `--cui-theme-*` tokens for its background, foreground, border, and focus styles — each with a fallback to the component's own default token. When no theme class is present, the fallback applies. Add a `.theme-*` class to the component (or to an ancestor) and it picks up that theme's colors instead.
+Themeable components also support a single family of composable `.theme-*` classes that recolor a component without a per-component color class. A themeable component reads a shared set of generic `--cui-theme-*` tokens for its background, foreground, border, and focus styles — each with a fallback to the component's own default token. When no theme class is present, the fallback applies. Add a `.theme-*` class to the component, to an ancestor, or to one of its parts, and it picks up that theme’s colors instead.
 
 | Token | Description |
 | --- | --- |
@@ -64,33 +64,27 @@ The classic color classes — `.btn-primary`, `.alert-success`, `.badge` color s
 
 ### Building a themeable component
 
-A component reads a theme token **inside its own token's default**, never around that token at the property. Both forms below render identically until something overrides the token — and then the position of the slot decides who wins:
+Read the theme slot **at the property**, wrapping the component's own token. Slots inherit, so one form covers every case — the class works on the component, on an ancestor, or on any part of it:
 
 ```scss
-// Do this: the slot is the token's default, so the token stays the override point
---cui-badge-bg: var(--cui-theme-base, #{$badge-bg}),
+--#{$prefix}badge-bg: #{$badge-bg},
 // …
-background-color: var(--cui-badge-bg);
-
-// Not this: the slot wraps the token, so the token can no longer win
---cui-badge-bg: #{$badge-bg},
-// …
-background-color: var(--cui-theme-base, var(--cui-badge-bg));
+background-color: var(--#{$prefix}theme-base, var(--#{$prefix}badge-bg));
 ```
 
-With the slot inside, setting `--cui-badge-bg` on a themed element beats the theme. With the slot outside, the theme always wins and the token is dead — and that takes every structural variant with it, because a variant is a rule that redeclares the component token. `.badge-subtle` and `.badge-outline` both collapse into the solid theme color.
-
-The rule holds one level down too. Where a state remaps a token, the slot belongs to the default being remapped from, not around it:
+A structural variant maps the token to a slot of its own, and then **re-declares the property with a plain read** so it wins over the base rule:
 
 ```scss
---cui-stepper-step-indicator-complete-color: var(--cui-theme-contrast, #{$stepper-step-indicator-complete-color}),
-// …
-.stepper-step-button.complete {
-  --cui-stepper-step-indicator-color: var(--cui-stepper-step-indicator-complete-color);
+.badge-subtle {
+  --#{$prefix}badge-bg: var(--#{$prefix}theme-bg-subtle);
+
+  background-color: var(--#{$prefix}badge-bg);
 }
 ```
 
-One consequence to design around: a `var()` resolves where the property is declared, so a token declared on the component root cannot see a theme class placed on one of its parts. Declare the token on the part that should carry the theme.
+The second line is the part that is easy to miss. Set the token alone and the base rule still applies its own slot, so `.badge-subtle` and `.badge-outline` collapse into the solid theme color.
+
+While no theme class is present the token behaves as an override point; under one, the theme wins.
 
 ## Responsive
 

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -69,9 +69,9 @@ $accordion-tokens: defaults(
     --#{$prefix}accordion-btn-active-icon-color: #{$accordion-icon-active-color},
     --#{$prefix}accordion-btn-icon-transform: #{$accordion-icon-transform},
     --#{$prefix}accordion-btn-icon-transition: #{$accordion-icon-transition},
-    --#{$prefix}accordion-active-color: var(--#{$prefix}theme-fg-emphasis, #{$accordion-button-active-color}),
-    --#{$prefix}accordion-active-bg: var(--#{$prefix}theme-bg-subtle, #{$accordion-button-active-bg}),
-    --#{$prefix}accordion-active-border-color: var(--#{$prefix}theme-border, #{$accordion-active-border-color}),
+    --#{$prefix}accordion-active-color: #{$accordion-button-active-color},
+    --#{$prefix}accordion-active-bg: #{$accordion-button-active-bg},
+    --#{$prefix}accordion-active-border-color: #{$accordion-active-border-color},
     --#{$prefix}accordion-content-duration: #{$accordion-content-duration},
     --#{$prefix}accordion-content-easing: #{$accordion-content-easing},
   ),
@@ -143,16 +143,16 @@ $accordion-tokens: defaults(
 
     &[open] {
       z-index: 2;
-      border-color: var(--#{$prefix}accordion-active-border-color);
+      border-color: var(--#{$prefix}theme-border, var(--#{$prefix}accordion-active-border-color));
 
       &::details-content {
         block-size: auto;
       }
 
       > .accordion-header {
-        color: var(--#{$prefix}accordion-active-color);
-        background-color: var(--#{$prefix}accordion-active-bg);
-        box-shadow: inset 0 calc(-1 * var(--#{$prefix}accordion-border-width)) 0 var(--#{$prefix}accordion-active-border-color);
+        color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}accordion-active-color));
+        background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}accordion-active-bg));
+        box-shadow: inset 0 calc(-1 * var(--#{$prefix}accordion-border-width)) 0 var(--#{$prefix}theme-border, var(--#{$prefix}accordion-active-border-color));
 
         &::after {
           mask-image: var(--#{$prefix}accordion-btn-active-icon);

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -22,14 +22,14 @@ $alert-tokens: () !default;
 // scss-docs-start alert-css-vars
 $alert-tokens: defaults(
   (
-    --#{$prefix}alert-bg: var(--#{$prefix}theme-bg-subtle, transparent),
+    --#{$prefix}alert-bg: transparent,
     --#{$prefix}alert-padding-x: #{$alert-padding-x},
     --#{$prefix}alert-padding-y: #{$alert-padding-y},
     --#{$prefix}alert-gap: #{$alert-gap},
     --#{$prefix}alert-margin-bottom: #{$alert-margin-bottom},
-    --#{$prefix}alert-color: var(--#{$prefix}theme-fg-emphasis, inherit),
-    --#{$prefix}alert-border-color: var(--#{$prefix}theme-border, transparent),
-    --#{$prefix}alert-border: #{$alert-border-width} solid var(--#{$prefix}alert-border-color),
+    --#{$prefix}alert-color: inherit,
+    --#{$prefix}alert-border-color: transparent,
+    --#{$prefix}alert-border-width: #{$alert-border-width},
     --#{$prefix}alert-border-radius: #{$alert-border-radius},
     --#{$prefix}alert-link-color: inherit,
     --#{$prefix}hr-border-color: var(--#{$prefix}theme-border, var(--#{$prefix}border-color)),
@@ -59,9 +59,9 @@ $alert-variants: (
     align-items: start;
     padding: var(--#{$prefix}alert-padding-y) var(--#{$prefix}alert-padding-x);
     margin-bottom: var(--#{$prefix}alert-margin-bottom);
-    color: var(--#{$prefix}alert-color);
-    background-color: var(--#{$prefix}alert-bg);
-    border: var(--#{$prefix}alert-border);
+    color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}alert-color));
+    background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}alert-bg));
+    border: var(--#{$prefix}alert-border-width) solid var(--#{$prefix}theme-border, var(--#{$prefix}alert-border-color));
     @include border-radius(var(--#{$prefix}alert-border-radius));
   }
 
@@ -105,6 +105,10 @@ $alert-variants: (
           --#{$prefix}alert-#{$property}: var(--#{$prefix}theme-#{$value});
         }
       }
+
+      color: var(--#{$prefix}alert-color);
+      background-color: var(--#{$prefix}alert-bg);
+      border-color: var(--#{$prefix}alert-border-color);
     }
   }
   // scss-docs-end alert-modifiers

--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -39,8 +39,8 @@ $avatar-tokens: () !default;
 $avatar-tokens: defaults(
   (
     --#{$prefix}avatar-size: #{$avatar-size},
-    --#{$prefix}avatar-color: var(--#{$prefix}theme-contrast, #{$avatar-color}),
-    --#{$prefix}avatar-bg: var(--#{$prefix}theme-base, #{$avatar-bg}),
+    --#{$prefix}avatar-color: #{$avatar-color},
+    --#{$prefix}avatar-bg: #{$avatar-bg},
     --#{$prefix}avatar-border-radius: #{$avatar-border-radius},
     --#{$prefix}avatar-status-size: #{$avatar-status-size},
     --#{$prefix}avatar-status-border-radius: #{$avatar-status-border-radius},
@@ -74,9 +74,9 @@ $avatar-variants: (
     // Declared as a fallback rather than a token, so the derived size is the
     // default and an explicit one still wins.
     font-size: var(--#{$prefix}avatar-font-size, calc(var(--#{$prefix}avatar-size) * #{$avatar-font-size-ratio}));
-    color: var(--#{$prefix}avatar-color);
+    color: var(--#{$prefix}theme-contrast, var(--#{$prefix}avatar-color));
     vertical-align: middle;
-    background-color: var(--#{$prefix}avatar-bg);
+    background-color: var(--#{$prefix}theme-base, var(--#{$prefix}avatar-bg));
     @include border-radius(var(--#{$prefix}avatar-border-radius));
     @include transition($avatar-transition);
   }
@@ -87,6 +87,9 @@ $avatar-variants: (
       @each $property, $value in $properties {
         --#{$prefix}avatar-#{$property}: var(--#{$prefix}theme-#{$value});
       }
+
+      color: var(--#{$prefix}avatar-color);
+      background-color: var(--#{$prefix}avatar-bg);
     }
   }
   // scss-docs-end avatar-modifiers

--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -41,8 +41,8 @@ $badge-tokens: defaults(
     --#{$prefix}badge-padding-y: #{$badge-padding-y},
     --#{$prefix}badge-font-size: clamp(#{$badge-font-size-floor}, #{$badge-font-size}, #{$badge-font-size}),
     --#{$prefix}badge-font-weight: #{$badge-font-weight},
-    --#{$prefix}badge-color: var(--#{$prefix}theme-contrast, #{$badge-color}),
-    --#{$prefix}badge-bg: var(--#{$prefix}theme-base, #{$badge-bg}),
+    --#{$prefix}badge-color: #{$badge-color},
+    --#{$prefix}badge-bg: #{$badge-bg},
     --#{$prefix}badge-border-width: #{$badge-border-width},
     --#{$prefix}badge-border-color: #{$badge-border-color},
     --#{$prefix}badge-border-radius: #{$badge-border-radius},
@@ -81,14 +81,14 @@ $badge-variants: (
     font-size: var(--#{$prefix}badge-font-size);
     font-weight: var(--#{$prefix}badge-font-weight);
     line-height: 1;
-    color: var(--#{$prefix}badge-color);
+    color: var(--#{$prefix}theme-contrast, var(--#{$prefix}badge-color));
     text-align: center;
     text-decoration: none;
     white-space: nowrap;
     vertical-align: baseline;
     border: var(--#{$prefix}badge-border-width) solid var(--#{$prefix}badge-border-color);
     border-radius: var(--#{$prefix}badge-border-radius, 0); // stylelint-disable-line property-disallowed-list
-    @include gradient-bg(var(--#{$prefix}badge-bg));
+    @include gradient-bg(var(--#{$prefix}theme-base, var(--#{$prefix}badge-bg)));
 
     // Empty badges collapse automatically
     &:empty {
@@ -112,6 +112,10 @@ $badge-variants: (
           --#{$prefix}badge-#{$property}: var(--#{$prefix}theme-#{$value});
         }
       }
+
+      color: var(--#{$prefix}badge-color);
+      border-color: var(--#{$prefix}badge-border-color);
+      @include gradient-bg(var(--#{$prefix}badge-bg));
     }
   }
   // scss-docs-end badge-modifiers

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -41,23 +41,23 @@ $list-group-tokens: () !default;
 // scss-docs-start list-group-css-vars
 $list-group-tokens: defaults(
   (
-    --#{$prefix}list-group-color: var(--#{$prefix}theme-fg-emphasis, #{$list-group-color}),
-    --#{$prefix}list-group-bg: var(--#{$prefix}theme-bg-subtle, #{$list-group-bg}),
-    --#{$prefix}list-group-border-color: var(--#{$prefix}theme-border, #{$list-group-border-color}),
+    --#{$prefix}list-group-color: #{$list-group-color},
+    --#{$prefix}list-group-bg: #{$list-group-bg},
+    --#{$prefix}list-group-border-color: #{$list-group-border-color},
     --#{$prefix}list-group-border-width: #{$list-group-border-width},
     --#{$prefix}list-group-border-radius: #{$list-group-border-radius},
     --#{$prefix}list-group-item-padding-x: #{$list-group-item-padding-x},
     --#{$prefix}list-group-item-padding-y: #{$list-group-item-padding-y},
     --#{$prefix}list-group-action-color: #{$list-group-action-color},
     --#{$prefix}list-group-action-hover-color: #{$list-group-action-hover-color},
-    --#{$prefix}list-group-action-hover-bg: var(--#{$prefix}theme-border, #{$list-group-hover-bg}),
+    --#{$prefix}list-group-action-hover-bg: #{$list-group-hover-bg},
     --#{$prefix}list-group-action-active-color: #{$list-group-action-active-color},
-    --#{$prefix}list-group-action-active-bg: var(--#{$prefix}theme-border, #{$list-group-action-active-bg}),
+    --#{$prefix}list-group-action-active-bg: #{$list-group-action-active-bg},
     --#{$prefix}list-group-disabled-color: #{$list-group-disabled-color},
     --#{$prefix}list-group-disabled-bg: #{$list-group-disabled-bg},
-    --#{$prefix}list-group-active-color: var(--#{$prefix}theme-bg-subtle, #{$list-group-active-color}),
-    --#{$prefix}list-group-active-bg: var(--#{$prefix}theme-fg-emphasis, #{$list-group-active-bg}),
-    --#{$prefix}list-group-active-border-color: var(--#{$prefix}theme-fg-emphasis, #{$list-group-active-border-color}),
+    --#{$prefix}list-group-active-color: #{$list-group-active-color},
+    --#{$prefix}list-group-active-bg: #{$list-group-active-bg},
+    --#{$prefix}list-group-active-border-color: #{$list-group-active-border-color},
   ),
   $list-group-tokens
 );
@@ -96,10 +96,10 @@ $list-group-tokens: defaults(
     position: relative;
     display: block;
     padding: var(--#{$prefix}list-group-item-padding-y) var(--#{$prefix}list-group-item-padding-x);
-    color: var(--#{$prefix}list-group-color);
+    color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}list-group-color));
     text-decoration: if(not sass($link-decoration == none): none);
-    background-color: var(--#{$prefix}list-group-bg);
-    border: var(--#{$prefix}list-group-border-width) solid var(--#{$prefix}list-group-border-color);
+    background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}list-group-bg));
+    border: var(--#{$prefix}list-group-border-width) solid var(--#{$prefix}theme-border, var(--#{$prefix}list-group-border-color));
 
     &:first-child {
       @include border-top-radius(inherit);
@@ -119,9 +119,9 @@ $list-group-tokens: defaults(
     // Include both here for `<a>`s and `<button>`s
     &.active {
       z-index: 2; // Place active items above their siblings for proper border styling
-      color: var(--#{$prefix}list-group-active-color);
-      background-color: var(--#{$prefix}list-group-active-bg);
-      border-color: var(--#{$prefix}list-group-active-border-color);
+      color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}list-group-active-color));
+      background-color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}list-group-active-bg));
+      border-color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}list-group-active-border-color));
     }
 
     // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
@@ -152,12 +152,12 @@ $list-group-tokens: defaults(
         z-index: 1; // Place hover/focus items above their siblings for proper border styling
         color: var(--#{$prefix}list-group-action-hover-color);
         text-decoration: none;
-        background-color: var(--#{$prefix}list-group-action-hover-bg);
+        background-color: var(--#{$prefix}theme-border, var(--#{$prefix}list-group-action-hover-bg));
       }
 
       &:active {
         color: var(--#{$prefix}list-group-action-active-color);
-        background-color: var(--#{$prefix}list-group-action-active-bg);
+        background-color: var(--#{$prefix}theme-border, var(--#{$prefix}list-group-action-active-bg));
       }
     }
   }

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -68,8 +68,8 @@ $nav-tokens: defaults(
     --#{$prefix}nav-link-padding-y: #{$nav-link-padding-y},
     --#{$prefix}nav-link-font-size: #{$nav-link-font-size},
     --#{$prefix}nav-link-font-weight: #{$nav-link-font-weight},
-    --#{$prefix}nav-link-color: var(--#{$prefix}theme-fg, #{$nav-link-color}),
-    --#{$prefix}nav-link-hover-color: var(--#{$prefix}theme-fg-emphasis, #{$nav-link-hover-color}),
+    --#{$prefix}nav-link-color: #{$nav-link-color},
+    --#{$prefix}nav-link-hover-color: #{$nav-link-hover-color},
     --#{$prefix}nav-link-disabled-color: #{$nav-link-disabled-color},
   ),
   $nav-tokens
@@ -107,8 +107,8 @@ $nav-pills-tokens: () !default;
 $nav-pills-tokens: defaults(
   (
     --#{$prefix}nav-pills-border-radius: #{$nav-pills-border-radius},
-    --#{$prefix}nav-pills-link-active-color: var(--#{$prefix}theme-contrast, #{$nav-pills-link-active-color}),
-    --#{$prefix}nav-pills-link-active-bg: var(--#{$prefix}theme-base, #{$nav-pills-link-active-bg}),
+    --#{$prefix}nav-pills-link-active-color: #{$nav-pills-link-active-color},
+    --#{$prefix}nav-pills-link-active-bg: #{$nav-pills-link-active-bg},
   ),
   $nav-pills-tokens
 );
@@ -125,7 +125,7 @@ $nav-underline-tokens: defaults(
   (
     --#{$prefix}nav-underline-gap: #{$nav-underline-gap},
     --#{$prefix}nav-underline-border-width: #{$nav-underline-border-width},
-    --#{$prefix}nav-underline-link-active-color: var(--#{$prefix}theme-fg, #{$nav-underline-link-active-color}),
+    --#{$prefix}nav-underline-link-active-color: #{$nav-underline-link-active-color},
   ),
   $nav-underline-tokens
 );
@@ -146,7 +146,7 @@ $nav-underline-border-tokens: defaults(
     --#{$prefix}nav-underline-border-link-padding-x: #{$nav-underline-border-link-padding-x},
     --#{$prefix}nav-underline-border-link-padding-y: #{$nav-underline-border-link-padding-y},
     --#{$prefix}nav-underline-border-link-color: #{$nav-underline-border-link-color},
-    --#{$prefix}nav-underline-border-link-active-color: var(--#{$prefix}theme-base, #{$nav-underline-border-link-active-color}),
+    --#{$prefix}nav-underline-border-link-active-color: #{$nav-underline-border-link-active-color},
     --#{$prefix}nav-underline-border-link-disabled-color: #{$nav-underline-border-link-disabled-color},
   ),
   $nav-underline-border-tokens
@@ -170,7 +170,7 @@ $nav-underline-border-tokens: defaults(
     padding: var(--#{$prefix}nav-link-padding-y) var(--#{$prefix}nav-link-padding-x);
     font-size: var(--#{$prefix}nav-link-font-size);
     font-weight: var(--#{$prefix}nav-link-font-weight);
-    color: var(--#{$prefix}nav-link-color);
+    color: var(--#{$prefix}theme-fg, var(--#{$prefix}nav-link-color));
     text-decoration: if(not sass($link-decoration == none): none);
     background: none;
     border: 0;
@@ -178,7 +178,7 @@ $nav-underline-border-tokens: defaults(
 
     &:hover,
     &:focus {
-      color: var(--#{$prefix}nav-link-hover-color);
+      color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}nav-link-hover-color));
       // stylelint-disable-next-line scss/at-function-named-arguments
       text-decoration: if(sass($link-hover-decoration == underline): none);
     }
@@ -247,8 +247,8 @@ $nav-underline-border-tokens: defaults(
 
     .nav-link.active,
     .show > .nav-link {
-      color: var(--#{$prefix}nav-pills-link-active-color);
-      @include gradient-bg(var(--#{$prefix}nav-pills-link-active-bg));
+      color: var(--#{$prefix}theme-contrast, var(--#{$prefix}nav-pills-link-active-color));
+      @include gradient-bg(var(--#{$prefix}theme-base, var(--#{$prefix}nav-pills-link-active-bg)));
     }
   }
 
@@ -276,7 +276,7 @@ $nav-underline-border-tokens: defaults(
     .nav-link.active,
     .show > .nav-link {
       font-weight: var(--#{$prefix}font-weight-bold);
-      color: var(--#{$prefix}nav-underline-link-active-color);
+      color: var(--#{$prefix}theme-fg, var(--#{$prefix}nav-underline-link-active-color));
       border-bottom-color: currentcolor;
     }
   }
@@ -305,7 +305,7 @@ $nav-underline-border-tokens: defaults(
     .nav-link.active,
     .show > .nav-link {
       font-weight: var(--#{$prefix}font-weight-bold);
-      color: var(--#{$prefix}nav-underline-border-link-active-color);
+      color: var(--#{$prefix}theme-base, var(--#{$prefix}nav-underline-border-link-active-color));
       border-bottom-color: currentcolor;
     }
   }

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -55,19 +55,19 @@ $pagination-tokens: defaults(
   (
     --#{$prefix}pagination-padding-x: #{$pagination-padding-x},
     --#{$prefix}pagination-padding-y: #{$pagination-padding-y},
-    --#{$prefix}pagination-color: var(--#{$prefix}theme-fg, #{$pagination-color}),
+    --#{$prefix}pagination-color: #{$pagination-color},
     --#{$prefix}pagination-bg: #{$pagination-bg},
     --#{$prefix}pagination-border-width: #{$pagination-border-width},
     --#{$prefix}pagination-border-color: #{$pagination-border-color},
     --#{$prefix}pagination-border-radius: #{$pagination-border-radius},
-    --#{$prefix}pagination-hover-color: var(--#{$prefix}theme-fg-emphasis, #{$pagination-hover-color}),
-    --#{$prefix}pagination-hover-bg: var(--#{$prefix}theme-bg-subtle, #{$pagination-hover-bg}),
-    --#{$prefix}pagination-hover-border-color: var(--#{$prefix}theme-border, #{$pagination-hover-border-color}),
+    --#{$prefix}pagination-hover-color: #{$pagination-hover-color},
+    --#{$prefix}pagination-hover-bg: #{$pagination-hover-bg},
+    --#{$prefix}pagination-hover-border-color: #{$pagination-hover-border-color},
     --#{$prefix}pagination-focus-color: #{$pagination-focus-color},
     --#{$prefix}pagination-focus-bg: #{$pagination-focus-bg},
-    --#{$prefix}pagination-active-color: var(--#{$prefix}theme-contrast, #{$pagination-active-color}),
-    --#{$prefix}pagination-active-bg: var(--#{$prefix}theme-base, #{$pagination-active-bg}),
-    --#{$prefix}pagination-active-border-color: var(--#{$prefix}theme-base, #{$pagination-active-border-color}),
+    --#{$prefix}pagination-active-color: #{$pagination-active-color},
+    --#{$prefix}pagination-active-bg: #{$pagination-active-bg},
+    --#{$prefix}pagination-active-border-color: #{$pagination-active-border-color},
     --#{$prefix}pagination-disabled-color: #{$pagination-disabled-color},
     --#{$prefix}pagination-disabled-bg: #{$pagination-disabled-bg},
     --#{$prefix}pagination-disabled-border-color: #{$pagination-disabled-border-color},
@@ -91,7 +91,7 @@ $pagination-tokens: defaults(
     display: block;
     padding: var(--#{$prefix}pagination-padding-y) var(--#{$prefix}pagination-padding-x);
     font-size: var(--#{$prefix}pagination-font-size);
-    color: var(--#{$prefix}pagination-color);
+    color: var(--#{$prefix}theme-fg, var(--#{$prefix}pagination-color));
     text-decoration: if(not sass($link-decoration == none): none);
     background-color: var(--#{$prefix}pagination-bg);
     border: var(--#{$prefix}pagination-border-width) solid var(--#{$prefix}pagination-border-color);
@@ -99,11 +99,11 @@ $pagination-tokens: defaults(
 
     &:hover {
       z-index: 2;
-      color: var(--#{$prefix}pagination-hover-color);
+      color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}pagination-hover-color));
       // stylelint-disable-next-line scss/at-function-named-arguments
       text-decoration: if(sass($link-hover-decoration == underline): none);
-      background-color: var(--#{$prefix}pagination-hover-bg);
-      border-color: var(--#{$prefix}pagination-hover-border-color);
+      background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}pagination-hover-bg));
+      border-color: var(--#{$prefix}theme-border, var(--#{$prefix}pagination-hover-border-color));
     }
 
     &:focus-visible {
@@ -116,9 +116,9 @@ $pagination-tokens: defaults(
     &.active,
     .active > & {
       z-index: 3;
-      color: var(--#{$prefix}pagination-active-color);
-      @include gradient-bg(var(--#{$prefix}pagination-active-bg));
-      border-color: var(--#{$prefix}pagination-active-border-color);
+      color: var(--#{$prefix}theme-contrast, var(--#{$prefix}pagination-active-color));
+      @include gradient-bg(var(--#{$prefix}theme-base, var(--#{$prefix}pagination-active-bg)));
+      border-color: var(--#{$prefix}theme-base, var(--#{$prefix}pagination-active-border-color));
     }
 
     &.disabled,

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -33,8 +33,8 @@ $progress-tokens: defaults(
     --#{$prefix}progress-bg: #{$progress-bg},
     --#{$prefix}progress-border-radius: #{$progress-border-radius},
     --#{$prefix}progress-box-shadow: #{$progress-box-shadow},
-    --#{$prefix}progress-bar-color: var(--#{$prefix}theme-contrast, #{$progress-bar-color}),
-    --#{$prefix}progress-bar-bg: var(--#{$prefix}theme-base, #{$progress-bar-bg}),
+    --#{$prefix}progress-bar-color: #{$progress-bar-color},
+    --#{$prefix}progress-bar-bg: #{$progress-bar-bg},
     --#{$prefix}progress-bar-transition: #{$progress-bar-transition},
     --#{$prefix}progress-font-size: $progress-font-size,
   ),
@@ -72,10 +72,10 @@ $progress-tokens: defaults(
     flex-direction: column;
     justify-content: center;
     overflow: hidden;
-    color: var(--#{$prefix}progress-bar-color);
+    color: var(--#{$prefix}theme-contrast, var(--#{$prefix}progress-bar-color));
     text-align: center;
     white-space: nowrap;
-    background-color: var(--#{$prefix}progress-bar-bg);
+    background-color: var(--#{$prefix}theme-base, var(--#{$prefix}progress-bar-bg));
     @include transition(var(--#{$prefix}progress-bar-transition));
   }
 

--- a/scss/_stepper.scss
+++ b/scss/_stepper.scss
@@ -66,12 +66,12 @@ $stepper-tokens: defaults(
     --#{$prefix}stepper-step-indicator-border-width: #{$stepper-step-indicator-border-width},
     --#{$prefix}stepper-step-indicator-border-color: #{$stepper-step-indicator-border-color},
     --#{$prefix}stepper-step-indicator-transition: #{$stepper-step-indicator-transition},
-    --#{$prefix}stepper-step-indicator-active-color: var(--#{$prefix}theme-base, #{$stepper-step-indicator-active-color}),
+    --#{$prefix}stepper-step-indicator-active-color: #{$stepper-step-indicator-active-color},
     --#{$prefix}stepper-step-indicator-active-bg: #{$stepper-step-indicator-active-bg},
-    --#{$prefix}stepper-step-indicator-active-border-color: var(--#{$prefix}theme-base, #{$stepper-step-indicator-active-border-color}),
-    --#{$prefix}stepper-step-indicator-complete-color: var(--#{$prefix}theme-contrast, #{$stepper-step-indicator-complete-color}),
-    --#{$prefix}stepper-step-indicator-complete-bg: var(--#{$prefix}theme-base, #{$stepper-step-indicator-complete-bg}),
-    --#{$prefix}stepper-step-indicator-complete-border-color: var(--#{$prefix}theme-base, #{$stepper-step-indicator-complete-border-color}),
+    --#{$prefix}stepper-step-indicator-active-border-color: #{$stepper-step-indicator-active-border-color},
+    --#{$prefix}stepper-step-indicator-complete-color: #{$stepper-step-indicator-complete-color},
+    --#{$prefix}stepper-step-indicator-complete-bg: #{$stepper-step-indicator-complete-bg},
+    --#{$prefix}stepper-step-indicator-complete-border-color: #{$stepper-step-indicator-complete-border-color},
     --#{$prefix}stepper-step-indicator-disabled-color: #{$stepper-step-indicator-disabled-color},
     --#{$prefix}stepper-step-indicator-disabled-bg: #{$stepper-step-indicator-disabled-bg},
     --#{$prefix}stepper-step-indicator-disabled-border-color: #{$stepper-step-indicator-disabled-border-color},
@@ -81,7 +81,7 @@ $stepper-tokens: defaults(
     --#{$prefix}stepper-step-connector-height: #{$stepper-step-connector-height},
     --#{$prefix}stepper-step-connector-gap: #{$stepper-step-connector-gap},
     --#{$prefix}stepper-step-connector-bg: #{$stepper-step-connector-bg},
-    --#{$prefix}stepper-step-connector-complete-bg: var(--#{$prefix}theme-base, #{$stepper-step-connector-complete-bg}),
+    --#{$prefix}stepper-step-connector-complete-bg: #{$stepper-step-connector-complete-bg},
     --#{$prefix}stepper-step-connector-transition: #{$stepper-step-connector-transition},
     --#{$prefix}stepper-step-content-transition: #{$stepper-step-content-transition},
   ),
@@ -149,9 +149,9 @@ $stepper-tokens: defaults(
 
     &.active {
       --#{$prefix}stepper-step-button-color: var(--#{$prefix}stepper-step-button-active-color);
-      --#{$prefix}stepper-step-indicator-color: var(--#{$prefix}stepper-step-indicator-active-color);
+      --#{$prefix}stepper-step-indicator-color: var(--#{$prefix}theme-base, var(--#{$prefix}stepper-step-indicator-active-color));
       --#{$prefix}stepper-step-indicator-bg: var(--#{$prefix}stepper-step-indicator-active-bg);
-      --#{$prefix}stepper-step-indicator-border-color: var(--#{$prefix}stepper-step-indicator-active-border-color);
+      --#{$prefix}stepper-step-indicator-border-color: var(--#{$prefix}theme-base, var(--#{$prefix}stepper-step-indicator-active-border-color));
     }
 
     &:disabled {
@@ -163,16 +163,16 @@ $stepper-tokens: defaults(
 
     &.complete {
       --#{$prefix}stepper-step-button-color: var(--#{$prefix}stepper-step-button-complete-color);
-      --#{$prefix}stepper-step-indicator-color: var(--#{$prefix}stepper-step-indicator-complete-color);
-      --#{$prefix}stepper-step-indicator-bg: var(--#{$prefix}stepper-step-indicator-complete-bg);
-      --#{$prefix}stepper-step-indicator-border-color: var(--#{$prefix}stepper-step-indicator-complete-border-color);
+      --#{$prefix}stepper-step-indicator-color: var(--#{$prefix}theme-contrast, var(--#{$prefix}stepper-step-indicator-complete-color));
+      --#{$prefix}stepper-step-indicator-bg: var(--#{$prefix}theme-base, var(--#{$prefix}stepper-step-indicator-complete-bg));
+      --#{$prefix}stepper-step-indicator-border-color: var(--#{$prefix}theme-base, var(--#{$prefix}stepper-step-indicator-complete-border-color));
 
       .stepper-step-indicator-text {
         display: none;
       }
 
       ~ .stepper-step-connector {
-        --#{$prefix}stepper-step-connector-bg: var(--#{$prefix}stepper-step-connector-complete-bg);
+        --#{$prefix}stepper-step-connector-bg: var(--#{$prefix}theme-base, var(--#{$prefix}stepper-step-connector-complete-bg));
       }
     }
 


### PR DESCRIPTION
A component's tokens resolve their `var()` references on the component root, so a `.theme-*` class landing on a part was read as if it were not there — **44 of 58 themed tokens** are declared on a parent and read on a child.

Every themeable component now reads the slot **at the property**, wrapping its own token. Slots inherit, so one form covers the component, an ancestor and any part, and nothing is generated per state.

Structural variants map the token to a slot of their own **and re-declare the property with a plain read**, so they still win over the base rule:

```scss
.badge-subtle {
  --#{$prefix}badge-bg: var(--#{$prefix}theme-bg-subtle);

  background-color: var(--#{$prefix}badge-bg);   // ← the half that was missing
}
```

Setting the token alone leaves the base rule applying its own slot, which is why an earlier attempt (#849) collapsed `.badge-subtle` and `.badge-outline` into the solid theme color. With both halves there are no per-component exceptions.

Verified in Chromium against a build of `v6-dev`:

| probe | result |
| --- | --- |
| `.theme-success` on `.list-group-item`, `.page-link`, `.progress-bar`, `.accordion-item`, `.nav-link`, `.stepper-step-button` | **now themed** (was inert) |
| `.theme-*` on each component root | unchanged |
| `.badge-subtle`, `.badge-outline`, `.alert-solid`, `.avatar-subtle`, `.list-group-item-danger` | unchanged |
| `.navbar-nav .nav-link` | unchanged — navbar keeps its own colors |

The trade: a component token stops being an override point while a theme class is present. Choosing a theme and hand-setting the same token on one element are alternatives, not something to combine.

Gates: stylelint clean, `docs-build` clean, visual suite 35/35, bundlewatch passes with ceilings untouched (`coreui.css` 64.16 → 64.17 kB gzip).

Docs: the authoring section now states the single rule and shows both halves of it.