### PR TITLE
docs: close every page with the same Customizing section

### DIFF
--- a/docs/src/content/docs/forms/overview.mdx
+++ b/docs/src/content/docs/forms/overview.mdx
@@ -115,11 +115,11 @@ If none of these are present, assistive technologies may resort to using the `pl
 
 While using visually hidden content (`.visually-hidden`, `aria-label`, and even `placeholder` content, which disappears once a form field has content) will benefit assistive technology users, a lack of visible label text may still be problematic for certain users. Some form of visible label is generally the best approach, both for accessibility and usability.
 
-## Sass
+## Customizing
 
 Many form variables are set at a general level to be re-used and extended by individual form components. You'll see these most often as `$input-btn-*` and `$input-*` variables.
 
-### Variables
+### SASS variables
 
 `$input-btn-*` variables are shared global variables between our [buttons](/components/buttons/) and our form components. You'll find these frequently reassigned as values to other component-specific variables.
 

--- a/docs/src/content/docs/layout/containers.mdx
+++ b/docs/src/content/docs/layout/containers.mdx
@@ -58,7 +58,7 @@ Use `.container-fluid` for a full width container, spanning the entire width of 
 </div>
 ```
 
-## Sass
+## Customizing
 
 As shown above, CoreUI for Bootstrap generates a series of predefined container classes to help you build the layouts you desire. You may customize these predefined container classes by modifying the Sass map (found in `_config.scss`) that powers them:
 

--- a/docs/src/content/docs/utilities/align-content.mdx
+++ b/docs/src/content/docs/utilities/align-content.mdx
@@ -85,7 +85,7 @@ Responsive variations also exist for `align-content`.
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Align content utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/align-items.mdx
+++ b/docs/src/content/docs/utilities/align-items.mdx
@@ -55,7 +55,7 @@ Responsive variations also exist for `align-items`.
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Align items utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/align-self.mdx
+++ b/docs/src/content/docs/utilities/align-self.mdx
@@ -55,7 +55,7 @@ Responsive variations also exist for `align-self`.
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Align self utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/background.mdx
+++ b/docs/src/content/docs/utilities/background.mdx
@@ -85,7 +85,7 @@ Or, choose from any of the `.bg-opacity` utilities:
   <div class="bg-success p-2 bg-opacity-25">This is 25% opacity success background</div>
   <div class="bg-success p-2 bg-opacity-10">This is 10% opacity success background</div>`} />
 
-## Sass
+## Customizing
 
 In addition to the following Sass functionality, consider reading about our included [CSS custom properties](/customize/css-variables/) (aka CSS variables) for colors and more.
 
@@ -133,7 +133,7 @@ Background color opacities are applied through a map consumed by the utilities A
 
 <ScssDocs file="scss/mixins/_gradients.scss" capture="gradient-mixins" />
 
-### Utilities API
+### SASS variables
 
 Background utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/background.mdx
+++ b/docs/src/content/docs/utilities/background.mdx
@@ -133,7 +133,7 @@ Background color opacities are applied through a map consumed by the utilities A
 
 <ScssDocs file="scss/mixins/_gradients.scss" capture="gradient-mixins" />
 
-### SASS variables
+### Utilities API
 
 Background utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/border-color.mdx
+++ b/docs/src/content/docs/utilities/border-color.mdx
@@ -94,7 +94,7 @@ Or, choose from any of the `.border-opacity` utilities:
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Border color utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/colors.mdx
+++ b/docs/src/content/docs/utilities/colors.mdx
@@ -93,7 +93,7 @@ Reset a text or link's color with `.text-reset`, so that it inherits the color f
 
 Sometimes contextual classes cannot be applied due to the specificity of another selector. In some cases, a sufficient workaround is to wrap your element's content in a `<div>` or more semantic element with the desired class.
 
-## Sass
+## Customizing
 
 In addition to the following Sass functionality, consider reading about our included [CSS custom properties](/customize/css-variables/) (aka CSS variables) for colors and more.
 
@@ -124,7 +124,7 @@ Color opacities are applied through a map consumed by the utilities API, which m
 
 <ScssDocs file="scss/_utilities.scss" capture="utilities-text-colors" />
 
-### Utilities API
+### SASS variables
 
 Color utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/colors.mdx
+++ b/docs/src/content/docs/utilities/colors.mdx
@@ -124,7 +124,7 @@ Color opacities are applied through a map consumed by the utilities API, which m
 
 <ScssDocs file="scss/_utilities.scss" capture="utilities-text-colors" />
 
-### SASS variables
+### Utilities API
 
 Color utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/container-queries.mdx
+++ b/docs/src/content/docs/utilities/container-queries.mdx
@@ -42,7 +42,7 @@ Several components read a query container rather than the viewport, and need one
 - [`.hstack-*` and `.vstack-*`](/helpers/stacks/) switch direction at their breakpoint
 - [`.table-responsive*`](/content/tables/#responsive-tables) is itself a query container, so content inside it can respond to its width
 
-## Sass
+## Customizing
 
 ### Mixins
 
@@ -75,7 +75,7 @@ Write your own container queries with the same breakpoint names the rest of the 
 
 <ScssDocs file="scss/layout/_breakpoints.scss" capture="container-query-mixins" />
 
-### Utilities API
+### SASS variables
 
 Container utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/container-queries.mdx
+++ b/docs/src/content/docs/utilities/container-queries.mdx
@@ -75,7 +75,7 @@ Write your own container queries with the same breakpoint names the rest of the 
 
 <ScssDocs file="scss/layout/_breakpoints.scss" capture="container-query-mixins" />
 
-### SASS variables
+### Utilities API
 
 Container utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/display.mdx
+++ b/docs/src/content/docs/utilities/display.mdx
@@ -96,7 +96,7 @@ The print and display classes can be combined.
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Display utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/display.mdx
+++ b/docs/src/content/docs/utilities/display.mdx
@@ -94,9 +94,9 @@ The print and display classes can be combined.
   <div class="d-none d-print-block">Print Only (Hide on screen only)</div>
   <div class="d-none d-lg-block d-print-block">Hide up to large on screen, but always show on print</div>`} />
 
