### PR TITLE
docs(forms): lead the Customizing section with the runtime tokens

### DIFF
--- a/docs/src/content/docs/forms/checkbox.mdx
+++ b/docs/src/content/docs/forms/checkbox.mdx
@@ -196,15 +196,15 @@ Modify the appearance of checked checkboxes by adding a [`.theme-{color}` class]
 
 ## Customizing
 
+### CSS variables
+
+Checkboxes read their own custom properties, so restyling one control does not touch the other two. Set them on the control itself — an ancestor cannot override a token the element declares for itself.
+
+<ScssDocs file="scss/forms/_check.scss" capture="check-css-vars" />
+
 ### SASS variables
 
 <ScssDocs file="scss/forms/_check.scss" capture="check-variables" />
-
-### CSS variables
-
-Checkboxs read their own custom properties, so restyling one control does not touch the other two. Set them on the control itself — an ancestor cannot override a token the element declares for itself.
-
-<ScssDocs file="scss/forms/_check.scss" capture="check-css-vars" />
 
 ### Shared variables
 

--- a/docs/src/content/docs/forms/field.mdx
+++ b/docs/src/content/docs/forms/field.mdx
@@ -95,10 +95,10 @@ See [validation](/forms/validation/) for the full picture, including the server-
 
 ## Customizing
 
-### SASS variables
-
-<ScssDocs file="scss/forms/_form-field.scss" capture="form-field-variables" />
-
 ### CSS variables
 
 <ScssDocs file="scss/forms/_form-field.scss" capture="form-field-css-vars" />
+
+### SASS variables
+
+<ScssDocs file="scss/forms/_form-field.scss" capture="form-field-variables" />

--- a/docs/src/content/docs/forms/radio.mdx
+++ b/docs/src/content/docs/forms/radio.mdx
@@ -186,15 +186,15 @@ Modify the appearance of checked radios by adding a [`.theme-{color}` class](/cu
 
 ## Customizing
 
-### SASS variables
-
-<ScssDocs file="scss/forms/_radio.scss" capture="radio-variables" />
-
 ### CSS variables
 
 Radios read their own custom properties, so restyling one control does not touch the other two. Set them on the control itself — an ancestor cannot override a token the element declares for itself.
 
 <ScssDocs file="scss/forms/_radio.scss" capture="radio-css-vars" />
+
+### SASS variables
+
+<ScssDocs file="scss/forms/_radio.scss" capture="radio-variables" />
 
 ### Shared variables
 

--- a/docs/src/content/docs/forms/switch.mdx
+++ b/docs/src/content/docs/forms/switch.mdx
@@ -109,6 +109,12 @@ Modify the appearance of checked switches by adding a [`.theme-{color}` class](/
 
 ## Customizing
 
+### CSS variables
+
+Switches read their own custom properties, so restyling one control does not touch the other two. Set them on the control itself — an ancestor cannot override a token the element declares for itself.
+
+<ScssDocs file="scss/forms/_switch.scss" capture="switch-css-vars" />
+
 ### SASS variables
 
 <ScssDocs file="scss/forms/_switch.scss" capture="switch-variables" />
@@ -118,12 +124,6 @@ Each size carries its own height and font size, and both maps merge with your ov
 <ScssDocs file="scss/forms/_switch.scss" capture="switch-sizes" />
 
 <ScssDocs file="scss/forms/_switch.scss" capture="form-switch-sizes" />
-
-### CSS variables
-
-Switchs read their own custom properties, so restyling one control does not touch the other two. Set them on the control itself — an ancestor cannot override a token the element declares for itself.
-
-<ScssDocs file="scss/forms/_switch.scss" capture="switch-css-vars" />
 
 ### Shared variables
 


### PR DESCRIPTION
`forms/field`, `forms/radio`, `forms/checkbox` and `forms/switch` listed `### SASS variables` before `### CSS variables` — the reverse of every other page in the tree.

The order carries information rather than being cosmetic: in v6 a token is overridden in the browser without recompiling, while a Sass variable only changes the value the build starts from. The reader who needs no build step should meet their half of the section first.

Also spells the plural of checkbox and switch correctly in the sentence those three control pages share ("Checkboxs" → "Checkboxes", "Switchs" → "Switches").

## Verification

`npm run docs-build` — 172 pages, exit 0, no broken links. Content within each subsection is unchanged; only the two blocks swap places.