### PR TITLE
feat(Figure): declare the image-to-caption gap as a token

### DIFF
--- a/docs/src/content/docs/content/figures.mdx
+++ b/docs/src/content/docs/content/figures.mdx
@@ -24,7 +24,7 @@ Aligning the figure's caption is easy with our [text utilities](/utilities/text/
 
 ### CSS variables
 
-The caption declares its own size and colour, so it works the same inside a `.figure` or on its own:
+Each part declares what it reads: `.figure-img` the gap below the image, `.figure-caption` its own size and colour. That is why a caption works the same inside a `.figure` or on its own:
 
 <ScssDocs file="scss/content/_images.scss" capture="figure-css-vars" />
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1308,6 +1308,10 @@ Multi Select's option indicators moved with it — they render as a decorative
   reported them and an override had to guess the name. `.img-thumbnail` and
   `.figure-caption` declare their full set on the element, padding, border width
   and caption font size included.
+- **`--cui-figure-img-margin-bottom` is new.** The gap between a figure's image
+  and its caption was compiled into the rule, so the only way to change it was to
+  rebuild from Sass. `.figure-img` declares it now, and it is the one figure
+  measurement you can retune in the browser.
 
 #### Reboot
 

--- a/scss/content/_images.scss
+++ b/scss/content/_images.scss
@@ -21,6 +21,7 @@ $figure-caption-color:              var(--#{$prefix}secondary-color) !default;
 // scss-docs-end figure-variables
 
 $thumbnail-tokens: () !default;
+$figure-img-tokens: () !default;
 $figure-caption-tokens: () !default;
 
 // stylelint-disable scss/dollar-variable-default
@@ -40,6 +41,13 @@ $thumbnail-tokens: defaults(
 // scss-docs-end thumbnail-css-vars
 
 // scss-docs-start figure-css-vars
+$figure-img-tokens: defaults(
+  (
+    --#{$prefix}figure-img-margin-bottom: #{$figure-img-margin-bottom},
+  ),
+  $figure-img-tokens
+);
+
 $figure-caption-tokens: defaults(
   (
     --#{$prefix}figure-caption-font-size: #{$figure-caption-font-size},
@@ -84,7 +92,9 @@ $figure-caption-tokens: defaults(
   }
 
   .figure-img {
-    margin-bottom: $figure-img-margin-bottom;
+    @include tokens($figure-img-tokens);
+
+    margin-bottom: var(--#{$prefix}figure-img-margin-bottom);
     line-height: 1;
   }
 


### PR DESCRIPTION
- `.figure-img` declares `--cui-figure-img-margin-bottom` and reads it. The gap between a figure's image and its caption was compiled into the rule, so retuning it meant rebuilding from Sass — the last measurement in `scss/content/` with no token behind it. Value unchanged.
- The token sits on `.figure-img` rather than on `.figure`, matching `.figure-caption`: each part declares what it reads, so neither depends on being inside the other.
- Docs: the figures page explains what each block owns, and the migration guide lists the new token.

`.figure` keeps `display: inline-block`. Upstream rewrote it as a `flex` column with `gap`, which is worth flagging because it does not work: a block-level flex container plus the default `align-items: stretch` stretches the image to the container. Measured in Chromium against a 400×200 image in a 1000px column — upstream renders it at **920×460**, and the caption spans the container rather than the image, which is what the comment above their own rule says the class is for. `.img-fluid` does not save it (`max-width: 100%` of the stretched container is the stretched width).