### PR TITLE
feat(menu): give the menu its own split-toggle class

### DIFF
--- a/docs/src/content/docs/components/menu.mdx
+++ b/docs/src/content/docs/components/menu.mdx
@@ -41,6 +41,7 @@ Use [button groups](/components/button-group/) to create split button menus wher
   <div class="btn-group">
     <button type="button" class="btn btn-secondary">Split</button>
     <button type="button" class="btn btn-secondary menu-toggle-split" data-coreui-toggle="menu" aria-expanded="false">
+      <svg class="icon" viewBox="0 0 512 512" aria-hidden="true"><path d="M256 144a64 64 0 1 0-64-64 64.07 64.07 0 0 0 64 64m0-96a32 32 0 1 1-32 32 32.036 32.036 0 0 1 32-32m0 320a64 64 0 1 0 64 64 64.07 64.07 0 0 0-64-64m0 96a32 32 0 1 1 32-32 32.036 32.036 0 0 1-32 32m0-272a64 64 0 1 0 64 64 64.07 64.07 0 0 0-64-64m0 96a32 32 0 1 1 32-32 32.036 32.036 0 0 1-32 32"></path></svg>
       <span class="visually-hidden">Toggle menu</span>
     </button>
     <div class="menu">
@@ -477,6 +478,7 @@ Use `data-coreui-offset` or `data-coreui-reference` to change the location of th
     <div class="btn-group">
       <button type="button" class="btn btn-secondary">Reference</button>
       <button type="button" class="btn btn-secondary menu-toggle-split" data-coreui-toggle="menu" aria-expanded="false" data-coreui-reference="parent">
+        <svg class="icon" viewBox="0 0 512 512" aria-hidden="true"><path d="M256 144a64 64 0 1 0-64-64 64.07 64.07 0 0 0 64 64m0-96a32 32 0 1 1-32 32 32.036 32.036 0 0 1 32-32m0 320a64 64 0 1 0 64 64 64.07 64.07 0 0 0-64-64m0 96a32 32 0 1 1 32-32 32.036 32.036 0 0 1-32 32m0-272a64 64 0 1 0 64 64 64.07 64.07 0 0 0-64-64m0 96a32 32 0 1 1 32-32 32.036 32.036 0 0 1-32 32"></path></svg>
         <span class="visually-hidden">Toggle Menu</span>
       </button>
       <div class="menu">

--- a/docs/src/content/docs/components/menu.mdx
+++ b/docs/src/content/docs/components/menu.mdx
@@ -27,7 +27,7 @@ Menus are built on a third party library, [Floating UI](https://floating-ui.com/
 
 While `<button>` is the recommended control for a menu toggle, there might be situations where you have to use an `<a>` element. If you do, we recommend adding a `role="button"` attribute to appropriately convey control’s purpose to assistive technologies such as screen readers.
 
-Use [button groups](/components/button-group/) to create split button menus where the menu is displayed when a secondary button is clicked.
+Use [button groups](/components/button-group/) to create split button menus where the menu is displayed when a secondary button is clicked. Give that second button `.menu-toggle-split`, which narrows its padding so the pair reads as one control.
 
 <Example code={`<a class="btn btn-primary" href="#" role="button" data-coreui-toggle="menu" aria-expanded="false">
     Toggle menu

--- a/scss/buttons/_button-group.scss
+++ b/scss/buttons/_button-group.scss
@@ -51,8 +51,11 @@
     }
 
     // Reset rounded corners
-    > .btn:not(:last-child, .dropdown-toggle),
+    // A menu trigger carries no class of its own, so it is recognised by the
+    // `.menu` that follows it.
+    > .btn:not(:last-child, .dropdown-toggle, :has(+ .menu)),
     > .btn.dropdown-toggle-split:first-child,
+    > .btn.menu-toggle-split:first-child,
     > .btn-group:not(:last-child) > .btn {
       @include border-end-radius(0);
     }
@@ -69,7 +72,8 @@
     }
   }
 
-  .dropdown-toggle-split {
+  .dropdown-toggle-split,
+  .menu-toggle-split {
     padding-inline: calc(var(--#{$prefix}btn-padding-x) * .75);
   }
 
@@ -106,7 +110,7 @@
     }
 
     // Reset rounded corners
-    > .btn:not(:last-child, .dropdown-toggle),
+    > .btn:not(:last-child, .dropdown-toggle, :has(+ .menu)),
     > .btn-group:not(:last-child) > .btn {
       @include border-bottom-radius(0);
     }


### PR DESCRIPTION
The menu page taught `.menu-toggle-split` on both of its split-button examples, and nothing styled it. Two things went wrong at once, and neither is visible in the source:

- the toggle kept full button padding, so the split pair read as two buttons rather than one control;
- the corner reset in `.btn-group` skips `.dropdown-toggle`, and a menu trigger carries no class of its own — so the toggle was treated as a middle button and lost its end radius. The square edge showed up next to the menu it opens.

`.menu-toggle-split` now sets the same narrowed padding as its dropdown counterpart, and the reset recognises a trigger by the `.menu` that follows it (`:has(+ .menu)`), which covers plain triggers too, not just split ones. Both button groups — horizontal and vertical — get the same treatment.

## Why not just use `.dropdown-toggle-split`

That was the first fix, in #877's sibling PR, and it is the wrong trade: it puts pre-rename vocabulary on the page that documents the replacement. A reader copying the snippet learns a `dropdown-*` class for a `.menu`.

## Verification

```
$ grep -n "menu-toggle-split" dist/css/coreui.css
5092:  .btn-group > .btn.menu-toggle-split:first-child,
5104:  .menu-toggle-split {
```

`npm run css`, `npx stylelint scss/buttons/_button-group.scss` (clean), full pre-push gate (lint → build → tests → bundlewatch) green. Cascade layers unchanged — `@layer colors, config, root, …;` still precedes the first `@layer` block.

## Noted, not changed

Our split-toggle example has no visible glyph — the button holds only `<span class="visually-hidden">`, so it renders as a narrow empty rectangle. Upstream puts an explicit chevron SVG inside theirs. Picking a glyph is a design call, so it is left for a separate decision.
