### PR TITLE
refactor(scss): declare and generate every size from a map

### DIFF
--- a/docs/src/content/docs/components/avatar.mdx
+++ b/docs/src/content/docs/components/avatar.mdx
@@ -151,3 +151,7 @@ Avatars use local CSS variables on `.avatar` for enhanced real-time customizatio
 ### SASS variables
 
 <ScssDocs file="scss/_avatar.scss" capture="avatar-variables" />
+
+Each size carries its own dimensions, and the map merges with your overrides — set a key to `null` to drop a size:
+
+<ScssDocs file="scss/_avatar.scss" capture="avatar-sizes" />

--- a/docs/src/content/docs/components/badge.mdx
+++ b/docs/src/content/docs/components/badge.mdx
@@ -103,6 +103,10 @@ Badges use local CSS variables on `.badge` for enhanced real-time customization.
 
 <ScssDocs file="scss/_badge.scss" capture="badge-variables" />
 
+Each size is one entry, and the map merges with your overrides — add a key to define a size, or set one to `null` to drop it:
+
+<ScssDocs file="scss/_badge.scss" capture="badge-sizes" />
+
 Each entry in the variants map names the theme role every token reads, so adding a variant takes a map entry rather than a new rule.
 
 <ScssDocs file="scss/_badge.scss" capture="badge-variants" />

--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -346,6 +346,10 @@ The variables below are the neutral fallbacks — what a variant renders as when
 
 <ScssDocs file="scss/buttons/_button.scss" capture="btn-variables" />
 
+The sizes are a map, so `@use ... with()` can add one or drop one — set a key to `null` to remove it:
+
+<ScssDocs file="scss/buttons/_button.scss" capture="btn-sizes" />
+
 ### SASS maps
 
 `$button-variants` holds every variant. Each entry names, per state, the theme token a button variable reads and the neutral value behind it; `disabled` repeats `base`. Add an entry and both spellings of the new variant are generated — the variant class and the `.btn-{variant}-{color}` class.

--- a/docs/src/content/docs/forms/chip-input.mdx
+++ b/docs/src/content/docs/forms/chip-input.mdx
@@ -296,3 +296,7 @@ Chips inputs use local CSS variables on `.chip-input` for enhanced real-time cus
 ### SASS variables
 
 <ScssDocs file="scss/forms/_chip-input.scss" capture="chip-input-variables" />
+
+Each size is one entry, and the map merges with your overrides — add a key to define a size, or set one to `null` to drop it:
+
+<ScssDocs file="scss/forms/_chip-input.scss" capture="chip-input-sizes" />

--- a/docs/src/content/docs/forms/form-control.mdx
+++ b/docs/src/content/docs/forms/form-control.mdx
@@ -185,3 +185,7 @@ The colour picker keeps a width of its own, since it is not as wide as it is tal
 `$form-file-*` are for file input.
 
 <ScssDocs file="scss/forms/_form-control.scss" capture="form-file-variables" />
+
+The sizes are a map, so `@use ... with()` can add one or drop one — each entry maps the control onto the matching `--cui-btn-input-<size>-*` values:
+
+<ScssDocs file="scss/forms/_form-control.scss" capture="form-control-sizes" />

--- a/docs/src/content/docs/forms/input-group.mdx
+++ b/docs/src/content/docs/forms/input-group.mdx
@@ -291,3 +291,7 @@ Input groups include support for custom selects and custom file inputs. Browser 
 
 ### SASS variables
 <ScssDocs file="scss/forms/_input-group.scss" capture="input-group-variables" />
+
+The sizes are a map, so `@use ... with()` can add one or drop one — set a key to `null` to remove it:
+
+<ScssDocs file="scss/forms/_input-group.scss" capture="input-group-sizes" />

--- a/docs/src/content/docs/forms/number-input.mdx
+++ b/docs/src/content/docs/forms/number-input.mdx
@@ -133,3 +133,7 @@ The frame, the buttons and their sizing are the group's, and read the shared
 ### Sass variables
 
 <ScssDocs file="scss/forms/_form-control-group.scss" capture="form-control-group-variables" />
+
+The group takes its own icon and action sizes per size class, and the map merges with your overrides:
+
+<ScssDocs file="scss/forms/_form-control-group.scss" capture="form-control-group-sizes" />

