### PR TITLE
refactor(ListGroup): color the whole item from the theme tokens

### DIFF
--- a/docs/src/content/docs/components/list-group.mdx
+++ b/docs/src/content/docs/components/list-group.mdx
@@ -414,6 +414,8 @@ List groups use local CSS variables on `.list-group` for enhanced real-time cust
 ### SASS loop
 
 Loop that generates the [contextual variant classes](#contextual-classes) for
-`.list-group-item`s, pointing each one's tokens at the matching theme color.
+`.list-group-item`s. Each class sets the generic `--cui-theme-*` tokens, which the
+item, its `.active` state and `.list-group-item-action` read directly. Putting
+[`.theme-{color}`](/customize/theme/) on a list group colors it the same way.
 
 <ScssDocs file="scss/_list-group.scss" capture="list-group-modifiers" />

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -6,8 +6,6 @@
 @use "theme" as *;
 @use "config" as *;
 
-// stylelint-disable custom-property-no-missing-var-function
-
 // List group
 // scss-docs-start list-group-variables
 $list-group-color:                  var(--#{$prefix}body-color) !default;
@@ -126,11 +124,11 @@ $list-group-tokens: defaults(
 
     // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
     & + .list-group-item {
-      border-top-width: 0;
+      border-block-start-width: 0;
 
       &.active {
         margin-top: calc(-1 * var(--#{$prefix}list-group-border-width));
-        border-top-width: var(--#{$prefix}list-group-border-width);
+        border-block-start-width: var(--#{$prefix}list-group-border-width);
       }
     }
   }
@@ -142,7 +140,7 @@ $list-group-tokens: defaults(
 
   .list-group-item-action {
     width: 100%; // For `<button>`s (anchors become 100% by default though)
-    color: var(--#{$prefix}list-group-action-color);
+    color: var(--#{$prefix}theme-fg, var(--#{$prefix}list-group-action-color));
     text-align: inherit; // For `<button>`s (anchors inherit)
 
     &:not(.active) {
@@ -150,13 +148,13 @@ $list-group-tokens: defaults(
       &:hover,
       &:focus {
         z-index: 1; // Place hover/focus items above their siblings for proper border styling
-        color: var(--#{$prefix}list-group-action-hover-color);
+        color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}list-group-action-hover-color));
         text-decoration: none;
-        background-color: var(--#{$prefix}theme-border, var(--#{$prefix}list-group-action-hover-bg));
+        background-color: var(--#{$prefix}theme-bg-muted, var(--#{$prefix}list-group-action-hover-bg));
       }
 
       &:active {
-        color: var(--#{$prefix}list-group-action-active-color);
+        color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}list-group-action-active-color));
         background-color: var(--#{$prefix}theme-border, var(--#{$prefix}list-group-action-active-bg));
       }
     }
@@ -218,11 +216,10 @@ $list-group-tokens: defaults(
       border-width: 0 0 var(--#{$prefix}list-group-border-width);
 
       &:last-child {
-        border-bottom-width: 0;
+        border-block-end-width: 0;
       }
     }
   }
-
 
   // scss-docs-start list-group-modifiers
   // List group contextual variants
@@ -230,23 +227,9 @@ $list-group-tokens: defaults(
   // Add modifier classes to change text and background color on individual items.
   // Organizationally, this must come after the `:hover` states.
 
-  // The variant sets the theme tokens, then maps them again on the item: the
-  // base tokens resolve their var() references on .list-group, so slots set on
-  // a single item are invisible to them.
   @each $state in map.keys($theme-colors) {
     .list-group-item-#{$state} {
       @include theme-tokens($state);
-
-      --#{$prefix}list-group-color: var(--#{$prefix}theme-fg-emphasis);
-      --#{$prefix}list-group-bg: var(--#{$prefix}theme-bg-subtle);
-      --#{$prefix}list-group-border-color: var(--#{$prefix}theme-border);
-      --#{$prefix}list-group-action-hover-color: var(--#{$prefix}emphasis-color);
-      --#{$prefix}list-group-action-hover-bg: var(--#{$prefix}theme-border);
-      --#{$prefix}list-group-action-active-color: var(--#{$prefix}emphasis-color);
-      --#{$prefix}list-group-action-active-bg: var(--#{$prefix}theme-border);
-      --#{$prefix}list-group-active-color: var(--#{$prefix}theme-bg-subtle);
-      --#{$prefix}list-group-active-bg: var(--#{$prefix}theme-fg-emphasis);
-      --#{$prefix}list-group-active-border-color: var(--#{$prefix}theme-fg-emphasis);
     }
   }
   // scss-docs-end list-group-modifiers


### PR DESCRIPTION
- Contextual variants declared ten `--cui-list-group-*` overrides on top of `theme-tokens()`. Eight never applied — the properties already read the matching `--cui-theme-*` slot, so the fallback those overrides targeted never resolved. `.list-group-item-{color}` is the theme mixin alone now, and renders identically to `.theme-{color}` on the same element.
- `.list-group-item-action` kept unthemed colors inside a themed item: grey link text on a tinted background, near-black on hover, next to plain items that were already colored. It reads `--cui-theme-fg` and `--cui-theme-fg-emphasis` now.
- Themed hover background moves from `--cui-theme-border` to `--cui-theme-bg-muted`. It resolved to the same tone as the border, so hovering a row erased the line separating it from its neighbours. Pressed keeps the border tone, putting the two states on separate steps.
- Item borders switch to `border-block-start-width` / `border-block-end-width`, matching the inline-axis borders the horizontal variant already sets.
- Docs: the SASS-loop note now says the loop sets the generic theme tokens, and points at `.theme-{color}` for the same effect on a whole list.

Measured in Chromium against the compiled stylesheet, before and after: the only computed-style changes are the four intended ones on `.list-group-item-action` in a themed item. Plain items, `.active`, flush and horizontal variants are byte-identical, and `.list-group-item-primary` still matches `.theme-primary` exactly.

`coreui.css` drops to 64.29 kB gzip (80 fewer declarations).