### PR TITLE
feat(Modal)!: apply a size modifier at every viewport

### DIFF
--- a/docs/src/content/docs/components/modal.mdx
+++ b/docs/src/content/docs/components/modal.mdx
@@ -391,9 +391,9 @@ Embedding YouTube videos in modals requires additional JavaScript not in Bootstr
 
 ## Optional sizes
 
-Modals have three optional sizes, available via modifier classes to be placed on the `<dialog class="modal">`. These sizes kick in at certain breakpoints to avoid horizontal scrollbars on narrower viewports.
+Modals have three optional sizes, available via modifier classes to be placed on the `<dialog class="modal">`. A size is a request: the modal is as wide as the class asks for, capped to the viewport less its margins, so it never produces a horizontal scrollbar.
 
-| Size | Class | Modal max-width
+| Size | Class | Modal width
 | --- | --- | --- |
 | Small | `.modal-sm` | `300px` |
 | Default | <span class="text-body-secondary">None</span> | `500px` |
@@ -649,6 +649,10 @@ Modals use local CSS variables on `.modal` for enhanced real-time customization.
 ### SASS variables
 
 <ScssDocs file="scss/_modal.scss" capture="modal-variables" />
+
+Each size is one entry, and the map merges with your overrides — add a key to define a size, or set one to `null` to drop it:
+
+<ScssDocs file="scss/_modal.scss" capture="modal-sizes" />
 
 ### SASS Loop
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1508,6 +1508,28 @@ Multi Select's option indicators moved with it — they render as a decorative
   element that actually animates, instead of the tab button, which only
   transitions its colours.
 
+#### Modal
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **A size modifier applies at every viewport.** `.modal-lg` and `.modal-xl`
+  were withheld until the `lg` and `xl` breakpoints, so on a tablet a large
+  modal was **500 px** — the same as one with no modifier at all — and an
+  extra-large modal on a 1100 px screen was 800 px. Both ask for their width
+  everywhere now, capped by `max-width: calc(100% - margin * 2)` exactly as
+  before, which is what kept horizontal scrollbars away in the first place.
+  At 768 px `.modal-lg` goes 500 → 712 px, and at 1100 px `.modal-xl` goes
+  800 → 1044 px.
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`.modal-sm` is narrow on phones too.** It used to fall back to the default
+  width below the `sm` breakpoint, so on a 360 px screen it filled the width;
+  it is 300 px there now. Drop the modifier for markup that should fill a small
+  screen.
+
+- **`$modal-sizes` replaces the three breakpoint blocks.** Sizes come from a map
+  and a loop, the same shape `.dialog-*` already used — one model for both
+  windows instead of two.
+
 #### Pagination
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -52,6 +52,20 @@ $modal-transition-duration:         .3s !default;
 $modal-transition-timing:           ease-out !default;
 // scss-docs-end modal-variables
 
+$modal-sizes: () !default;
+
+// scss-docs-start modal-sizes
+// stylelint-disable-next-line scss/dollar-variable-default
+$modal-sizes: defaults(
+  (
+    sm: $modal-sm,
+    lg: $modal-lg,
+    xl: $modal-xl,
+  ),
+  $modal-sizes
+);
+// scss-docs-end modal-sizes
+
 $modal-tokens: () !default;
 
 // stylelint-disable scss/dollar-variable-default
@@ -235,24 +249,16 @@ $modal-tokens: defaults(
       --#{$prefix}modal-margin: #{$modal-dialog-margin-y-sm-up};
       --#{$prefix}modal-box-shadow: #{$modal-content-box-shadow-sm-up};
     }
-
-    .modal-sm {
-      --#{$prefix}modal-width: #{$modal-sm};
-    }
   }
 
-  @include media-breakpoint-up(lg) {
-    .modal-lg,
-    .modal-xl {
-      --#{$prefix}modal-width: #{$modal-lg};
+  // Modal sizes
+  // scss-docs-start modal-sizes-loop
+  @each $size, $value in $modal-sizes {
+    .modal-#{$size} {
+      --#{$prefix}modal-width: #{$value};
     }
   }
-
-  @include media-breakpoint-up(xl) {
-    .modal-xl {
-      --#{$prefix}modal-width: #{$modal-xl};
-    }
-  }
+  // scss-docs-end modal-sizes-loop
 
   // scss-docs-start modal-fullscreen-loop
   @each $breakpoint in map.keys($grid-breakpoints) {


### PR DESCRIPTION
`.modal-lg` and `.modal-xl` set their width inside `lg` and `xl` media queries, so below those breakpoints the modifier did nothing at all. The cap that keeps a modal inside the viewport — `max-width: calc(100% - margin * 2)` — was already there, so withholding the width bought nothing; it only made the class inert across half its range.

Sizes come from `$modal-sizes` and a loop now, the shape `.dialog-*` has always used. The library stops carrying two ideas of how a window is sized.

## Measured on the built stylesheet

Modal width by viewport, before and after:

| viewport | | base | `sm` | `lg` | `xl` |
| --- | --- | --- | --- | --- | --- |
| 360 px | before | 344 | **344** | 344 | 344 |
| | after | 344 | **300** | 344 | 344 |
| 768 px | before | 500 | 300 | **500** | **500** |
| | after | 500 | 300 | **712** | **712** |
| 1100 px | before | 500 | 300 | 800 | **800** |
| | after | 500 | 300 | 800 | **1044** |
| 1400 px | before | 500 | 300 | 800 | 1140 |
| | after | — unchanged — | | | |

At 768 px a "large" modal was the same width as a plain one. That is the defect.

## The one regression

`.modal-sm` loses its gate with the others, so on a 360 px phone it is 300 px where it used to fall back to the default width and fill the screen. Markup that wants a small screen filled should carry no size modifier.

Worth knowing: `.dialog-sm` has behaved this way all along — 280 px at every width — so this makes the two consistent rather than introducing something new. If we decide narrow-on-phone is wrong, it needs fixing in **both**, and through a floor in the width rather than a return to media queries.

## What stays

The `sm`-up block: it raises `--cui-modal-margin` and `--cui-modal-box-shadow`, which has nothing to do with width.

Docs: the Optional sizes section says a size is a request capped to the viewport, the table header says "width" rather than "max-width", the size map is cited under Customizing, and the migration guide gets a Modal entry.

Gates: stylelint, `css-test-class-api`, unit 3212/3212, visual 35/35, `docs-build` clean, bundlewatch PASS.