### PR TITLE
docs: describe the colors, imports and section names v6 actually ships

### DIFF
--- a/docs/src/content/docs/components/alerts.mdx
+++ b/docs/src/content/docs/components/alerts.mdx
@@ -156,7 +156,7 @@ Add `.alert-solid` for a high-contrast alert. The background takes the theme col
 Using the JavaScript plugin, you can remove any alert.
 
 - Ensure that you've loaded the Bootstrap alert plugin or the compiled CoreUI JavaScript.
-- Add a [close button](/components/close-button//) as a child of the alert. It is pushed to the end of the alert on its own — the `.alert-dismissible` class is no longer required.
+- Add a [close button](/components/close-button/) as a child of the alert. It is pushed to the end of the alert on its own — the `.alert-dismissible` class is no longer required.
 - `.alert-dismissible` no longer carries any styling. Markup that still has it renders the same, so there is nothing to remove, but the close button has to be a direct child of the alert to be pushed to its end — a button nested in a wrapper is laid out by that wrapper.
 - On the close button, include the `data-coreui-dismiss="alert"` attribute, which triggers the JavaScript functionality. You must use the `<button>` element with it for proper behavior across all devices.
 - Every alert fades out when dismissed — the JavaScript marks it with `.hiding` for the length of the transition, then removes it. Add `.alert-instant` to an alert that should go at once, or retime the fade with `--cui-alert-transition-duration` and `--cui-alert-transition-timing`.

--- a/docs/src/content/docs/components/collapse.mdx
+++ b/docs/src/content/docs/components/collapse.mdx
@@ -194,7 +194,7 @@ myCollapsible.addEventListener('hidden.coreui.collapse', event => {
 })
 ```
 
-## Customization
+## Customizing
 
 ### CSS variables
 

--- a/docs/src/content/docs/components/menu.mdx
+++ b/docs/src/content/docs/components/menu.mdx
@@ -559,22 +559,6 @@ Menus include built-in keyboard support for navigating menu items.
 | `Home` / `End` | Jump to first/last menu item |
 | `Tab` | Move focus and close the menu |
 
-## CSS
-
-### Variables
-
-<ScssDocs file="scss/_menu.scss" capture="menu-css-vars" />
-
-### Sass variables
-
-<ScssDocs file="scss/_menu.scss" capture="menu-variables" />
-
-<Callout>
-Menu items include at least one variable that is not set on `.menu`. This allows you to provide a new value while CoreUI defaults to a fallback value.
-
-- `--cui-menu-item-border-radius`
-</Callout>
-
 ## Usage
 
 Via data attributes or JavaScript, the menu plugin toggles hidden content (menus) by toggling the `.show` class on the `.menu`. The `data-coreui-toggle="menu"` attribute is relied on for closing menus at an application level, so it’s a good idea to always use it.
@@ -681,3 +665,19 @@ myMenu.addEventListener('show.coreui.menu', event => {
   // do something...
 })
 ```
+
+## Customizing
+
+### CSS variables
+
+<ScssDocs file="scss/_menu.scss" capture="menu-css-vars" />
+
+### SASS variables
+
+<ScssDocs file="scss/_menu.scss" capture="menu-variables" />
+
+<Callout>
+Menu items include at least one variable that is not set on `.menu`. This allows you to provide a new value while CoreUI defaults to a fallback value.
+
+- `--cui-menu-item-border-radius`
+</Callout>

--- a/docs/src/content/docs/components/offcanvas.mdx
+++ b/docs/src/content/docs/components/offcanvas.mdx
@@ -325,7 +325,7 @@ myOffcanvas.addEventListener('hidden.coreui.offcanvas', event => {
 })
 ```
 
-## Customization
+## Customizing
 
 ### CSS variables
 

--- a/docs/src/content/docs/components/placeholders.mdx
+++ b/docs/src/content/docs/components/placeholders.mdx
@@ -97,7 +97,7 @@ Animate Bootstrap placeholders using `.placeholder-glow` or `.placeholder-wave` 
     <span class="placeholder col-12"></span>
   </p>`} />
 
