### PR TITLE
docs(time-picker): document the tokens the component actually declares

### DIFF
--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -176,7 +176,11 @@ Options belonging to the inner [calendar](/components/calendar/#options) or
 
 ### CSS variables
 
+The date half and the time half keep their own tokens, each declared on its own popup.
+
 <ScssDocs file="scss/_date-picker.scss" capture="date-picker-css-vars" />
+
+<ScssDocs file="scss/_time-picker.scss" capture="time-picker-css-vars" />
 
 ### SASS variables
 

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -243,16 +243,14 @@ context.disabled         // disabled state
 
 ### CSS variables
 
-<ScssDocs file="scss/_date-picker.scss" capture="date-picker-css-vars" />
+The tokens are declared on `.time-picker-popup`, which is the element that survives being teleported away from the field — set them there rather than on an ancestor.
+
+<ScssDocs file="scss/_time-picker.scss" capture="time-picker-css-vars" />
 
 ### SASS variables
 
 <DeprecatedIn version="6.0.0" />
 
 Sass variables set these defaults at build time and are removed in v7. The CSS variables above reach the same values without recompiling, and can be set on a single element.
-
-The shell reuses the existing `$time-picker-*` variables for the selection body
-and the `$date-picker-*` shell-layer variables for the frame — this adds no new
-configuration surface.
 
 <ScssDocs file="scss/_time-picker.scss" capture="time-picker-variables" />


### PR DESCRIPTION
The CSS-variables section on the time-picker page rendered the **date picker's** three footer tokens. The time picker declares 35 tokens of its own and reads 19 of them, none of which is a `--cui-date-picker-*` — so every name the page offered was one the component ignores, and every name that works was absent.

```
$ grep -c -- "--cui-time-picker-[a-z-]*:" dist/css/coreui.css        → 35   (declared)
$ grep -o -- "var(--cui-time-picker-[a-z-]*" … | sort -u | wc -l     → 19   (read)
$ grep -n "date-picker" scss/_time-picker.scss                       → one comment, no token
```

The `time-picker-css-vars` block has existed all along (`scss/_time-picker.scss:38`) and nothing referenced it.

## Two follow-ons from the same mix-up

- The Sass section claimed the frame reuses the `$date-picker-*` shell variables. It does not: `$time-picker-footer-padding`, `-border-width` and `-border-color` are the component's own (`scss/_time-picker.scss:11-13`). The sentence is gone.
- The date-time picker listed both components under **Sass** variables but only the date half under **CSS** variables. It now lists both, since restyling the time roll needs the time picker's tokens.

Both pages now say where the tokens are declared — on the popup, which is what survives being teleported away from the field, so setting them on an ancestor does nothing.

## How isolated is this

Swept every page for the same signature — an own `<page>-css-vars` block existing in `scss/` while the page cites someone else's. The time picker was the only hit. (Pages citing a *related* capture are normal: plural page vs singular block like `alerts` → `alert`, variants like `nav` → `nav-pills`, sub-parts like `sidebar` → `sidebar-nav`.)

## Verification

`npm run docs-build` — 172 pages, exit 0, no broken links. Checked the rendered HTML rather than the source: `_site/forms/time-picker/index.html` now contains `--cui-time-picker-roll-cell-width` and zero `--cui-date-picker-footer*`; the date-time picker page carries both families.
