### PR TITLE
docs(utilities): declare each page's utility family for the class reference

### DIFF
--- a/docs/src/content/docs/utilities/align-content.mdx
+++ b/docs/src/content/docs/utilities/align-content.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Align Content"
 name: "Align content"
 description: "Distribute the space between and around rows of a wrapped flex container."
+utility: "align-content"
 ---
 
 ## Align content

--- a/docs/src/content/docs/utilities/align-items.mdx
+++ b/docs/src/content/docs/utilities/align-items.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Align Items"
 name: "Align items"
 description: "Align items along the cross axis, in both flexbox and grid containers."
+utility: "align-items"
 ---
 
 ## Align items

--- a/docs/src/content/docs/utilities/align-self.mdx
+++ b/docs/src/content/docs/utilities/align-self.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Align Self"
 name: "Align self"
 description: "Override the container’s cross-axis alignment for a single item."
+utility: "align-self"
 ---
 
 ## Align self

--- a/docs/src/content/docs/utilities/aspect-ratio.mdx
+++ b/docs/src/content/docs/utilities/aspect-ratio.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Aspect Ratio"
 name: "Aspect ratio"
 description: "Make an element hold an aspect ratio of your choosing. Perfect for responsively handling video or slideshow embeds based on the width of the parent."
+utility: "ratio"
 ---
 
 ## Example

--- a/docs/src/content/docs/utilities/background.mdx
+++ b/docs/src/content/docs/utilities/background.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Background"
 name: "Background"
 description: "Convey meaning through `background-color` and add decoration with gradients."
+utility: ["bg", "bg-opacity", "bg-gradient"]
 ---
 
 import { getData } from '@coreui/astro-docs/data'

--- a/docs/src/content/docs/utilities/border-color.mdx
+++ b/docs/src/content/docs/utilities/border-color.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 6 Border Color"
 name: "Border color"
 description: "Change the border color of an element with utilities built on our theme colors, and fade it with the opacity utilities."
-utility: "border"
+utility: [{prefix: "border", property: "border-color"}, "border-opacity"]
 ---
 
 import { getData } from '@coreui/astro-docs/data'

--- a/docs/src/content/docs/utilities/border-color.mdx
+++ b/docs/src/content/docs/utilities/border-color.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Border Color"
 name: "Border color"
 description: "Change the border color of an element with utilities built on our theme colors, and fade it with the opacity utilities."
+utility: "border"
 ---
 
 import { getData } from '@coreui/astro-docs/data'

--- a/docs/src/content/docs/utilities/border-radius.mdx
+++ b/docs/src/content/docs/utilities/border-radius.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Border Radius"
 name: "Border radius"
 description: "Round the corners of an element with our border-radius utilities, from a subtle radius to a full pill."
+utility: "rounded"
 ---
 
 ## Examples

--- a/docs/src/content/docs/utilities/border.mdx
+++ b/docs/src/content/docs/utilities/border.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Border"
 name: "Border"
 description: "Use border utilities to add or remove an element's borders, and to set how thick they are."
+utility: "border"
 ---
 
 ## Additive

--- a/docs/src/content/docs/utilities/border.mdx
+++ b/docs/src/content/docs/utilities/border.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 6 Border"
 name: "Border"
 description: "Use border utilities to add or remove an element's borders, and to set how thick they are."
-utility: "border"
+utility: [{prefix: "border", property: "border"}, {prefix: "border", property: "border-width"}, {prefix: "border", property: "border-top-width"}, {prefix: "border", property: "border-inline-end-width"}, {prefix: "border", property: "border-bottom-width"}, {prefix: "border", property: "border-inline-start-width"}]
 ---
 
 ## Additive

--- a/docs/src/content/docs/utilities/colors.mdx
+++ b/docs/src/content/docs/utilities/colors.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Colors"
 name: "Colors"
 description: "Convey meaning through `color` with a handful of color utility classes. Includes support for styling links with hover states, too."
+utility: ["text", "text-opacity"]
 ---
 
 import { getData } from '@coreui/astro-docs/data'