-## Customization
+## Customizing
 
 ### CSS variables
 

--- a/docs/src/content/docs/customize/color-modes.mdx
+++ b/docs/src/content/docs/customize/color-modes.mdx
@@ -232,7 +232,7 @@ Here's a look at the JavaScript that powers it. Feel free to inspect our own doc
 
 A theme color is one entry in the `$theme-colors` map — a map of slots covering both color modes, described on [the Theme page](/customize/theme/). Merge your entry and the library generates everything else: the `--cui-custom-color-*` tokens, the 100–900 runtime scale the slots read, and the `.theme-custom-color` class.
 
-<Callout color="info"><Fragment set:html={`<p> <strong>Heads up!</strong> Since <code>@coreui/coreui</code> v5.3.0 and <code>@coreui/coreui-pro</code> v5.10.0, we support Sass modules. </p> <p> You can now use the modern <code>@use</code> and <code>@forward</code> rules instead of <code>@import</code>, which is deprecated and will be removed in Dart Sass 3.0.0. Using <code>@import</code> will result in a compilation warning. You can learn more about this transition <a href="https://sass-lang.com/documentation/breaking-changes/import/" target="_blank">here</a>. </p>`} /></Callout>
+<Callout color="info"><Fragment set:html={`<p> <strong>Heads up!</strong> Reach our Sass with <code>@use</code>. The <code>*.import.scss</code> files that let <code>@import</code> resolve our modules are gone, so the snippet below will not compile behind an <code>@import</code>. </p>`} /></Callout>
 
 ```scss
 @use "sass:map";
@@ -266,7 +266,7 @@ Global colors are declared once as `light-dark()` pairs, so the color mode selec
 
 Do the same in your own color modes: declare `color-scheme` and override only the tokens whose value is genuinely mode-specific.
 
-### Sass variables
+### SASS variables
 
 Each theme color gets a 100–900 scale of `color-mix()` tokens in `:root`, mixed at runtime from the color's own token. The subtle backgrounds, borders and emphasis text are `light-dark()` pairs of those stops, so overriding `$primary` (or the `--cui-primary` token at runtime) retints the whole family in both color modes:
 

--- a/docs/src/content/docs/customize/color.mdx
+++ b/docs/src/content/docs/customize/color.mdx
@@ -9,11 +9,13 @@ import { getData, getSequence } from '@coreui/astro-docs/data'
 
 <AddedIn version="5.0.0" />
 
-Bootstrap's color palette has continued to expand and become more nuanced in v5.0.0. We've added new variables for `secondary` and `tertiary` text and background colors, plus `{color}-bg-subtle`, `{color}-border-subtle`, and `{color}-text-emphasis` for our theme colors. These new colors are available through Sass and CSS variables (but not our color maps or utility classes) with the express goal of making it easier to customize across multiple colors modes like light and dark. These new variables are globally set on `:root` and are adapted for our new dark color mode while our original theme colors remain unchanged.
+The palette below covers two different jobs. `secondary` and `tertiary` text and background colors describe **surfaces** — the page, its dividers, its disabled states. The `{color}-bg-subtle`, `{color}-border-subtle`, and `{color}-text-emphasis` sets are **tinted variants of the theme colors**, so that a single theme color can carry a background, a border, and a readable text tone that all shift together between color modes.
 
-Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()` and `rgba()` color modes. For example, `rgba(var(--cui-secondary-bg-rgb), .5)`.
+All of them are declared globally on `:root` and are available through Sass and CSS variables (but not through our color maps or utility classes).
 
-**Heads up!** There's some potential confusion with our new secondary and tertiary colors, and our existing secondary theme color, as well as our light and dark theme colors. Expect this to be ironed out in v6.
+To fade any of these colors, mix it toward `transparent` rather than reaching for a channel triplet — `color-mix(in srgb, var(--cui-secondary-bg) 50%, transparent)`.
+
+**Heads up!** The surface colors and the theme colors overlap in name without overlapping in purpose: `--cui-secondary-color` is body text at a lighter weight, while `--cui-secondary` is the theme color that `.btn-secondary` and friends are built from. The same split applies to `light` and `dark`.
 
 <table class="table table-swatches">
   <thead>
