### PR TITLE
fix(Range): let a theme win, and give the label's padding a reader

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -927,6 +927,13 @@ adornment in the library — so the button needs no icon markup at all:
 
 #### Range / Range Slider
 
+- **A theme beats `--cui-range-thumb-bg`, as everywhere else.** The token carried
+  the `--cui-theme-*` slot inside its own default, so setting it inside a themed
+  container dropped the theme. The slot sits on the property now.
+- **`--cui-range-slider-label-padding-x`/`-y` reach the label.** Both were
+  declared and nothing read them, so the knob existed and did nothing. They
+  default to `0`, so no label moves.
+
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
   **The pressed thumb adapts to the color mode.** Its color was 70% white
   mixed into the theme color at build time, so in dark mode the pressed

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -258,6 +258,7 @@ $range-slider-vertical-tokens: defaults(
 
   .range-slider-label {
     position: absolute;
+    padding: var(--#{$prefix}range-slider-label-padding-y) var(--#{$prefix}range-slider-label-padding-x);
     font-size: var(--#{$prefix}range-slider-label-font-size);
     color: var(--#{$prefix}range-slider-label-color);
     @include ltr-rtl("transform", translateX(-50%), null, translateX(50%));

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -17,7 +17,7 @@ $form-range-track-box-shadow:              var(--#{$prefix}box-shadow-inset) !de
 
 $form-range-thumb-width:                   1rem !default;
 $form-range-thumb-height:                  var(--#{$prefix}range-thumb-width) !default;
-$form-range-thumb-bg:                      var(--#{$prefix}theme-base, var(--#{$prefix}primary)) !default;
+$form-range-thumb-bg:                      var(--#{$prefix}primary) !default;
 $form-range-thumb-border:                  0 !default;
 $form-range-thumb-border-radius:           1rem !default;
 $form-range-thumb-box-shadow:              0 .1rem .25rem color-mix(in srgb, var(--#{$prefix}black) 10%, transparent) !default;
@@ -65,7 +65,7 @@ $form-range-tokens: defaults(
   width: var(--#{$prefix}range-thumb-width);
   height: var(--#{$prefix}range-thumb-height);
   appearance: none;
-  @include gradient-bg(var(--#{$prefix}range-thumb-bg));
+  @include gradient-bg(var(--#{$prefix}theme-base, var(--#{$prefix}range-thumb-bg)));
   border: var(--#{$prefix}range-thumb-border);
   @include border-radius(var(--#{$prefix}range-thumb-border-radius));
   @include box-shadow(var(--#{$prefix}range-thumb-box-shadow));


### PR DESCRIPTION
Two small defects in the range family, both found by comparing the `--cui-range-*` tokens the compiled stylesheet reads against the ones it declares.

- **`--cui-range-thumb-bg` carried the `--cui-theme-*` slot inside its own default** instead of on the property that reads it, inverting the precedence the rest of the library follows (#852, applied in #862 and #865). A `.theme-success` range with `--cui-range-thumb-bg: red` rendered red; it renders the theme's green now. The unthemed thumb is unchanged.
- **`--cui-range-slider-label-padding-x` / `-y` were declared and read by nothing.** `.range-slider-label` reads them now. Both default to `0`, so no label moves; setting the x to `1rem` gives 16px where it used to give 0.

### Checked and not a defect

- `.form-range`'s height looked like it baked the focus-ring width into a `calc()`. It does not — `$form-range-thumb-focus-ring-width` holds `var(--cui-focus-ring-width)`, so the interpolation emits the `var()`. Measured: `1rem` on the element takes the input from 24px to 48px.
- `--cui-range-slider-track-from`, `-track-to` and `-tooltip-position` read a hard-coded `--cui-` prefix and are declared by nothing in the stylesheet. Both are deliberate: the component writes them from JavaScript, and #725 keeps the CSS-to-JS signals out of `$prefix`.

### Two things for you, not in this PR

**Upstream's `.form-range` is now our PRO Range Slider.** They split it into `.form-range` + `.form-range-input` and added a filled track driven by a `--range-fill` variable their plugin keeps in sync, a value bubble reusing the tooltip markup, and tick marks generated from a linked `<datalist>`. That is where their extra 75 lines went, and it is the same shape as `forms/_strength.scss` and `forms/_combobox.scss`: a feature we sell as PRO arriving in their free tier. Taking it would mean either duplicating our own Range Slider or restructuring the `.form-range` markup.

**20 `--cui-*-box-shadow` tokens are declared and unreadable.** `$enable-shadows` defaults to `false`, so `@include box-shadow()` emits nothing, and every component that declares a shadow token ships one nobody can use — `--cui-btn-box-shadow`, `--cui-card-box-shadow`, `--cui-modal-box-shadow` and 17 more. Setting one in DevTools does nothing, which is exactly the kind of silent no-op we have been removing elsewhere. It needs a decision rather than a patch: stop declaring them when shadows are off, or always emit `box-shadow: var(--cui-x-box-shadow)` and let the token default to `none` so a shadow can be turned on per component at runtime.