### PR TITLE
fix(Lists): declare the gap between inline list items

### DIFF
--- a/docs/src/content/docs/content/typography.mdx
+++ b/docs/src/content/docs/content/typography.mdx
@@ -259,6 +259,11 @@ Blockquotes carry their spacing, size and source colour as CSS variables, on the
 
 <ScssDocs file="scss/content/_blockquote.scss" capture="blockquote-footer-css-vars" />
 
+An inline list carries the gap between its items, declared on the list so one
+value spaces the whole row:
+
+<ScssDocs file="scss/content/_lists.scss" capture="list-inline-css-vars" />
+
 ### SASS variables
 
 Headings have some dedicated variables for sizing and spacing.

--- a/docs/src/content/docs/forms/floating-labels.mdx
+++ b/docs/src/content/docs/forms/floating-labels.mdx
@@ -8,29 +8,31 @@ otherFrameworks:
 
 ## Example
 
-Wrap a pair of `<input class="form-control" />` and `<label>` elements in `.form-floating` to enable floating labels with CoreUI for Bootstrap's textual form fields. A `placeholder` is required on each `<input />` as our method of CSS-only floating labels uses the `:placeholder-shown` pseudo-element. Also note that the `<input />` must come first so we can utilize a sibling selector (e.g., `~`).
+Wrap a `<label>` and an `<input class="form-control" />` in `.form-floating` to enable floating labels with CoreUI for Bootstrap's textual form fields. A `placeholder` is required on each `<input />` as our method of CSS-only floating labels uses the `:placeholder-shown` pseudo-element.
+
+Write the `<label>` first, so a screen reader announces it before the field's value. The v5 order — control first, label after — keeps working: every state is matched in both directions, forward with `:has()` and backward with the sibling combinator.
 
 <Example code={`<div class="form-floating mb-3">
-    <input type="email" class="form-control" id="floatingInput" placeholder="name@example.com">
     <label for="floatingInput">Email address</label>
+    <input type="email" class="form-control" id="floatingInput" placeholder="name@example.com">
   </div>
   <div class="form-floating">
-    <input type="password" class="form-control" id="floatingPassword" placeholder="Password">
     <label for="floatingPassword">Password</label>
+    <input type="password" class="form-control" id="floatingPassword" placeholder="Password">
   </div>`} />
 
 When there's a `value` already defined, `<label>`s will automatically adjust to their floated position.
 
 <Example code={`<form class="form-floating">
-    <input type="email" class="form-control" id="floatingInputValue" placeholder="name@example.com" value="test@example.com">
     <label for="floatingInputValue">Input with value</label>
+    <input type="email" class="form-control" id="floatingInputValue" placeholder="name@example.com" value="test@example.com">
   </form>`} />
 
 Form validation styles also work as expected.
 
 <Example code={`<form class="form-floating">
-    <input type="email" class="form-control is-invalid" id="floatingInputInvalid" placeholder="name@example.com" value="test@example.com">
     <label for="floatingInputInvalid">Invalid input</label>
+    <input type="email" class="form-control is-invalid" id="floatingInputInvalid" placeholder="name@example.com" value="test@example.com">
   </form>`} />
 
 ## Textareas
@@ -38,15 +40,15 @@ Form validation styles also work as expected.
 By default, `<textarea>`s with `.form-control` will be the same height as `<input />`s.
 
 <Example code={`<div class="form-floating">
-    <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextarea"></textarea>
     <label for="floatingTextarea">Comments</label>
+    <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextarea"></textarea>
   </div>`} />
 
 To set a custom height on your `<textarea>`, do not use the `rows` attribute. Instead, set an explicit `height` (either inline or via custom CSS).
 
 <Example code={`<div class="form-floating">
-    <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextarea2" style="height: 100px"></textarea>
     <label for="floatingTextarea2">Comments</label>
+    <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextarea2" style="height: 100px"></textarea>
   </div>`} />
 
 ## Selects
@@ -54,13 +56,13 @@ To set a custom height on your `<textarea>`, do not use the `rows` attribute. In
 Other than `.form-control`, floating labels are only available on `.form-control`s. They work in the same way, but unlike `<input />`s, they'll always show the `<label>` in its floated state. **Selects with `size` and `multiple` are not supported.**
 
 <Example code={`<div class="form-floating">
+    <label for="floatingSelect">Works with selects</label>
     <select class="form-control" id="floatingSelect" aria-label="Floating label select example">
       <option selected>Open this select menu</option>
       <option value="1">One</option>
       <option value="2">Two</option>
       <option value="3">Three</option>
     </select>
-    <label for="floatingSelect">Works with selects</label>
   </div>`} />
 
 ## Disabled