--- a/docs/src/content/docs/forms/otp-input.mdx
+++ b/docs/src/content/docs/forms/otp-input.mdx
@@ -395,3 +395,7 @@ Each cell is an input, so it carries the shared `--cui-control-*` tokens on `.fo
 Everything except the cell width and the gap defaults to the shared `--cui-btn-input-*` frame, so restyling the text controls reaches the OTP input without touching these. Override one when the cell should differ from the rest of the family:
 
 <ScssDocs file="scss/forms/_otp-input.scss" capture="form-otp-variables" />
+
+Each size is one entry, and the map merges with your overrides — add a key to define a size, or set one to `null` to drop it:
+
+<ScssDocs file="scss/forms/_otp-input.scss" capture="form-otp-sizes" />

--- a/docs/src/content/docs/forms/rating.mdx
+++ b/docs/src/content/docs/forms/rating.mdx
@@ -203,3 +203,7 @@ Ratings use local CSS variables on `.rating` for enhanced real-time customizatio
 ### SASS variables
 
 <ScssDocs file="scss/_rating.scss" capture="rating-variables" />
+
+Each size is one entry, and the map merges with your overrides — add a key to define a size, or set one to `null` to drop it:
+
+<ScssDocs file="scss/_rating.scss" capture="rating-sizes" />

--- a/docs/src/content/docs/forms/switch.mdx
+++ b/docs/src/content/docs/forms/switch.mdx
@@ -113,6 +113,12 @@ Modify the appearance of checked switches by adding a [`.theme-{color}` class](/
 
 <ScssDocs file="scss/forms/_switch.scss" capture="switch-variables" />
 
+Each size carries its own height and font size, and both maps merge with your overrides — set a key to `null` to drop a size:
+
+<ScssDocs file="scss/forms/_switch.scss" capture="switch-sizes" />
+
+<ScssDocs file="scss/forms/_switch.scss" capture="form-switch-sizes" />
+
 ### CSS variables
 
 Switchs read their own custom properties, so restyling one control does not touch the other two. Set them on the control itself — an ancestor cannot override a token the element declares for itself.

--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -22,14 +22,23 @@ $avatar-status-border-color:   var(--#{$prefix}body-bg) !default;
 $avatar-stack-hover-transform: translateY(-2px) !default;
 $avatar-transition:            transform .15s ease-in-out !default;
 
-// `status-size` is optional: leave it out and the indicator keeps the base size.
-$avatar-sizes: (
-  sm: (size: 1.5rem, status-size: .4rem),
-  md: (size: 2.5rem, status-size: .7rem),
-  lg: (size: 3rem,   status-size: .8rem),
-  xl: (size: 4rem,   status-size: 1rem),
-) !default;
 // scss-docs-end avatar-variables
+
+$avatar-sizes: () !default;
+
+// `status-size` is optional: leave it out and the indicator keeps the base size.
+// scss-docs-start avatar-sizes
+// stylelint-disable-next-line scss/dollar-variable-default
+$avatar-sizes: defaults(
+  (
+    sm: (size: 1.5rem, status-size: .4rem),
+    md: (size: 2.5rem, status-size: .7rem),
+    lg: (size: 3rem,   status-size: .8rem),
+    xl: (size: 4rem,   status-size: 1rem),
+  ),
+  $avatar-sizes
+);
+// scss-docs-end avatar-sizes
 
 $avatar-tokens: () !default;
 

--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 @use "functions/defaults" as *;
 @use "mixins/gradients" as *;
 @use "mixins/tokens" as *;
@@ -27,6 +28,19 @@ $badge-padding-y-lg:                .375em !default;
 $badge-padding-x-lg:                .875em !default;
 $badge-font-size-lg:                .875em !default;
 // scss-docs-end badge-variables
+
+$badge-sizes: () !default;
+
+// scss-docs-start badge-sizes
+// stylelint-disable-next-line scss/dollar-variable-default
+$badge-sizes: defaults(
+  (
+    "sm": (min-height: $badge-min-height-sm, padding-y: $badge-padding-y-sm, padding-x: $badge-padding-x-sm, font-size: $badge-font-size-sm),
+    "lg": (min-height: $badge-min-height-lg, padding-y: $badge-padding-y-lg, padding-x: $badge-padding-x-lg, font-size: $badge-font-size-lg),
+  ),
+  $badge-sizes
+);
+// scss-docs-end badge-sizes
 
 $badge-tokens: () !default;
 
@@ -120,17 +134,14 @@ $badge-variants: (
   }
   // scss-docs-end badge-modifiers
 
-  .badge-sm {
-    --#{$prefix}badge-min-height: #{$badge-min-height-sm};
-    --#{$prefix}badge-padding-x: #{$badge-padding-x-sm};
-    --#{$prefix}badge-padding-y: #{$badge-padding-y-sm};
-    --#{$prefix}badge-font-size: clamp(#{$badge-font-size-floor}, #{$badge-font-size-sm}, #{$badge-font-size-sm});
+  // scss-docs-start badge-sizes-loop
+  @each $size, $values in $badge-sizes {
+    .badge-#{$size} {
+      --#{$prefix}badge-min-height: #{map.get($values, min-height)};
+      --#{$prefix}badge-padding-x: #{map.get($values, padding-x)};
+      --#{$prefix}badge-padding-y: #{map.get($values, padding-y)};
+      --#{$prefix}badge-font-size: clamp(#{$badge-font-size-floor}, #{map.get($values, font-size)}, #{map.get($values, font-size)});
+    }
   }
-
-  .badge-lg {
-    --#{$prefix}badge-min-height: #{$badge-min-height-lg};
-    --#{$prefix}badge-padding-x: #{$badge-padding-x-lg};
-    --#{$prefix}badge-padding-y: #{$badge-padding-y-lg};
-    --#{$prefix}badge-font-size: clamp(#{$badge-font-size-floor}, #{$badge-font-size-lg}, #{$badge-font-size-lg});
-  }
+  // scss-docs-end badge-sizes-loop
 }

--- a/scss/_rating.scss
+++ b/scss/_rating.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 @use "functions/defaults" as *;
 @use "functions/escape-svg" as *;
 @use "mixins/tokens" as *;
@@ -18,6 +19,19 @@ $rating-item-scale-transform:  scale(1.2) !default;
 $rating-item-active-color:     var(--#{$prefix}warning) !default;
 $rating-item-icon:             url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='currentColor' d='M470.935,194.043,333.8,171.757,270.227,48.22a16,16,0,0,0-28.454,0L178.2,171.757,41.065,194.043A16,16,0,0,0,32.273,221.1l97.845,98.636L108.936,457.051a16,16,0,0,0,23.02,16.724L256,411.2l124.044,62.576a16,16,0,0,0,23.02-16.724L381.882,319.74,479.727,221.1A16,16,0,0,0,470.935,194.043Z'%3E%3C/path%3E%3C/svg%3E") !default;
 // scss-docs-end rating-variables
+
+$rating-sizes: () !default;
+
+// scss-docs-start rating-sizes
+// stylelint-disable-next-line scss/dollar-variable-default
+$rating-sizes: defaults(
+  (
+    "sm": (item-height: $rating-item-height-sm),
+    "lg": (item-height: $rating-item-height-lg),
+  ),
+  $rating-sizes
+);
+// scss-docs-end rating-sizes
 
 $rating-tokens: () !default;
 
@@ -125,11 +139,11 @@ $rating-tokens: defaults(
     display: none;
   }
 
-  .rating-sm {
-    --#{$prefix}rating-item-height: #{$rating-item-height-sm};
+  // scss-docs-start rating-sizes-loop
+  @each $size, $values in $rating-sizes {
+    .rating-#{$size} {
+      --#{$prefix}rating-item-height: #{map.get($values, item-height)};
+    }
   }
-
-  .rating-lg {
-    --#{$prefix}rating-item-height: #{$rating-item-height-lg};
-  }
+  // scss-docs-end rating-sizes-loop
 }

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -180,8 +180,13 @@ $button-link-tokens: defaults(
 );
 // scss-docs-end btn-link-tokens
 
+$button-sizes: () !default;
+
 // scss-docs-start btn-sizes
-$button-sizes: ("xs", "sm", "lg") !default;
+$button-sizes: defaults(
+  ("xs", "sm", "lg"),
+  $button-sizes
+);
 // scss-docs-end btn-sizes
 
 // stylelint-enable custom-property-no-missing-var-function, scss/dollar-variable-default
@@ -453,7 +458,7 @@ $btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), st
   //
 
   // scss-docs-start btn-sizes-loop
-  @each $size in $button-sizes {
+  @each $size, $_ in $button-sizes {
     .btn-#{$size},
     .btn-group-#{$size} > .btn,
     .input-group-#{$size} > .btn {

--- a/scss/forms/_chip-input.scss
+++ b/scss/forms/_chip-input.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 @use "../functions/defaults" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
@@ -32,6 +33,33 @@ $chip-input-font-size-lg:      var(--#{$prefix}btn-input-lg-font-size) !default;
 $chip-input-border-radius-lg:  var(--#{$prefix}border-radius-lg) !default;
 $chip-input-gap-lg:            .5rem !default;
 // scss-docs-end chip-input-variables
+
+$chip-input-sizes: () !default;
+
+// scss-docs-start chip-input-sizes
+// stylelint-disable-next-line scss/dollar-variable-default
+$chip-input-sizes: defaults(
+  (
+    "sm": (
+      min-height:    $chip-input-min-height-sm,
+      padding-y:     $chip-input-padding-y-sm,
+      padding-x:     $chip-input-padding-x-sm,
+      font-size:     $chip-input-font-size-sm,
+      border-radius: $chip-input-border-radius-sm,
+      gap:           $chip-input-gap-sm,
+    ),
+    "lg": (
+      min-height:    $chip-input-min-height-lg,
+      padding-y:     $chip-input-padding-y-lg,
+      padding-x:     $chip-input-padding-x-lg,
+      font-size:     $chip-input-font-size-lg,
+      border-radius: $chip-input-border-radius-lg,
+      gap:           $chip-input-gap-lg,
+    ),
+  ),
+  $chip-input-sizes
+);
+// scss-docs-end chip-input-sizes
 
 // stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
 
@@ -83,21 +111,16 @@ $chip-input-tokens: defaults(
     outline: 0;
   }
 
-  .chip-input-lg {
-    --#{$prefix}chip-input-min-height: #{$chip-input-min-height-lg};
-    --#{$prefix}control-padding-y: #{$chip-input-padding-y-lg};
-    --#{$prefix}control-padding-x: #{$chip-input-padding-x-lg};
-    --#{$prefix}control-border-radius: #{$chip-input-border-radius-lg};
-    --#{$prefix}control-font-size: #{$chip-input-font-size-lg};
-    --#{$prefix}chip-input-gap: #{$chip-input-gap-lg};
+  // scss-docs-start chip-input-sizes-loop
+  @each $size, $values in $chip-input-sizes {
+    .chip-input-#{$size} {
+      --#{$prefix}chip-input-min-height: #{map.get($values, min-height)};
+      --#{$prefix}control-padding-y: #{map.get($values, padding-y)};
+      --#{$prefix}control-padding-x: #{map.get($values, padding-x)};
+      --#{$prefix}control-border-radius: #{map.get($values, border-radius)};
+      --#{$prefix}control-font-size: #{map.get($values, font-size)};
+      --#{$prefix}chip-input-gap: #{map.get($values, gap)};
+    }
   }
-
-  .chip-input-sm {
-    --#{$prefix}chip-input-min-height: #{$chip-input-min-height-sm};
-    --#{$prefix}control-padding-y: #{$chip-input-padding-y-sm};
-    --#{$prefix}control-padding-x: #{$chip-input-padding-x-sm};
-    --#{$prefix}control-border-radius: #{$chip-input-border-radius-sm};
-    --#{$prefix}control-font-size: #{$chip-input-font-size-sm};
-    --#{$prefix}chip-input-gap: #{$chip-input-gap-sm};
-  }
+  // scss-docs-end chip-input-sizes-loop
 }

--- a/scss/forms/_form-control-group.scss
+++ b/scss/forms/_form-control-group.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/focus-ring" as *;
@@ -20,6 +21,19 @@ $form-control-group-action-hover-color: var(--#{$prefix}body-color) !default;
 $form-control-group-action-bg:        transparent !default;
 $form-control-group-action-hover-bg:  var(--#{$prefix}tertiary-bg) !default;
 // scss-docs-end form-control-group-variables
+
+$form-control-group-sizes: () !default;
+
+// scss-docs-start form-control-group-sizes
+// stylelint-disable-next-line scss/dollar-variable-default
+$form-control-group-sizes: defaults(
+  (
+    "sm": (icon-size: $form-control-group-icon-size-sm, action-size: $form-control-group-action-size-sm),
+    "lg": (icon-size: $form-control-group-icon-size-lg, action-size: $form-control-group-action-size-lg),
+  ),
+  $form-control-group-sizes
+);
+// scss-docs-end form-control-group-sizes
 
 // stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
 
@@ -79,25 +93,19 @@ $form-control-group-tokens: defaults(
 
     // Answered here because the group's own token block outranks the size
     // classes' declarations, which sit earlier in the cascade.
-    &.form-control-sm {
-      --#{$prefix}control-min-height: var(--#{$prefix}btn-input-sm-min-height);
-      --#{$prefix}control-padding-y: var(--#{$prefix}btn-input-sm-padding-y);
-      --#{$prefix}control-padding-x: var(--#{$prefix}btn-input-sm-padding-x);
-      --#{$prefix}control-font-size: var(--#{$prefix}btn-input-sm-font-size);
-      --#{$prefix}control-border-radius: var(--#{$prefix}btn-input-sm-border-radius);
-      --#{$prefix}control-group-icon-size: #{$form-control-group-icon-size-sm};
-      --#{$prefix}control-group-action-size: #{$form-control-group-action-size-sm};
+    // scss-docs-start form-control-group-sizes-loop
+    @each $size, $values in $form-control-group-sizes {
+      &.form-control-#{$size} {
+        --#{$prefix}control-min-height: var(--#{$prefix}btn-input-#{$size}-min-height);
+        --#{$prefix}control-padding-y: var(--#{$prefix}btn-input-#{$size}-padding-y);
+        --#{$prefix}control-padding-x: var(--#{$prefix}btn-input-#{$size}-padding-x);
+        --#{$prefix}control-font-size: var(--#{$prefix}btn-input-#{$size}-font-size);
+        --#{$prefix}control-border-radius: var(--#{$prefix}btn-input-#{$size}-border-radius);
+        --#{$prefix}control-group-icon-size: #{map.get($values, icon-size)};
+        --#{$prefix}control-group-action-size: #{map.get($values, action-size)};
+      }
     }
-
-    &.form-control-lg {
-      --#{$prefix}control-min-height: var(--#{$prefix}btn-input-lg-min-height);
-      --#{$prefix}control-padding-y: var(--#{$prefix}btn-input-lg-padding-y);
-      --#{$prefix}control-padding-x: var(--#{$prefix}btn-input-lg-padding-x);
-      --#{$prefix}control-font-size: var(--#{$prefix}btn-input-lg-font-size);
-      --#{$prefix}control-border-radius: var(--#{$prefix}btn-input-lg-border-radius);
-      --#{$prefix}control-group-icon-size: #{$form-control-group-icon-size-lg};
-      --#{$prefix}control-group-action-size: #{$form-control-group-action-size-lg};
-    }
+    // scss-docs-end form-control-group-sizes-loop
 
     &:focus-within {
       @include form-control-group-focus();

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -25,6 +25,15 @@ $form-file-button-hover-bg:       var(--#{$prefix}secondary-bg) !default;
 
 // stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
 
+$form-control-sizes: () !default;
+
+// scss-docs-start form-control-sizes
+$form-control-sizes: defaults(
+  ("sm", "lg"),
+  $form-control-sizes
+);
+// scss-docs-end form-control-sizes
+
 // scss-docs-start form-control-tokens
 $form-control-tokens: () !default;
 $form-control-tokens: defaults(
@@ -262,45 +271,29 @@ $form-control-select-tokens: defaults(
   //
   // Repeated in `_input_group.scss` to avoid Sass extend issues.
 
-  .form-control-sm,
-  .form-select-sm {
-    --#{$prefix}control-min-height: var(--#{$prefix}btn-input-sm-min-height);
-    --#{$prefix}control-padding-y: var(--#{$prefix}btn-input-sm-padding-y);
-    --#{$prefix}control-padding-x: var(--#{$prefix}btn-input-sm-padding-x);
-    --#{$prefix}control-font-size: var(--#{$prefix}btn-input-sm-font-size);
-    --#{$prefix}control-border-radius: var(--#{$prefix}btn-input-sm-border-radius);
+  // scss-docs-start form-control-sizes-loop
+  @each $size, $_ in $form-control-sizes {
+    .form-control-#{$size},
+    .form-select-#{$size} {
+      --#{$prefix}control-min-height: var(--#{$prefix}btn-input-#{$size}-min-height);
+      --#{$prefix}control-padding-y: var(--#{$prefix}btn-input-#{$size}-padding-y);
+      --#{$prefix}control-padding-x: var(--#{$prefix}btn-input-#{$size}-padding-x);
+      --#{$prefix}control-font-size: var(--#{$prefix}btn-input-#{$size}-font-size);
+      --#{$prefix}control-border-radius: var(--#{$prefix}btn-input-#{$size}-border-radius);
 
-    min-height: var(--#{$prefix}control-min-height);
-    padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
-    font-size: var(--#{$prefix}control-font-size);
-    @include border-radius(var(--#{$prefix}control-border-radius));
-
-    &::file-selector-button {
+      min-height: var(--#{$prefix}control-min-height);
       padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
-      margin: calc(var(--#{$prefix}control-padding-y) * -1) calc(var(--#{$prefix}control-padding-x) * -1);
-      margin-inline-end: var(--#{$prefix}control-padding-x);
+      font-size: var(--#{$prefix}control-font-size);
+      @include border-radius(var(--#{$prefix}control-border-radius));
+
+      &::file-selector-button {
+        padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
+        margin: calc(var(--#{$prefix}control-padding-y) * -1) calc(var(--#{$prefix}control-padding-x) * -1);
+        margin-inline-end: var(--#{$prefix}control-padding-x);
+      }
     }
   }
-
-  .form-control-lg,
-  .form-select-lg {
-    --#{$prefix}control-min-height: var(--#{$prefix}btn-input-lg-min-height);
-    --#{$prefix}control-padding-y: var(--#{$prefix}btn-input-lg-padding-y);
-    --#{$prefix}control-padding-x: var(--#{$prefix}btn-input-lg-padding-x);
-    --#{$prefix}control-font-size: var(--#{$prefix}btn-input-lg-font-size);
-    --#{$prefix}control-border-radius: var(--#{$prefix}btn-input-lg-border-radius);
-
-    min-height: var(--#{$prefix}control-min-height);
-    padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
-    font-size: var(--#{$prefix}control-font-size);
-    @include border-radius(var(--#{$prefix}control-border-radius));
-
-    &::file-selector-button {
-      padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
-      margin: calc(var(--#{$prefix}control-padding-y) * -1) calc(var(--#{$prefix}control-padding-x) * -1);
-      margin-inline-end: var(--#{$prefix}control-padding-x);
-    }
-  }
+  // scss-docs-end form-control-sizes-loop
 
   // stylelint-disable selector-no-qualifying-type
   select.form-control,

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -13,10 +13,18 @@ $input-group-addon-font-weight:         var(--#{$prefix}btn-input-font-weight) !
 $input-group-addon-color:               var(--#{$prefix}btn-input-color) !default;
 $input-group-addon-bg:                  var(--#{$prefix}tertiary-bg) !default;
 $input-group-addon-border-color:        var(--#{$prefix}btn-input-border-color) !default;
+// scss-docs-end input-group-variables
+
+$input-group-sizes: () !default;
 
 // A button in the group sizes itself from `$button-sizes`, so it is not listed here.
-$input-group-sizes:                     ("sm", "lg") !default;
-// scss-docs-end input-group-variables
+// scss-docs-start input-group-sizes
+// stylelint-disable-next-line scss/dollar-variable-default
+$input-group-sizes: defaults(
+  ("sm", "lg"),
+  $input-group-sizes
+);
+// scss-docs-end input-group-sizes
 
 // stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
 
@@ -109,7 +117,7 @@ $input-group-tokens: defaults(
   // Remix the default form control sizing classes into new ones for easier
   // manipulation.
 
-  @each $size in $input-group-sizes {
+  @each $size, $_ in $input-group-sizes {
     .input-group-#{$size} > .form-control,
     .input-group-#{$size} > .form-select,
     .input-group-#{$size} > .input-group-text {

--- a/scss/forms/_otp-input.scss
+++ b/scss/forms/_otp-input.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 @use "sass:math";
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
@@ -42,6 +43,31 @@ $form-otp-control-padding-x-lg:        0 !default;
 $form-otp-control-font-size-lg:        var(--#{$prefix}btn-input-lg-font-size) !default;
 $form-otp-control-border-radius-lg:    var(--#{$prefix}btn-input-lg-border-radius) !default;
 // scss-docs-end form-otp-variables
+
+$form-otp-sizes: () !default;
+
+// scss-docs-start form-otp-sizes
+// stylelint-disable-next-line scss/dollar-variable-default
+$form-otp-sizes: defaults(
+  (
+    "sm": (
+      width:         $form-otp-control-width-sm,
+      padding-y:     $form-otp-control-padding-y-sm,
+      padding-x:     $form-otp-control-padding-x-sm,
+      font-size:     $form-otp-control-font-size-sm,
+      border-radius: $form-otp-control-border-radius-sm,
+    ),
+    "lg": (
+      width:         $form-otp-control-width-lg,
+      padding-y:     $form-otp-control-padding-y-lg,
+      padding-x:     $form-otp-control-padding-x-lg,
+      font-size:     $form-otp-control-font-size-lg,
+      border-radius: $form-otp-control-border-radius-lg,
+    ),
+  ),
+  $form-otp-sizes
+);
+// scss-docs-end form-otp-sizes
 
 // stylelint-disable scss/dollar-variable-default
 
@@ -133,29 +159,20 @@ $form-otp-control-tokens: defaults(
     }
   }
 
-  .form-otp-sm .form-otp-control {
-    --#{$prefix}control-padding-y: #{$form-otp-control-padding-y-sm};
-    --#{$prefix}control-padding-x: #{$form-otp-control-padding-x-sm};
-    --#{$prefix}control-font-size: #{$form-otp-control-font-size-sm};
-    --#{$prefix}control-border-radius: #{$form-otp-control-border-radius-sm};
-    --#{$prefix}form-otp-control-width: #{$form-otp-control-width-sm};
+  // scss-docs-start form-otp-sizes-loop
+  @each $size, $values in $form-otp-sizes {
+    .form-otp-#{$size} .form-otp-control {
+      --#{$prefix}control-padding-y: #{map.get($values, padding-y)};
+      --#{$prefix}control-padding-x: #{map.get($values, padding-x)};
+      --#{$prefix}control-font-size: #{map.get($values, font-size)};
+      --#{$prefix}control-border-radius: #{map.get($values, border-radius)};
+      --#{$prefix}form-otp-control-width: #{map.get($values, width)};
 
-    width: var(--#{$prefix}form-otp-control-width);
-    padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
-    font-size: var(--#{$prefix}control-font-size);
-    @include border-radius(var(--#{$prefix}control-border-radius));
+      width: var(--#{$prefix}form-otp-control-width);
+      padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
+      font-size: var(--#{$prefix}control-font-size);
+      @include border-radius(var(--#{$prefix}control-border-radius));
+    }
   }
-
-  .form-otp-lg .form-otp-control {
-    --#{$prefix}control-padding-y: #{$form-otp-control-padding-y-lg};
-    --#{$prefix}control-padding-x: #{$form-otp-control-padding-x-lg};
-    --#{$prefix}control-font-size: #{$form-otp-control-font-size-lg};
-    --#{$prefix}control-border-radius: #{$form-otp-control-border-radius-lg};
-    --#{$prefix}form-otp-control-width: #{$form-otp-control-width-lg};
-
-    width: var(--#{$prefix}form-otp-control-width);
-    padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
-    font-size: var(--#{$prefix}control-font-size);
-    @include border-radius(var(--#{$prefix}control-border-radius));
-  }
+  // scss-docs-end form-otp-sizes-loop
 }

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -1,4 +1,3 @@
-@use "sass:list";
 @use "sass:map";
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
@@ -24,15 +23,32 @@ $switch-checked-thumb-bg:     var(--#{$prefix}primary-contrast) !default;
 $switch-disabled-bg:          var(--#{$prefix}control-disabled-bg) !default;
 $switch-disabled-thumb-bg:    var(--#{$prefix}tertiary-color) !default;
 
-$switch-sizes: (
-  sm: (height: 1rem,    font-size: var(--#{$prefix}font-size-sm)),
-  lg: (height: 1.5rem,  font-size: var(--#{$prefix}font-size-lg)),
-  xl: (height: 1.75rem, font-size: var(--#{$prefix}font-size-lg))
-) !default;
+// scss-docs-end switch-variables
+
+$switch-sizes: () !default;
+
+// scss-docs-start switch-sizes
+// stylelint-disable-next-line scss/dollar-variable-default
+$switch-sizes: defaults(
+  (
+    sm: (height: 1rem,    font-size: var(--#{$prefix}font-size-sm)),
+    lg: (height: 1.5rem,  font-size: var(--#{$prefix}font-size-lg)),
+    xl: (height: 1.75rem, font-size: var(--#{$prefix}font-size-lg))
+  ),
+  $switch-sizes
+);
+// scss-docs-end switch-sizes
+
+$form-switch-sizes: () !default;
 
 // The v5 spelling shipped two sizes; both take their height from the map above.
-$form-switch-sizes: ("lg", "xl") !default;
-// scss-docs-end switch-variables
+// scss-docs-start form-switch-sizes
+// stylelint-disable-next-line scss/dollar-variable-default
+$form-switch-sizes: defaults(
+  ("lg", "xl"),
+  $form-switch-sizes
+);
+// scss-docs-end form-switch-sizes
 
 $switch-tokens: () !default;
 
@@ -153,7 +169,7 @@ $switch-selector: if(sass($enable-deprecated-form-check): ".switch, .form-switch
       }
     }
 
-    @if $enable-deprecated-form-check and list.index($form-switch-sizes, $size) {
+    @if $enable-deprecated-form-check and map.has-key($form-switch-sizes, $size) {
       // Set on the input — the control declares these tokens itself, so an
       // inherited value would lose to its own declaration.
       .form-switch-#{$size} .form-check-input {


### PR DESCRIPTION
Two commits. The first brings the remaining bare declarations onto `defaults()`; the second turns the last three hand-written size families into loops.

## 1. Every size map goes through `defaults()`

A bare `!default` list or map can only be replaced wholesale. Adding `xl` to the buttons meant restating `("xs", "sm", "lg", "xl")` — freezing our list into the override, so a size we ship later never reaches that project. Changing one avatar size meant restating the other three with values nobody wanted to touch. Through `defaults()` an override **merges**, and a key set to `null` removes a size.

`$button-sizes`, `$input-group-sizes`, `$switch-sizes`, `$form-switch-sizes`, `$avatar-sizes` — `$dialog-sizes` and `$pagination-sizes` already had it.

Three consequences, two of which do not announce themselves:

- `defaults()` turns a list into a map keyed on its entries, so loops must destructure the pair. The failure surfaces at CSS time as `Unexpected token Ident("true-min-height")`, not in SCSS.
- `list.index($form-switch-sizes, $size)` searched for bare strings and would have **silently** stopped matching against a map of pairs — the whole `@if` branch would have vanished. It asks `map.has-key()` now.
- Moving a map out of its `*-variables` block removes it from the docs unless the page cites the new block. Four pages updated.

## 2. The control sizes come from a loop

`.form-control-sm` and `.form-control-lg` were two eighteen-line blocks differing only in the word `sm` or `lg`; the control group and the OTP input repeated the same shape again.

- `$form-control-sizes` is a plain list — every value it needs comes from `--cui-btn-input-<size>-*`.
- `$form-control-group-sizes` and `$form-otp-sizes` are maps, because those two carry values of their own (icon and action size; control width and padding). The existing per-size Sass variables feed the maps, so every knob that was there still is.

Three more docs pages cite the new blocks.

## Verified identical

Both commits were checked by building each side from source — not the committed `dist`, which is stale between releases and would show tens of thousands of unrelated diff lines:

```
git worktree add --detach <tmp> origin/v6-dev
npx sass <tmp>/scss/coreui.scss base.css
npx sass scss/coreui.scss head.css
diff base.css head.css   →   0 lines
```

## What stays hand-written, deliberately

`.modal-sm` / `-lg` / `-xl` each sit behind a **different** breakpoint (`sm-up`, `lg-up`, `xl-up`), so they do not reduce to a flat loop — unlike `.dialog-*`, which does and already has one. `.placeholder-*`, `.spinner-sm`, `.table-sm` and `.badge-*` are single-property one-liners; upstream writes those by hand too.

Left for a decision, not included: `.chip-input-{sm,lg}` and `.rating-{sm,lg}` are ours-only and would each need a values map for two sizes — worth it only if we expect a third.

Rule written up in `architecture/scss-sizes-and-variants.md` (coreui/dev-workspace#11).

Gates on both commits: stylelint, `css-test-class-api`, unit 3212/3212, visual 35/35, `docs-build` clean, bundlewatch PASS.