### PR TITLE
fix(Alert): drive the exit from .hiding instead of the .fade class

### DIFF
--- a/docs/src/content/docs/components/alerts.mdx
+++ b/docs/src/content/docs/components/alerts.mdx
@@ -159,11 +159,12 @@ Using the JavaScript plugin, you can remove any alert.
 - Add a [close button](/components/close-button//) as a child of the alert. It is pushed to the end of the alert on its own — the `.alert-dismissible` class is no longer required.
 - `.alert-dismissible` no longer carries any styling. Markup that still has it renders the same, so there is nothing to remove, but the close button has to be a direct child of the alert to be pushed to its end — a button nested in a wrapper is laid out by that wrapper.
 - On the close button, include the `data-coreui-dismiss="alert"` attribute, which triggers the JavaScript functionality. You must use the `<button>` element with it for proper behavior across all devices.
-- Add the `.fade` and `.show` classes to animate the alert. It fades out when dismissed, and an alert added to the page while carrying them fades in on its own.
+- Every alert fades out when dismissed — the JavaScript marks it with `.hiding` for the length of the transition, then removes it. Add `.alert-instant` to an alert that should go at once, or retime the fade with `--cui-alert-transition-duration` and `--cui-alert-transition-timing`.
+- Add `.fade` and `.show` to an alert you insert into the page at runtime, and it fades **in** as well. An alert that is already in the markup does not need them.
 
 You can observe this in action with a live demonstration:
 
-<Example code={`<div class="alert alert-warning fade show" role="alert">
+<Example code={`<div class="alert alert-warning" role="alert">
     Wow, you might want to take a look at some of the fields listed below.
     <button type="button" class="btn-close" data-coreui-dismiss="alert" aria-label="Close"></button>
   </div>`} />

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -973,6 +973,16 @@ adornment in the library — so the button needs no icon markup at all:
 
 #### Alert
 
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **Every alert fades out when dismissed, and `.fade` no longer decides that.**
+  The alert carries its own transition and
+  `--cui-alert-transition-property` / `-duration` / `-timing`; the JavaScript
+  marks it with `.hiding` for the length of it, then removes the element. An
+  alert is already on the page, so only the exit is animated — `.fade` and
+  `.show` remain the way to fade one **in** when you insert it at runtime. Add
+  `.alert-instant` to an alert that should go at once, which is what an alert
+  without `.fade` used to do.
+
 - **`.alert-dismissible` is optional now.** An alert that contains a close
   button as a direct child makes room for it and positions it on its own
   (`.alert:has(> .btn-close)`). The class keeps working — and is still the way

--- a/js/src/alert.ts
+++ b/js/src/alert.ts
@@ -11,7 +11,7 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import { enableDismissTrigger } from './util/component-functions.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, getTransitionDurationFromElement } from './util/index.js'
 
 /**
  * Constants
@@ -23,7 +23,7 @@ const EVENT_KEY = `.${DATA_KEY}`
 
 const EVENT_CLOSE = `close${EVENT_KEY}`
 const EVENT_CLOSED = `closed${EVENT_KEY}`
-const CLASS_NAME_FADE = 'fade'
+const CLASS_NAME_HIDING = 'hiding'
 const CLASS_NAME_SHOW = 'show'
 
 /**
@@ -44,9 +44,12 @@ class Alert extends BaseComponent {
       return
     }
 
+    // `.hiding` drives the exit transition in CSS. An alert is visible in the
+    // markup, with or without `.show`, so its absence cannot mark the exit.
     this._element.classList.remove(CLASS_NAME_SHOW)
+    this._element.classList.add(CLASS_NAME_HIDING)
 
-    const isAnimated = this._element.classList.contains(CLASS_NAME_FADE)
+    const isAnimated = getTransitionDurationFromElement(this._element) > 0
     await this._queueCallback(() => this._destroyElement(), this._element, isAnimated)
   }
 

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -2,6 +2,7 @@
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/tokens" as *;
+@use "mixins/transition" as *;
 @use "theme" as *;
 @use "config" as *;
 
@@ -13,6 +14,10 @@ $alert-margin-bottom:           1rem !default;
 $alert-border-radius:           var(--#{$prefix}border-radius) !default;
 $alert-link-font-weight:        var(--#{$prefix}font-weight-bold) !default;
 $alert-border-width:            var(--#{$prefix}border-width) !default;
+
+$alert-transition-property:     opacity !default;
+$alert-transition-duration:     .15s !default;
+$alert-transition-timing:       linear !default;
 // scss-docs-end alert-variables
 
 $alert-tokens: () !default;
@@ -32,6 +37,9 @@ $alert-tokens: defaults(
     --#{$prefix}alert-border-width: #{$alert-border-width},
     --#{$prefix}alert-border-radius: #{$alert-border-radius},
     --#{$prefix}alert-link-color: inherit,
+    --#{$prefix}alert-transition-property: #{$alert-transition-property},
+    --#{$prefix}alert-transition-duration: #{$alert-transition-duration},
+    --#{$prefix}alert-transition-timing: #{$alert-transition-timing},
     --#{$prefix}hr-border-color: var(--#{$prefix}theme-border, var(--#{$prefix}border-color)),
   ),
   $alert-tokens
@@ -63,6 +71,23 @@ $alert-variants: (
     background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}alert-bg));
     border: var(--#{$prefix}alert-border-width) solid var(--#{$prefix}theme-border, var(--#{$prefix}alert-border-color));
     @include border-radius(var(--#{$prefix}alert-border-radius));
+
+    // scss-docs-start alert-transition
+    // An alert is already on the page, so only the exit animates. The JS marks
+    // it with `.hiding` for the length of the transition, then removes the
+    // element. Add `.alert-instant` to have it go at once.
+    &:not(.alert-instant) {
+      @include transition-props(
+        var(--#{$prefix}alert-transition-property),
+        var(--#{$prefix}alert-transition-duration),
+        var(--#{$prefix}alert-transition-timing)
+      );
+    }
+
+    &.hiding {
+      opacity: 0;
+    }
+    // scss-docs-end alert-transition
   }
 
   .alert > p {


### PR DESCRIPTION
Point 2 of three from the `.fade` sweep. Follows #856 (Tab); `util/backdrop.ts` is still open as a decision.

## Why `.show` could not mark the exit

`close()` removed `.show` and waited only if the element carried `.fade`:

```js
this._element.classList.remove(CLASS_NAME_SHOW)
const isAnimated = this._element.classList.contains(CLASS_NAME_FADE)
```

An alert is already on the page — unlike a toast or a tip, nothing inserts it — so it is visible with or without `.show`, and removing a class it may never have had cannot signal that it is leaving. An alert written without `.fade` was simply deleted mid-frame.

## The fix

`.alert` carries its own transition and `--cui-alert-transition-property` / `-duration` / `-timing`. `close()` marks the element with `.hiding` for the length of it, then removes it. `.alert-instant` opts out — that is the class for markup that used to omit `.fade`.

`.hiding` is the marker the dialog, drawer and offcanvas already use for a running exit, so this brings the alert onto the same convention rather than inventing one.

`.fade` and `.show` keep their meaning for the other direction: an alert inserted at runtime while carrying them still fades **in**, through the `@starting-style` rule that was already in `_alert.scss`. Only the exit changes hands. The two markers now read as what they are — `.fade` is the author saying "I insert this dynamically", `.hiding` is the component saying "I am leaving".

Measured in Chromium on the built bundle, clicking the close button:

| | |
| --- | --- |
| `.alert` transition | `0.15s` |
| `.alert-instant` transition | `0s` |
| classes right after the click | `alert theme-warning hiding` |
| `closed.coreui.alert` | 156 ms after the click |
| element in the DOM afterwards | no |

Docs: the Dismissing list says the fade is built in and points at `.alert-instant` and the tokens, the live example drops `fade show` (an alert in the markup needs neither), and the migration guide gets an Alert entry.

Gates: stylelint, eslint, `js-typecheck`, `css-test-class-api`, `js-test` (3212 unit + jquery + both integration bundles), visual 35/35, `docs-build` clean, bundlewatch PASS.