@@ -68,25 +70,25 @@ Other than `.form-control`, floating labels are only available on `.form-control
 Add the `disabled` boolean attribute on an input, a textarea or a select to give it a grayed out appearance, remove pointer events, and prevent focusing.
 
 <Example code={`<div class="form-floating mb-3">
-    <input type="email" class="form-control" id="floatingInputDisabled" placeholder="name@example.com" disabled>
     <label for="floatingInputDisabled">Email address</label>
+    <input type="email" class="form-control" id="floatingInputDisabled" placeholder="name@example.com" disabled>
   </div>
   <div class="form-floating mb-3">
-    <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextareaDisabled" disabled></textarea>
     <label for="floatingTextareaDisabled">Comments</label>
+    <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextareaDisabled" disabled></textarea>
   </div>
   <div class="form-floating mb-3">
-    <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextarea2Disabled" style="height: 100px" disabled>Disabled textarea with some text inside</textarea>
     <label for="floatingTextarea2Disabled">Comments</label>
+    <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextarea2Disabled" style="height: 100px" disabled>Disabled textarea with some text inside</textarea>
   </div>
   <div class="form-floating">
+    <label for="floatingSelectDisabled">Works with selects</label>
     <select class="form-control" id="floatingSelectDisabled" aria-label="Floating label disabled select example" disabled>
       <option selected>Open this select menu</option>
       <option value="1">One</option>
       <option value="2">Two</option>
       <option value="3">Three</option>
     </select>
-    <label for="floatingSelectDisabled">Works with selects</label>
   </div>`} />
 
 ## Readonly plaintext
@@ -94,12 +96,12 @@ Add the `disabled` boolean attribute on an input, a textarea or a select to give
 Floating labels also support `.form-control-plaintext`, which can be helpful for toggling from an editable `<input />` to a plaintext value without affecting the page layout.
 
 <Example code={`<div class="form-floating mb-3">
-    <input type="email" readonly class="form-control-plaintext" id="floatingEmptyPlaintextInput" placeholder="name@example.com">
     <label for="floatingEmptyPlaintextInput">Empty input</label>
+    <input type="email" readonly class="form-control-plaintext" id="floatingEmptyPlaintextInput" placeholder="name@example.com">
   </div>
   <div class="form-floating mb-3">
-    <input type="email" readonly class="form-control-plaintext" id="floatingPlaintextInput" placeholder="name@example.com" value="name@example.com">
     <label for="floatingPlaintextInput">Input with value</label>
+    <input type="email" readonly class="form-control-plaintext" id="floatingPlaintextInput" placeholder="name@example.com" value="name@example.com">
   </div>`} />
 
 ## Layout
@@ -109,19 +111,19 @@ When working with the CoreUI for Bootstrap grid system, be sure to place form el
 <Example code={`<div class="row g-2">
     <div class="col-md">
       <div class="form-floating">
-        <input type="email" class="form-control" id="floatingInputGrid" placeholder="name@example.com" value="mdo@example.com">
         <label for="floatingInputGrid">Email address</label>
+        <input type="email" class="form-control" id="floatingInputGrid" placeholder="name@example.com" value="mdo@example.com">
       </div>
     </div>
     <div class="col-md">
       <div class="form-floating">