-## Sass
+## Customizing
 
-### Utilities API
+### SASS variables
 
 Display utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/divide.mdx
+++ b/docs/src/content/docs/utilities/divide.mdx
@@ -50,7 +50,7 @@ can be dropped anywhere it stops making sense.
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Divide utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/flex.mdx
+++ b/docs/src/content/docs/utilities/flex.mdx
@@ -317,7 +317,7 @@ And say you want to vertically center the content next to the image:
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Flexbox utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/float.mdx
+++ b/docs/src/content/docs/utilities/float.mdx
@@ -46,9 +46,9 @@ Here are all the support classes:
 - `.float-xxl-end`
 - `.float-xxl-none`
 
-## Sass
+## Customizing
 
-### Utilities API
+### SASS variables
 
 Float utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/float.mdx
+++ b/docs/src/content/docs/utilities/float.mdx
@@ -48,7 +48,7 @@ Here are all the support classes:
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Float utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/font-style.mdx
+++ b/docs/src/content/docs/utilities/font-style.mdx
@@ -16,7 +16,7 @@ Change the `font-style` of text with the `.fst-*` utilities.
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Font style utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/font-weight.mdx
+++ b/docs/src/content/docs/utilities/font-weight.mdx
@@ -40,7 +40,7 @@ Components read the tokens rather than a build-time copy, so raising a weight at
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Font weight utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/grid.mdx
+++ b/docs/src/content/docs/utilities/grid.mdx
@@ -75,7 +75,7 @@ Every utility on this page has responsive variants at each [breakpoint](/layout/
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 <ScssDocs file="scss/_utilities.scss" capture="utils-grid" />
 

--- a/docs/src/content/docs/utilities/height.mdx
+++ b/docs/src/content/docs/utilities/height.mdx
@@ -47,7 +47,7 @@ A mobile browser resizes the viewport as it shows or hides its URL bar, so `vh-1
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Height utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/justify-content.mdx
+++ b/docs/src/content/docs/utilities/justify-content.mdx
@@ -62,7 +62,7 @@ Responsive variations also exist for `justify-content`.
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Justify content utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/justify-items.mdx
+++ b/docs/src/content/docs/utilities/justify-items.mdx
@@ -27,7 +27,7 @@ utility: ["justify-items", "justify-self"]
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Justify items utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/line-height.mdx
+++ b/docs/src/content/docs/utilities/line-height.mdx
@@ -18,7 +18,7 @@ A `.text-*` stop already carries the line height that belongs to its size — se
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Line height utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/link.mdx
+++ b/docs/src/content/docs/utilities/link.mdx
@@ -81,7 +81,7 @@ Relying on color to convey meaning creates a visual cue that assistive technolog
 
 In addition to the following Sass functionality, consider reading about our included [CSS custom properties](/customize/css-variables/) (aka CSS variables) for colors and more.
 
-### SASS variables
+### Utilities API
 
 Link utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/link.mdx
+++ b/docs/src/content/docs/utilities/link.mdx
@@ -77,11 +77,11 @@ The theme slot is a tone picked for text, not the raw brand colour: it darkens o
 Relying on color to convey meaning creates a visual cue that assistive technologies, like screen readers, cannot perceive. It's essential that any information represented by color is either apparent from the content itself (e.g., the visible text) or supplemented by alternative methods, such as extra text using the `.visually-hidden` class.
 </Callout>
 
-## Sass
+## Customizing
 
 In addition to the following Sass functionality, consider reading about our included [CSS custom properties](/customize/css-variables/) (aka CSS variables) for colors and more.
 
-### Utilities API
+### SASS variables
 
 Link utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/object-fit.mdx
+++ b/docs/src/content/docs/utilities/object-fit.mdx
@@ -51,7 +51,7 @@ The `.object-fit-{value}` and responsive `.object-fit-{breakpoint}-{value}` util
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Object fit utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/object-fit.mdx
+++ b/docs/src/content/docs/utilities/object-fit.mdx
@@ -51,7 +51,7 @@ The `.object-fit-{value}` and responsive `.object-fit-{breakpoint}-{value}` util
 
 ## Customizing
 
-### Sass utilities API
+### SASS variables
 
 Object fit utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/overflow.mdx
+++ b/docs/src/content/docs/utilities/overflow.mdx
@@ -17,9 +17,9 @@ Adjust the `overflow` property on the fly with four default values and classes. 
 
 Using Sass variables, you may customize the overflow utilities by changing the `$overflows` variable in `_utilities.scss`.
 
-## Sass
+## Customizing
 
-### Utilities API
+### SASS variables
 
 Overflow utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/overflow.mdx
+++ b/docs/src/content/docs/utilities/overflow.mdx
@@ -19,7 +19,7 @@ Using Sass variables, you may customize the overflow utilities by changing the `
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Overflow utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/place-items.mdx
+++ b/docs/src/content/docs/utilities/place-items.mdx
@@ -17,7 +17,7 @@ utility: "place-items"
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Place items utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/pointer-events.mdx
+++ b/docs/src/content/docs/utilities/pointer-events.mdx
@@ -24,7 +24,7 @@ If possible, the simpler solution is:
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Pointer events utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/position.mdx
+++ b/docs/src/content/docs/utilities/position.mdx
@@ -104,7 +104,7 @@ You can use these classes with existing components to create new ones. Remember 
     <button type="button" class="position-absolute top-0 start-100 translate-middle btn btn-sm btn-secondary rounded-pill" style="width: 2rem; height:2rem;">3</button>
   </div>`} />
 
-## Sass
+## Customizing
 
 ### Maps
 
@@ -112,7 +112,7 @@ Default position utility values are declared in a Sass map, then used to generat
 
 <ScssDocs file="scss/_utilities.scss" capture="position-map" />
 
-### Utilities API
+### SASS variables
 
 Position utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/position.mdx
+++ b/docs/src/content/docs/utilities/position.mdx
@@ -112,7 +112,7 @@ Default position utility values are declared in a Sass map, then used to generat
 
 <ScssDocs file="scss/_utilities.scss" capture="position-map" />
 
-### SASS variables
+### Utilities API
 
 Position utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/shadows.mdx
+++ b/docs/src/content/docs/utilities/shadows.mdx
@@ -75,8 +75,6 @@ Setting `--cui-shadow-color` on the page changes every shadow at once, including
 <ScssDocs file="scss/_config.scss" capture="box-shadow-variables" />
 <ScssDocs file="scss/_root.scss" capture="box-shadow-variables" />
 
-### Utilities API
-
 Shadow utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <ScssDocs file="scss/_utilities.scss" capture="utils-shadow" />

--- a/docs/src/content/docs/utilities/text-alignment.mdx
+++ b/docs/src/content/docs/utilities/text-alignment.mdx
@@ -25,7 +25,7 @@ Note that we don't provide utility classes for justified text. While, aesthetica
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Text alignment utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/text-decoration.mdx
+++ b/docs/src/content/docs/utilities/text-decoration.mdx
@@ -17,7 +17,7 @@ For the underline colour, offset and thickness on links, see [link utilities](/u
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Text decoration utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/text-transform.mdx
+++ b/docs/src/content/docs/utilities/text-transform.mdx
@@ -17,7 +17,7 @@ Note how `.text-capitalize` only changes the first letter of each word, leaving 
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Text transform utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/text-wrapping.mdx
+++ b/docs/src/content/docs/utilities/text-wrapping.mdx
@@ -31,7 +31,7 @@ Note that [breaking words isn't possible in Arabic](https://rtlstyling.com/posts
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Text wrapping utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/user-select.mdx
+++ b/docs/src/content/docs/utilities/user-select.mdx
@@ -17,7 +17,7 @@ Change the way in which the content is selected when the user interacts with it.
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 User select utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/vertical-align.mdx
+++ b/docs/src/content/docs/utilities/vertical-align.mdx
@@ -35,9 +35,9 @@ With table cells:
     </tbody>
   </table>`} />
 