@@ -32,7 +34,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2" style="background-color: var(--cui-body-color);">&nbsp;</div>
       </td>
       <td>
-        `--cui-body-color`<br />`--cui-body-color-rgb`
+        `--cui-body-color`
       </td>
     </tr>
     <tr>
@@ -40,7 +42,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2 border" style="background-color: var(--cui-body-bg);">&nbsp;</div>
       </td>
       <td>
-        `--cui-body-bg`<br />`--cui-body-bg-rgb`
+        `--cui-body-bg`
       </td>
     </tr>
     <tr>
@@ -51,7 +53,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2" style="background-color: var(--cui-secondary-color);">&nbsp;</div>
       </td>
       <td>
-        `--cui-secondary-color`<br />`--cui-secondary-color-rgb`
+        `--cui-secondary-color`
       </td>
     </tr>
     <tr>
@@ -59,7 +61,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2 border" style="background-color: var(--cui-secondary-bg);">&nbsp;</div>
       </td>
       <td>
-        `--cui-secondary-bg`<br />`--cui-secondary-bg-rgb`
+        `--cui-secondary-bg`
       </td>
     </tr>
     <tr>
@@ -70,7 +72,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2" style="background-color: var(--cui-tertiary-color);">&nbsp;</div>
       </td>
       <td>
-        `--cui-tertiary-color`<br />`--cui-tertiary-color-rgb`
+        `--cui-tertiary-color`
       </td>
     </tr>
     <tr>
@@ -78,7 +80,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2 border" style="background-color: var(--cui-tertiary-bg);">&nbsp;</div>
       </td>
       <td>
-        `--cui-tertiary-bg`<br />`--cui-tertiary-bg-rgb`
+        `--cui-tertiary-bg`
       </td>
     </tr>
     <tr>
@@ -89,7 +91,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2" style="background-color: var(--cui-emphasis-color);">&nbsp;</div>
       </td>
       <td>
-        `--cui-emphasis-color`<br />`--cui-emphasis-color-rgb`
+        `--cui-emphasis-color`
       </td>
     </tr>
     <tr>
@@ -100,7 +102,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2" style="background-color: var(--cui-border-color);">&nbsp;</div>
       </td>
       <td>
-        `--cui-border-color`<br />`--cui-border-color-rgb`
+        `--cui-border-color`
       </td>
     </tr>
     <tr>
@@ -111,7 +113,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2 bg-primary">&nbsp;</div>
       </td>
       <td>
-        `--cui-primary`<br />`--cui-primary-rgb`
+        `--cui-primary`
       </td>
     </tr>
     <tr>
@@ -146,7 +148,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2 bg-success">&nbsp;</div>
       </td>
       <td>
-        `--cui-success`<br />`--cui-success-rgb`
+        `--cui-success`
       </td>
     </tr>
     <tr>
@@ -181,7 +183,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2 bg-danger">&nbsp;</div>
       </td>
       <td>
-        `--cui-danger`<br />`--cui-danger-rgb`
+        `--cui-danger`
       </td>
     </tr>
     <tr>
@@ -216,7 +218,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2 bg-warning">&nbsp;</div>
       </td>
       <td>
-        `--cui-warning`<br />`--cui-warning-rgb`
+        `--cui-warning`
       </td>
     </tr>
     <tr>
@@ -251,7 +253,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2 bg-info">&nbsp;</div>
       </td>
       <td>
-        `--cui-info`<br />`--cui-info-rgb`
+        `--cui-info`
       </td>
     </tr>
     <tr>
@@ -286,7 +288,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2 bg-light">&nbsp;</div>
       </td>
       <td>
-        `--cui-light`<br />`--cui-light-rgb`
+        `--cui-light`
       </td>
     </tr>
     <tr>
@@ -321,7 +323,7 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
         <div class="p-3 rounded-2 bg-dark">&nbsp;</div>
       </td>
       <td>
-        `--cui-dark`<br />`--cui-dark-rgb`
+        `--cui-dark`
       </td>
     </tr>
     <tr>
