### PR TITLE
feat(spinner): size spinners in em and merge the small variants

### DIFF
--- a/build/class-api-removals.json
+++ b/build/class-api-removals.json
@@ -106,6 +106,8 @@
   "modal-dialog-scrollable": "Renamed to .modal-scrollable, placed on the <dialog class=\"modal\"> itself now that the wrapper layers are gone.",
   "offcanvas-backdrop": "The backdrop is the native ::backdrop pseudo-element now - no element is inserted into the DOM. Style it through the --cui-offcanvas-backdrop-bg / --cui-offcanvas-backdrop-opacity tokens on .offcanvas.",
   "showing": "Offcanvas state classes are replaced by the native <dialog> [open] attribute; the exit transition still uses .hiding while the JS keeps the dialog in the top layer. There is no entry counterpart to migrate to - [open] is set before the transition starts.",
+  "spinner-border-sm": "Replaced by .spinner-sm, which works on both spinner types. Spinners are sized in em now, so the small variant no longer has to correct the border width and needed no per-type class. Note that a spinner already takes the font size of whatever contains it, so inside a button or a paragraph you can usually drop the size class entirely.",
+  "spinner-grow-sm": "Replaced by .spinner-sm, which works on both spinner types. Spinners are sized in em now, so the small variant no longer has to correct the border width and needed no per-type class. Note that a spinner already takes the font size of whatever contains it, so inside a button or a paragraph you can usually drop the size class entirely.",
   "text-bg-*-gradient": "Removed in v6 — a CoreUI-only addition. Use class=\"text-bg-primary bg-gradient\".",
   "text-disabled-inverse": "Removed in v6 — a CoreUI-only addition, deprecated since v5.0.0. Use .text-white with an opacity utility.",
   "text-high-emphasis": "Removed in v6 — a CoreUI-only addition, deprecated since v5.0.0. Use .text-body.",

--- a/docs/src/content/docs/components/spinners.mdx
+++ b/docs/src/content/docs/components/spinners.mdx
@@ -54,7 +54,7 @@ Once again, this spinner is built with `currentColor`, so you can easily change 
 
 ## Alignment
 
-Spinners in Bootstrap are built with `rem`s, `currentColor`, and `display: inline-flex`. This means they can easily be resized, recolored, and quickly aligned.
+Spinners in Bootstrap are built with `em`s, `currentColor`, and `display: inline-flex`. This means they can easily be resized, recolored, and quickly aligned.
 
 ### Margin
 
