### PR TITLE
docs(customize): name the theme tokens and colors the build emits

### DIFF
--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -319,7 +319,7 @@ Each variant class rewrites those variables from the theme tokens, falling back 
 
 A brand colour of your own is a theme, not a button: set the theme tokens anywhere above the buttons and every variant follows, in plain CSS. The tokens inherit, so one ancestor themes the whole subtree.
 
-<Example code={`<div style="--cui-theme-base: #6f42c1; --cui-theme-contrast: #fff; --cui-theme-hover: #6134ae; --cui-theme-active: #56309b; --cui-theme-bg-subtle: #e9e0f7; --cui-theme-fg: #59359a; --cui-theme-fg-emphasis: #432a72;">
+<Example code={`<div style="--cui-theme-bg: #6f42c1; --cui-theme-contrast: #fff; --cui-theme-hover: #6134ae; --cui-theme-active: #56309b; --cui-theme-bg-subtle: #e9e0f7; --cui-theme-fg: #59359a; --cui-theme-fg-emphasis: #432a72;">
     <button type="button" class="btn-solid">Solid</button>
     <button type="button" class="btn-outline">Outline</button>
     <button type="button" class="btn-subtle">Subtle</button>
@@ -330,7 +330,7 @@ In your own stylesheet that is a class, and the buttons carry it the way they ca
 
 ```css
 .theme-brand {
-  --cui-theme-base: #6f42c1;
+  --cui-theme-bg: #6f42c1;
   --cui-theme-contrast: #fff;
   --cui-theme-hover: #6134ae;
   --cui-theme-active: #56309b;

--- a/docs/src/content/docs/customize/color.mdx
+++ b/docs/src/content/docs/customize/color.mdx
@@ -328,7 +328,7 @@ These colors are accessible via CSS variables and utility classes—like `--cui-
 
 ## Theme colors
 
-We use a subset of all colors to create a smaller color palette for generating color schemes, also available as Sass variables and a Sass map in CoreUI for Bootstrap's `scss/_config.scss` file.
+We use a subset of all colors to create a smaller color palette for generating color schemes, also available as Sass variables and a Sass map in CoreUI for Bootstrap's `scss/_theme.scss` file.
 
 <div class="row">
   {getData('theme-colors').map((c) => (
@@ -346,7 +346,7 @@ Check out [our Sass maps and loops docs](/customize/sass/#maps-and-loops) for ho
 
 ## All colors
 
-All CoreUI for Bootstrap colors are available as Sass variables and a Sass map in `scss/_config.scss` file. To avoid increased file sizes, we don't create text or background color classes for each of these variables. Instead, we choose a subset of these colors for a [theme palette](#theme-colors).
+All CoreUI for Bootstrap colors are available as Sass variables and a Sass map in `scss/_colors.scss` file. To avoid increased file sizes, we don't create text or background color classes for each of these variables. Instead, we choose a subset of these colors for a [theme palette](#theme-colors).
 
 Be sure to monitor contrast ratios as you customize colors. As shown below, we've added three contrast ratios to each of the main colors—one for the swatch's current colors, one for against white, and one for against black.
 
@@ -370,7 +370,7 @@ Be sure to monitor contrast ratios as you customize colors. As shown below, we'v
   <div class="col-md-4 mb-3">
     <div class="p-3 mb-2 position-relative swatch-gray-500">
       <strong class="d-block">$gray-500</strong>
-      #9da5b1
+      #aab3c5
     </div>
     {getData('grays').map((gray) => (
       <div class={`p-3 docs-gray-${gray.name}`}>$gray-{gray.name}</div>
@@ -416,7 +416,7 @@ CoreUI for Bootstrap's source Sass files include three maps to help you quickly 
 - `$theme-colors` lists all semantically named theme colors (shown below)
 - `$grays` lists all tints and shades of gray
 
-Within `scss/_config.scss`, you'll find CoreUI for Bootstrap's color variables and Sass map. Here's an example of the `$colors` Sass map:
+Within `scss/_colors.scss`, you'll find CoreUI for Bootstrap's color variables and Sass map. Here's an example of the `$colors` Sass map:
 
 <ScssDocs file="scss/_colors.scss" capture="colors-map" />
 

--- a/docs/src/content/docs/customize/components.mdx
+++ b/docs/src/content/docs/customize/components.mdx
@@ -27,7 +27,7 @@ Themeable components also support a single family of composable `.theme-*` class
 
 | Token | Description |
 | --- | --- |
-| `--cui-theme-base` | The theme color itself, e.g. a solid badge or button background |
+| `--cui-theme-bg` | The theme color itself, e.g. a solid badge or button background |
 | `--cui-theme-contrast` | Contrasting color for text and icons sitting on the solid base |
 | `--cui-theme-fg` | The theme's readable text color |
 | `--cui-theme-fg-emphasis` | High-contrast foreground, one step darker |
@@ -43,8 +43,13 @@ The `.theme-{name}` classes mirror the keys of the `$theme-colors` map in `scss/
 To see how a component consumes these tokens, here's the badge in `scss/_badge.scss`. Its color and background each read a theme token first, falling back to the badge's own default:
 
 ```scss
---cui-badge-color: var(--cui-theme-contrast, #{$badge-color}),
---cui-badge-bg: var(--cui-theme-base, #{$badge-bg}),
+// the token map carries only the badge's own default
+--#{$prefix}badge-color: #{$badge-color},
+--#{$prefix}badge-bg: #{$badge-bg},
+
+// the theme is read at the property, with the token as the fallback
+color: var(--#{$prefix}theme-contrast, var(--#{$prefix}badge-color));
+@include gradient-bg(var(--#{$prefix}theme-bg, var(--#{$prefix}badge-bg)));
 ```
 
 With no theme class the badge stays neutral; add `.theme-success` and the very same element resolves the success tokens — no `.badge-success` selector required. Structural variants compose with any theme:
@@ -55,12 +60,12 @@ Because the theme tokens are plain CSS variables, you can also scope a theme to 
 
 ```css
 .my-brand {
-  --cui-theme-base: #6f42c1;
+  --cui-theme-bg: #6f42c1;
   --cui-theme-contrast: #fff;
 }
 ```
 
-The classic color classes — `.btn-primary`, `.alert-success`, `.badge` color spellings from v5 — keep working: they are generated from the same theme tokens, so both APIs stay pixel-identical.
+Where a classic color class still exists — `.btn-primary`, `.alert-success` — it is generated from the same theme tokens, so both APIs stay pixel-identical. The badge is the exception: it has no `.badge-{color}` spelling, and `.theme-{color}` is the only way to color it.
 
 ### Building a themeable component
 
@@ -69,7 +74,7 @@ Read the theme slot **at the property**, wrapping the component's own token. Slo
 ```scss
 --#{$prefix}badge-bg: #{$badge-bg},
 // …
-background-color: var(--#{$prefix}theme-base, var(--#{$prefix}badge-bg));
+background-color: var(--#{$prefix}theme-bg, var(--#{$prefix}badge-bg));
 ```
 
 A structural variant maps the token to a slot of its own, and then **re-declares the property with a plain read** so it wins over the base rule:

--- a/docs/src/content/docs/customize/theme.mdx
+++ b/docs/src/content/docs/customize/theme.mdx
@@ -19,15 +19,14 @@ From this one map the library generates:
 | Theme color | Default value | Description |
 | --- | --- | --- |
 | `primary` | `#5856d6` | Main brand color for primary actions |
-| `secondary` | `#6b7785` | Less prominent actions and states |
+| `secondary` | `light-dark(var(--cui-gray-100), var(--cui-gray-600))` | Less prominent actions and states |
 | `success` | `#1b9e3e` | Positive actions and successful states |
 | `info` | `#39f` | Informational messages and neutral states |
 | `warning` | `#f9b115` | Cautionary messages and states |
 | `danger` | `#e55353` | Destructive actions and error states |
-| `light` | `$gray-100` | Light surfaces and low-emphasis elements |
-| `dark` | `$gray-900` | Dark surfaces and high-contrast elements |
+| `inverse` | `light-dark(var(--cui-gray-900), var(--cui-gray-100))` | Surfaces that flip against the page, e.g. a dark bar on a light page |
 
-Each base value is a standalone Sass variable (`$primary`, `$danger`, …) feeding the `base` slot of its entry, so overriding the one variable retints the whole family.
+Each base value is a standalone Sass variable (`$primary`, `$danger`, …) feeding the `base` slot of its entry, so overriding the one variable retints the whole family. `secondary` and `inverse` are `light-dark()` pairs rather than fixed hexes, so they follow the color mode on their own.
 
 ## Color slots
 


### PR DESCRIPTION
Four pages documented a theme surface that no longer matches the stylesheet. Following them produces a component that never responds to a theme class.

## `--cui-theme-base` does not exist

```
$ grep -c -- '--cui-theme-base' dist/css/coreui.css
0
$ grep -oE -- '--cui-theme-[a-z-]+' dist/css/coreui.css | sort -u
--cui-theme-active --cui-theme-bg --cui-theme-bg-muted --cui-theme-bg-subtle
--cui-theme-border --cui-theme-contrast --cui-theme-fg --cui-theme-fg-emphasis
--cui-theme-focus-ring --cui-theme-hover
```

The generic slot is `--cui-theme-bg`. `migration/v6.mdx` already records the rename, but `customize/components.mdx` still taught the old name in four places — including the recipe for building a themeable component — and `components/buttons.mdx` used it in a **live example**, so the button rendered on that page stayed grey instead of purple.

## The badge snippet showed the wrong mechanism

It put the theme read inside the token map. `scss/_badge.scss` declares only the badge's own defaults there (`:58-59`) and reads the theme **at the property** (`:98`, `:105`). A token map alone never picks up a theme, so the snippet as printed could not work.

## The theme color table listed colors we removed and omitted the one that replaced them

`$theme-colors` keys are `primary secondary success info warning danger inverse`. The table still listed `light` and `dark` (removed in #878) and had no row for `inverse`; `.bg-light`, `.bg-dark`, `.theme-light` and `.theme-dark` are all absent from the compiled CSS. It also gave `secondary` a fixed hex — `secondary` and `inverse` are `light-dark()` pairs, which is why they follow the color mode on their own.

## Smaller corrections on the color pages

- `.badge-{color}` does not exist (`grep -oF '.badge-primary'` → 0), so the claim that every v5 color class keeps working was false for the badge.
- `$colors`, `$grays` and `$theme-colors` were sourced to `scss/_config.scss`; since the palette split they live in `scss/_colors.scss` and `scss/_theme.scss`. The `<ScssDocs>` blocks two lines below already pointed at the right files.
- `$gray-500` was printed as `#9da5b1`; it is `#aab3c5`.

## Verification

`npm run docs-build` — 172 pages, exit 0, no broken links. Every claim above was checked against `dist/css/coreui.css` from a fresh `npm run css`, and against `scss/_theme.scss` / `scss/_colors.scss` / `scss/_badge.scss`.