### PR TITLE
feat(utilities): add the bg-*-muted surfaces

### DIFF
--- a/docs/src/content/docs/utilities/background.mdx
+++ b/docs/src/content/docs/utilities/background.mdx
@@ -10,8 +10,11 @@ import { getData } from '@coreui/astro-docs/data'
 
 Similar to the contextual text color classes, set the background of an element to any contextual class. Background utilities **do not set `color`**, so in some cases you'll want to use `.text-*` [color utilities](/utilities/colors/).
 
+Each theme color comes in three weights: the solid color, `.bg-*-muted` and `.bg-*-subtle`. The two lighter ones are surfaces to read text on, and `.text-*-emphasis` is the color that reads on them — `.bg-*-muted` is the step you want when a subtle surface has to separate from a subtle surface behind it, which is what a hovered row or a selected item needs.
+
 <Example code={[
   ...getData('theme-colors').map((c) => `<div class="p-3 mb-2 bg-${c.name} ${c.contrast_color ? `text-${c.contrast_color}` : `text-white`}">.bg-${c.name}</div>
+<div class="p-3 mb-2 bg-${c.name}-muted text-${c.name}-emphasis">.bg-${c.name}-muted</div>
 <div class="p-3 mb-2 bg-${c.name}-subtle text-${c.name}-emphasis">.bg-${c.name}-subtle</div>`),
   `<p class="p-3 mb-2 bg-body-secondary">.bg-body-secondary</p>
 <p class="p-3 mb-2 bg-body-tertiary">.bg-body-tertiary</p>
@@ -94,6 +97,10 @@ Grayscale colors are also available, but only a subset are used to generate any 
 Variables for setting `background-color` in `.bg-*-subtle` utilities in light and dark mode:
 
 <ScssDocs file="scss/_theme.scss" capture="theme-bg-subtle-map" />
+
+And the same for `.bg-*-muted`:
+
+<ScssDocs file="scss/_theme.scss" capture="theme-bg-muted-map" />
 
 ### Map
 

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -36,6 +36,7 @@ $utilities-bg-colors: map.merge(
 ) !default;
 
 $utilities-bg-subtle: theme-color-refs("bg-subtle", "-subtle") !default;
+$utilities-bg-muted: theme-color-refs("bg-muted", "-muted") !default;
 // scss-docs-end utilities-bg-colors
 
 // scss-docs-start utilities-border-colors
@@ -1046,6 +1047,11 @@ $utilities: map.merge(
       property: background-color,
       class: bg,
       values: $utilities-bg-subtle
+    ),
+    "muted-background-color": (
+      property: background-color,
+      class: bg,
+      values: $utilities-bg-muted
     ),
     // scss-docs-end utils-bg-color
     // scss-docs-start utils-theme


### PR DESCRIPTION
Stacked on #878 — it needs `theme-color-refs()`, which that PR introduces. GitHub retargets the base to `v6-dev` once #878 lands.

`--cui-{color}-bg-muted` has been on `:root` for every theme color with no way to reach it from markup. The only reader in the whole stylesheet is `.btn-subtle:hover`. Seven tokens nobody outside the SCSS could see, use, or find in the docs — the same ghost-token shape we chased through `scss/content/`.

`.bg-*-muted` is the step between `.bg-*-subtle` and the solid color: a subtle surface that still separates from a subtle surface behind it, which is what a hovered row or a selected item needs.

Class order follows ours (`.bg-primary-muted`), not upstream's (`.bg-muted-primary`) — flipping the modifier would break BS5 compatibility for no functional gain.

## Docs

The background page's example now walks the full ramp per color — solid, muted, subtle — and the Sass section cites `theme-bg-muted-map` next to the subtle one.

## Gates

`css-compile` · `css-lint` · `css-test-class-api` · `docs-build` · `bundlewatch` — `coreui.css` 64.12 kB against 66 kB, `coreui-utilities.css` 15.58 kB against 16.5 kB. Seven classes, no ceiling change.