@@ -351,9 +353,9 @@ Colors ending in `-rgb` provide the `red, green, blue` values for use in `rgb()`
   </tbody>
 </table>
 
-### Using the new colors
+### Using the colors
 
-These new colors are accessible via CSS variables and utility classes—like `--cui-primary-bg-subtle` and `.bg-primary-subtle`—allowing you to compose your own CSS rules with the variables, or to quickly apply styles via classes. The utilities are built with the color's associated CSS variables, and since we customize those CSS variables for dark mode, they are also adaptive to color mode by default.
+These colors are accessible via CSS variables and utility classes—like `--cui-primary-bg-subtle` and `.bg-primary-subtle`—allowing you to compose your own CSS rules with the variables, or to quickly apply styles via classes. The utilities are built with the color's associated CSS variables, and since we customize those CSS variables for dark mode, they are also adaptive to color mode by default.
 
 <Example code={`<div class="p-3 text-primary-emphasis bg-primary-subtle border border-primary-subtle rounded-3">
     Example element with utilities

--- a/docs/src/content/docs/customize/optimize.mdx
+++ b/docs/src/content/docs/customize/optimize.mdx
@@ -5,11 +5,11 @@ description: "Keep your projects lean, responsive, and maintainable so you can d
 
 ## Lean Sass imports
 
-When using Sass in your asset pipeline, make sure you optimize CoreUI for Bootstrap by only `@import`ing the components you need. Your largest optimizations will likely come from the `Layout & Components` section of our `coreui.scss`.
+When using Sass in your asset pipeline, make sure you optimize CoreUI for Bootstrap by only forwarding the components you need. Your largest optimizations will likely come from the `Layout & Components` section of our `coreui.scss`.
 
 <ScssDocs file="scss/coreui.scss" capture="import-stack" />
 
-If you're not using a component, comment it out or delete it entirely. For example, if you're not using the carousel, remove that import to save some file size in your compiled CSS. Keep in mind there are some dependencies across Sass imports that may make it more difficult to omit a file.
+If you're not using a component, comment it out or delete it entirely. For example, if you're not using the carousel, remove that `@forward` to save some file size in your compiled CSS. Keep in mind there are some dependencies between our Sass modules that may make it more difficult to omit a file.
 
 ## Lean JavaScript
 

--- a/docs/src/content/docs/forms/number-input.mdx
+++ b/docs/src/content/docs/forms/number-input.mdx
@@ -121,7 +121,7 @@ already listening to the field keeps working.
   it.
 </Callout>
 
-## Customization options
+## Customizing
 
 ### CSS variables
 
@@ -130,7 +130,7 @@ The frame, the buttons and their sizing are the group's, and read the shared
 
 <ScssDocs file="scss/forms/_form-control-group.scss" capture="form-control-group-tokens" />
 
-### Sass variables
+### SASS variables
 
 <ScssDocs file="scss/forms/_form-control-group.scss" capture="form-control-group-variables" />
 

--- a/docs/src/content/docs/forms/password-input.mdx
+++ b/docs/src/content/docs/forms/password-input.mdx
@@ -53,7 +53,7 @@ button is pressed.
 <input type="password" class="form-control" placeholder="Enter your password" data-coreui-toggle="password-input">
 ```
 
-## Customization options
+## Customizing
 
 A password field is an `<input>` and a toggle button inside a
 [`form-control-group`](/forms/form-control-group/). Almost everything you would
@@ -93,7 +93,7 @@ field, or globally to restyle every field component at once:
 
 <ScssDocs file="scss/forms/_form-control-group.scss" capture="form-control-group-tokens" />
 
-### Sass variables
+### SASS variables
 
 The frame every form control draws is configured once, with `$input-btn-*`:
 

--- a/docs/src/content/docs/forms/stepper.mdx
+++ b/docs/src/content/docs/forms/stepper.mdx
@@ -643,15 +643,15 @@ A [theme class](/customize/components/#theme-variants) colors the active and com
     </ol>
   </div>`} />
 
-## Customization
+## Customizing
 
-### CSS Variables
+### CSS variables
 
 The Stepper component uses CSS variables to allow easy customization of colors, borders, spacing, and indicators.
 
 <ScssDocs file="scss/_stepper.scss" capture="stepper-css-vars" />
 
-### Sass Variables
+### SASS variables
 
 Advanced theming is possible via Sass variables.
 

--- a/docs/src/content/docs/helpers/focus-ring.mdx
+++ b/docs/src/content/docs/helpers/focus-ring.mdx
@@ -16,7 +16,7 @@ Click directly on the link below to see the focus ring in action, or into the ex
     Custom focus ring
   </a>`} />
 
-## Customize
+## Customizing
 
 Modify the styling of a focus ring with our CSS variables, Sass variables, utilities, or custom styles.
 
@@ -41,7 +41,7 @@ Push it away from the element with `--cui-focus-ring-offset`, which defaults to
     Offset focus ring
   </a>`} />
 
-### Sass variables
+### SASS variables
 
 Customize the focus ring Sass variables to modify all usage of the focus ring styles across your Bootstrap-powered project.
 

--- a/docs/src/content/docs/helpers/icon-link.mdx
+++ b/docs/src/content/docs/helpers/icon-link.mdx
@@ -38,7 +38,7 @@ Add `.icon-link-hover` to move the icon to the right on hover.
     </svg>
   </a>`} />
 