--- a/docs/src/content/docs/utilities/colors.mdx
+++ b/docs/src/content/docs/utilities/colors.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 5 Colors"
 name: "Colors"
 description: "Convey meaning through `color` with a handful of color utility classes. Includes support for styling links with hover states, too."
-utility: ["text", "text-opacity"]
+utility: [{prefix: "text", property: "color"}, "text-opacity"]
 ---
 
 import { getData } from '@coreui/astro-docs/data'

--- a/docs/src/content/docs/utilities/container-queries.mdx
+++ b/docs/src/content/docs/utilities/container-queries.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Container Queries"
 name: "Container queries"
 description: "Turn an element into a query container so its descendants can respond to its size instead of the viewport."
+utility: "contains"
 ---
 
 Use the `.contains-*` utilities to set the `container-type` property, establishing an element as a [query container](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries). Once an element is a query container, its descendants can adapt their styles to the container's size rather than to the viewport.

--- a/docs/src/content/docs/utilities/display.mdx
+++ b/docs/src/content/docs/utilities/display.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Display Property"
 name: "Display property"
 description: "Quickly and responsively toggle the display value of components and more with our display utilities. Includes support for some of the more common values, as well as some extras for controlling display when printing."
+utility: "d"
 ---
 
 ## How it works

--- a/docs/src/content/docs/utilities/divide.mdx
+++ b/docs/src/content/docs/utilities/divide.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Divide"
 name: "Divide"
 description: "Draw a border between children without one on the outer edges, for lists of rows and rows of actions."
+utility: "divide"
 ---
 
 ## Overview

--- a/docs/src/content/docs/utilities/flex.mdx
+++ b/docs/src/content/docs/utilities/flex.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Flex"
 name: "Flex"
 description: "Quickly manage the layout, alignment, and sizing of grid columns, navigation, components, and more with a full suite of responsive flexbox utilities. For more complex implementations, custom CSS may be necessary."
+utility: ["flex", "order"]
 ---
 
 ## Enable flex behaviors

--- a/docs/src/content/docs/utilities/float.mdx
+++ b/docs/src/content/docs/utilities/float.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Float"
 name: "Float"
 description: "Toggle floats on any element, across any breakpoint, using our responsive float utilities."
+utility: "float"
 ---
 
 ## Overview

--- a/docs/src/content/docs/utilities/font-family.mdx
+++ b/docs/src/content/docs/utilities/font-family.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Font Family"
 name: "Font family"
 description: "Switch a selection to our monospace font stack."
+utility: "font"
 ---
 
 ## Monospace

--- a/docs/src/content/docs/utilities/font-size.mdx
+++ b/docs/src/content/docs/utilities/font-size.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 6 Font Size"
 name: "Font size"
 description: "Change the font size of text with numbered stops, named stops, or the paired size-and-leading utilities."
-utility: ["fs", "text"]
+utility: ["fs", {prefix: "text", property: "font-size"}]
 ---
 
 ## Font size

--- a/docs/src/content/docs/utilities/font-size.mdx
+++ b/docs/src/content/docs/utilities/font-size.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Font Size"
 name: "Font size"
 description: "Change the font size of text with numbered stops, named stops, or the paired size-and-leading utilities."
+utility: ["fs", "text"]
 ---
 
 ## Font size

--- a/docs/src/content/docs/utilities/font-style.mdx
+++ b/docs/src/content/docs/utilities/font-style.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Font Style"
 name: "Font style"
 description: "Italicize text, or take the italics off something that arrives with them."
+utility: "fst"
 ---
 
 ## Font style

--- a/docs/src/content/docs/utilities/font-weight.mdx
+++ b/docs/src/content/docs/utilities/font-weight.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Font Weight"
 name: "Font weight"
 description: "Change the weight of text, and add a step to the scale without rewriting the map."
+utility: "fw"
 ---
 
 ## Font weight

--- a/docs/src/content/docs/utilities/gap.mdx
+++ b/docs/src/content/docs/utilities/gap.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Gap"
 name: "Gap"
 description: "Space children of a flex or grid container from the container itself with our gap utilities."
