### PR TITLE
feat(placeholder): expose the two opacities as tokens

### DIFF
--- a/docs/src/content/docs/components/placeholders.mdx
+++ b/docs/src/content/docs/components/placeholders.mdx
@@ -99,6 +99,20 @@ Animate Bootstrap placeholders using `.placeholder-glow` or `.placeholder-wave` 
 
 ## Customization
 
+### CSS variables
+
+Placeholders use local CSS variables on `.placeholder` and `.placeholder-wave` for real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
+
+<ScssDocs file="scss/_placeholder.scss" capture="placeholder-css-vars" />
+
+Both animations read them, so lowering the minimum deepens the pulse of `.placeholder-glow` and the trough of the `.placeholder-wave` gradient:
+
+```html
+<p class="placeholder-glow" style="--cui-placeholder-opacity-min: 0">
+  <span class="placeholder col-12"></span>
+</p>
+```
+
 ### SASS variables
 
 <ScssDocs file="scss/_placeholder.scss" capture="placeholders" />

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1508,6 +1508,16 @@ Multi Select's option indicators moved with it — they render as a decorative
   element that actually animates, instead of the tab button, which only
   transitions its colours.
 
+#### Placeholder
+
+- **The two opacities are CSS variables.** `--cui-placeholder-opacity-max` and
+  `--cui-placeholder-opacity-min` are declared on `.placeholder` and
+  `.placeholder-wave`, and both animations read them, so the resting opacity,
+  the glow's pulse and the wave's gradient can be retuned on an instance. They
+  were compiled in, and the wave's trough was Sass arithmetic
+  (`1 - $placeholder-opacity-min`) resolved at build time — it is
+  `calc(1 - var(…))` now.
+
 #### Popover and Tooltip
 
 - **The fade moved to CSS.** Neither component renders the `fade` helper class

--- a/scss/_placeholder.scss
+++ b/scss/_placeholder.scss
@@ -1,3 +1,5 @@
+@use "functions/defaults" as *;
+@use "mixins/tokens" as *;
 @use "config" as *;
 
 // scss-docs-start placeholders
@@ -5,14 +7,37 @@ $placeholder-opacity-max:           .5 !default;
 $placeholder-opacity-min:           .2 !default;
 // scss-docs-end placeholders
 
+$placeholder-tokens: () !default;
+
+// stylelint-disable scss/dollar-variable-default
+
+// scss-docs-start placeholder-css-vars
+$placeholder-tokens: defaults(
+  (
+    --#{$prefix}placeholder-opacity-max: #{$placeholder-opacity-max},
+    --#{$prefix}placeholder-opacity-min: #{$placeholder-opacity-min},
+  ),
+  $placeholder-tokens
+);
+// scss-docs-end placeholder-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 @layer components {
+  // `.placeholder-wave` sits on the parent and reads the min opacity, so the
+  // tokens are declared there too — on `.placeholder` alone they would be
+  // invisible to it and the mask would resolve to `none`.
+  .placeholder,
+  .placeholder-wave {
+    @include tokens($placeholder-tokens);
+  }
+
   .placeholder {
     display: inline-block;
     min-height: 1em;
     vertical-align: middle;
     cursor: wait;
     background-color: currentcolor;
-    opacity: $placeholder-opacity-max;
+    opacity: var(--#{$prefix}placeholder-opacity-max);
 
     &.btn::before {
       display: inline-block;
@@ -48,12 +73,12 @@ $placeholder-opacity-min:           .2 !default;
 
   @keyframes placeholder-glow {
     50% {
-      opacity: $placeholder-opacity-min;
+      opacity: var(--#{$prefix}placeholder-opacity-min);
     }
   }
 
   .placeholder-wave {
-    mask-image: linear-gradient(130deg, var(--#{$prefix}black) 55%, rgba(0, 0, 0, (1 - $placeholder-opacity-min)) 75%, var(--#{$prefix}black) 95%);
+    mask-image: linear-gradient(130deg, var(--#{$prefix}black) 55%, rgb(0 0 0 / calc(1 - var(--#{$prefix}placeholder-opacity-min))) 75%, var(--#{$prefix}black) 95%);
     mask-size: 200% 100%;
     animation: placeholder-wave 2s linear infinite;
 


### PR DESCRIPTION
`_placeholder.scss` had **no tokens at all** — the only component file left in that state. The resting opacity, the glow keyframe and the wave's gradient were all compiled in, so nothing about a placeholder could be retuned without recompiling.

- `--cui-placeholder-opacity-max` and `--cui-placeholder-opacity-min`, read by `.placeholder`, by the `placeholder-glow` keyframe and by the `placeholder-wave` mask.
- The wave's trough was `1 - $placeholder-opacity-min`, Sass arithmetic resolved at build time — a leftover the August sweep over derived values missed. It is `calc(1 - var(…))` now.

## The tokens are declared on `.placeholder-wave` too, and that part is not cosmetic

Upstream declares them on `.placeholder` only. `.placeholder-wave` sits on the **parent** and `.placeholder` on the child, so the mask is built where the token is unset — `calc(1 - <unset>)` is invalid at computed-value time and takes the whole `mask-image` declaration with it.

Measured in Chromium, upstream's shape against ours:

| | computed `mask-image` |
| --- | --- |
| token on `.placeholder` only (upstream) | `none` |
| token on both (this PR) | `linear-gradient(130deg, rgb(8,10,12) 55%, rgba(0,0,0,0.8) 75%, rgb(8,10,12) 95%)` |

`none` means no wave. So porting this one verbatim would have shipped a broken animation; the declaration site is what makes it work.

## Verified

On the built stylesheet, in Chromium:

- wave mask resolves to `rgba(0, 0, 0, 0.8)` at the trough — pixel-identical to the old compiled value
- `style="--cui-placeholder-opacity-min: .05"` on the wave moves it to `rgba(0, 0, 0, 0.95)`
- `--cui-placeholder-opacity-min: 0` on a glowing placeholder drives its opacity to ~0 at the 50% mark, where it was pinned at `.2`
- `.placeholder` rests at `0.5` from the token

Docs: the Customization section gains `### CSS variables` ahead of the Sass block, with an example of retuning the pulse. Migration guide gets a Placeholder entry.

Sass variables stay.

Gates: stylelint, `css-test-class-api`, visual 35/35, `docs-build` clean, bundlewatch PASS (`coreui.css` 64.34 kB, ceilings untouched). Pre-push gate green.