### PR TITLE
docs(helpers): describe the focus ring and hover lift we actually ship

### DIFF
--- a/docs/src/content/docs/helpers/focus-ring.mdx
+++ b/docs/src/content/docs/helpers/focus-ring.mdx
@@ -6,15 +6,23 @@ description: "Utility classes that allows you to add and modify custom focus rin
 
 import { getData } from '@coreui/astro-docs/data'
 
-The `.focus-ring` helper removes the default `outline` on `:focus`, replacing it with a `box-shadow` that can be more broadly customized. The new shadow is made up of a series of CSS variables, inherited from the `:root` level, that can be modified for any element or component.
+The `.focus-ring` helper replaces the browser's default focus indicator with one of our own on `:focus-visible`. It is an `outline`, sized and coloured from a series of CSS variables inherited from the `:root` level, so it can be modified for any element or component.
 
 ## Example
 
-Click directly on the link below to see the focus ring in action, or into the example below and then press <kbd>Tab</kbd>.
+Tab to the link below to see the focus ring. Clicking it will not show one — the helper styles `:focus-visible`, which the browser reserves for keyboard focus.
 
 <Example code={`<a href="#" class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2">
     Custom focus ring
   </a>`} />
+
+## Variants
+
+Pair `.focus-ring` with a [theme color](/customize/theme/) class to recolour the ring. The helper reads `--cui-theme-focus-ring`, which every `.theme-*` class sets, so the ring follows the element's theme rather than needing its own class.
+
+<Example class="vstack gap-2 align-items-start" code={getData('theme-colors').map((c) => `<a href="#" class="d-inline-flex focus-ring theme-${c.name} py-1 px-2 text-decoration-none border rounded-2">${c.title} focus</a>`)} />
+
+Use this when the element already carries a theme; reach for the `.focus-ring-*` utilities below when you only want to change the ring.
 
 ## Customizing
 

--- a/docs/src/content/docs/helpers/hover-lift.mdx
+++ b/docs/src/content/docs/helpers/hover-lift.mdx
@@ -1,24 +1,47 @@
 ---
-title: "Bootstrap 5 Hover Lift"
+title: "Bootstrap 6 Hover Lift"
 name: "Hover lift"
 description: "Lift an element and add a shadow on hover or focus for a subtle sense of depth."
 ---
 
-Add `.hover-lift` to any element to translate it upward and add a `box-shadow` on `:hover` and `:focus-visible`. Respects `prefers-reduced-motion`.
+## How it works
 
-<Example code={`<div class="card hover-lift" style="width: 18rem;">
+Add `.hover-lift` to any element to translate it upward and deepen its `box-shadow` on `:hover` and `:focus-visible`. It is a lightweight way to signal that a card, tile or other surface is interactive.
+
+The effect sets only `transform` and `box-shadow`, so it composes with anything — cards, buttons, list items, plain containers — and it honours [`prefers-reduced-motion`](/getting-started/accessibility/#reduced-motion): a reader who asks for reduced motion still gets the raised shadow and offset, without the animation.
+
+## Example
+
+Hover the card below, or tab to it. It is an `<a>` rather than a `<div>` so the `:focus-visible` half of the helper is reachable from the keyboard.
+
+<Example code={`<a href="#" class="card hover-lift text-decoration-none" style="width: 18rem;">
     <div class="card-body">
-      <h5 class="card-title">Card with hover lift</h5>
-      <p class="card-text">Hover or focus this card to see it lift with a shadow.</p>
+      <h5 class="card-title">Hover me</h5>
+      <p class="card-text mb-0">Hover or focus this card to see it lift with a shadow.</p>
     </div>
-  </div>`} />
+  </a>`} />
 
-## CSS variables
+Because it only touches those two properties, it works just as well on a control:
+
+<Example class="d-flex gap-3" code={`<button type="button" class="btn btn-primary hover-lift">Lift on hover</button>`} />
+
+## Customizing
+
+### CSS variables
 
 CoreUI for Bootstrap's hover lift uses local CSS variables on `.hover-lift` for enhanced real-time customization.
 
 <ScssDocs file="scss/helpers/_hover-lift.scss" capture="hover-lift-css-vars" />
 
-## Sass variables
+Override them to tune the distance, the shadow or the timing — a larger rise with a snappier transition:
+
+<Example code={`<a href="#" class="card hover-lift text-decoration-none" style="--cui-hover-lift-transform: translateY(-.5rem); --cui-hover-lift-transition-duration: .1s; width: 18rem;">
+    <div class="card-body">
+      <h5 class="card-title">Bigger lift</h5>
+      <p class="card-text mb-0">Customized transform and duration.</p>
+    </div>
+  </a>`} />
+
+### SASS variables
 
 <ScssDocs file="scss/helpers/_hover-lift.scss" capture="hover-lift-variables" />


### PR DESCRIPTION
Read our helper pages next to upstream's. Seven of the nine shared pages differ only in our `## Customizing` heading against their `## CSS`, which is our convention. Two had drifted from the code.

## Focus ring

The page opened with:

> The `.focus-ring` helper **removes the default `outline`** on `:focus`, replacing it with a **`box-shadow`**

What v6 compiles is:

```css
.focus-ring:focus-visible {
  outline: var(--cui-focus-ring-width) solid var(--cui-theme-focus-ring, var(--cui-focus-ring-color));
  outline-offset: var(--cui-focus-ring-offset);
}
```

An `outline`, on `:focus-visible`. The same page already said so further down — "The ring is an `outline`, so it is never clipped by an ancestor's `overflow`" — so it contradicted itself, and the intro was the half people read first.

The example then said **"Click directly on the link below to see the focus ring in action"**, which is precisely what does not show one: `:focus-visible` is the browser's keyboard-focus signal.

**Missing variant.** The rule resolves `var(--cui-theme-focus-ring, …)`, and every `.theme-*` class sets that token — `.focus-ring.theme-primary` recolours the ring with no extra class. That is a different knob from the `.focus-ring-*` utilities already documented: the theme follows the element, the utility only touches the ring. New `## Variants` section says which to reach for.

## Hover lift

Variables and no explanation. Its two headings sat at H2 instead of under `## Customizing`, against our own convention.

And the example was a `<div>`. The helper styles `:hover` **and** `:focus-visible`, and a div takes no keyboard focus — so half of what the page documents could not be reached from the example. It is an `<a>` now, and the page says why.

Also gained what upstream has and we lacked: how it composes, the `prefers-reduced-motion` behaviour, and the tokens shown being overridden rather than only listed. All four `--cui-hover-lift-*` names were checked against the compiled CSS.

## Verification

`docs-build` green, 173 pages, link checker clean. Checked in the rendered output: the Variants section renders 18 theme examples and the hover-lift example is an `<a>`.

Companion React port: coreui-react-pro#134.