### PR TITLE
feat(utilities): name the default border color and the page background

### DIFF
--- a/docs/src/content/docs/utilities/border-color.mdx
+++ b/docs/src/content/docs/utilities/border-color.mdx
@@ -17,14 +17,21 @@ Change the border color using utilities built on our theme colors.
 
 ## Neutral
 
-Four weights sit between the page and a themed border, for lines that separate content without naming a color. `.border-emphasized` is the strongest, the default `--cui-border-color` sits in the middle, and `.border-subtle` is the faintest.
+Four weights sit between the page and a themed border, for lines that separate content without naming a color. `.border-emphasized` is the strongest, `.border-body` is the default weight a plain `.border` already draws, and `.border-subtle` is the faintest.
 
 <Example class="docs-example-border-utils" code={`<span class="border border-emphasized"></span>
-  <span class="border"></span>
+  <span class="border border-body"></span>
   <span class="border border-muted"></span>
   <span class="border border-subtle"></span>`} />
 
 Each is a `light-dark()` pair, so the ladder keeps its order in both color schemes rather than fading out in one of them.
+
+Naming the default is what lets you return to it. Dropping `.border-primary` gets you there when the class is yours to remove, but not when the color arrives from a component's own rule, a breakpoint or a `.theme-*` block — there, `.border-body` is the way back.
+
+`.border-bg` is the odd one out: it paints the line in the page background color, so the border holds its space without being seen. Reach for it when a visible border appears on hover or on a state, and the element would otherwise shift by the width of the line.
+
+<Example class="docs-example-border-utils" code={`<span class="border border-bg"></span>
+  <span class="border border-body"></span>`} />
 
 ## Sides
 

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -45,8 +45,10 @@ $utilities-border-colors: map.merge(
   (
     "black": var(--#{$prefix}black),
     "white": var(--#{$prefix}white),
+    "bg": var(--#{$prefix}bg-body),
     "subtle": var(--#{$prefix}border-subtle),
     "muted": var(--#{$prefix}border-muted),
+    "body": var(--#{$prefix}border-color),
     "emphasized": var(--#{$prefix}border-emphasized)
   )
 ) !default;


### PR DESCRIPTION
The neutral border ladder could name every weight except the one in the middle. `.border-subtle`, `.border-muted` and `.border-emphasized` shipped; the default weight was reachable only by applying no color class at all.

That is fine while the class is yours to delete. It stops working when the color arrives from somewhere you cannot remove — a component's own rule, a breakpoint, a `.theme-*` block. `.border-body` is the way back.

```
.border-subtle       light-dark(gray-100, gray-900)
.border-muted        light-dark(gray-200, gray-800)
.border-body         light-dark(gray-300, gray-800)   ← new, the default weight
.border-emphasized   light-dark(gray-400, gray-700)
```

`.border-bg` is the second addition and a different idea: it paints the line in the page background color, so a border holds its space while staying invisible. Without it an element shifts by the width of the line the moment a state adds a visible border.

Both are entries in `$utilities-border-colors`, so they compose with `.border-opacity-*` and the per-side variants exactly like every other border color — no new mechanism.

## Docs

The page already described the gap: it told readers the middle of the ladder was "the default `--cui-border-color`" and demonstrated it with a bare `.border`, because there was nothing else to point at. That paragraph and its example now name the class, and `.border-bg` gets the shift-on-hover rationale that is its whole reason to exist.

## A naming difference worth knowing

Bootstrap v6 keeps two parallel things: `--bs-border-color` (gray-200/700, what a plain `.border` draws) and a separate `$theme-borders` palette whose `body` rung is gray-300/800. Ours coincide — `--cui-border-color` *is* gray-300/800 — so one class covers both meanings here and no second palette was introduced. If those values ever diverge on our side, this collapse stops being true and the two roles need splitting.

## Verification

```
$ grep -A 4 "^\s*\.border-body {" dist/css/coreui.css
  .border-body { --cui-border: var(--cui-border-color); --cui-border-opacity: 1; … }
$ grep -A 4 "^\s*\.border-bg {" dist/css/coreui.css
  .border-bg   { --cui-border: var(--cui-bg-body);      --cui-border-opacity: 1; … }
```

`npx stylelint scss/_utilities.scss` clean, `npm run docs-build` 172 pages / no broken links, full pre-push gate green. bundlewatch passes with room: `coreui.css` 64.9 KB against a 66 KB ceiling, so no budget was raised.