+utility: ["gap", "row-gap", "column-gap"]
 ---
 
 ## Overview

--- a/docs/src/content/docs/utilities/grid.mdx
+++ b/docs/src/content/docs/utilities/grid.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Grid utilities"
 name: "Grid"
 description: "Lay out and align CSS Grid containers and their items with responsive utilities for track counts, auto flow, and inline-axis alignment."
+utility: ["grid-cols", "col-span", "grid-flow"]
 ---
 
 These utilities work on any CSS Grid container — our [`.grid`](/layout/css-grid/), a `.d-grid`, or an element you gave `display: grid` yourself. They do nothing in flexbox: flex has no `justify-items`, and it ignores `justify-self`.

--- a/docs/src/content/docs/utilities/height.mdx
+++ b/docs/src/content/docs/utilities/height.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Height"
 name: "Height"
 description: "Set an element's height relative to its parent or to the viewport with our height utilities."
+utility: ["h", "mh", "vh", "min-vh", "dvh", "min-dvh"]
 ---
 
 ## Relative to the parent

--- a/docs/src/content/docs/utilities/justify-content.mdx
+++ b/docs/src/content/docs/utilities/justify-content.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Justify Content"
 name: "Justify content"
 description: "Align flex items along the main axis of a flex container."
+utility: "justify-content"
 ---
 
 ## Justify content

--- a/docs/src/content/docs/utilities/justify-items.mdx
+++ b/docs/src/content/docs/utilities/justify-items.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Justify Items"
 name: "Justify items"
 description: "Set the inline-axis alignment for every item in a grid container, or override it for one."
+utility: ["justify-items", "justify-self"]
 ---
 
 ## Justify items

--- a/docs/src/content/docs/utilities/line-height.mdx
+++ b/docs/src/content/docs/utilities/line-height.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Line Height"
 name: "Line height"
 description: "Change the line height of text with our line-height utilities."
+utility: "lh"
 ---
 
 ## Line height

--- a/docs/src/content/docs/utilities/link.mdx
+++ b/docs/src/content/docs/utilities/link.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Link"
 name: "Link"
 description: "Link utilities are used to stylize your anchors to adjust their color, opacity, underline offset, underline color, and more."
+utility: ["link-opacity", "link-offset", "link-underline"]
 ---
 
 import { getData } from '@coreui/astro-docs/data'

--- a/docs/src/content/docs/utilities/margin.mdx
+++ b/docs/src/content/docs/utilities/margin.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Margin"
 name: "Margin"
 description: "Assign responsive-friendly margin values to an element or a subset of its sides with shorthand classes."
+utility: "m"
 ---
 
 ## Overview

--- a/docs/src/content/docs/utilities/motion.mdx
+++ b/docs/src/content/docs/utilities/motion.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Motion"
 name: "Motion"
 description: "Remove the transition from a single element with motion utilities."
+utility: "transition"
 ---
 
 Components animate with CSS transitions, and the timing is customizable — see [transitions](/customize/transitions/). Add `.transition-none` to set `transition: none` on one element, so its property changes apply instantly instead of animating.

--- a/docs/src/content/docs/utilities/object-fit.mdx
+++ b/docs/src/content/docs/utilities/object-fit.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Object Fit"
 name: "Object fit"
 description: "Use the object fit utilities to modify how the content of a [replaced element](https://developer.mozilla.org/en-US/docs/Web/CSS/Replaced_element), such as an `<img>` or `<video>`, should be resized to fit its container."
+utility: "object-fit"
 ---
 
 ## How it works

--- a/docs/src/content/docs/utilities/opacity.mdx
+++ b/docs/src/content/docs/utilities/opacity.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Opacity"
 name: "Opacity"
 description: "Control the opacity of elements."
+utility: "opacity"
 ---
 
 The `opacity` property sets the opacity level for an element. The opacity level describes the transparency level, where `1` is not transparent at all, `.5` is 50% visible, and `0` is completely transparent.

