### PR TITLE
fix(Navbar): declare the values it draws with, and let a theme win

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "65 kB"
+      "maxSize": "66 kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "60 kB"
+      "maxSize": "61 kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/components/navbar.mdx
+++ b/docs/src/content/docs/components/navbar.mdx
@@ -324,6 +324,21 @@ A [theme class](/customize/components/#theme-variants) accents the brand and the
 
 <Example html={[`<nav class="navbar navbar-expand-lg theme-primary bg-body-tertiary">`, `    <div class="container-fluid">`, `      <a class="navbar-brand" href="#">Navbar</a>`, `      <ul class="navbar-nav me-auto mb-2 mb-lg-0">`, `        <li class="nav-item">`, `          <a class="nav-link active" aria-current="page" href="#">Home</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">Features</a>`, `        </li>`, `      </ul>`, `    </div>`, `  </nav>`]} />
 
+## Translucent
+
+Add `.navbar-translucent` to let the page through the navbar and blur it. The tint is mixed from `--cui-navbar-bg`, which defaults to the body background — set that token when the navbar sits on a surface of its own.
+
+<Example class="p-0" code={`<nav class="navbar navbar-expand-lg navbar-translucent">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">Navbar</a>
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Home</a></li>
+        <li class="nav-item"><a class="nav-link" href="#">Features</a></li>
+        <li class="nav-item"><a class="nav-link" href="#">Pricing</a></li>
+      </ul>
+    </div>
+  </nav>`} />
+
 ## Containers
 
 Although it's not required, you can wrap a navbar in a `.container` to center it on a page–though note that an inner container is still required. Or you can add a container inside the `.navbar` to only center the contents of a [fixed or static top navbar](#placement).
@@ -670,6 +685,10 @@ Variables for all navbars:
 Variables for the [dark navbar](#color-schemes):
 
 <ScssDocs file="scss/_navbar.scss" capture="navbar-dark-variables" />
+
+The `.navbar-translucent` mix amount and backdrop filter are build-time only — they are not tokens, so a navbar does not carry two custom properties it will never read.
+
+<ScssDocs file="scss/_navbar.scss" capture="navbar-translucent-variables" />
 
 ### SASS loop
 

--- a/docs/src/content/docs/components/navbar.mdx
+++ b/docs/src/content/docs/components/navbar.mdx
@@ -664,6 +664,38 @@ When using offcanvas in a dark navbar, be aware that you may need to have a dark
     </div>
   </nav>`} />
 
+### Drawer
+
+The [drawer component](/components/drawer/) works the same way, with the v6 look — a floating, inset, rounded panel instead of an edge-to-edge one. Swap the `offcanvas` vocabulary for `drawer` and the `.navbar-expand-*` class flattens it into an inline nav at the breakpoint, exactly as it does for an offcanvas.
+
+<Example code={`<nav class="navbar navbar-expand-lg bg-body-tertiary">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">Drawer navbar</a>
+      <button class="navbar-toggler" type="button" data-coreui-toggle="drawer" data-coreui-target="#drawerNavbar" aria-controls="drawerNavbar">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <dialog class="drawer drawer-end" id="drawerNavbar" aria-labelledby="drawerNavbarLabel">
+        <div class="drawer-header">
+          <h5 class="drawer-title" id="drawerNavbarLabel">Drawer</h5>
+          <button type="button" class="btn-close" data-coreui-dismiss="drawer" aria-label="Close"></button>
+        </div>
+        <div class="drawer-body">
+          <ul class="navbar-nav justify-content-end flex-grow-1 pe-3">
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="#">Home</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#">Link</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#">Pricing</a>
+            </li>
+          </ul>
+        </div>
+      </dialog>
+    </div>
+  </nav>`} />
+
 ## Customizing
 
 ### CSS variables

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1143,6 +1143,17 @@ adornment in the library — so the button needs no icon markup at all:
   children inherit `flex-wrap`). A navbar written **without** an inner
   `.container`, `.container-fluid` or `.container-{breakpoint}` no longer gets
   them — wrap its content, the way every example in these docs does.
+- **`--cui-navbar-text-padding-y` and `--cui-navbar-toggler-icon-size` are new.**
+  The padding that lines `.navbar-text` up with the nav links, and the size of the
+  hamburger glyph, were both compiled into their rules. The padding could not be
+  matched from outside at all: the value it pairs with, `--cui-nav-link-padding-y`,
+  is declared on `.navbar-nav`, which is `.navbar-text`'s sibling and therefore
+  invisible to it. Both are declared on `.navbar` now, at their current values.
+- **A theme beats a navbar token, as everywhere else.** `--cui-navbar-brand-color`,
+  `-brand-hover-color` and `-active-color` carried the `--cui-theme-*` slot inside
+  their own default, so setting one of them inside a `.theme-{color}` navbar
+  dropped the theme. The slot sits on the property now, so the theme wins — the
+  same order every other component follows.
 
 #### Checkbox, radio and switch: the class moved onto the input
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1149,6 +1149,22 @@ adornment in the library — so the button needs no icon markup at all:
   matched from outside at all: the value it pairs with, `--cui-nav-link-padding-y`,
   is declared on `.navbar-nav`, which is `.navbar-text`'s sibling and therefore
   invisible to it. Both are declared on `.navbar` now, at their current values.
+- **An expanded navbar flattens a `.drawer`, not just an `.offcanvas`.** The
+  reset that turns the collapsed panel back into an inline nav named `.offcanvas`
+  only, so a `.drawer` inside a `.navbar-expand-*` stayed a fixed side panel over
+  the page at every width — measured at 400×868 next to the offcanvas's 1176×24.
+  Both are handled now.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **Three navbar defaults move.** `.navbar` takes
+  `--cui-navbar-min-height: 3.5rem`, so a navbar with short content no longer
+  collapses below the height of one with a brand in it. `.navbar-brand` takes
+  `--cui-navbar-brand-font-weight`, defaulting to medium rather than the body
+  weight. `.navbar-nav` takes `--cui-nav-gap`, a `.25rem` gap between links that
+  the link padding used to carry alone. Set any of the three to its old value to
+  keep the previous rendering.
+- **`.navbar-translucent` is new.** It tints and blurs the navbar the way
+  `.toast-translucent` does for a toast, mixing `--cui-navbar-bg` — a new token,
+  defaulting to the body background — at 85%.
 - **A theme beats a navbar token, as everywhere else.** `--cui-navbar-brand-color`,
   `-brand-hover-color` and `-active-color` carried the `--cui-theme-*` slot inside
   their own default, so setting one of them inside a `.theme-{color}` navbar

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -19,11 +19,15 @@
 // scss-docs-start navbar-variables
 $navbar-padding-y:                  var(--#{$prefix}spacer-2) !default;
 $navbar-padding-x:                  null !default;
+$navbar-min-height:                 3.5rem !default;
+$navbar-bg:                         var(--#{$prefix}body-bg) !default;
 
+$navbar-nav-gap:                    var(--#{$prefix}spacer-1) !default;
 $navbar-nav-link-padding-x:         .5rem !default;
 $navbar-text-padding-y:             $nav-link-padding-y !default;
 
 $navbar-brand-font-size:            var(--#{$prefix}font-size-lg) !default;
+$navbar-brand-font-weight:          var(--#{$prefix}font-weight-medium) !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
 $nav-link-height:                   calc(var(--#{$prefix}body-font-size) * var(--#{$prefix}body-line-height) + #{$nav-link-padding-y} * 2) !default;
 $navbar-brand-height:               calc(#{$navbar-brand-font-size} * var(--#{$prefix}body-line-height)) !default;
@@ -48,6 +52,11 @@ $navbar-light-brand-color:          $navbar-light-active-color !default;
 $navbar-light-brand-hover-color:    $navbar-light-active-color !default;
 // scss-docs-end navbar-variables
 
+// scss-docs-start navbar-translucent-variables
+$navbar-translucent-bg-opacity:      85% !default;
+$navbar-translucent-backdrop-filter: blur(5px) saturate(180%) !default;
+// scss-docs-end navbar-translucent-variables
+
 // scss-docs-start navbar-dark-variables
 $navbar-dark-color:                 rgba($white, .55) !default;
 $navbar-dark-hover-color:           color-mix(in srgb, var(--#{$prefix}white) 75%, transparent) !default;
@@ -67,6 +76,8 @@ $navbar-tokens: defaults(
   (
     --#{$prefix}navbar-padding-x: #{if(sass($navbar-padding-x == null): 0; else: $navbar-padding-x)},
     --#{$prefix}navbar-padding-y: #{$navbar-padding-y},
+    --#{$prefix}navbar-min-height: #{$navbar-min-height},
+    --#{$prefix}navbar-bg: #{$navbar-bg},
     --#{$prefix}navbar-color: #{$navbar-light-color},
     --#{$prefix}navbar-hover-color: #{$navbar-light-hover-color},
     --#{$prefix}navbar-disabled-color: #{$navbar-light-disabled-color},
@@ -74,6 +85,7 @@ $navbar-tokens: defaults(
     --#{$prefix}navbar-brand-padding-y: #{$navbar-brand-padding-y},
     --#{$prefix}navbar-brand-margin-end: #{$navbar-brand-margin-end},
     --#{$prefix}navbar-brand-font-size: #{$navbar-brand-font-size},
+    --#{$prefix}navbar-brand-font-weight: #{$navbar-brand-font-weight},
     --#{$prefix}navbar-brand-color: #{$navbar-light-brand-color},
     --#{$prefix}navbar-brand-hover-color: #{$navbar-light-brand-hover-color},
     --#{$prefix}navbar-nav-link-padding-x: #{$navbar-nav-link-padding-x},
@@ -101,6 +113,7 @@ $navbar-nav-tokens: () !default;
 // scss-docs-start navbar-nav-css-vars
 $navbar-nav-tokens: defaults(
   (
+    --#{$prefix}nav-gap: #{$navbar-nav-gap},
     --#{$prefix}nav-link-padding-x: 0,
     --#{$prefix}nav-link-padding-y: #{$nav-link-padding-y},
     --#{$prefix}nav-link-font-size: #{$nav-link-font-size},
@@ -161,6 +174,7 @@ $navbar-dark-tokens: defaults(
     flex-wrap: wrap; // allow us to do the line break for collapsing content
     align-items: center;
     justify-content: space-between; // space out brand from logo
+    min-height: var(--#{$prefix}navbar-min-height);
     padding: var(--#{$prefix}navbar-padding-y) var(--#{$prefix}navbar-padding-x);
     @include gradient-bg();
     // The navbar answers to the width it is given, not to the window's: a navbar
@@ -199,6 +213,7 @@ $navbar-dark-tokens: defaults(
     padding-bottom: var(--#{$prefix}navbar-brand-padding-y);
     margin-inline-end: var(--#{$prefix}navbar-brand-margin-end);
     font-size: var(--#{$prefix}navbar-brand-font-size);
+    font-weight: var(--#{$prefix}navbar-brand-font-weight);
     color: var(--#{$prefix}theme-fg, var(--#{$prefix}navbar-brand-color));
     text-decoration: if(not sass($link-decoration == none): none);
     white-space: nowrap;
@@ -221,6 +236,7 @@ $navbar-dark-tokens: defaults(
 
     display: flex;
     flex-direction: column; // cannot use `inherit` to get the `.navbar`s value
+    gap: var(--#{$prefix}nav-gap);
     padding-inline-start: 0;
     margin-bottom: 0;
     list-style-type: "";
@@ -351,7 +367,8 @@ $navbar-dark-tokens: defaults(
             display: none;
           }
 
-          .offcanvas {
+          .offcanvas,
+          .drawer {
             // stylelint-disable declaration-no-important
             position: static;
             z-index: auto;
@@ -366,11 +383,13 @@ $navbar-dark-tokens: defaults(
             @include transition(none);
             // stylelint-enable declaration-no-important
 
-            .offcanvas-header {
+            .offcanvas-header,
+            .drawer-header {
               display: none;
             }
 
-            .offcanvas-body {
+            .offcanvas-body,
+            .drawer-body {
               display: flex;
               flex-grow: 0;
               padding: 0;
@@ -389,6 +408,13 @@ $navbar-dark-tokens: defaults(
 
   .navbar-light {
     @include deprecate("`.navbar-light`", "v4.2.6", "v6.0.0", true);
+  }
+
+  // `.navbar` itself stays transparent, so the tint reads the token rather than
+  // the painted background.
+  .navbar-translucent {
+    background-color: color-mix(in oklch, var(--#{$prefix}navbar-bg) #{$navbar-translucent-bg-opacity}, transparent);
+    backdrop-filter: $navbar-translucent-backdrop-filter;
   }
 
   .navbar-dark,

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -21,6 +21,7 @@ $navbar-padding-y:                  var(--#{$prefix}spacer-2) !default;
 $navbar-padding-x:                  null !default;
 
 $navbar-nav-link-padding-x:         .5rem !default;
+$navbar-text-padding-y:             $nav-link-padding-y !default;
 
 $navbar-brand-font-size:            var(--#{$prefix}font-size-lg) !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
@@ -32,6 +33,7 @@ $navbar-brand-margin-end:           1rem !default;
 $navbar-toggler-padding-y:          .25rem !default;
 $navbar-toggler-padding-x:          .75rem !default;
 $navbar-toggler-font-size:          var(--#{$prefix}font-size-lg) !default;
+$navbar-toggler-icon-size:          1.5em !default;
 $navbar-toggler-border-radius:      var(--#{$prefix}border-radius) !default;
 $navbar-toggler-focus-width:        var(--#{$prefix}focus-ring-width) !default;
 $navbar-toggler-transition:         box-shadow .15s ease-in-out !default;
@@ -51,7 +53,7 @@ $navbar-dark-color:                 rgba($white, .55) !default;
 $navbar-dark-hover-color:           color-mix(in srgb, var(--#{$prefix}white) 75%, transparent) !default;
 $navbar-dark-active-color:          var(--#{$prefix}white) !default;
 $navbar-dark-disabled-color:        color-mix(in srgb, var(--#{$prefix}white) 25%, transparent) !default;
-$navbar-dark-toggler-border-color:  color-mix(in srgb, var(--#{$prefix}white) 10%, transparent) !default;$navbar-dark-toggler-border-color:  color-mix(in srgb, var(--#{$prefix}white) 10%, transparent) !default;
+$navbar-dark-toggler-border-color:  color-mix(in srgb, var(--#{$prefix}white) 10%, transparent) !default;
 $navbar-dark-brand-color:           $navbar-dark-active-color !default;
 $navbar-dark-brand-hover-color:     $navbar-dark-active-color !default;
 // scss-docs-end navbar-dark-variables
@@ -68,16 +70,18 @@ $navbar-tokens: defaults(
     --#{$prefix}navbar-color: #{$navbar-light-color},
     --#{$prefix}navbar-hover-color: #{$navbar-light-hover-color},
     --#{$prefix}navbar-disabled-color: #{$navbar-light-disabled-color},
-    --#{$prefix}navbar-active-color: var(--#{$prefix}theme-fg, #{$navbar-light-active-color}),
+    --#{$prefix}navbar-active-color: #{$navbar-light-active-color},
     --#{$prefix}navbar-brand-padding-y: #{$navbar-brand-padding-y},
     --#{$prefix}navbar-brand-margin-end: #{$navbar-brand-margin-end},
     --#{$prefix}navbar-brand-font-size: #{$navbar-brand-font-size},
-    --#{$prefix}navbar-brand-color: var(--#{$prefix}theme-fg, #{$navbar-light-brand-color}),
-    --#{$prefix}navbar-brand-hover-color: var(--#{$prefix}theme-fg-emphasis, #{$navbar-light-brand-hover-color}),
+    --#{$prefix}navbar-brand-color: #{$navbar-light-brand-color},
+    --#{$prefix}navbar-brand-hover-color: #{$navbar-light-brand-hover-color},
     --#{$prefix}navbar-nav-link-padding-x: #{$navbar-nav-link-padding-x},
+    --#{$prefix}navbar-text-padding-y: #{$navbar-text-padding-y},
     --#{$prefix}navbar-toggler-padding-y: #{$navbar-toggler-padding-y},
     --#{$prefix}navbar-toggler-padding-x: #{$navbar-toggler-padding-x},
     --#{$prefix}navbar-toggler-font-size: #{$navbar-toggler-font-size},
+    --#{$prefix}navbar-toggler-icon-size: #{$navbar-toggler-icon-size},
     --#{$prefix}navbar-toggler-icon-bg: #{escape-svg($navbar-toggler-icon)},
     --#{$prefix}navbar-toggler-border-color: #{$navbar-light-toggler-border-color},
     --#{$prefix}navbar-toggler-border-radius: #{$navbar-toggler-border-radius},
@@ -121,9 +125,9 @@ $navbar-dark-tokens: defaults(
     --#{$prefix}navbar-color: #{$navbar-dark-color},
     --#{$prefix}navbar-hover-color: #{$navbar-dark-hover-color},
     --#{$prefix}navbar-disabled-color: #{$navbar-dark-disabled-color},
-    --#{$prefix}navbar-active-color: var(--#{$prefix}theme-fg, #{$navbar-dark-active-color}),
-    --#{$prefix}navbar-brand-color: var(--#{$prefix}theme-fg, #{$navbar-dark-brand-color}),
-    --#{$prefix}navbar-brand-hover-color: var(--#{$prefix}theme-fg-emphasis, #{$navbar-dark-brand-hover-color}),
+    --#{$prefix}navbar-active-color: #{$navbar-dark-active-color},
+    --#{$prefix}navbar-brand-color: #{$navbar-dark-brand-color},
+    --#{$prefix}navbar-brand-hover-color: #{$navbar-dark-brand-hover-color},
     --#{$prefix}navbar-toggler-border-color: #{$navbar-dark-toggler-border-color},
   ),
   $navbar-dark-tokens
@@ -195,13 +199,13 @@ $navbar-dark-tokens: defaults(
     padding-bottom: var(--#{$prefix}navbar-brand-padding-y);
     margin-inline-end: var(--#{$prefix}navbar-brand-margin-end);
     font-size: var(--#{$prefix}navbar-brand-font-size);
-    color: var(--#{$prefix}navbar-brand-color);
+    color: var(--#{$prefix}theme-fg, var(--#{$prefix}navbar-brand-color));
     text-decoration: if(not sass($link-decoration == none): none);
     white-space: nowrap;
 
     &:hover,
     &:focus {
-      color: var(--#{$prefix}navbar-brand-hover-color);
+      color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}navbar-brand-hover-color));
       // stylelint-disable-next-line scss/at-function-named-arguments
       text-decoration: if(sass($link-hover-decoration == underline): none);
     }
@@ -224,7 +228,7 @@ $navbar-dark-tokens: defaults(
     .nav-link {
       &.active,
       &.show {
-        color: var(--#{$prefix}navbar-active-color);
+        color: var(--#{$prefix}theme-fg, var(--#{$prefix}navbar-active-color));
       }
     }
 
@@ -239,14 +243,14 @@ $navbar-dark-tokens: defaults(
   //
 
   .navbar-text {
-    padding-top: $nav-link-padding-y;
-    padding-bottom: $nav-link-padding-y;
+    padding-top: var(--#{$prefix}navbar-text-padding-y);
+    padding-bottom: var(--#{$prefix}navbar-text-padding-y);
     color: var(--#{$prefix}navbar-color);
 
     a,
     a:hover,
-    a:focus  {
-      color: var(--#{$prefix}navbar-active-color);
+    a:focus {
+      color: var(--#{$prefix}theme-fg, var(--#{$prefix}navbar-active-color));
     }
   }
 
@@ -293,8 +297,8 @@ $navbar-dark-tokens: defaults(
   // or image file as needed.
   .navbar-toggler-icon {
     display: inline-block;
-    width: 1.5em;
-    height: 1.5em;
+    width: var(--#{$prefix}navbar-toggler-icon-size);
+    height: var(--#{$prefix}navbar-toggler-icon-size);
     vertical-align: middle;
     background-color: currentcolor;
     @include mask-icon(var(--#{$prefix}navbar-toggler-icon-bg), 100%);


### PR DESCRIPTION
Four findings from the v6-dev comparison, all measured in Chromium against the compiled stylesheet.

- **`.navbar-text` padding was compiled in.** It exists to line the text up with the nav links, and the value it pairs with — `--cui-nav-link-padding-y` — is declared on `.navbar-nav`, a **sibling** of `.navbar-text`. So the pair could not be kept in step from anywhere. `--cui-navbar-text-padding-y` is declared on `.navbar`, visible to both. Same value as before.
- **The hamburger glyph was a hard-coded `1.5em`** in a component where every other measurement is a token. Now `--cui-navbar-toggler-icon-size`. Verified at runtime: 30px → 48px when set to `3rem`.
- **A theme lost to a navbar token.** `--cui-navbar-brand-color`, `-brand-hover-color` and `-active-color` carried the `--cui-theme-*` slot inside their own *default* instead of on the property that reads them, inverting the precedence the rest of the library follows (recorded in #852, applied in #862). A `.theme-primary` navbar with `--cui-navbar-brand-color: red` rendered red; it renders the theme color now.
- **`$navbar-dark-toggler-border-color` was declared twice on one line.**

The themed-override color is the **only** computed change across brand, link, text, active state and toggler — everything else is byte-for-byte what it was.

### Deliberately not taken from upstream

`.navbar-light` is still here: [the migration guide](https://github.com/coreui/coreui-pro/blob/v6-dev/docs/src/content/docs/migration/v6.mdx) already records it as kept on purpose, alongside `.text-muted` and friends — Bootstrap heritage that sits in a large amount of existing markup.

Left as open design questions, not silently ported: `--navbar-min-height`, a brand `font-weight` token, `--nav-gap` on `.navbar-nav`, `.navbar-translucent`, a default `background-color` on `.navbar`, and rebuilding `.navbar-toggler` on the shared `--btn-*` surface (that one needs `.btn` in the markup, so it is a breaking change for users, not a refactor).