### PR TITLE
fix(Nav): put the link's transition and the nav's gap on tokens

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -30,6 +30,8 @@ export default defineConfig({
   // redirect target, so read it from the same config the engine does.
   redirects: {
     '/forms/checks-radios/': `${base}/forms/checkbox/`,
+    // `/components/navs-tabs/` split into a nav page and a tab page in v6.
+    '/components/navs-tabs/': `${base}/components/nav/`,
   },
   outDir: '../_site',
   cacheDir: '../.cache/astro',

--- a/docs/src/content/docs/components/button-group.mdx
+++ b/docs/src/content/docs/components/button-group.mdx
@@ -24,7 +24,7 @@ For assistive technologies (ex. screen readers) to communicate that a series of 
 Besides, groups and toolbars should be provided an understandable label, as most assistive technologies will otherwise not declare them, despite the appearance of the specific role attribute. In the following examples provided here, we apply `aria-label`, but options such as `aria-labelledby` can also be used.
 </Callout>
 
-These classes can also be added to groups of links, as an alternative to the [`.nav` navigation components](/components/navs-tabs/).
+These classes can also be added to groups of links, as an alternative to the [`.nav` navigation components](/components/nav/).
 
 <Example code={`<div class="btn-group">
     <a href="#" class="btn btn-primary active" aria-current="page">Active link</a>

--- a/docs/src/content/docs/components/card.mdx
+++ b/docs/src/content/docs/components/card.mdx
@@ -276,7 +276,7 @@ You can instantly change the text arrangement of any card—in its whole or spec
 
 ## Navigation
 
-Add some navigation to a card's header (or block) with CoreUI for Bootstrap's [nav components](/components/navs-tabs/).
+Add some navigation to a card's header (or block) with CoreUI for Bootstrap's [nav components](/components/nav/).
 
 <Example code={`<div class="card text-center">
     <div class="card-header">

--- a/docs/src/content/docs/components/nav.mdx
+++ b/docs/src/content/docs/components/nav.mdx
@@ -1,0 +1,403 @@
+---
+title: "Bootstrap 5 Nav"
+name: "Nav"
+description: "Documentation and examples for how to use CoreUI for Bootstrap's included navigation components."
+otherFrameworks:
+  - navs-tabs
+---
+
+## Base nav
+
+Navigation available in Bootstrap share general markup and styles, from the base `.nav` class to the active and disabled states. Swap modifier classes to switch between each style.
+
+The base `.nav` component is built with flexbox and provide a strong foundation for building all types of navigation components. It includes some style overrides (for working with lists), some link padding for larger hit areas, and basic disabled styling.
+
+<Callout color="info">
+The base `.nav` component does not include any `.active` state. The following examples include the class, mainly to demonstrate that this particular class does not trigger any special styling.
+
+To convey the active state to assistive technologies, use the `aria-current` attribute — using the `page` value for current page, or `true` for the current item in a set.
+</Callout>
+
+<Example code={`<ul class="nav">
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Active</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+    </li>
+  </ul>`} />
+
+Classes are used throughout, so your markup can be super flexible. Use `<ul>`s like above, `<ol>` if the order of your items is important, or roll your own with a `<nav>` element. Because the `.nav` uses `display: flex`, the nav links behave the same as nav items would, but without the extra markup.
+
+<Example code={`<nav class="nav">
+    <a class="nav-link active" aria-current="page" href="#">Active</a>
+    <a class="nav-link" href="#">Link</a>
+    <a class="nav-link" href="#">Link</a>
+    <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+  </nav>`} />
+
+## Available styles
+
+Change the style of `.nav`s component with modifiers and utilities. Mix and match as needed, or build your own.
+
+### Horizontal alignment
+
+Change the horizontal alignment of your nav with [flexbox utilities](/utilities/flex/#horizontal-alignment). By default, navs are left-aligned, but you can easily change them to center or right aligned.
+
+Centered with `.justify-content-center`:
+
+<Example code={`<ul class="nav justify-content-center">
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Active</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+    </li>
+  </ul>`} />
+
+Right-aligned with `.justify-content-end`:
+
+<Example code={`<ul class="nav justify-content-end">
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Active</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+    </li>
+  </ul>`} />
+
+### Vertical
+
+Stack your navigation by changing the flex item direction with the `.flex-column` utility. Need to stack them on some viewports but not others? Use the responsive versions (e.g., `.flex-sm-column`).
+
+<Example code={`<ul class="nav flex-column">
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Active</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+    </li>
+  </ul>`} />
+
+As always, vertical navigation is possible without `<ul>`s, too.
+
+<Example code={`<nav class="nav flex-column">
+    <a class="nav-link active" aria-current="page" href="#">Active</a>
+    <a class="nav-link" href="#">Link</a>
+    <a class="nav-link" href="#">Link</a>
+    <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+  </nav>`} />
+
+### Tabs
+
+Takes the basic nav from above and adds the `.nav-tabs` class to generate a tabbed interface. Use them to create tabbable regions with our [tab plugin](/components/tab/).
+
+<Example code={`<ul class="nav nav-tabs">
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Active</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+    </li>
+  </ul>`} />
+
+### Pills
+
+Take that same HTML, but use `.nav-pills` instead:
+
+<Example code={`<ul class="nav nav-pills">
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Active</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+    </li>
+  </ul>`} />
+
+### Underline
+
+Take that same HTML, but use `.nav-underline` instead:
+
+<Example code={`<ul class="nav nav-underline">
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Active</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+    </li>
+  </ul>`} />
+
+### Underline border
+
+Take that same HTML, but use `.nav-underline-border` instead:
+
+<Example code={`<ul class="nav nav-underline-border">
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Active</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+    </li>
+  </ul>`} />
+
+### Enclosed
+
+Use the `.nav-enclosed` class to give your navigation items a subtle border and rounded styling.
+
+<Example code={`<ul class="nav nav-enclosed">
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Active</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+    </li>
+  </ul>`} />
+
+### Enclosed pills
+
+Combine `.nav-enclosed` with `.nav-enclosed-pills` to achieve a pill-style appearance for each nav item, using pill-shaped borders and smoother outlines.
+
+<Example code={`<ul class="nav nav-enclosed nav-enclosed-pills">
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Active</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+    </li>
+  </ul>`} />
+
+### Fill and justify
+
+Force your `.nav`'s contents to extend the full available width one of two modifier classes. To proportionately fill all available space with your `.nav-item`s, use `.nav-fill`. Notice that all horizontal space is occupied, but not every nav item has the same width.
+
+<Example code={`<ul class="nav nav-pills nav-fill">
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Active</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Much longer nav link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+    </li>
+  </ul>`} />
+
+When using a `<nav>`-based navigation, you can safely omit `.nav-item` as only `.nav-link` is required for styling `<a>` elements.
+
+<Example code={`<nav class="nav nav-pills nav-fill">
+    <a class="nav-link active" aria-current="page" href="#">Active</a>
+    <a class="nav-link" href="#">Much longer nav link</a>
+    <a class="nav-link" href="#">Link</a>
+    <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+  </nav>`} />
+
+For equal-width elements, use `.nav-justified`. All horizontal space will be occupied by nav links, but unlike the `.nav-fill` above, every nav item will be the same width.
+
+<Example code={`<ul class="nav nav-pills nav-justified">
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Active</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Much longer nav link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+    </li>
+  </ul>`} />
+
+Similar to the `.nav-fill` example using a `<nav>`-based navigation.
+
+<Example code={`<nav class="nav nav-pills nav-justified">
+    <a class="nav-link active" aria-current="page" href="#">Active</a>
+    <a class="nav-link" href="#">Much longer nav link</a>
+    <a class="nav-link" href="#">Link</a>
+    <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+  </nav>`} />
+## Working with flex utilities
+
+If you need responsive nav variations, consider using a series of [flexbox utilities](/utilities/flex/). While more verbose, these utilities offer greater customization across responsive breakpoints. In the example below, our nav will be stacked on the lowest breakpoint, then adapt to a horizontal layout that fills the available width starting from the small breakpoint.
+
+<Example code={`<nav class="nav nav-pills flex-column flex-sm-row">
+    <a class="flex-sm-fill text-sm-center nav-link active" aria-current="page" href="#">Active</a>
+    <a class="flex-sm-fill text-sm-center nav-link" href="#">Longer nav link</a>
+    <a class="flex-sm-fill text-sm-center nav-link" href="#">Link</a>
+    <a class="flex-sm-fill text-sm-center nav-link disabled" aria-disabled="true">Disabled</a>
+  </nav>`} />
+
+## Regarding accessibility
+
+If you're using navs to provide a navigation bar, be sure to add a `role="navigation"` to the most logical parent container of the `<ul>`, or wrap a `<nav>` element around the whole navigation. Do not add the role to the `<ul>` itself, as this would prevent it from being announced as an actual list by assistive technologies.
+
+Note that navigation bars, even if visually styled as tabs with the `.nav-tabs` class, should **not** be given `role="tablist"`, `role="tab"` or `role="tabpanel"` attributes. These are only appropriate for dynamic tabbed interfaces, as described in the [ARIA Authoring Practices Guide tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/). See the [tab plugin](/components/tab/) for dynamic tabbed interfaces. The `aria-current` attribute is not necessary on dynamic tabbed interfaces since our JavaScript handles the selected state by adding `aria-selected="true"` on the active tab.
+
+## Using dropdowns
+
+Add dropdown menus with a little extra HTML and the [dropdowns JavaScript plugin](/components/dropdowns/#usage).
+
+### Tabs with dropdowns
+
+<Example code={`<ul class="nav nav-tabs">
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Active</a>
+    </li>
+    <li class="nav-item dropdown">
+      <a class="nav-link dropdown-toggle" data-coreui-toggle="dropdown" href="#" role="button" aria-expanded="false">Dropdown</a>
+      <ul class="dropdown-menu">
+        <li><a class="dropdown-item" href="#">Action</a></li>
+        <li><a class="dropdown-item" href="#">Another action</a></li>
+        <li><a class="dropdown-item" href="#">Something else here</a></li>
+        <li><hr class="dropdown-divider"></li>
+        <li><a class="dropdown-item" href="#">Separated link</a></li>
+      </ul>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+    </li>
+  </ul>`} />
+
+### Pills with dropdowns
+
+<Example code={`<ul class="nav nav-pills">
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Active</a>
+    </li>
+    <li class="nav-item dropdown">
+      <a class="nav-link dropdown-toggle" data-coreui-toggle="dropdown" href="#" role="button" aria-expanded="false">Dropdown</a>
+      <ul class="dropdown-menu">
+        <li><a class="dropdown-item" href="#">Action</a></li>
+        <li><a class="dropdown-item" href="#">Another action</a></li>
+        <li><a class="dropdown-item" href="#">Something else here</a></li>
+        <li><hr class="dropdown-divider"></li>
+        <li><a class="dropdown-item" href="#">Separated link</a></li>
+      </ul>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#">Link</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+    </li>
+  </ul>`} />
+
+## Theming
+
+A [theme class](/customize/components/#theme-variants) recolors a nav: links read the theme's foreground and the active pill or underline its solid color.
+
+<Example code={`<ul class="nav nav-pills theme-success">
+    <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+  </ul>`} />
+
+<Example code={`<ul class="nav nav-underline theme-success">
+    <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+  </ul>`} />
+
+## Customizing
+
+### CSS variables
+
+Navs use local CSS variables on `.nav`, `.nav-tabs`, `.nav-pills`, `.nav-underline` and `.nav-underline-border` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
+
+On the `.nav` base class:
+
+<ScssDocs file="scss/_nav.scss" capture="nav-css-vars" />
+
+On the `.nav-tabs` modifier class:
+
+<ScssDocs file="scss/_nav.scss" capture="nav-tabs-css-vars" />
+
+On the `.nav-pills` modifier class:
+
+<ScssDocs file="scss/_nav.scss" capture="nav-pills-css-vars" />
+
+<AddedIn version="5.0.0" />
+
+On the `.nav-underline` modifier class:
+
+<ScssDocs file="scss/_nav.scss" capture="nav-underline-css-vars" />
+
+<AddedIn version="5.0.0" />
+
+On the `.nav-underline-border` modifier class:
+
+<ScssDocs file="scss/_nav.scss" capture="nav-underline-border-css-vars" />
+
+Tab pane variables:
+
+<ScssDocs file="scss/_nav.scss" capture="tab-pane-css-vars" />
+
+### SASS variables
+
+<ScssDocs file="scss/_nav.scss" capture="nav-variables" />

--- a/docs/src/content/docs/components/nav.mdx
+++ b/docs/src/content/docs/components/nav.mdx
@@ -350,7 +350,13 @@ Add dropdown menus with a little extra HTML and the [dropdowns JavaScript plugin
 
 ## Theming
 
-A [theme class](/customize/components/#theme-variants) recolors a nav: links read the theme's foreground and the active pill or underline its solid color.
+A [theme class](/customize/components/#theme-variants) recolors a nav. Every link reads the theme's foreground; what marks the active one follows the variant — a tint on the base nav, a solid fill on pills, the line on either underline.
+
+<Example code={`<ul class="nav theme-success">
+    <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+  </ul>`} />
 
 <Example code={`<ul class="nav nav-pills theme-success">
     <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
@@ -359,6 +365,12 @@ A [theme class](/customize/components/#theme-variants) recolors a nav: links rea
   </ul>`} />
 
 <Example code={`<ul class="nav nav-underline theme-success">
+    <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+  </ul>`} />
+
+<Example code={`<ul class="nav nav-underline-border theme-success">
     <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
     <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
     <li class="nav-item"><a class="nav-link" href="#">Link</a></li>

--- a/docs/src/content/docs/components/scrollspy.mdx
+++ b/docs/src/content/docs/components/scrollspy.mdx
@@ -8,7 +8,7 @@ description: "Automatically update Bootstrap navigation or list group components
 
 Scrollspy has a few requirements to function properly:
 
-- It must be used on a Bootstrap [nav component](/components/navs-tabs/) or [list group](/components/list-group/).
+- It must be used on a Bootstrap [nav component](/components/nav/) or [list group](/components/list-group/).
 - Scrollspy requires `position: relative;` on the element you're spying on, usually the `<body>`.
 - Anchors (`<a>`) are required and must point to an element with that `id`.
 

--- a/docs/src/content/docs/components/tab.mdx
+++ b/docs/src/content/docs/components/tab.mdx
@@ -1,356 +1,13 @@
 ---
-title: "Bootstrap 5 Navs And Tabs"
-name: "Navs and tabs"
-description: "Documentation and examples for how to use CoreUI for Bootstrap's included navigation components."
+title: "Bootstrap 5 Tabs"
+name: "Tabs"
+description: "Turn a nav into a tabbable interface with the tab plugin: panes of local content that swap without leaving the page."
 otherFrameworks:
   - navs-tabs
 ---
 
-## Base nav
-
-Navigation available in Bootstrap share general markup and styles, from the base `.nav` class to the active and disabled states. Swap modifier classes to switch between each style.
-
-The base `.nav` component is built with flexbox and provide a strong foundation for building all types of navigation components. It includes some style overrides (for working with lists), some link padding for larger hit areas, and basic disabled styling.
-
-<Callout color="info">
-The base `.nav` component does not include any `.active` state. The following examples include the class, mainly to demonstrate that this particular class does not trigger any special styling.
-
-To convey the active state to assistive technologies, use the `aria-current` attribute — using the `page` value for current page, or `true` for the current item in a set.
-</Callout>
-
-<Example code={`<ul class="nav">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">Active</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-    </li>
-  </ul>`} />
-
-Classes are used throughout, so your markup can be super flexible. Use `<ul>`s like above, `<ol>` if the order of your items is important, or roll your own with a `<nav>` element. Because the `.nav` uses `display: flex`, the nav links behave the same as nav items would, but without the extra markup.
-
-<Example code={`<nav class="nav">
-    <a class="nav-link active" aria-current="page" href="#">Active</a>
-    <a class="nav-link" href="#">Link</a>
-    <a class="nav-link" href="#">Link</a>
-    <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-  </nav>`} />
-
-## Available styles
-
-Change the style of `.nav`s component with modifiers and utilities. Mix and match as needed, or build your own.
-
-### Horizontal alignment
-
-Change the horizontal alignment of your nav with [flexbox utilities](/utilities/flex/#horizontal-alignment). By default, navs are left-aligned, but you can easily change them to center or right aligned.
-
-Centered with `.justify-content-center`:
-
-<Example code={`<ul class="nav justify-content-center">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">Active</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-    </li>
-  </ul>`} />
-
-Right-aligned with `.justify-content-end`:
-
-<Example code={`<ul class="nav justify-content-end">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">Active</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-    </li>
-  </ul>`} />
-
-### Vertical
-
-Stack your navigation by changing the flex item direction with the `.flex-column` utility. Need to stack them on some viewports but not others? Use the responsive versions (e.g., `.flex-sm-column`).
-
-<Example code={`<ul class="nav flex-column">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">Active</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-    </li>
-  </ul>`} />
-
-As always, vertical navigation is possible without `<ul>`s, too.
-
-<Example code={`<nav class="nav flex-column">
-    <a class="nav-link active" aria-current="page" href="#">Active</a>
-    <a class="nav-link" href="#">Link</a>
-    <a class="nav-link" href="#">Link</a>
-    <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-  </nav>`} />
-
-### Tabs
-
-Takes the basic nav from above and adds the `.nav-tabs` class to generate a tabbed interface. Use them to create tabbable regions with our [tab JavaScript plugin](#javascript-behavior).
-
-<Example code={`<ul class="nav nav-tabs">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">Active</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-    </li>
-  </ul>`} />
-
-### Pills
-
-Take that same HTML, but use `.nav-pills` instead:
-
-<Example code={`<ul class="nav nav-pills">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">Active</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-    </li>
-  </ul>`} />
-
-### Underline
-
-Take that same HTML, but use `.nav-underline` instead:
-
-<Example code={`<ul class="nav nav-underline">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">Active</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-    </li>
-  </ul>`} />
-
-### Underline border
-
-Take that same HTML, but use `.nav-underline-border` instead:
-
-<Example code={`<ul class="nav nav-underline-border">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">Active</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-    </li>
-  </ul>`} />
-
-### Enclosed
-
-Use the `.nav-enclosed` class to give your navigation items a subtle border and rounded styling.
-
-<Example code={`<ul class="nav nav-enclosed">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">Active</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-    </li>
-  </ul>`} />
-
-### Enclosed pills
-
-Combine `.nav-enclosed` with `.nav-enclosed-pills` to achieve a pill-style appearance for each nav item, using pill-shaped borders and smoother outlines.
-
-<Example code={`<ul class="nav nav-enclosed nav-enclosed-pills">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">Active</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-    </li>
-  </ul>`} />
-
-### Fill and justify
-
-Force your `.nav`'s contents to extend the full available width one of two modifier classes. To proportionately fill all available space with your `.nav-item`s, use `.nav-fill`. Notice that all horizontal space is occupied, but not every nav item has the same width.
-
-<Example code={`<ul class="nav nav-pills nav-fill">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">Active</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Much longer nav link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-    </li>
-  </ul>`} />
-
-When using a `<nav>`-based navigation, you can safely omit `.nav-item` as only `.nav-link` is required for styling `<a>` elements.
-
-<Example code={`<nav class="nav nav-pills nav-fill">
-    <a class="nav-link active" aria-current="page" href="#">Active</a>
-    <a class="nav-link" href="#">Much longer nav link</a>
-    <a class="nav-link" href="#">Link</a>
-    <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-  </nav>`} />
-
-For equal-width elements, use `.nav-justified`. All horizontal space will be occupied by nav links, but unlike the `.nav-fill` above, every nav item will be the same width.
-
-<Example code={`<ul class="nav nav-pills nav-justified">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">Active</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Much longer nav link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-    </li>
-  </ul>`} />
-
-Similar to the `.nav-fill` example using a `<nav>`-based navigation.
-
-<Example code={`<nav class="nav nav-pills nav-justified">
-    <a class="nav-link active" aria-current="page" href="#">Active</a>
-    <a class="nav-link" href="#">Much longer nav link</a>
-    <a class="nav-link" href="#">Link</a>
-    <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-  </nav>`} />
-## Working with flex utilities
-
-If you need responsive nav variations, consider using a series of [flexbox utilities](/utilities/flex/). While more verbose, these utilities offer greater customization across responsive breakpoints. In the example below, our nav will be stacked on the lowest breakpoint, then adapt to a horizontal layout that fills the available width starting from the small breakpoint.
-
-<Example code={`<nav class="nav nav-pills flex-column flex-sm-row">
-    <a class="flex-sm-fill text-sm-center nav-link active" aria-current="page" href="#">Active</a>
-    <a class="flex-sm-fill text-sm-center nav-link" href="#">Longer nav link</a>
-    <a class="flex-sm-fill text-sm-center nav-link" href="#">Link</a>
-    <a class="flex-sm-fill text-sm-center nav-link disabled" aria-disabled="true">Disabled</a>
-  </nav>`} />
-
-## Regarding accessibility
-
-If you're using navs to provide a navigation bar, be sure to add a `role="navigation"` to the most logical parent container of the `<ul>`, or wrap a `<nav>` element around the whole navigation. Do not add the role to the `<ul>` itself, as this would prevent it from being announced as an actual list by assistive technologies.
-
-Note that navigation bars, even if visually styled as tabs with the `.nav-tabs` class, should **not** be given `role="tablist"`, `role="tab"` or `role="tabpanel"` attributes. These are only appropriate for dynamic tabbed interfaces, as described in the [ARIA Authoring Practices Guide tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/). See [JavaScript behavior](#javascript-behavior) for dynamic tabbed interfaces in this section for an example. The `aria-current` attribute is not necessary on dynamic tabbed interfaces since our JavaScript handles the selected state by adding `aria-selected="true"` on the active tab.
-
-## Using dropdowns
-
-Add dropdown menus with a little extra HTML and the [dropdowns JavaScript plugin](/components/dropdowns/#usage).
-
-### Tabs with dropdowns
-
-<Example code={`<ul class="nav nav-tabs">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">Active</a>
-    </li>
-    <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle" data-coreui-toggle="dropdown" href="#" role="button" aria-expanded="false">Dropdown</a>
-      <ul class="dropdown-menu">
-        <li><a class="dropdown-item" href="#">Action</a></li>
-        <li><a class="dropdown-item" href="#">Another action</a></li>
-        <li><a class="dropdown-item" href="#">Something else here</a></li>
-        <li><hr class="dropdown-divider"></li>
-        <li><a class="dropdown-item" href="#">Separated link</a></li>
-      </ul>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-    </li>
-  </ul>`} />
-
-### Pills with dropdowns
-
-<Example code={`<ul class="nav nav-pills">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page" href="#">Active</a>
-    </li>
-    <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle" data-coreui-toggle="dropdown" href="#" role="button" aria-expanded="false">Dropdown</a>
-      <ul class="dropdown-menu">
-        <li><a class="dropdown-item" href="#">Action</a></li>
-        <li><a class="dropdown-item" href="#">Another action</a></li>
-        <li><a class="dropdown-item" href="#">Something else here</a></li>
-        <li><hr class="dropdown-divider"></li>
-        <li><a class="dropdown-item" href="#">Separated link</a></li>
-      </ul>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link disabled" aria-disabled="true">Disabled</a>
-    </li>
-  </ul>`} />
-
-## JavaScript behavior
-
-Use the tab JavaScript plugin—include it individually or through the compiled `coreui.js` file—to extend our navigational tabs and pills to create tabbable panes of local content, even via dropdown menus.
+The tab plugin turns a [nav](/components/nav/) into a tabbable interface. The nav carries the markup and the styling; this page covers the behavior the plugin adds on top of it.
+Include the plugin individually or through the compiled `coreui.js` file to extend navigational tabs and pills into tabbable panes of local content, even via dropdown menus.
 
 Dynamic tabbed interfaces, as described in the [<abbr title="Web Accessibility Initiative">WAI</abbr> <abbr title="Accessible Rich Internet Applications">ARIA</abbr> Authoring Practices](https://www.w3.org/TR/wai-aria-practices/#tabpanel), require `role="tablist"`, `role="tab"`, `role="tabpanel"`, and additional `aria-` attributes in order to convey their structure, functionality and current state to users of assistive technologies (such as screen readers). As a best practice, we recommend using `<button>` elements for the tabs, as these are controls that trigger a dynamic change, rather than links that navigate to a new page or location.
 
@@ -452,7 +109,7 @@ And with vertical pills. Ideally, for vertical tabs, you should also add `aria-o
 </div>
 ```
 
-### Accessibility
+## Accessibility
 
 Dynamic tabbed interfaces, as described in the [ARIA Authoring Practices Guide tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/), require `role="tablist"`, `role="tab"`, `role="tabpanel"`, and additional `aria-` attributes in order to convey their structure, functionality, and current state to users of assistive technologies (such as screen readers). As a best practice, we recommend using `<button>` elements for the tabs, as these are controls that trigger a dynamic change, rather than links that navigate to a new page or location.
 
@@ -466,7 +123,7 @@ In general, to facilitate keyboard navigation, it's recommended to make the tab 
 The tab JavaScript plugin **does not** support tabbed interfaces that contain dropdown menus, as these cause both usability and accessibility issues. From a usability perspective, the fact that the currently displayed tab's trigger element is not immediately visible (as it's inside the closed dropdown menu) can cause confusion. From an accessibility point of view, there is currently no sensible way to map this sort of construct to a standard WAI ARIA pattern, meaning that it cannot be easily made understandable to users of assistive technologies.
 </Callout>
 
-### Using data attributes
+## Using data attributes
 
 You can activate a tab or pill navigation without writing any JavaScript by simply specifying `data-coreui-toggle="tab"` or `data-coreui-toggle="pill"` on an element. Use these data attributes on `.nav-tabs` or `.nav-pills`.
 
@@ -496,7 +153,7 @@ You can activate a tab or pill navigation without writing any JavaScript by simp
 </div>
 ```
 
-### Via JavaScript
+## Via JavaScript
 
 Enable tabbable tabs via JavaScript (each tab needs to be activated individually):
 
@@ -522,7 +179,7 @@ const triggerFirstTabEl = document.querySelector('#myTab li:first-child button')
 coreui.Tab.getInstance(triggerFirstTabEl).show() // Select first tab
 ```
 
-### Fade effect
+## Fade effect
 
 Every `.tab-pane` fades in as it becomes active — no class to add. The pane you leave goes at once, because two in-flow panes cannot cross-fade without one stacking under the other.
 
@@ -535,7 +192,7 @@ Add `.tab-pane-instant` to a pane to switch its fade off, or retime it with `--c
 </div>
 ```
 
-### Methods
+## Methods
 
 <Callout color="info">
 #### Promises and transitions
@@ -560,7 +217,7 @@ const cuiTab = new coreui.Tab('#myTab')
 | `getOrCreateInstance` | *Static* method which allows you to get the tab instance associated with a DOM element, or create a new one in case it wasn't initialized You can use it like this: `coreui.Tab.getOrCreateInstance(element)`. |
 | `show` | Selects the given tab and shows its associated pane. Any other tab that was previously selected becomes unselected and its associated pane is hidden. **Returns to the caller before the tab pane has actually been shown** (i.e. before the `shown.coreui.tab` event occurs). |
 
-### Events
+## Events
 
 When showing a new tab, the events fire in the following order:
 
@@ -585,57 +242,3 @@ tabEl.addEventListener('shown.coreui.tab', event => {
   event.relatedTarget // previous active tab
 })
 ```
-
-## Theming
-
-A [theme class](/customize/components/#theme-variants) recolors a nav: links read the theme's foreground and the active pill or underline its solid color.
-
-<Example code={`<ul class="nav nav-pills theme-success">
-    <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
-    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-  </ul>`} />
-
-<Example code={`<ul class="nav nav-underline theme-success">
-    <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
-    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-  </ul>`} />
-
-## Customizing
-
-### CSS variables
-
-Navs use local CSS variables on `.nav`, `.nav-tabs`, `.nav-pills`, `.nav-underline` and `.nav-underline-border` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
-
-On the `.nav` base class:
-
-<ScssDocs file="scss/_nav.scss" capture="nav-css-vars" />
-
-On the `.nav-tabs` modifier class:
-
-<ScssDocs file="scss/_nav.scss" capture="nav-tabs-css-vars" />
-
-On the `.nav-pills` modifier class:
-
-<ScssDocs file="scss/_nav.scss" capture="nav-pills-css-vars" />
-
-<AddedIn version="5.0.0" />
-
-On the `.nav-underline` modifier class:
-
-<ScssDocs file="scss/_nav.scss" capture="nav-underline-css-vars" />
-
-<AddedIn version="5.0.0" />
-
-On the `.nav-underline-border` modifier class:
-
-<ScssDocs file="scss/_nav.scss" capture="nav-underline-border-css-vars" />
-
-Tab pane variables:
-
-<ScssDocs file="scss/_nav.scss" capture="tab-pane-css-vars" />
-
-### SASS variables
-
-<ScssDocs file="scss/_nav.scss" capture="nav-variables" />

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -965,6 +965,11 @@ adornment in the library — so the button needs no icon markup at all:
   It also takes `--cui-nav-link-hover-bg` and `--cui-nav-link-active-bg`, rounded
   by `--cui-nav-link-border-radius` — the base nav used to change text color
   alone. Set the two backgrounds to `transparent` to keep the old look.
+  Under a theme, hover marks itself with the fill or the line and the tone change
+  belongs to the active item: hover reads `--cui-theme-fg` and the lighter
+  `--cui-theme-bg-subtle`, active the darker `--cui-theme-fg-emphasis` and
+  `--cui-theme-bg-muted`. `.nav-underline-border`'s themed active link takes the
+  emphasis tone with them, where it used to take the theme's base color.
   `.nav-tabs`, `.nav-underline` and `.nav-underline-border` square the link off,
   and the two underline variants take neither fill, hover or active: they mark
   their state with a line, and a radius curves that line's ends while a fill says

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -965,11 +965,9 @@ adornment in the library — so the button needs no icon markup at all:
   It also takes `--cui-nav-link-hover-bg` and `--cui-nav-link-active-bg`, rounded
   by `--cui-nav-link-border-radius` — the base nav used to change text color
   alone. Set the two backgrounds to `transparent` to keep the old look.
-  Under a theme, hover marks itself with the fill or the line and the tone change
-  belongs to the active item: hover reads `--cui-theme-fg` and the lighter
-  `--cui-theme-bg-subtle`, active the darker `--cui-theme-fg-emphasis` and
-  `--cui-theme-bg-muted`. `.nav-underline-border`'s themed active link takes the
-  emphasis tone with them, where it used to take the theme's base color.
+  Under a theme, hover reads `--cui-theme-fg` and the lighter
+  `--cui-theme-bg-subtle`, and the active item the darker `--cui-theme-bg-muted`,
+  so hovering a link never outweighs the selected one.
   `.nav-tabs`, `.nav-underline` and `.nav-underline-border` square the link off,
   and the two underline variants take neither fill, hover or active: they mark
   their state with a line, and a radius curves that line's ends while a fill says

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -965,9 +965,10 @@ adornment in the library — so the button needs no icon markup at all:
   It also takes `--cui-nav-link-hover-bg` and `--cui-nav-link-active-bg`, rounded
   by `--cui-nav-link-border-radius` — the base nav used to change text color
   alone. Set the two backgrounds to `transparent` to keep the old look.
-  `.nav-underline` and `.nav-underline-border` opt out of the active fill
-  already: they mark the active item with a line, so a filled background would
-  say the same thing twice.
+  `.nav-tabs`, `.nav-underline` and `.nav-underline-border` square the link off
+  and the two underline variants also opt out of the active fill: they mark the
+  active item with a line, and a radius curves that line's ends while a fill says
+  the same thing twice.
 - **`--cui-nav-gap` is new**, declared on `.nav` and defaulting to `0`, so the
   base nav renders exactly as it did. It gives the token a home on the component
   whose name it carries: `.navbar-nav` already overrode it, and `.nav-underline`

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -958,6 +958,16 @@ adornment in the library — so the button needs no icon markup at all:
   while `.tab-pane` in the same file already read the three-token form, so half
   the file could be retimed in the browser and half could not. Setting
   `--cui-nav-link-transition-duration` now takes effect; before it was ignored.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`.nav-link` is a flex row, and it fills on hover and when active.** The link
+  lays its children out with `--cui-nav-link-gap`, `--cui-nav-link-align` and
+  `--cui-nav-link-justify`, so an icon and its label line up without a wrapper.
+  It also takes `--cui-nav-link-hover-bg` and `--cui-nav-link-active-bg`, rounded
+  by `--cui-nav-link-border-radius` — the base nav used to change text color
+  alone. Set the two backgrounds to `transparent` to keep the old look.
+  `.nav-underline` and `.nav-underline-border` opt out of the active fill
+  already: they mark the active item with a line, so a filled background would
+  say the same thing twice.
 - **`--cui-nav-gap` is new**, declared on `.nav` and defaulting to `0`, so the
   base nav renders exactly as it did. It gives the token a home on the component
   whose name it carries: `.navbar-nav` already overrode it, and `.nav-underline`

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -952,6 +952,16 @@ adornment in the library — so the button needs no icon markup at all:
   activated anything.
 - The `data-coreui-toggle="pill"` and `"list"` toggles **stay** — they are
   documented markup, and v6 keeps documented markup working.
+- **`$nav-link-transition` splits into
+  `$nav-link-transition-property`/`-duration`/`-timing`**, emitted as
+  `--cui-nav-link-transition-*`. The link's transition was compiled into its rule
+  while `.tab-pane` in the same file already read the three-token form, so half
+  the file could be retimed in the browser and half could not. Setting
+  `--cui-nav-link-transition-duration` now takes effect; before it was ignored.
+- **`--cui-nav-gap` is new**, declared on `.nav` and defaulting to `0`, so the
+  base nav renders exactly as it did. It gives the token a home on the component
+  whose name it carries: `.navbar-nav` already overrode it, and `.nav-underline`
+  keeps its own `--cui-nav-underline-gap`.
 
 #### Tooltip
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -965,9 +965,9 @@ adornment in the library — so the button needs no icon markup at all:
   It also takes `--cui-nav-link-hover-bg` and `--cui-nav-link-active-bg`, rounded
   by `--cui-nav-link-border-radius` — the base nav used to change text color
   alone. Set the two backgrounds to `transparent` to keep the old look.
-  `.nav-tabs`, `.nav-underline` and `.nav-underline-border` square the link off
-  and the two underline variants also opt out of the active fill: they mark the
-  active item with a line, and a radius curves that line's ends while a fill says
+  `.nav-tabs`, `.nav-underline` and `.nav-underline-border` square the link off,
+  and the two underline variants take neither fill, hover or active: they mark
+  their state with a line, and a radius curves that line's ends while a fill says
   the same thing twice.
 - **`--cui-nav-gap` is new**, declared on `.nav` and defaulting to `0`, so the
   base nav renders exactly as it did. It gives the token a home on the component

--- a/docs/src/data/sidebar.yml
+++ b/docs/src/data/sidebar.yml
@@ -280,8 +280,8 @@
       to: /components/modal/
     - title: Navbar
       to: /components/navbar/
-    - title: Navs & tabs
-      to: /components/navs-tabs/
+    - title: Nav
+      to: /components/nav/
     - title: Offcanvas
       to: /components/offcanvas/
     - title: Pagination
@@ -306,6 +306,8 @@
         text: NEW
     - title: Spinners
       to: /components/spinners/
+    - title: Tabs
+      to: /components/tab/
     - title: Toasts
       to: /components/toasts/
     - title: Tooltips

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -340,6 +340,7 @@ $tab-pane-tokens: defaults(
     .show > .nav-link {
       font-weight: var(--#{$prefix}font-weight-bold);
       color: var(--#{$prefix}theme-fg, var(--#{$prefix}nav-underline-link-active-color));
+      background-color: var(--#{$prefix}nav-link-active-bg);
       border-bottom-color: currentcolor;
     }
   }
@@ -371,6 +372,7 @@ $tab-pane-tokens: defaults(
     .show > .nav-link {
       font-weight: var(--#{$prefix}font-weight-bold);
       color: var(--#{$prefix}theme-base, var(--#{$prefix}nav-underline-border-link-active-color));
+      background-color: var(--#{$prefix}nav-link-active-bg);
       border-bottom-color: currentcolor;
     }
   }

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -9,13 +9,16 @@
 // stylelint-disable custom-property-no-missing-var-function
 
 // scss-docs-start nav-variables
+$nav-gap:                           0 !default;
 $nav-link-padding-y:                .5rem !default;
 $nav-link-padding-x:                1rem !default;
 $nav-link-font-size:                null !default;
 $nav-link-font-weight:              null !default;
 $nav-link-color:                    var(--#{$prefix}link-color) !default;
 $nav-link-hover-color:              var(--#{$prefix}link-hover-color) !default;
-$nav-link-transition:               color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out !default;
+$nav-link-transition-property:      color, background-color, border-color !default;
+$nav-link-transition-duration:      .15s !default;
+$nav-link-transition-timing:        ease-in-out !default;
 $nav-link-disabled-color:           var(--#{$prefix}secondary-color) !default;
 
 $nav-tabs-border-color:             var(--#{$prefix}border-color) !default;
@@ -68,6 +71,7 @@ $nav-tokens: () !default;
 // scss-docs-start nav-css-vars
 $nav-tokens: defaults(
   (
+    --#{$prefix}nav-gap: #{$nav-gap},
     --#{$prefix}nav-link-padding-x: #{$nav-link-padding-x},
     --#{$prefix}nav-link-padding-y: #{$nav-link-padding-y},
     --#{$prefix}nav-link-font-size: #{$nav-link-font-size},
@@ -75,6 +79,9 @@ $nav-tokens: defaults(
     --#{$prefix}nav-link-color: #{$nav-link-color},
     --#{$prefix}nav-link-hover-color: #{$nav-link-hover-color},
     --#{$prefix}nav-link-disabled-color: #{$nav-link-disabled-color},
+    --#{$prefix}nav-link-transition-property: #{$nav-link-transition-property},
+    --#{$prefix}nav-link-transition-duration: #{$nav-link-transition-duration},
+    --#{$prefix}nav-link-transition-timing: #{$nav-link-transition-timing},
   ),
   $nav-tokens
 );
@@ -181,6 +188,7 @@ $tab-pane-tokens: defaults(
 
     display: flex;
     flex-wrap: wrap;
+    gap: var(--#{$prefix}nav-gap);
     padding-inline-start: 0;
     margin-bottom: 0;
     list-style-type: "";
@@ -195,7 +203,11 @@ $tab-pane-tokens: defaults(
     text-decoration: if(not sass($link-decoration == none): none);
     background: none;
     border: 0;
-    @include transition($nav-link-transition);
+    @include transition-props(
+      var(--#{$prefix}nav-link-transition-property),
+      var(--#{$prefix}nav-link-transition-duration),
+      var(--#{$prefix}nav-link-transition-timing)
+    );
 
     &:hover,
     &:focus {

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -237,7 +237,7 @@ $tab-pane-tokens: defaults(
 
     &.active,
     &:active {
-      color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}nav-link-active-color));
+      color: var(--#{$prefix}theme-fg, var(--#{$prefix}nav-link-active-color));
       background-color: var(--#{$prefix}theme-bg-muted, var(--#{$prefix}nav-link-active-bg));
     }
 
@@ -341,7 +341,7 @@ $tab-pane-tokens: defaults(
     .nav-link.active,
     .show > .nav-link {
       font-weight: var(--#{$prefix}font-weight-bold);
-      color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}nav-underline-link-active-color));
+      color: var(--#{$prefix}theme-fg, var(--#{$prefix}nav-underline-link-active-color));
       background-color: var(--#{$prefix}nav-link-active-bg);
       border-bottom-color: currentcolor;
     }
@@ -375,7 +375,7 @@ $tab-pane-tokens: defaults(
     .nav-link.active,
     .show > .nav-link {
       font-weight: var(--#{$prefix}font-weight-bold);
-      color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}nav-underline-border-link-active-color));
+      color: var(--#{$prefix}theme-base, var(--#{$prefix}nav-underline-border-link-active-color));
       background-color: var(--#{$prefix}nav-link-active-bg);
       border-bottom-color: currentcolor;
     }

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -322,6 +322,7 @@ $tab-pane-tokens: defaults(
 
     --#{$prefix}nav-link-active-bg: transparent;
     --#{$prefix}nav-link-border-radius: 0;
+    --#{$prefix}nav-link-hover-bg: transparent;
 
     gap: var(--#{$prefix}nav-underline-gap);
 
@@ -332,6 +333,7 @@ $tab-pane-tokens: defaults(
 
       &:hover,
       &:focus {
+        background-color: var(--#{$prefix}nav-link-hover-bg);
         border-bottom-color: currentcolor;
       }
     }
@@ -351,6 +353,7 @@ $tab-pane-tokens: defaults(
 
     --#{$prefix}nav-link-active-bg: transparent;
     --#{$prefix}nav-link-border-radius: 0;
+    --#{$prefix}nav-link-hover-bg: transparent;
     --#{$prefix}nav-link-color: var(--#{$prefix}nav-underline-border-link-color);
     --#{$prefix}nav-link-disabled-color: var(--#{$prefix}nav-underline-border-link-disabled-color);
 
@@ -364,6 +367,7 @@ $tab-pane-tokens: defaults(
 
       &:hover,
       &:focus {
+        background-color: var(--#{$prefix}nav-link-hover-bg);
         border-bottom-color: currentcolor;
       }
     }

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -229,16 +229,16 @@ $tab-pane-tokens: defaults(
 
     &:hover,
     &:focus {
-      color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}nav-link-hover-color));
+      color: var(--#{$prefix}theme-fg, var(--#{$prefix}nav-link-hover-color));
       // stylelint-disable-next-line scss/at-function-named-arguments
       text-decoration: if(sass($link-hover-decoration == underline): none);
-      background-color: var(--#{$prefix}theme-bg-muted, var(--#{$prefix}nav-link-hover-bg));
+      background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}nav-link-hover-bg));
     }
 
     &.active,
     &:active {
-      color: var(--#{$prefix}theme-fg, var(--#{$prefix}nav-link-active-color));
-      background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}nav-link-active-bg));
+      color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}nav-link-active-color));
+      background-color: var(--#{$prefix}theme-bg-muted, var(--#{$prefix}nav-link-active-bg));
     }
 
     &:focus-visible {
@@ -341,7 +341,7 @@ $tab-pane-tokens: defaults(
     .nav-link.active,
     .show > .nav-link {
       font-weight: var(--#{$prefix}font-weight-bold);
-      color: var(--#{$prefix}theme-fg, var(--#{$prefix}nav-underline-link-active-color));
+      color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}nav-underline-link-active-color));
       background-color: var(--#{$prefix}nav-link-active-bg);
       border-bottom-color: currentcolor;
     }
@@ -375,7 +375,7 @@ $tab-pane-tokens: defaults(
     .nav-link.active,
     .show > .nav-link {
       font-weight: var(--#{$prefix}font-weight-bold);
-      color: var(--#{$prefix}theme-base, var(--#{$prefix}nav-underline-border-link-active-color));
+      color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}nav-underline-border-link-active-color));
       background-color: var(--#{$prefix}nav-link-active-bg);
       border-bottom-color: currentcolor;
     }

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -13,9 +13,16 @@ $nav-gap:                           0 !default;
 $nav-link-padding-y:                .5rem !default;
 $nav-link-padding-x:                1rem !default;
 $nav-link-font-size:                null !default;
+$nav-link-gap:                      .5rem !default;
+$nav-link-align:                    center !default;
+$nav-link-justify:                  center !default;
+$nav-link-border-radius:            var(--#{$prefix}border-radius) !default;
 $nav-link-font-weight:              null !default;
 $nav-link-color:                    var(--#{$prefix}link-color) !default;
 $nav-link-hover-color:              var(--#{$prefix}link-hover-color) !default;
+$nav-link-hover-bg:                 var(--#{$prefix}tertiary-bg) !default;
+$nav-link-active-color:             var(--#{$prefix}emphasis-color) !default;
+$nav-link-active-bg:                var(--#{$prefix}secondary-bg) !default;
 $nav-link-transition-property:      color, background-color, border-color !default;
 $nav-link-transition-duration:      .15s !default;
 $nav-link-transition-timing:        ease-in-out !default;
@@ -72,12 +79,19 @@ $nav-tokens: () !default;
 $nav-tokens: defaults(
   (
     --#{$prefix}nav-gap: #{$nav-gap},
+    --#{$prefix}nav-link-gap: #{$nav-link-gap},
+    --#{$prefix}nav-link-align: #{$nav-link-align},
+    --#{$prefix}nav-link-justify: #{$nav-link-justify},
+    --#{$prefix}nav-link-border-radius: #{$nav-link-border-radius},
     --#{$prefix}nav-link-padding-x: #{$nav-link-padding-x},
     --#{$prefix}nav-link-padding-y: #{$nav-link-padding-y},
     --#{$prefix}nav-link-font-size: #{$nav-link-font-size},
     --#{$prefix}nav-link-font-weight: #{$nav-link-font-weight},
     --#{$prefix}nav-link-color: #{$nav-link-color},
     --#{$prefix}nav-link-hover-color: #{$nav-link-hover-color},
+    --#{$prefix}nav-link-hover-bg: #{$nav-link-hover-bg},
+    --#{$prefix}nav-link-active-color: #{$nav-link-active-color},
+    --#{$prefix}nav-link-active-bg: #{$nav-link-active-bg},
     --#{$prefix}nav-link-disabled-color: #{$nav-link-disabled-color},
     --#{$prefix}nav-link-transition-property: #{$nav-link-transition-property},
     --#{$prefix}nav-link-transition-duration: #{$nav-link-transition-duration},
@@ -195,7 +209,10 @@ $tab-pane-tokens: defaults(
   }
 
   .nav-link {
-    display: block;
+    display: flex;
+    gap: var(--#{$prefix}nav-link-gap);
+    align-items: var(--#{$prefix}nav-link-align);
+    justify-content: var(--#{$prefix}nav-link-justify);
     padding: var(--#{$prefix}nav-link-padding-y) var(--#{$prefix}nav-link-padding-x);
     font-size: var(--#{$prefix}nav-link-font-size);
     font-weight: var(--#{$prefix}nav-link-font-weight);
@@ -203,6 +220,7 @@ $tab-pane-tokens: defaults(
     text-decoration: if(not sass($link-decoration == none): none);
     background: none;
     border: 0;
+    @include border-radius(var(--#{$prefix}nav-link-border-radius));
     @include transition-props(
       var(--#{$prefix}nav-link-transition-property),
       var(--#{$prefix}nav-link-transition-duration),
@@ -214,6 +232,13 @@ $tab-pane-tokens: defaults(
       color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}nav-link-hover-color));
       // stylelint-disable-next-line scss/at-function-named-arguments
       text-decoration: if(sass($link-hover-decoration == underline): none);
+      background-color: var(--#{$prefix}theme-bg-muted, var(--#{$prefix}nav-link-hover-bg));
+    }
+
+    &.active,
+    &:active {
+      color: var(--#{$prefix}theme-fg, var(--#{$prefix}nav-link-active-color));
+      background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}nav-link-active-bg));
     }
 
     &:focus-visible {
@@ -293,6 +318,8 @@ $tab-pane-tokens: defaults(
   .nav-underline {
     @include tokens($nav-underline-tokens);
 
+    --#{$prefix}nav-link-active-bg: transparent;
+
     gap: var(--#{$prefix}nav-underline-gap);
 
     .nav-link {
@@ -318,6 +345,7 @@ $tab-pane-tokens: defaults(
   .nav-underline-border {
     @include tokens($nav-underline-border-tokens);
 
+    --#{$prefix}nav-link-active-bg: transparent;
     --#{$prefix}nav-link-color: var(--#{$prefix}nav-underline-border-link-color);
     --#{$prefix}nav-link-disabled-color: var(--#{$prefix}nav-underline-border-link-disabled-color);
 

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -261,6 +261,8 @@ $tab-pane-tokens: defaults(
   .nav-tabs {
     @include tokens($nav-tabs-tokens);
 
+    --#{$prefix}nav-link-border-radius: 0;
+
     border-bottom: var(--#{$prefix}nav-tabs-border-width) solid var(--#{$prefix}nav-tabs-border-color);
 
     .nav-link {
@@ -319,6 +321,7 @@ $tab-pane-tokens: defaults(
     @include tokens($nav-underline-tokens);
 
     --#{$prefix}nav-link-active-bg: transparent;
+    --#{$prefix}nav-link-border-radius: 0;
 
     gap: var(--#{$prefix}nav-underline-gap);
 
@@ -346,6 +349,7 @@ $tab-pane-tokens: defaults(
     @include tokens($nav-underline-border-tokens);
 
     --#{$prefix}nav-link-active-bg: transparent;
+    --#{$prefix}nav-link-border-radius: 0;
     --#{$prefix}nav-link-color: var(--#{$prefix}nav-underline-border-link-color);
     --#{$prefix}nav-link-disabled-color: var(--#{$prefix}nav-underline-border-link-disabled-color);
 


### PR DESCRIPTION
Two findings, both about a knob that does not exist where its name says it should.

- **`.nav-link` baked its transition into the rule** while `.tab-pane`, forty lines down the same file, already read the `--cui-*-transition-property/-duration/-timing` trio. Half of `_nav.scss` could be retimed from the browser and half could not. `$nav-link-transition` splits into three variables and the link reads `--cui-nav-link-transition-*`. Measured in Chromium: setting `--cui-nav-link-transition-duration: .9s` left the link at 0.15s before and moves it now.
- **`--cui-nav-gap` had no home.** `.navbar-nav` declares and reads it (added in #865), but `.nav` — the component whose prefix the token carries — never declared it, so it read as a token arriving from nowhere. It is declared on `.nav` now, defaulting to `0`, so the base nav renders exactly as before: measured `gap: 0px`, and `2rem` on the element gives 32px where it previously did nothing. `.nav-underline` keeps its own `--cui-nav-underline-gap`.

Token audit clean in both directions afterwards. All gates green.

### Not taken from upstream — design questions, not defects

Their `_nav.scss` has diverged a long way from ours and each of these changes how a nav looks or what markup it needs:

- `.nav-link` is a flex row with `--nav-link-gap`, `--nav-link-align` and `--nav-link-justify`, so an icon and its label line up. Ours is `display: block`.
- The base `.nav-link` gains `--nav-link-hover-bg` and `--nav-link-active-bg`. Ours only changes text color at the base level.
- `.nav-pills` becomes a segmented control: `inline-flex` on a `--nav-pills-bg` track with its own padding and radius. Ours is a plain row of pills.
- `.nav-tabs` draws its rule with `box-shadow: inset` instead of `border-bottom` plus a negative margin on each link.
- They ship `.nav-pills-vertical`; we do not.

Our own additions — `.nav-underline-border` and `.nav-enclosed` — have no upstream counterpart.