--- a/docs/src/content/docs/utilities/overflow.mdx
+++ b/docs/src/content/docs/utilities/overflow.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Overflow"
 name: "Overflow"
 description: "Use these shorthand utilities for quickly configuring how content overflows an element."
+utility: "overflow"
 ---
 
 Adjust the `overflow` property on the fly with four default values and classes. These classes are not responsive by default.

--- a/docs/src/content/docs/utilities/padding.mdx
+++ b/docs/src/content/docs/utilities/padding.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Padding"
 name: "Padding"
 description: "Assign responsive-friendly padding values to an element or a subset of its sides with shorthand classes."
+utility: ["p", "pt", "pb", "ps", "pe", "px", "py"]
 ---
 
 ## Overview

--- a/docs/src/content/docs/utilities/place-items.mdx
+++ b/docs/src/content/docs/utilities/place-items.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Place Items"
 name: "Place items"
 description: "Set both grid axes at once — the shorthand for align-items and justify-items."
+utility: "place-items"
 ---
 
 ## Place items

--- a/docs/src/content/docs/utilities/pointer-events.mdx
+++ b/docs/src/content/docs/utilities/pointer-events.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Pointer Events"
 name: "Pointer events"
 description: "Prevent or add element interactions with our pointer events utilities."
+utility: "pe"
 ---
 
 ## Pointer events

--- a/docs/src/content/docs/utilities/position.mdx
+++ b/docs/src/content/docs/utilities/position.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Position"
 name: "Position"
 description: "Use these shorthand utilities for quickly configuring the position of an element."
+utility: ["position", "top", "bottom", "start", "end", "translate-middle"]
 ---
 
 ## Position values

--- a/docs/src/content/docs/utilities/shadows.mdx
+++ b/docs/src/content/docs/utilities/shadows.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Shadows"
 name: "Shadows"
 description: "Add or remove shadows to elements with box-shadow utilities."
+utility: "shadow"
 ---
 
 ## Examples

--- a/docs/src/content/docs/utilities/space.mdx
+++ b/docs/src/content/docs/utilities/space.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Space Between"
 name: "Space between"
 description: "Space siblings in a plain flow layout, where gap has no container to work from."
+utility: ["space-x", "space-y"]
 ---
 
 ## Overview

--- a/docs/src/content/docs/utilities/text-alignment.mdx
+++ b/docs/src/content/docs/utilities/text-alignment.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Text Alignment"
 name: "Text alignment"
 description: "Realign text with our responsive text alignment utilities."
+utility: "text"
 ---
 
 ## Text alignment

--- a/docs/src/content/docs/utilities/text-alignment.mdx
+++ b/docs/src/content/docs/utilities/text-alignment.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 6 Text Alignment"
 name: "Text alignment"
 description: "Realign text with our responsive text alignment utilities."
-utility: "text"
+utility: {prefix: "text", property: "text-align"}
 ---
 
 ## Text alignment

--- a/docs/src/content/docs/utilities/text-decoration.mdx
+++ b/docs/src/content/docs/utilities/text-decoration.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Text Decoration"
 name: "Text decoration"
 description: "Underline, strike through, or remove the decoration from text."
+utility: "text-decoration"
 ---
 
 ## Text decoration

--- a/docs/src/content/docs/utilities/text-transform.mdx
+++ b/docs/src/content/docs/utilities/text-transform.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Text Transform"
 name: "Text transform"
 description: "Change the capitalization of text with our text transform utilities."
+utility: "text"
 ---
 
 ## Text transform

--- a/docs/src/content/docs/utilities/text-transform.mdx
+++ b/docs/src/content/docs/utilities/text-transform.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 6 Text Transform"
 name: "Text transform"
 description: "Change the capitalization of text with our text transform utilities."
-utility: "text"
+utility: {prefix: "text", property: "text-transform"}
 ---
 
 ## Text transform

--- a/docs/src/content/docs/utilities/text-wrapping.mdx
+++ b/docs/src/content/docs/utilities/text-wrapping.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Text Wrapping"
 name: "Text wrapping"
 description: "Control how text wraps, overflows, and breaks inside its container."