+        <label for="floatingSelectGrid">Works with selects</label>
         <select class="form-control" id="floatingSelectGrid">
           <option selected>Open this select menu</option>
           <option value="1">One</option>
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <label for="floatingSelectGrid">Works with selects</label>
       </div>
     </div>
   </div>`} />

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1425,6 +1425,17 @@ Multi Select's option indicators moved with it — they render as a decorative
   (`address`, `ol`/`ul`/`dl`, `dd`, `blockquote`, `pre`, `figure`). Values are
   unchanged.
 
+#### Floating labels
+
+- **The label may now come first.** `.form-floating` matches the control's state
+  in both directions — forward from the label with `:has()`, backward from the
+  control with `~` — so `<label>` before the control floats and disables exactly
+  like the v5 order, which keeps working. Writing the label first lets a screen
+  reader announce it before the field's value, and the docs examples do.
+- **A textarea's label stays at the top.** The label is a flex box centred on the
+  control, and `label:has(~ textarea)` anchors it to the start instead, so it
+  floats correctly however tall the textarea is.
+
 #### Lists
 
 - **`--cui-list-inline-padding` is new.** The gap between `.list-inline-item`s was

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1425,6 +1425,12 @@ Multi Select's option indicators moved with it — they render as a decorative
   (`address`, `ol`/`ul`/`dl`, `dd`, `blockquote`, `pre`, `figure`). Values are
   unchanged.
 
+#### Lists
+
+- **`--cui-list-inline-padding` is new.** The gap between `.list-inline-item`s was
+  compiled into the rule, so respacing an inline list meant rebuilding from Sass.
+  `.list-inline` declares it, at the same `.5rem`.
+
 #### Tables
 
 - **`.table-responsive*` is a query container.** It still scrolls horizontally

--- a/scss/content/_lists.scss
+++ b/scss/content/_lists.scss
@@ -1,9 +1,26 @@
+@use "../functions/defaults" as *;
 @use "../mixins/lists" as *;
+@use "../mixins/tokens" as *;
 @use "../config" as *;
 
 // scss-docs-start list-variables
 $list-inline-padding:         .5rem !default;
 // scss-docs-end list-variables
+
+$list-inline-tokens: () !default;
+
+// stylelint-disable scss/dollar-variable-default
+
+// scss-docs-start list-inline-css-vars
+$list-inline-tokens: defaults(
+  (
+    --#{$prefix}list-inline-padding: #{$list-inline-padding},
+  ),
+  $list-inline-tokens
+);
+// scss-docs-end list-inline-css-vars
+
+// stylelint-enable scss/dollar-variable-default
 
 @layer content {
   .list-unstyled {
@@ -12,13 +29,14 @@ $list-inline-padding:         .5rem !default;
 
   // Inline turns list items into inline-block
   .list-inline {
+    @include tokens($list-inline-tokens);
     @include list-unstyled();
   }
   .list-inline-item {
     display: inline-block;
 
     &:not(:last-child) {
-      margin-inline-end: $list-inline-padding;
+      margin-inline-end: var(--#{$prefix}list-inline-padding);
     }
   }
 }

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -56,6 +56,10 @@ $form-floating-tokens: defaults(
 // stylelint-enable scss/dollar-variable-default
 
 @layer forms {
+  // The label may sit either side of the control. Putting it first lets a screen
+  // reader announce it before the field's value, which is why the docs write it
+  // that way; the v5 order still works, so each state is matched in both
+  // directions — forward with `:has()`, backward with the sibling combinator.
   .form-floating {
     @include tokens($form-floating-tokens);
 
@@ -74,6 +78,8 @@ $form-floating-tokens: defaults(
       inset-inline-start: 0;
       top: 0;
       z-index: 2;
+      display: flex;
+      align-items: center;
       max-width: 100%;
       height: 100%; // allow textareas
       padding: var(--#{$prefix}form-floating-padding-y) var(--#{$prefix}form-floating-padding-x);
@@ -90,6 +96,12 @@ $form-floating-tokens: defaults(
         var(--#{$prefix}form-floating-transition-duration),
         var(--#{$prefix}form-floating-transition-timing)
       );
+    }
+
+    // A textarea grows, so its label stays at the top instead of centring
+    > label:has(~ textarea),
+    > textarea ~ label {
+      align-items: flex-start;
     }
 
     > .form-control,
@@ -118,44 +130,50 @@ $form-floating-tokens: defaults(
       padding-bottom: var(--#{$prefix}form-floating-input-padding-b);
     }
 
-    > .form-control:focus,
-    > .form-control:not(:placeholder-shown),
-    > .form-control-plaintext,
-    > .form-select {
-      ~ label {
-        transform: var(--#{$prefix}form-floating-label-transform);
-      }
+    > label:has(~ .form-control:focus),
+    > label:has(~ .form-control:not(:placeholder-shown)),
+    > label:has(~ .form-control-plaintext),
+    > label:has(~ .form-select),
+    > .form-control:focus ~ label,
+    > .form-control:not(:placeholder-shown) ~ label,
+    > .form-control-plaintext ~ label,
+    > .form-select ~ label {
+      transform: var(--#{$prefix}form-floating-label-transform);
     }
     // Duplicated because `:-webkit-autofill` invalidates other selectors when grouped
-    > .form-control:-webkit-autofill {
-      ~ label {
-        transform: var(--#{$prefix}form-floating-label-transform);
-      }
+    > label:has(~ .form-control:-webkit-autofill),
+    > .form-control:-webkit-autofill ~ label {
+      transform: var(--#{$prefix}form-floating-label-transform);
     }
-    > textarea:focus,
-    > textarea:not(:placeholder-shown) {
-      ~ label::after {
-        position: absolute;
-        inset: var(--#{$prefix}form-floating-padding-y) calc(var(--#{$prefix}form-floating-padding-x) * .5);
-        z-index: -1;
-        height: var(--#{$prefix}form-floating-label-height);
-        content: "";
-        background-color: var(--#{$prefix}form-floating-label-bg);
-        @include border-radius(var(--#{$prefix}form-floating-label-border-radius));
-      }
+
+    > label:has(~ textarea:focus)::after,
+    > label:has(~ textarea:not(:placeholder-shown))::after,
+    > textarea:focus ~ label::after,
+    > textarea:not(:placeholder-shown) ~ label::after {
+      position: absolute;
+      inset: var(--#{$prefix}form-floating-padding-y) calc(var(--#{$prefix}form-floating-padding-x) * .5);
+      z-index: -1;
+      height: var(--#{$prefix}form-floating-label-height);
+      content: "";
+      background-color: var(--#{$prefix}form-floating-label-bg);
+      @include border-radius(var(--#{$prefix}form-floating-label-border-radius));
     }
+
+    > label:has(~ textarea:disabled)::after,
     > textarea:disabled ~ label::after {
       background-color: var(--#{$prefix}form-floating-label-disabled-bg);
     }
 
-    > .form-control-plaintext {
-      ~ label {
-        border-width: var(--#{$prefix}btn-input-border-width) 0; // Required to properly position label text - as explained above
-      }
+    > label:has(~ .form-control-plaintext),
+    > .form-control-plaintext ~ label {
+      border-width: var(--#{$prefix}btn-input-border-width) 0; // Required to properly position label text - as explained above
     }
 
+    // `.form-control` is named on its own because of specificity
+    > label:has(~ :disabled),
+    > label:has(~ .form-control:disabled),
     > :disabled ~ label,
-    > .form-control:disabled ~ label { // Required for `.form-control`s because of specificity
+    > .form-control:disabled ~ label {
       color: var(--#{$prefix}form-floating-label-disabled-color);
     }
   }


### PR DESCRIPTION
Closing out the four small files left on the v6-dev comparison list. Only one of them had anything wrong with it.

**`content/_lists.scss`** — the space between `.list-inline-item`s was compiled into the rule, so respacing an inline list meant rebuilding from Sass. It was the last value in `scss/content/` without a token behind it after the figure gap in #863. `.list-inline` declares `--cui-list-inline-padding` and the item reads it; the token sits on the list because spacing a row is one decision, not one per item. Measured: unchanged at 8px by default, 48px when the list is set to `3rem`.

Upstream tokenized the same value and reads it as `var(--list-inline-padding, var(--spacer) / 2)` — that fallback is not valid CSS (a division outside `calc()`), so the idea is theirs and the spelling is not.

### The other three: nothing to change

- **`forms/_form-text.scss`** — equivalent. Ours reads `var(--x, inherit)` where theirs reads a bare `var(--x)`, which is the safer of the two.
- **`forms/_labels.scss`** — equivalent. Their labels default to `font-weight: 500` and an explicit `color`, ours inherit both. That is a design choice, not a defect, and it is visible on every form in the library.
- **`forms/_floating-labels.scss`** — token audit clean in both directions. The real difference is structural and needs your call, below.

### Checked, and deliberately not "fixed"

- `--cui-label-font-size`, `-font-style`, `-font-weight`, `-color` and the two `--cui-form-text-*` twins are read with a fallback and never declared. That looks like the ghost-token defect we have been removing, but here it is how "no opinion by default" is expressed — the `null` entries are dropped by `defaults()` and the property falls back to `inherit`. Upstream does exactly the same.
- The floating-label rules still name `.form-select`. That looked like dead code left over from absorbing it into `.form-control`, but `.form-select` is still emitted (50 selectors), so they match.

### For you

**Upstream reordered the floating-label markup.** The label now precedes the control in the DOM so screen readers announce it before the field's value, and the rules look forward with `:has(~ .form-control:focus)` instead of back with `~ label`. They also anchor the label to the top for textareas via `label:has(~ textarea)`. It is a genuine a11y improvement and it needs every floating-label block in every project rewritten, so it is the same kind of decision as the navbar toggler — not something to port quietly.