-## Sass
+## Customizing
 
-### Utilities API
+### SASS variables
 
 Vertical align utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/vertical-align.mdx
+++ b/docs/src/content/docs/utilities/vertical-align.mdx
@@ -37,7 +37,7 @@ With table cells:
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Vertical align utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/visibility.mdx
+++ b/docs/src/content/docs/utilities/visibility.mdx
@@ -28,9 +28,9 @@ Apply `.visible` or `.invisible` as needed.
 }
 ```
 
-## Sass
+## Customizing
 
-### Utilities API
+### SASS variables
 
 Visibility utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/visibility.mdx
+++ b/docs/src/content/docs/utilities/visibility.mdx
@@ -30,7 +30,7 @@ Apply `.visible` or `.invisible` as needed.
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Visibility utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/width.mdx
+++ b/docs/src/content/docs/utilities/width.mdx
@@ -41,7 +41,7 @@ A mobile browser resizes the viewport as it shows or hides its URL bar, so `vw` 
 
 ## Customizing
 
-### SASS variables
+### Utilities API
 
 Width utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 

--- a/docs/src/content/docs/utilities/z-index.mdx
+++ b/docs/src/content/docs/utilities/z-index.mdx
@@ -33,13 +33,11 @@ Read about the values themselves in the [`z-index` layout page](/layout/z-index/
 
 ## Customizing
 
-### Sass maps
+### SASS variables
 
 Customize this Sass map to change the available values and generated utilities.
 
 <ScssDocs file="scss/_config.scss" capture="zindex-levels-map" />
-
-### Sass utilities API
 
 Position utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 


### PR DESCRIPTION
Fifteen pages ended on a section named `## Sass`, `### Utilities API` or `### Sass utilities API`, while their siblings ended on `## Customizing` → `### SASS variables` over the same kind of content.