+utility: ["text-wrap", "text-nowrap", "text-break"]
 ---
 
 ## Wrapping

--- a/docs/src/content/docs/utilities/user-select.mdx
+++ b/docs/src/content/docs/utilities/user-select.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 User Select"
 name: "User select"
 description: "Change the way in which the content is selected when the user interacts with it."
+utility: "user-select"
 ---
 
 ## Text selection

--- a/docs/src/content/docs/utilities/vertical-align.mdx
+++ b/docs/src/content/docs/utilities/vertical-align.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 5 Vertical Alignment"
 name: "Vertical alignment"
 description: "Easily change the vertical alignment of inline, inline-block, inline-table, and table cell elements."
-utility: "align"
+utility: {prefix: "align", property: "vertical-align"}
 ---
 
 Change the alignment of elements with the [`vertical-alignment`](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align) utilities. Please note that vertical-align only affects inline, inline-block, inline-table, and table cell elements.

--- a/docs/src/content/docs/utilities/vertical-align.mdx
+++ b/docs/src/content/docs/utilities/vertical-align.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Vertical Alignment"
 name: "Vertical alignment"
 description: "Easily change the vertical alignment of inline, inline-block, inline-table, and table cell elements."
+utility: "align"
 ---
 
 Change the alignment of elements with the [`vertical-alignment`](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align) utilities. Please note that vertical-align only affects inline, inline-block, inline-table, and table cell elements.

--- a/docs/src/content/docs/utilities/visibility.mdx
+++ b/docs/src/content/docs/utilities/visibility.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Visibility"
 name: "Visibility"
 description: "Control the visibility of elements, without modifying their display, with visibility utilities."
+utility: ["visible", "invisible"]
 ---
 
 Set the `visibility` of elements with our visibility utilities. These utility classes do not modify the `display` value at all and do not affect layout – `.invisible` elements still take up space in the page.

--- a/docs/src/content/docs/utilities/width.mdx
+++ b/docs/src/content/docs/utilities/width.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Width"
 name: "Width"
 description: "Set an element's width relative to its parent or to the viewport with our width utilities."
+utility: ["w", "mw", "vw", "min-vw", "dvw", "min-dvw"]
 ---
 
 ## Relative to the parent

--- a/docs/src/content/docs/utilities/z-index.mdx
+++ b/docs/src/content/docs/utilities/z-index.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 5 Z-Index"
 name: "Z-index"
 description: "Use our low-level `z-index` utilities to quickly change the stack level of an element or component."
+utility: "z"
 ---
 
 ## Example


### PR DESCRIPTION
Adds a `utility:` frontmatter entry to every utility page. The engine turns it into a generated Class/Styles table under the ads — **961 rows across 45 pages**, read from the compiled stylesheet instead of written by hand.

```yaml
utility: "ratio"
utility: ["link-opacity", "link-offset", "link-underline"]
```

The prefixes are chosen per page rather than per Sass key, because a page usually documents several: `link` covers three families, `width` covers `w`, `mw`, `vw` and the viewport variants, `position` covers the offsets and `translate-middle`.

`utilities/api` gets none — it documents the API that generates the families, not a family.

## Needs the engine first

Depends on coreui/astro-docs#78, which adds the component and the schema field. Until that ships and the pin moves, the frontmatter is inert — the field is optional, so these pages render exactly as they do today.

## Verification

`docs-build` green, 172 pages, link checker clean. Every one of the 45 tables has rows; the component throws rather than rendering an empty one, so a silent gap is not possible.

Spot-checked the cases that are easy to get wrong:

| page | check |
| --- | --- |
| `divide` | `:where(.divide-y > :not(:first-child))` — the wrapper is the public class, and it lists |
| `link` | `.link-underline-primary` shows all three declarations, including the `color-mix()` |
| `margin` | 7 rows, breakpoint variants correctly excluded |
| `aspect-ratio` | matches upstream's table exactly |