@@ -99,12 +99,17 @@ Use [flexbox utilities][flex], [float utilities][float], or [text alignment][tex
 
 ## Size
 
-Add `.spinner-border-sm` and `.spinner-grow-sm` to make a smaller spinner that can quickly be used within other components.
+Both spinners are `1em` square, so they match the font size of whatever they sit in — drop one into a heading or a button and it scales along with the text.
 
-<Example code={`<div class="spinner-border spinner-border-sm" role="status">
+<Example code={`<h3>Heading <span class="spinner-border" role="status"><span class="visually-hidden">Loading...</span></span></h3>
+  <p>Paragraph <span class="spinner-border" role="status"><span class="visually-hidden">Loading...</span></span></p>`} />
+
+Add `.spinner-sm` to make a smaller spinner. It works on both types.
+
+<Example code={`<div class="spinner-border spinner-sm" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
-  <div class="spinner-grow spinner-grow-sm" role="status">
+  <div class="spinner-grow spinner-sm" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>`} />
 
@@ -117,25 +122,40 @@ Or, use custom CSS or inline styles to change the dimensions as needed.
     <span class="visually-hidden">Loading...</span>
   </div>`} />
 
+## Custom spinners
+
+Add `.spinner-rotate` to any element to spin it at the same speed as `.spinner-border`. Use it when you want your own artwork instead of a bordered circle.
+
+<Example code={`<svg class="spinner-rotate" width="2rem" height="2rem" viewBox="0 0 16 16" fill="none" stroke="currentcolor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+    <path d="M8 1V4"/>
+    <path opacity=".8" d="M3.05 3.05L5.17 5.17"/>
+    <path opacity=".6" d="M4 8L1 8"/>
+    <path opacity=".5" d="M5.17 10.83L3.05 12.95"/>
+    <path opacity=".4" d="M8 12V15"/>
+    <path opacity=".3" d="M10.83 10.83L12.95 12.95"/>
+    <path opacity=".2" d="M15 8L12 8"/>
+    <path opacity=".1" d="M12.95 3.05L10.83 5.17"/>
+  </svg>`} />
+
 ## Buttons
 
 Use spinners within buttons to indicate an action is currently processing or taking place. You may also swap the text out of the spinner element and utilize button text as needed.
 
 <Example code={`<button class="btn btn-primary" type="button" disabled>
-    <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
+    <span class="spinner-border" aria-hidden="true"></span>
     <span class="visually-hidden" role="status">Loading...</span>
   </button>
   <button class="btn btn-primary" type="button" disabled>
-    <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
+    <span class="spinner-border" aria-hidden="true"></span>
     <span role="status">Loading...</span>
   </button>`} />
 
 <Example code={`<button class="btn btn-primary" type="button" disabled>
-    <span class="spinner-grow spinner-grow-sm" aria-hidden="true"></span>
+    <span class="spinner-grow" aria-hidden="true"></span>
     <span class="visually-hidden" role="status">Loading...</span>
   </button>
   <button class="btn btn-primary" type="button" disabled>
-    <span class="spinner-grow spinner-grow-sm" aria-hidden="true"></span>
+    <span class="spinner-grow" aria-hidden="true"></span>
     <span role="status">Loading...</span>
   </button>`} />
 
@@ -153,9 +173,9 @@ Growing spinner variables:
 
 <ScssDocs file="scss/_spinner.scss" capture="spinner-grow-css-vars" />
 
-For both spinners, small spinner modifier classes are used to update the values of these CSS variables as needed. For example, the `.spinner-border-sm` class does the following:
+The `.spinner-sm` modifier updates the values of these CSS variables, so it applies to both spinners:
 
-<ScssDocs file="scss/_spinner.scss" capture="spinner-border-sm-css-vars" />
+<ScssDocs file="scss/_spinner.scss" capture="spinner-sm-css-vars" />
 
 ### SASS variables
 
@@ -163,7 +183,7 @@ For both spinners, small spinner modifier classes are used to update the values 
 
 ### Keyframes
 
-Used for creating the CSS animations for our spinners. Included in `scss/_spinners.scss`.
+Used for creating the CSS animations for our spinners. Included in `scss/_spinner.scss`.
 
 <ScssDocs file="scss/_spinner.scss" capture="spinner-border-keyframes" />
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1481,6 +1481,39 @@ Multi Select's option indicators moved with it — they render as a decorative
   list stays vertical. Plain `.list-group-horizontal` is unconditional and
   needs no container.
 
+#### Spinner
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **Spinners are sized in `em`, not `rem`.** `.spinner-border` and
+  `.spinner-grow` are now `1em` square with a `.125em` border, so a spinner
+  takes the font size of whatever it sits in instead of being a fixed 32 px
+  block. Inside a button or a paragraph it lands at the size you previously had
+  to ask for with a modifier; standalone it is half of what it was. Set
+  `--cui-spinner-width` / `-height`, or the `$spinner-width` /
+  `$spinner-height` Sass variables, to go back to a fixed size.
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`.spinner-border-sm` and `.spinner-grow-sm` are replaced by one
+  `.spinner-sm`.** The small variant no longer has to correct the border width,
+  so a single class serves both spinners.
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`--cui-spinner-vertical-align` is gone.** Spinners are
+  `inline-flex` and assume a flex parent; the `-.125em` baseline nudge it used
+  to need no longer applies.
+
+- **The animation timing function is a token.** `.spinner-border` keeps
+  `linear`, while `.spinner-grow` now eases with `ease-in-out` instead of
+  pulsing linearly. Override
+  `--cui-spinner-animation-timing-function` to change either.
+
+- **`.spinner-rotate` is new.** It applies only the rotation, so you can spin
+  your own SVG or icon without inheriting the bordered circle.
+
+- **`.btn-loading` sizes its spinner from the button.** `LoadingButton` no
+  longer adds a `-sm` class to the spinner it injects; the spinner follows the
+  button's font size, so it now scales with `.btn-sm` and `.btn-lg`.
+
 ### Sass architecture & design tokens
 
 v6 adopts the Bootstrap v6 SCSS architecture: CSS cascade layers, per-component

--- a/js/src/loading-button.ts
+++ b/js/src/loading-button.ts
@@ -135,7 +135,7 @@ class LoadingButton extends BaseComponent {
     if (this._config.spinner) {
       const spinner = document.createElement('span')
       const type = this._config.spinnerType
-      spinner.classList.add(CLASS_NAME_LOADING_BUTTON_SPINNER, `spinner-${type}`, `spinner-${type}-sm`)
+      spinner.classList.add(CLASS_NAME_LOADING_BUTTON_SPINNER, `spinner-${type}`)
       spinner.setAttribute('role', 'status')
       spinner.setAttribute('aria-hidden', 'true')
       this._element.insertBefore(spinner, this._element.firstChild)

--- a/js/tests/unit/loading-button.spec.js
+++ b/js/tests/unit/loading-button.spec.js
@@ -122,7 +122,6 @@ describe('LoadingButton', () => {
           const spinner = button.querySelector('.btn-loading-spinner')
           expect(spinner).toBeTruthy()
           expect(spinner.classList.contains('spinner-border')).toBe(true)
-          expect(spinner.classList.contains('spinner-border-sm')).toBe(true)
           expect(spinner.getAttribute('role')).toBe('status')
           expect(spinner.getAttribute('aria-hidden')).toBe('true')
           resolve()
@@ -145,7 +144,6 @@ describe('LoadingButton', () => {
           const spinner = button.querySelector('.btn-loading-spinner')
           expect(spinner).toBeTruthy()
           expect(spinner.classList.contains('spinner-grow')).toBe(true)
-          expect(spinner.classList.contains('spinner-grow-sm')).toBe(true)
           resolve()
         })
 

--- a/scss/_spinner.scss
+++ b/scss/_spinner.scss
@@ -5,15 +5,17 @@
 // stylelint-disable custom-property-no-missing-var-function
 
 // scss-docs-start spinner-variables
-$spinner-width:           2rem !default;
-$spinner-height:          $spinner-width !default;
-$spinner-vertical-align:  -.125em !default;
-$spinner-border-width:    .25em !default;
-$spinner-animation-speed: .75s !default;
+$spinner-width:                            1em !default;
+$spinner-height:                           $spinner-width !default;
+$spinner-border-width:                     .125em !default;
+$spinner-animation-speed:                  1s !default;
+$spinner-animation-timing-function:        linear !default;
+$spinner-grow-animation-timing-function:   ease-in-out !default;
 
-$spinner-width-sm:        1rem !default;
-$spinner-height-sm:       $spinner-width-sm !default;
-$spinner-border-width-sm: .2em !default;
+$spinner-width-sm:                         .75em !default;
+$spinner-height-sm:                        $spinner-width-sm !default;
+
+$spinner-reduced-motion-animation-speed:   $spinner-animation-speed * 1.5 !default;
 // scss-docs-end spinner-variables
 
 $spinner-border-tokens: () !default;
@@ -25,31 +27,14 @@ $spinner-border-tokens: defaults(
   (
     --#{$prefix}spinner-width: #{$spinner-width},
     --#{$prefix}spinner-height: #{$spinner-height},
-    --#{$prefix}spinner-vertical-align: #{$spinner-vertical-align},
     --#{$prefix}spinner-border-width: #{$spinner-border-width},
     --#{$prefix}spinner-animation-speed: #{$spinner-animation-speed},
+    --#{$prefix}spinner-animation-timing-function: #{$spinner-animation-timing-function},
     --#{$prefix}spinner-animation-name: spinner-border,
   ),
   $spinner-border-tokens
 );
 // scss-docs-end spinner-border-css-vars
-
-// stylelint-enable scss/dollar-variable-default
-
-$spinner-border-sm-tokens: () !default;
-
-// stylelint-disable scss/dollar-variable-default
-
-// scss-docs-start spinner-border-sm-css-vars
-$spinner-border-sm-tokens: defaults(
-  (
-    --#{$prefix}spinner-width: #{$spinner-width-sm},
-    --#{$prefix}spinner-height: #{$spinner-height-sm},
-    --#{$prefix}spinner-border-width: #{$spinner-border-width-sm},
-  ),
-  $spinner-border-sm-tokens
-);
-// scss-docs-end spinner-border-sm-css-vars
 
 // stylelint-enable scss/dollar-variable-default
 
@@ -62,8 +47,8 @@ $spinner-grow-tokens: defaults(
   (
     --#{$prefix}spinner-width: #{$spinner-width},
     --#{$prefix}spinner-height: #{$spinner-height},
-    --#{$prefix}spinner-vertical-align: #{$spinner-vertical-align},
     --#{$prefix}spinner-animation-speed: #{$spinner-animation-speed},
+    --#{$prefix}spinner-animation-timing-function: #{$spinner-grow-animation-timing-function},
     --#{$prefix}spinner-animation-name: spinner-grow,
   ),
   $spinner-grow-tokens
@@ -72,21 +57,21 @@ $spinner-grow-tokens: defaults(
 
 // stylelint-enable scss/dollar-variable-default
 @layer components {
+  // Assumes a flex parent
   .spinner-grow,
   .spinner-border {
-    display: inline-block;
+    display: inline-flex;
     flex-shrink: 0;
     width: var(--#{$prefix}spinner-width);
     height: var(--#{$prefix}spinner-height);
-    vertical-align: var(--#{$prefix}spinner-vertical-align);
     // stylelint-disable-next-line property-disallowed-list
     border-radius: 50%;
-    animation: var(--#{$prefix}spinner-animation-speed) linear infinite var(--#{$prefix}spinner-animation-name);
+    animation: var(--#{$prefix}spinner-animation-speed) var(--#{$prefix}spinner-animation-timing-function) infinite var(--#{$prefix}spinner-animation-name);
   }
 
   // scss-docs-start spinner-border-keyframes
   @keyframes spinner-border {
-    to { transform: rotate(360deg) #{"/* rtl:ignore */"}; }
+    to { transform: rotate(360deg); }
   }
   // scss-docs-end spinner-border-keyframes
 
@@ -94,11 +79,14 @@ $spinner-grow-tokens: defaults(
     @include tokens($spinner-border-tokens);
 
     border: var(--#{$prefix}spinner-border-width) solid currentcolor;
-    border-right-color: transparent;
+    border-inline-end-color: transparent;
   }
 
-  .spinner-border-sm {
-    @include tokens($spinner-border-sm-tokens);
+  .spinner-sm {
+    // scss-docs-start spinner-sm-css-vars
+    --#{$prefix}spinner-width: #{$spinner-width-sm};
+    --#{$prefix}spinner-height: #{$spinner-height-sm};
+    // scss-docs-end spinner-sm-css-vars
   }
 
   //
@@ -124,16 +112,19 @@ $spinner-grow-tokens: defaults(
     opacity: 0;
   }
 
-  .spinner-grow-sm {
-    --#{$prefix}spinner-width: #{$spinner-width-sm};
-    --#{$prefix}spinner-height: #{$spinner-height-sm};
+  .spinner-rotate {
+    animation: $spinner-animation-speed $spinner-animation-timing-function infinite spinner-border;
   }
 
   @if $enable-reduced-motion {
     @media (prefers-reduced-motion: reduce) {
       .spinner-border,
       .spinner-grow {
-        --#{$prefix}spinner-animation-speed: #{$spinner-animation-speed * 2};
+        --#{$prefix}spinner-animation-speed: #{$spinner-reduced-motion-animation-speed};
+      }
+
+      .spinner-rotate {
+        animation-duration: $spinner-reduced-motion-animation-speed;
       }
     }
   }

--- a/scss/buttons/_loading-button.scss
+++ b/scss/buttons/_loading-button.scss
@@ -12,14 +12,13 @@
   }
 
   .btn-loading-spinner {
-    margin-inline: ($spacer * -2) $spacer;
+    margin-inline: calc(-1 * (var(--#{$prefix}spinner-width) + #{$spacer})) $spacer;
     opacity: 0;
     @include transition(margin .15s, opacity .15s, border .15s);
   }
 
   .btn-loading.is-loading {
     .btn-loading-spinner {
-      width: 1rem;
       margin-inline-start: 0;
       opacity: 1;
     }


### PR DESCRIPTION
- `.spinner-border` / `.spinner-grow` are `1em` square with a `.125em` border and lay out as `inline-flex`, so a spinner takes the font size of whatever contains it instead of being a fixed 2rem block. The `--cui-spinner-vertical-align` baseline nudge is gone with it.
- `.spinner-border-sm` and `.spinner-grow-sm` collapse into one `.spinner-sm` — the small variant no longer has to correct the border width, so it needed no per-type class. Both are listed in `build/class-api-removals.json`.
- New `--cui-spinner-animation-timing-function` token. `.spinner-grow` eases with `ease-in-out` instead of pulsing linearly, and either spinner's easing is now changeable at runtime.
- New `.spinner-rotate`: rotation only, for spinning custom artwork that is not a bordered circle. Reduced motion slows it alongside the other two.
- `.btn-loading-spinner` derives its negative margin from the spinner width, so the slide-in still nets to zero; `LoadingButton` stops adding a `-sm` class and the spinner now scales with `.btn-sm` / `.btn-lg`.
- Fixes `border-right-color` on `.spinner-border`, which put the transparent gap on the wrong side in RTL — it is `border-inline-end-color` now, which also makes the `rtl:ignore` on the keyframes unnecessary.

Sass variables stay: `$spinner-width`, `$spinner-height`, `$spinner-border-width`, `$spinner-animation-speed`, `$spinner-animation-timing-function`, `$spinner-grow-animation-timing-function`, `$spinner-width-sm`, `$spinner-height-sm`, `$spinner-reduced-motion-animation-speed`.

Docs: the Size section gains a font-size demo, a new Custom spinners section covers `.spinner-rotate`, the button examples drop the size class, and the migration guide gets a Spinner entry.

Gates: stylelint, `css-test-class-api`, unit suite 3212/3212, visual suite 35/35, `docs-build` clean, bundlewatch PASS (`coreui.css` 64.19 kB, `coreui.min.css` 59.29 kB — both down, ceilings untouched).