-## Customize
+## Customizing
 
 Modify the styling of an icon link with our link CSS variables, Sass variables, utilities, or custom styles.
 
@@ -67,7 +67,7 @@ Customize the color by overriding the `--cui-link-*` CSS variable:
     </svg>
   </a>`} />
 
-### Sass variables
+### SASS variables
 
 Customize the icon link Sass variables to modify all icon link styles across your CoreUI-powered project.
 
@@ -75,7 +75,7 @@ Customize the icon link Sass variables to modify all icon link styles across you
 
 ### Sass utilities API
 
-Modify icon links with any of [our link utilities](/utilities/link//) for modifying underline color and offset.
+Modify icon links with any of [our link utilities](/utilities/link/) for modifying underline color and offset.
 
 <Example code={`<a class="icon-link icon-link-hover link-success link-underline-success link-underline-opacity-25" href="#">
     Icon link

--- a/docs/src/content/docs/migration/v5.mdx
+++ b/docs/src/content/docs/migration/v5.mdx
@@ -109,7 +109,7 @@ Learn more by reading the new [color modes documentation](/customize/color-modes
 
 #### Navs
 
-- Added new `.nav-underline` variant for our navigation with a simpler bottom border under the active nav link. [See the docs for an example.](/components/navs-tabs/#underline)
+- Added new `.nav-underline` variant for our navigation with a simpler bottom border under the active nav link. [See the docs for an example.](/components/nav/#underline)
 
 - Navs now have new `:focus-visible` styles that better match our custom button focus styles.
 

--- a/docs/src/content/docs/utilities/background.mdx
+++ b/docs/src/content/docs/utilities/background.mdx
@@ -40,7 +40,7 @@ Do you need a gradient in your custom CSS? Just add `background-image: var(gradi
 
 <AddedIn version="4.1.0" />
 
-As of v4.1.0, `background-color` utilities are generated with Sass using CSS variables. This allows for real-time color changes without compilation and dynamic alpha transparency changes.
+Every `.bg-*` utility resolves its color in the browser, so both the color and its alpha transparency can change without recompiling Sass.
 
 ### How it works
 
@@ -48,12 +48,15 @@ Consider our default `.bg-success` utility.
 
 ```css
 .bg-success {
+  --cui-bg: var(--cui-success);
   --cui-bg-opacity: 1;
-  background-color: rgba(var(--cui-success-rgb), var(--cui-bg-opacity));
+  background-color: color-mix(in srgb, var(--cui-bg) calc(var(--cui-bg-opacity) * 100%), transparent);
 }
 ```
 
-We use an RGB version of our `--cui-success` (with the value of `25, 135, 84`) CSS variable and attached a second CSS variable, `--cui-bg-opacity`, for the alpha transparency (with a default value `1` thanks to a local CSS variable). That means anytime you use `.bg-success` now, your computed `color` value is `rgba(25, 135, 84, 1)`. The local CSS variable inside each `.bg-*` class avoids inheritance issues so nested instances of the utilities don't automatically have a modified alpha transparency.
+The utility points `--cui-bg` at the theme color and sets `--cui-bg-opacity` to `1`. `color-mix()` then fades that color toward `transparent` by whatever share the opacity leaves, so `.bg-success` computes to the solid color by default.
+
+Both halves are separate knobs: override `--cui-bg` to repaint the utility with another color, or `--cui-bg-opacity` to change only the alpha. Both are declared on the class itself, so a nested instance of the utility starts from the default again instead of inheriting a modified transparency.
 
 ### Example
 

--- a/docs/src/content/docs/utilities/borders.mdx
+++ b/docs/src/content/docs/utilities/borders.mdx
@@ -66,7 +66,7 @@ Or modify the default `border-color` of a component:
 
 <AddedIn version="4.2.6" />
 
-Bootstrap `border-{color}` utilities are generated with Sass using CSS variables. This allows for real-time color changes without compilation and dynamic alpha transparency changes.
+Every `.border-{color}` utility resolves its color in the browser, so both the color and its alpha transparency can change without recompiling Sass.
 
 ### How it works
 
@@ -74,12 +74,15 @@ Consider our default `.border-success` utility.
 
 ```css
 .border-success {
+  --cui-border: var(--cui-success);
   --cui-border-opacity: 1;
-  border-color: rgba(var(--cui-success-rgb), var(--cui-border-opacity));
+  border-color: color-mix(in srgb, var(--cui-border) calc(var(--cui-border-opacity) * 100%), transparent);
 }
 ```
 
-We use an RGB version of our `--cui-success` (with the value of `25, 135, 84`) CSS variable and attached a second CSS variable, `--cui-border-opacity`, for the alpha transparency (with a default value `1` thanks to a local CSS variable). That means anytime you use `.border-success` now, your computed `color` value is `rgba(25, 135, 84, 1)`. The local CSS variable inside each `.border-*` class avoids inheritance issues so nested instances of the utilities don't automatically have a modified alpha transparency.
+The utility points `--cui-border` at the theme color and sets `--cui-border-opacity` to `1`. `color-mix()` then fades that color toward `transparent` by whatever share the opacity leaves, so `.border-success` computes to the solid color by default.
+
+Both halves are separate knobs: override `--cui-border` to repaint the utility with another color, or `--cui-border-opacity` to change only the alpha. Both are declared on the class itself, so a nested instance of the utility starts from the default again instead of inheriting a modified transparency.
 
 ### Example
 
@@ -204,7 +207,7 @@ can be dropped anywhere it stops making sense.
 
 <ScssDocs file="scss/_root.scss" capture="root-border-var" />
 
-### Sass variables
+### SASS variables
 
 <ScssDocs file="scss/_config.scss" capture="border-variables" />
 <ScssDocs file="scss/_root.scss" capture="border-variables" />

--- a/docs/src/content/docs/utilities/colors.mdx
+++ b/docs/src/content/docs/utilities/colors.mdx
@@ -39,7 +39,7 @@ Relying on color to convey meaning creates a visual cue that assistive technolog
 
 <AddedIn version="4.1.0" />
 
-As of v4.1.0, text color utilities are generated with Sass using CSS variables. This allows for real-time color changes without compilation and dynamic alpha transparency changes.
+Every `.text-*` utility resolves its color in the browser, so both the color and its alpha transparency can change without recompiling Sass.
 
 ### How it works
 
@@ -47,12 +47,15 @@ Consider our default `.text-primary` utility.
 
 ```css
 .text-primary {
+  --cui-text: var(--cui-primary);
   --cui-text-opacity: 1;
-  color: rgba(var(--cui-primary-rgb), var(--cui-text-opacity));
+  color: color-mix(in srgb, var(--cui-text) calc(var(--cui-text-opacity) * 100%), transparent);
 }
 ```
 
-We use an RGB version of our `--cui-primary` (with the value of `13, 110, 253`) CSS variable and attached a second CSS variable, `--cui-text-opacity`, for the alpha transparency (with a default value `1` thanks to a local CSS variable). That means anytime you use `.text-primary` now, your computed `color` value is `rgba(13, 110, 253, 1)`. The local CSS variable inside each `.text-*` class avoids inheritance issues so nested instances of the utilities don't automatically have a modified alpha transparency.
+The utility points `--cui-text` at the theme color and sets `--cui-text-opacity` to `1`. `color-mix()` then fades that color toward `transparent` by whatever share the opacity leaves, so `.text-primary` computes to the solid color by default.
+
+Both halves are separate knobs: override `--cui-text` to repaint the utility with another color, or `--cui-text-opacity` to change only the alpha. Both are declared on the class itself, so a nested instance of the utility starts from the default again instead of inheriting a modified transparency.
 
 ### Example
 

--- a/docs/src/content/docs/utilities/object-fit.mdx
+++ b/docs/src/content/docs/utilities/object-fit.mdx
@@ -48,7 +48,7 @@ The `.object-fit-{value}` and responsive `.object-fit-{breakpoint}-{value}` util
 <video src="..." class="object-fit-none" autoplay></video>
 ```
 
-## CSS
+## Customizing
 
 ### Sass utilities API
 

--- a/docs/src/content/docs/utilities/z-index.mdx
+++ b/docs/src/content/docs/utilities/z-index.mdx
@@ -30,7 +30,7 @@ Each of those layers has a matching utility, so your own element can join a laye
 
 Read about the values themselves in the [`z-index` layout page](/layout/z-index/).
 
-## CSS
+## Customizing
 
 ### Sass maps
 


### PR DESCRIPTION
Four defects that share one cause: pages describing v5 behavior while sitting in the v6 docs.

## Opacity utilities documented a dead mechanism

`utilities/{colors,background,borders}` taught `rgba(var(--cui-<color>-rgb), var(--cui-<x>-opacity))` as the way to fade a utility. The v6 build emits **zero** `-rgb` tokens (v5 emits 242) — `translucent-css-var()` replaced them with `color-mix()`. That `var()` is unresolvable, so the declaration is invalid at computed-value time and the property silently falls back to its initial value.

The three pages now show what the utilities really declare:

```css
.text-primary {
  --cui-text: var(--cui-primary);
  --cui-text-opacity: 1;
  color: color-mix(in srgb, var(--cui-text) calc(var(--cui-text-opacity) * 100%), transparent);
}
```

This also documents something that had no coverage at all: `--cui-text` / `--cui-bg` / `--cui-border` are separate knobs, so a utility can be repainted with another color, not only faded.

## The color page was a v5 page

It listed a `-rgb` twin for 15 tokens, opened with "Bootstrap's color palette has continued to expand … in v5.0.0", and told the reader to "expect this to be ironed out in v6" — inside the v6 docs. Replaced with what the palette is for (surface colors vs tinted theme variants) and a factual note on the `secondary` naming overlap, which still exists and is not going away.

## Sass prose still offered `@import`

`customize/optimize` told the reader to `@import` only the components they need, directly above a block of `@forward` rules; `customize/color-modes` framed `@use` as a newer option. Neither is true — the `*.import.scss` files are gone, so `@import` of anything in `scss/` does not resolve.

## Customizing sections had five different names

Eleven pages carried the section as `## CSS`, `## Customization`, `## Customization options` or `## Customize`, and Menu's sat mid-page before `## Usage`. A reader scanning for where to override tokens found a different heading on roughly every fourth page. All now read `## Customizing` → `### CSS variables` → `### SASS variables`, with Menu's moved to the end of the page.

Also: two links were dead on a doubled slash, and one pointed at the `navs-tabs` slug that v6 split into `nav` and `tab`.

## Verification

`npm run docs-build` + `docs-vnu` green; the broken-link checker reports clean across 154 pages. No SCSS touched — every `<ScssDocs>` block cited here already existed.