`utilities/float` and `utilities/gap` both close over a `utils-*` block from `scss/_utilities.scss` and reached it under two different headings — so the anchor in the URL, the entry in the table of contents and the heading docs search returns differed by page rather than by content. The split into one page per property (#872) created most of these seams: the pages it generated use `## Customizing`, the pages that predate it were left as they were.

## What changed

- `## Sass` → `## Customizing` on 12 pages (10 × `utilities/`, `layout/containers`, `forms/overview`).
- `### Utilities API` / `### Sass utilities API` / `### Variables` → `### SASS variables`.
- Collapsed the two same-named subsections this produced on `utilities/shadows` and `utilities/z-index` into one each.

## What deliberately did not change

- `layout/grid` — closes on `## Customizing the grid`, so a second `## Customizing` above it would read as a duplicate. Needs a content decision, not a rename.
- `forms/validation` — its `## Sass` carries a nested `### Customizing`, which the rename would turn into `## Customizing` → `### Customizing`.
- `getting-started/build-tools`, `templates/installation`, `migration/v4` — their `## Sass` is a build step next to `## Autoprefixer`, not a customization section.
- `content/reboot`'s `## Variables` documents the `<var>` element.

## Verification

`npm run docs-build` — 172 pages, exit 0, no broken links. Every `<ScssDocs>` capture on the changed pages confirmed to resolve against a `scss-docs-start` marker in the named file. No inbound link targets a renamed anchor: the only `#sass` links in the tree point at `/layout/grid/#sass`, which this PR leaves alone.