### PR TITLE
docs: name every page after Bootstrap 6

### DIFF
--- a/docs/src/content/docs/components/accordion.mdx
+++ b/docs/src/content/docs/components/accordion.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Accordion"
+title: "Bootstrap 6 Accordion"
 name: "Accordion"
 description: "Build vertically collapsing accordions on top of the native HTML disclosure element."
 otherFrameworks:

--- a/docs/src/content/docs/components/alerts.mdx
+++ b/docs/src/content/docs/components/alerts.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Alerts"
+title: "Bootstrap 6 Alerts"
 name: "Alerts"
 description: "Bootstrap alerts give contextual feedback information for common user operations. The alert component is delivered with a bunch of usable and adjustable alert messages."
 otherFrameworks:

--- a/docs/src/content/docs/components/avatar.mdx
+++ b/docs/src/content/docs/components/avatar.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Avatar"
+title: "Bootstrap 6 Avatar"
 name: "Avatar"
 description: "The Avatar component is used to display circular user profile pictures. Avatars can portray people or objects and support images, icons, or letters."
 otherFrameworks:

--- a/docs/src/content/docs/components/badge.mdx
+++ b/docs/src/content/docs/components/badge.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Badges"
+title: "Bootstrap 6 Badges"
 name: "Badges"
 description: "Small components for indicating status and counts, or labelling items."
 otherFrameworks:

--- a/docs/src/content/docs/components/breadcrumb.mdx
+++ b/docs/src/content/docs/components/breadcrumb.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Breadcrumb"
+title: "Bootstrap 6 Breadcrumb"
 name: "Breadcrumb"
 description: "Bootstrap breadcrumb navigation component which indicates the current location within a navigational hierarchy that automatically adds separators."
 otherFrameworks:

--- a/docs/src/content/docs/components/button-group.mdx
+++ b/docs/src/content/docs/components/button-group.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Button Group"
+title: "Bootstrap 6 Button Group"
 name: "Button group"
 description: "Bootstrap button group allows to group a series of buttons and power them with JavaScript."
 otherFrameworks:

--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Buttons"
+title: "Bootstrap 6 Buttons"
 name: "Buttons"
 description: "Bootstrap button component for actions in tables, forms, cards, and more. CoreUI for Bootstrap provides various styles, states, and size. Ready to use and easy to customize."
 otherFrameworks:

--- a/docs/src/content/docs/components/calendar.mdx
+++ b/docs/src/content/docs/components/calendar.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 Calendar"
+title: "Bootstrap 6 Calendar"
 name: "Calendar"
 description: "The Bootstrap Calendar Component is a versatile, customizable tool for creating responsive calendars in Bootstrap, supporting day, month, and year selection, and global locales."
 otherFrameworks:
@@ -14,7 +14,7 @@ import calendarCustomizeCells from './snippets/calendar-customize-cells.js?raw'
 
 ## Example
 
-Explore the Bootstrap 5 Calendar component's basic usage through sample code snippets demonstrating its core functionality.
+Explore the Bootstrap 6 Calendar component's basic usage through sample code snippets demonstrating its core functionality.
 
 ### Days
 
@@ -101,7 +101,7 @@ Display multiple calendar panels side by side by setting the `data-coreui-calend
 
 ## Range selection
 
-Enable range selection by adding `data-coreui-range="true"` to allow users to pick a start and end date. This example demonstrates how to configure the Bootstrap 5 Calendar component to handle date ranges.
+Enable range selection by adding `data-coreui-range="true"` to allow users to pick a start and end date. This example demonstrates how to configure the Bootstrap 6 Calendar component to handle date ranges.
 
 <Example pro code={`<div class="d-flex justify-content-center">
     <div 

--- a/docs/src/content/docs/components/callout.mdx
+++ b/docs/src/content/docs/components/callout.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Callout"
+title: "Bootstrap 6 Callout"
 name: "Callout"
 description: "Callouts provide presentation of content in a visually distinct manner. Includes a heading, icon and typically text-based content."
 otherFrameworks:

--- a/docs/src/content/docs/components/card.mdx
+++ b/docs/src/content/docs/components/card.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Card"
+title: "Bootstrap 6 Card"
 name: "Card"
 description: "Bootstrap card component provides a flexible and extensible container for displaying content. Bootstrap card is delivered with a bunch of variants and options."
 otherFrameworks:

--- a/docs/src/content/docs/components/carousel.mdx
+++ b/docs/src/content/docs/components/carousel.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Carousel"
+title: "Bootstrap 6 Carousel"
 name: "Carousel"
 description: "Bootstrap carousel is a slideshow component for cycling through elements—images or slides of text—like a carousel."
 otherFrameworks:

--- a/docs/src/content/docs/components/chip-set.mdx
+++ b/docs/src/content/docs/components/chip-set.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Chip Set"
+title: "Bootstrap 6 Chip Set"
 name: "Chip set"
 preRelease: true
 description: "Bootstrap Chip set component for CoreUI — group chips into an accessible, keyboard-navigable container with single or multiple selection."

--- a/docs/src/content/docs/components/chip.mdx
+++ b/docs/src/content/docs/components/chip.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Chip"
+title: "Bootstrap 6 Chip"
 name: "Chip"
 preRelease: true
 description: "Bootstrap Chip component for CoreUI — build removable tags, selectable labels, and filterable chips with icons, avatars, and full keyboard support."

--- a/docs/src/content/docs/components/close-button.mdx
+++ b/docs/src/content/docs/components/close-button.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Close Button"
+title: "Bootstrap 6 Close Button"
 name: "Close button"
 description: "A generic close button for dismissing content like modals and alerts."
 otherFrameworks:

--- a/docs/src/content/docs/components/collapse.mdx
+++ b/docs/src/content/docs/components/collapse.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Collapse"
+title: "Bootstrap 6 Collapse"
 name: "Collapse"
 description: "Bootstrap collapse component toggles the visibility of content across your project with a few classes and some scripts. Useful for a large amount of content."
 otherFrameworks:

--- a/docs/src/content/docs/components/dropdowns.mdx
+++ b/docs/src/content/docs/components/dropdowns.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Dropdowns"
+title: "Bootstrap 6 Dropdowns"
 name: "Dropdowns"
 description: "Bootstrap dropdown component allows you to toggle contextual overlays for displaying lists, links, and more html elements."
 otherFrameworks:

--- a/docs/src/content/docs/components/footer.mdx
+++ b/docs/src/content/docs/components/footer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Footer"
+title: "Bootstrap 6 Footer"
 name: "Footer"
 description: "Bootstrap Footer is an additional navigation used for displaying general information that a user might want to access from any page within your site. It is a place to display boilerplate text about the site, company info, copyrights, links to a contact form, sitemap, FAQ and other such resources."
 otherFrameworks:

--- a/docs/src/content/docs/components/header.mdx
+++ b/docs/src/content/docs/components/header.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Header"
+title: "Bootstrap 6 Header"
 name: "Header"
 description: "Documentation and examples for CoreUI's powerful, responsive header. Includes support for branding, navigation, and more."
 otherFrameworks:

--- a/docs/src/content/docs/components/jumbotron.mdx
+++ b/docs/src/content/docs/components/jumbotron.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Jumbotron"
+title: "Bootstrap 6 Jumbotron"
 name: "Jumbotron"
 description: "Bootstrap jumbotron component indicates a big grey box for showcasing hero unit style content."
 ---

--- a/docs/src/content/docs/components/list-group.mdx
+++ b/docs/src/content/docs/components/list-group.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 List Group"
+title: "Bootstrap 6 List Group"
 name: "List group"
 description: "Bootstrap List Groups allows displaying are a series of content. Learn how to use Bootstrap list group to build complex list structure on your website."
 otherFrameworks:

--- a/docs/src/content/docs/components/loading-buttons.mdx
+++ b/docs/src/content/docs/components/loading-buttons.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 Loading Buttons"
+title: "Bootstrap 6 Loading Buttons"
 name: "Loading Buttons"
 description: "Bootstrap loading buttons are interactive elements that provide visual feedback to users, indicating that an action is being processed. These buttons typically display a loading spinner or animation."
 otherFrameworks:

--- a/docs/src/content/docs/components/menu.mdx
+++ b/docs/src/content/docs/components/menu.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Menu"
+title: "Bootstrap 6 Menu"
 name: "Menu"
 description: "The Menu component toggles contextual overlays with submenus, container teleport and responsive placement - the new generation the Dropdown compatibility layer is built on."
 ---

--- a/docs/src/content/docs/components/modal.mdx
+++ b/docs/src/content/docs/components/modal.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Modal"
+title: "Bootstrap 6 Modal"
 name: "Modal"
 description: "Bootstrap Modals offer a lightweight, multi-purpose JavaScript popup to add dialogs to yours. Learn how to customize Bootstrap Modals easily. Multiple examples and tutorial."
 otherFrameworks:

--- a/docs/src/content/docs/components/nav.mdx
+++ b/docs/src/content/docs/components/nav.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Nav"
+title: "Bootstrap 6 Nav"
 name: "Nav"
 description: "Documentation and examples for how to use CoreUI for Bootstrap's included navigation components."
 otherFrameworks:

--- a/docs/src/content/docs/components/navbar.mdx
+++ b/docs/src/content/docs/components/navbar.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Navbar"
+title: "Bootstrap 6 Navbar"
 name: "Navbar"
 description: "Documentation and examples for CoreUI for Bootstrap's powerful, responsive navigation header, the navbar. Includes support for branding, navigation, and more, including support for our collapse plugin."
 otherFrameworks:

--- a/docs/src/content/docs/components/offcanvas.mdx
+++ b/docs/src/content/docs/components/offcanvas.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Offcanvas"
+title: "Bootstrap 6 Offcanvas"
 name: "Offcanvas"
 description: "Build hidden sidebars into your project for navigation, shopping carts, and more with a few classes and our JavaScript plugin."
 otherFrameworks:

--- a/docs/src/content/docs/components/pagination.mdx
+++ b/docs/src/content/docs/components/pagination.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Pagination"
+title: "Bootstrap 6 Pagination"
 name: "Pagination"
 description: "Documentation and examples for showing pagination to indicate a series of related content exists across multiple pages."
 otherFrameworks:

--- a/docs/src/content/docs/components/placeholders.mdx
+++ b/docs/src/content/docs/components/placeholders.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Placeholders"
+title: "Bootstrap 6 Placeholders"
 name: "Placeholders"
 description: "Use loading placeholders for your components or pages to indicate something may still be loading."
 otherFrameworks:

--- a/docs/src/content/docs/components/popovers.mdx
+++ b/docs/src/content/docs/components/popovers.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Popovers"
+title: "Bootstrap 6 Popovers"
 name: "Popovers"
 description: "Documentation and examples for adding Bootstrap popovers, like those found in iOS, to any element on your site."
 otherFrameworks:

--- a/docs/src/content/docs/components/progress.mdx
+++ b/docs/src/content/docs/components/progress.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Progress"
+title: "Bootstrap 6 Progress"
 name: "Progress"
 description: "Documentation and examples for using Bootstrap custom progress bars featuring support for stacked bars, animated backgrounds, and text labels."
 otherFrameworks:

--- a/docs/src/content/docs/components/scrollspy.mdx
+++ b/docs/src/content/docs/components/scrollspy.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Scrollspy"
+title: "Bootstrap 6 Scrollspy"
 name: "Scrollspy"
 description: "Automatically update Bootstrap navigation or list group components based on scroll position to indicate which link is currently active in the viewport."
 ---

--- a/docs/src/content/docs/components/search-button.mdx
+++ b/docs/src/content/docs/components/search-button.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Search Button"
+title: "Bootstrap 6 Search Button"
 name: "Search Button"
 preRelease: true
 description: "Bootstrap Search Button for CoreUI is a keyboard-aware trigger component that can open search interfaces, modals, offcanvas panels, and custom flows from click or shortcut."

--- a/docs/src/content/docs/components/sidebar.mdx
+++ b/docs/src/content/docs/components/sidebar.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Sidebar"
+title: "Bootstrap 6 Sidebar"
 name: "Sidebar"
 description: "Bootstrap Sidebar is a powerful and customizable responsive navigation component for any type of vertical navigation. Bootstrap Sidebar come with built-in support for branding, navigation, and more."
 otherFrameworks:

--- a/docs/src/content/docs/components/spinners.mdx
+++ b/docs/src/content/docs/components/spinners.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Spinners"
+title: "Bootstrap 6 Spinners"
 name: "Spinners"
 description: "Indicate the loading state of a component or page with Bootstrap spinners, built entirely with HTML, CSS, and no JavaScript."
 otherFrameworks:

--- a/docs/src/content/docs/components/tab.mdx
+++ b/docs/src/content/docs/components/tab.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Tabs"
+title: "Bootstrap 6 Tabs"
 name: "Tabs"
 description: "Turn a nav into a tabbable interface with the tab plugin: panes of local content that swap without leaving the page."
 otherFrameworks:

--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Toasts"
+title: "Bootstrap 6 Toasts"
 name: "Toasts"
 description: "Send push notifications to your visitors with a toast, a lightweight and easily customizable alert message."
 otherFrameworks:

--- a/docs/src/content/docs/components/tooltips.mdx
+++ b/docs/src/content/docs/components/tooltips.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Tooltips"
+title: "Bootstrap 6 Tooltips"
 name: "Tooltips"
 description: "Use Bootstrap Tooltips to add small, informative text boxes that appear when users hover or focus on an element. This feature enhances UX by providing contextual help without cluttering your interface."
 otherFrameworks:

--- a/docs/src/content/docs/content/figures.mdx
+++ b/docs/src/content/docs/content/figures.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Figures"
+title: "Bootstrap 6 Figures"
 name: "Figures"
 description: "Documentation and examples for displaying related images and text with the figure component in Bootstrap."
 ---

--- a/docs/src/content/docs/content/images.mdx
+++ b/docs/src/content/docs/content/images.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Images"
+title: "Bootstrap 6 Images"
 name: "Images"
 description: "Documentation and examples for opting images into responsive behavior (so they never become wider than their parent) and add lightweight styles to them—all via classes."
 otherFrameworks:

--- a/docs/src/content/docs/content/reboot.mdx
+++ b/docs/src/content/docs/content/reboot.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Reboot"
+title: "Bootstrap 6 Reboot"
 name: "Reboot"
 description: "Reboot, a collection of element-specific CSS changes in a single file, kickstart CoreUI for Bootstrap to provide an elegant, consistent, and simple baseline to build upon."
 ---

--- a/docs/src/content/docs/content/tables.mdx
+++ b/docs/src/content/docs/content/tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Tables"
+title: "Bootstrap 6 Tables"
 name: "Tables"
 description: "Documentation and examples for opt-in styling of tables (given their prevalent use in JavaScript plugins) with Bootstrap."
 otherFrameworks:

--- a/docs/src/content/docs/content/typography.mdx
+++ b/docs/src/content/docs/content/typography.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Typography"
+title: "Bootstrap 6 Typography"
 name: "Typography"
 description: "Documentation and examples for Bootstrap typography, including global settings, headings, body text, lists, and more."
 ---

--- a/docs/src/content/docs/forms/autocomplete.mdx
+++ b/docs/src/content/docs/forms/autocomplete.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 Autocomplete"
+title: "Bootstrap 6 Autocomplete"
 name: "Autocomplete"
 description: "Create intelligent, responsive input fields using the Bootstrap Autocomplete plugin. This component enhances user input with dynamic dropdown suggestions, flexible data providers, and callback support."
 otherFrameworks:

--- a/docs/src/content/docs/forms/checkbox.mdx
+++ b/docs/src/content/docs/forms/checkbox.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Checkbox"
+title: "Bootstrap 6 Checkbox"
 name: "Checkbox"
 description: "Create consistent cross-browser and cross-device checkboxes with CoreUI's custom checkbox component."
 otherFrameworks:

--- a/docs/src/content/docs/forms/chip-input.mdx
+++ b/docs/src/content/docs/forms/chip-input.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Chip Input"
+title: "Bootstrap 6 Chip Input"
 name: "Chip input"
 preRelease: true
 description: "Bootstrap Chip Input component for CoreUI — create tag-like multi-value inputs for skills, categories, or recipients with keyboard support, selection, and form integration."
@@ -57,7 +57,7 @@ Wrap chips and add `data-coreui-chip-input` to enable behavior.
 
 ## Variants
 
-Use contextual chip classes inside Bootstrap 5 Chip Input to represent categories, status, or priority.
+Use contextual chip classes inside Bootstrap 6 Chip Input to represent categories, status, or priority.
 
 <Example code={`<div class="chip-input" data-coreui-chip-input data-coreui-name="issues" data-coreui-placeholder="Add label...">
     <span class="chip chip-primary">Feature</span>

--- a/docs/src/content/docs/forms/date-input.mdx
+++ b/docs/src/content/docs/forms/date-input.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 Date Input"
+title: "Bootstrap 6 Date Input"
 name: "Date Input"
 description: "Create date fields with a section-based input mask. Users type the day, month, and year in separate sections with automatic navigation and validation — like the native date input, but with full control over the format."
 otherFrameworks:

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 Date Picker"
+title: "Bootstrap 6 Date Picker"
 name: "Date Picker"
 description: "The v6 date picker: a section-based masked field composed with a calendar popup. Projected footer regions replace button configuration props."
 ---

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 Date Range Picker"
+title: "Bootstrap 6 Date Range Picker"
 name: "Date Range Picker"
 description: "The v6 date range picker: two section-based masked fields composed with a multi-month calendar. Projected ranges and footer replace button configuration props."
 ---

--- a/docs/src/content/docs/forms/date-time-input.mdx
+++ b/docs/src/content/docs/forms/date-time-input.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 Date Time Input"
+title: "Bootstrap 6 Date Time Input"
 name: "Date Time Input"
 description: "Create combined date and time fields with a section-based input mask. Users type the day, month, year, hour, and minutes in separate sections with automatic navigation and validation — like the native datetime-local input, but with full control over the format."
 otherFrameworks:

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 Date Time Picker"
+title: "Bootstrap 6 Date Time Picker"
 name: "Date Time Picker"
 description: "The v6 date time picker: a masked date-time field composed with a calendar and the time selection body. Replaces the timepicker flag of the v1 date picker."
 ---

--- a/docs/src/content/docs/forms/field.mdx
+++ b/docs/src/content/docs/forms/field.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Form Field"
+title: "Bootstrap 6 Form Field"
 name: "Field"
 description: "A layout wrapper for a form control, its label, description and validation feedback, built on CSS grid."
 ---

--- a/docs/src/content/docs/forms/floating-labels.mdx
+++ b/docs/src/content/docs/forms/floating-labels.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Floating Labels"
+title: "Bootstrap 6 Floating Labels"
 name: "Floating labels"
 description: "Create beautifully simple form labels that float over your input fields."
 otherFrameworks:

--- a/docs/src/content/docs/forms/form-control-group.mdx
+++ b/docs/src/content/docs/forms/form-control-group.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Form Control Group"
+title: "Bootstrap 6 Form Control Group"
 name: "Form Control Group"
 description: "Assemble an input, icons and action buttons into one control that looks and behaves like a single form field — the frame every CoreUI field component is built on."
 ---

--- a/docs/src/content/docs/forms/form-control.mdx
+++ b/docs/src/content/docs/forms/form-control.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Form Controls"
+title: "Bootstrap 6 Form Controls"
 name: "Form controls"
 description: "Give textual form controls like `<input>`s and `<textarea>`s an upgrade with custom styles, sizing, focus states, and more."
 otherFrameworks:

--- a/docs/src/content/docs/forms/input-group.mdx
+++ b/docs/src/content/docs/forms/input-group.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Input Group"
+title: "Bootstrap 6 Input Group"
 name: "Input group"
 description: "Easily extend form controls by adding text, buttons, or button groups on either side of textual inputs, custom selects, and custom file inputs."
 otherFrameworks:

--- a/docs/src/content/docs/forms/layout.mdx
+++ b/docs/src/content/docs/forms/layout.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Layout"
+title: "Bootstrap 6 Layout"
 name: "Layout"
 description: "Give your forms some structure—from inline to horizontal to custom grid implementations—with our form layout options."
 ---

--- a/docs/src/content/docs/forms/multi-select.mdx
+++ b/docs/src/content/docs/forms/multi-select.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 Multi Select"
+title: "Bootstrap 6 Multi Select"
 name: "Multi Select"
 description: "Customize the native `<select>`s with a powerful Bootstrap Multi-Select component that changes the element's initial appearance and brings some new functionalities."
 otherFrameworks:

--- a/docs/src/content/docs/forms/number-input.mdx
+++ b/docs/src/content/docs/forms/number-input.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 Number Input"
+title: "Bootstrap 6 Number Input"
 name: "Number Input"
 description: "Add accessible increment and decrement buttons to a Bootstrap number field, with min, max and step handled by the browser."
 ---

--- a/docs/src/content/docs/forms/otp-input.mdx
+++ b/docs/src/content/docs/forms/otp-input.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 One Time Password (OTP) Input"
+title: "Bootstrap 6 One Time Password (OTP) Input"
 name: "One Time Password (OTP) Input"
 description: "Create secure and user-friendly one-time password input fields with automatic navigation, paste support, validation, and customizable options for modern authentication flows."
 otherFrameworks:

--- a/docs/src/content/docs/forms/overview.mdx
+++ b/docs/src/content/docs/forms/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Forms"
+title: "Bootstrap 6 Forms"
 name: "Forms"
 description: "Examples and usage guidelines for form control styles, layout options, and custom components for creating a wide variety of forms."
 ---

--- a/docs/src/content/docs/forms/password-input.mdx
+++ b/docs/src/content/docs/forms/password-input.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 Password Input"
+title: "Bootstrap 6 Password Input"
 name: "Password Input"
 description: "Enhance your password input fields in Bootstrap with custom styles, sizing options, toggle visibility button, and more."
 otherFrameworks:

--- a/docs/src/content/docs/forms/radio.mdx
+++ b/docs/src/content/docs/forms/radio.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Radio"
+title: "Bootstrap 6 Radio"
 name: "Radio"
 description: "Create consistent cross-browser and cross-device radio buttons with CoreUI's custom radio component."
 otherFrameworks:

--- a/docs/src/content/docs/forms/range-slider.mdx
+++ b/docs/src/content/docs/forms/range-slider.mdx
@@ -1,8 +1,8 @@
 ---
 pro: true
-title: "Bootstrap 5 Range Slider"
+title: "Bootstrap 6 Range Slider"
 name: "Range Slider"
-description: "Enhance your forms with our customizable Bootstrap 5 Range Slider component for advanced range selection."
+description: "Enhance your forms with our customizable Bootstrap 6 Range Slider component for advanced range selection."
 otherFrameworks:
   - range-slider
 ---
@@ -14,7 +14,7 @@ import rangeSliderCustomTooltips from './snippets/range-slider-custom-tooltips.j
 
 ## Overview
 
-The **Bootstrap 5 Range Slider** component allows users to select a value or range of values within a predefined range. Unlike the standard `<input type="range" />`, the Range Slider offers enhanced customization options, including multiple handles, labels, tooltips, and vertical orientation. It ensures consistent styling across browsers and provides a rich set of features for advanced use cases.
+The **Bootstrap 6 Range Slider** component allows users to select a value or range of values within a predefined range. Unlike the standard `<input type="range" />`, the Range Slider offers enhanced customization options, including multiple handles, labels, tooltips, and vertical orientation. It ensures consistent styling across browsers and provides a rich set of features for advanced use cases.
 
 <Example pro code={`<div data-coreui-toggle="range-slider"
        data-coreui-value="25,75"

--- a/docs/src/content/docs/forms/range.mdx
+++ b/docs/src/content/docs/forms/range.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Range"
+title: "Bootstrap 6 Range"
 name: "Range"
 description: "Use our custom range inputs for consistent cross-browser styling and built-in customization."
 otherFrameworks:

--- a/docs/src/content/docs/forms/rating.mdx
+++ b/docs/src/content/docs/forms/rating.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 Rating"
+title: "Bootstrap 6 Rating"
 name: "Rating"
 description: "The Rating component allows users to provide feedback on content or services by selecting a rating value. It is customizable, supports various sizes and icons, and can be made interactive or read-only."
 otherFrameworks:

--- a/docs/src/content/docs/forms/select.mdx
+++ b/docs/src/content/docs/forms/select.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Select"
+title: "Bootstrap 6 Select"
 name: "Select"
 description: "Customize the native `<select>`s with custom CSS that changes the element's initial appearance."
 otherFrameworks:

--- a/docs/src/content/docs/forms/stepper.mdx
+++ b/docs/src/content/docs/forms/stepper.mdx
@@ -1,8 +1,8 @@
 ---
 pro: true
-title: "Bootstrap 5 Stepper"
+title: "Bootstrap 6 Stepper"
 name: "Stepper"
-description: "Build responsive, accessible multi-step forms and form wizards using CoreUI's Bootstrap 5 Stepper Component. Vertical and horizontal layouts, built-in validation, full customization."
+description: "Build responsive, accessible multi-step forms and form wizards using CoreUI's Bootstrap 6 Stepper Component. Vertical and horizontal layouts, built-in validation, full customization."
 ---
 
 # Stepper
@@ -10,7 +10,7 @@ description: "Build responsive, accessible multi-step forms and form wizards usi
 The Bootstrap Stepper component allows you to easily create multi-step form wizards, perfect for guiding users through long forms, registrations, or checkout flows.
 It supports horizontal and vertical layouts, built-in form validation, accessibility features, and full customization.
 
-If you're looking for a Form Wizard in Bootstrap 5 or a flexible Stepper Component, CoreUI Stepper is the complete solution.
+If you're looking for a Form Wizard in Bootstrap 6 or a flexible Stepper Component, CoreUI Stepper is the complete solution.
 
 ## Example
 

--- a/docs/src/content/docs/forms/switch.mdx
+++ b/docs/src/content/docs/forms/switch.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Switch"
+title: "Bootstrap 6 Switch"
 name: "Switch"
 description: "Render a checkbox as a toggle switch with CoreUI's switch component, in four sizes."
 otherFrameworks:

--- a/docs/src/content/docs/forms/time-input.mdx
+++ b/docs/src/content/docs/forms/time-input.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 Time Input"
+title: "Bootstrap 6 Time Input"
 name: "Time Input"
 description: "Create time fields with a section-based input mask. Users type the hour, minutes, and seconds in separate sections with automatic navigation and validation — like the native time input, but with full control over the format."
 otherFrameworks:

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -1,6 +1,6 @@
 ---
 pro: true
-title: "Bootstrap 5 Time Picker"
+title: "Bootstrap 6 Time Picker"
 name: "Time Picker"
 description: "The v6 time picker: a section-based masked field composed with the shared time selection body."
 ---

--- a/docs/src/content/docs/forms/validation.mdx
+++ b/docs/src/content/docs/forms/validation.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Validation"
+title: "Bootstrap 6 Validation"
 name: "Validation"
 description: "Provide valuable, actionable feedback to your users with HTML5 form validation, via browser default behaviors or custom styles and JavaScript."
 ---

--- a/docs/src/content/docs/helpers/clearfix.mdx
+++ b/docs/src/content/docs/helpers/clearfix.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Clearfix"
+title: "Bootstrap 6 Clearfix"
 name: "Clearfix"
 description: "Quickly and easily clear floated content within a container by adding a clearfix utility."
 ---

--- a/docs/src/content/docs/helpers/color-background.mdx
+++ b/docs/src/content/docs/helpers/color-background.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Color & Background"
+title: "Bootstrap 6 Color & Background"
 name: "Color & background"
 description: "Set a background color with contrasting foreground color."
 ---

--- a/docs/src/content/docs/helpers/focus-ring.mdx
+++ b/docs/src/content/docs/helpers/focus-ring.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Focus Ring"
+title: "Bootstrap 6 Focus Ring"
 name: "Focus ring"
 description: "Utility classes that allows you to add and modify custom focus ring styles to elements and components."
 ---

--- a/docs/src/content/docs/helpers/position.mdx
+++ b/docs/src/content/docs/helpers/position.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Position"
+title: "Bootstrap 6 Position"
 name: "Position"
 description: "Use these helpers for quickly configuring the position of an element."
 ---

--- a/docs/src/content/docs/helpers/stacks.mdx
+++ b/docs/src/content/docs/helpers/stacks.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Stacks"
+title: "Bootstrap 6 Stacks"
 name: "Stacks"
 description: "Shorthand helpers that build on top of our flexbox utilities to make component layout faster and easier than ever."
 ---

--- a/docs/src/content/docs/helpers/stretched-link.mdx
+++ b/docs/src/content/docs/helpers/stretched-link.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Stretched Link"
+title: "Bootstrap 6 Stretched Link"
 name: "Stretched link"
 description: "Make any HTML element or CoreUI for Bootstrap component clickable by \"stretching\" a nested link via CSS."
 ---

--- a/docs/src/content/docs/helpers/text-truncation.mdx
+++ b/docs/src/content/docs/helpers/text-truncation.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Text Truncation"
+title: "Bootstrap 6 Text Truncation"
 name: "Text truncation"
 description: "Truncate long strings of text with an ellipsis."
 ---

--- a/docs/src/content/docs/helpers/vertical-rule.mdx
+++ b/docs/src/content/docs/helpers/vertical-rule.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Vertical Rule"
+title: "Bootstrap 6 Vertical Rule"
 name: "Vertical rule"
 description: "Use the custom vertical rule helper to create vertical dividers like the `<hr>` element."
 ---

--- a/docs/src/content/docs/helpers/visually-hidden.mdx
+++ b/docs/src/content/docs/helpers/visually-hidden.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Visually Hidden"
+title: "Bootstrap 6 Visually Hidden"
 name: "Visually hidden"
 description: "Use these helpers to visually hide elements but keep them accessible to assistive technologies."
 ---

--- a/docs/src/content/docs/layout/breakpoints.mdx
+++ b/docs/src/content/docs/layout/breakpoints.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Breakpoints"
+title: "Bootstrap 6 Breakpoints"
 name: "Breakpoints"
 description: "Breakpoints are the triggers in CoreUI for Bootstrap for how your layout responsive changes across device or viewport sizes."
 ---

--- a/docs/src/content/docs/layout/columns.mdx
+++ b/docs/src/content/docs/layout/columns.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Columns"
+title: "Bootstrap 6 Columns"
 name: "Columns"
 description: "Learn how to modify columns with a handful of options for alignment, ordering, and offsetting thanks to our flexbox grid system. Plus, see how to use column classes to manage widths of non-grid elements."
 ---

--- a/docs/src/content/docs/layout/containers.mdx
+++ b/docs/src/content/docs/layout/containers.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Containers"
+title: "Bootstrap 6 Containers"
 name: "Containers"
 description: "Containers are a fundamental building block of CoreUI for Bootstrap that contain, pad, and align your content within a given device or viewport."
 ---

--- a/docs/src/content/docs/layout/css-grid.mdx
+++ b/docs/src/content/docs/layout/css-grid.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 CSS Grid"
+title: "Bootstrap 6 CSS Grid"
 name: "CSS Grid"
 description: "Learn how to enable, use, and customize our alternate layout system built on CSS Grid with examples and code snippets."
 ---

--- a/docs/src/content/docs/layout/grid.mdx
+++ b/docs/src/content/docs/layout/grid.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Grid System"
+title: "Bootstrap 6 Grid System"
 name: "Grid system"
 description: "Use our powerful mobile-first flexbox grid to build layouts of all shapes and sizes thanks to a twelve column system, six default responsive tiers, Sass variables and mixins, and dozens of predefined classes."
 ---

--- a/docs/src/content/docs/layout/gutters.mdx
+++ b/docs/src/content/docs/layout/gutters.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Gutters"
+title: "Bootstrap 6 Gutters"
 name: "Gutters"
 description: "Gutters are the padding between your columns, used to responsively space and align content in the CoreUI for Bootstrap grid system."
 ---

--- a/docs/src/content/docs/layout/utilities.mdx
+++ b/docs/src/content/docs/layout/utilities.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Utilities For Layout"
+title: "Bootstrap 6 Utilities For Layout"
 name: "Utilities for layout"
 description: "For faster mobile-friendly and responsive development, CoreUI for Bootstrap includes dozens of utility classes for showing, hiding, aligning, and spacing content."
 ---

--- a/docs/src/content/docs/layout/z-index.mdx
+++ b/docs/src/content/docs/layout/z-index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Z-Index"
+title: "Bootstrap 6 Z-Index"
 name: "Z-index"
 description: "While not a part of CoreUI for Bootstrap's grid system, z-indexes play an important part in how our components overlay and interact with one another."
 ---

--- a/docs/src/content/docs/utilities/background.mdx
+++ b/docs/src/content/docs/utilities/background.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Background"
+title: "Bootstrap 6 Background"
 name: "Background"
 description: "Convey meaning through `background-color` and add decoration with gradients."
 ---

--- a/docs/src/content/docs/utilities/colors.mdx
+++ b/docs/src/content/docs/utilities/colors.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Colors"
+title: "Bootstrap 6 Colors"
 name: "Colors"
 description: "Convey meaning through `color` with a handful of color utility classes. Includes support for styling links with hover states, too."
 utility: [{prefix: "text", property: "color"}, "text-opacity"]

--- a/docs/src/content/docs/utilities/container-queries.mdx
+++ b/docs/src/content/docs/utilities/container-queries.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Container Queries"
+title: "Bootstrap 6 Container Queries"
 name: "Container queries"
 description: "Turn an element into a query container so its descendants can respond to its size instead of the viewport."
 utility: "contains"

--- a/docs/src/content/docs/utilities/display.mdx
+++ b/docs/src/content/docs/utilities/display.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Display Property"
+title: "Bootstrap 6 Display Property"
 name: "Display property"
 description: "Quickly and responsively toggle the display value of components and more with our display utilities. Includes support for some of the more common values, as well as some extras for controlling display when printing."
 utility: "d"

--- a/docs/src/content/docs/utilities/flex.mdx
+++ b/docs/src/content/docs/utilities/flex.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Flex"
+title: "Bootstrap 6 Flex"
 name: "Flex"
 description: "Quickly manage the layout, alignment, and sizing of grid columns, navigation, components, and more with a full suite of responsive flexbox utilities. For more complex implementations, custom CSS may be necessary."
 utility: ["flex", "order"]

--- a/docs/src/content/docs/utilities/float.mdx
+++ b/docs/src/content/docs/utilities/float.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Float"
+title: "Bootstrap 6 Float"
 name: "Float"
 description: "Toggle floats on any element, across any breakpoint, using our responsive float utilities."
 utility: "float"

--- a/docs/src/content/docs/utilities/grid.mdx
+++ b/docs/src/content/docs/utilities/grid.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Grid utilities"
+title: "Bootstrap 6 Grid utilities"
 name: "Grid"
 description: "Lay out and align CSS Grid containers and their items with responsive utilities for track counts, auto flow, and inline-axis alignment."
 utility: ["grid-cols", "col-span", "grid-flow"]

--- a/docs/src/content/docs/utilities/link.mdx
+++ b/docs/src/content/docs/utilities/link.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Link"
+title: "Bootstrap 6 Link"
 name: "Link"
 description: "Link utilities are used to stylize your anchors to adjust their color, opacity, underline offset, underline color, and more."
 utility: ["link-opacity", "link-offset", "link-underline"]

--- a/docs/src/content/docs/utilities/motion.mdx
+++ b/docs/src/content/docs/utilities/motion.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Motion"
+title: "Bootstrap 6 Motion"
 name: "Motion"
 description: "Remove the transition from a single element with motion utilities."
 utility: "transition"

--- a/docs/src/content/docs/utilities/object-fit.mdx
+++ b/docs/src/content/docs/utilities/object-fit.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Object Fit"
+title: "Bootstrap 6 Object Fit"
 name: "Object fit"
 description: "Use the object fit utilities to modify how the content of a [replaced element](https://developer.mozilla.org/en-US/docs/Web/CSS/Replaced_element), such as an `<img>` or `<video>`, should be resized to fit its container."
 utility: "object-fit"

--- a/docs/src/content/docs/utilities/opacity.mdx
+++ b/docs/src/content/docs/utilities/opacity.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Opacity"
+title: "Bootstrap 6 Opacity"
 name: "Opacity"
 description: "Control the opacity of elements."
 utility: "opacity"

--- a/docs/src/content/docs/utilities/overflow.mdx
+++ b/docs/src/content/docs/utilities/overflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Overflow"
+title: "Bootstrap 6 Overflow"
 name: "Overflow"
 description: "Use these shorthand utilities for quickly configuring how content overflows an element."
 ---

--- a/docs/src/content/docs/utilities/position.mdx
+++ b/docs/src/content/docs/utilities/position.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Position"
+title: "Bootstrap 6 Position"
 name: "Position"
 description: "Use these shorthand utilities for quickly configuring the position of an element."
 utility: ["position", "top", "bottom", "start", "end", "translate-middle"]

--- a/docs/src/content/docs/utilities/shadows.mdx
+++ b/docs/src/content/docs/utilities/shadows.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Shadows"
+title: "Bootstrap 6 Shadows"
 name: "Shadows"
 description: "Add or remove shadows to elements with box-shadow utilities."
 ---

--- a/docs/src/content/docs/utilities/vertical-align.mdx
+++ b/docs/src/content/docs/utilities/vertical-align.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Vertical Alignment"
+title: "Bootstrap 6 Vertical Alignment"
 name: "Vertical alignment"
 description: "Easily change the vertical alignment of inline, inline-block, inline-table, and table cell elements."
 utility: {prefix: "align", property: "vertical-align"}

--- a/docs/src/content/docs/utilities/visibility.mdx
+++ b/docs/src/content/docs/utilities/visibility.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Visibility"
+title: "Bootstrap 6 Visibility"
 name: "Visibility"
 description: "Control the visibility of elements, without modifying their display, with visibility utilities."
 utility: ["visible", "invisible"]

--- a/docs/src/content/docs/utilities/z-index.mdx
+++ b/docs/src/content/docs/utilities/z-index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Z-Index"
+title: "Bootstrap 6 Z-Index"
 name: "Z-index"
 description: "Use our low-level `z-index` utilities to quickly change the stack level of an element or component."
 utility: "z"

--- a/docs/src/data/config.yml
+++ b/docs/src/data/config.yml
@@ -17,7 +17,7 @@ header:
 seo:
   url: https://coreui.io/bootstrap/docs
   titleTemplate: "%s · CoreUI"
-  description: Open Source UI Components library built on top of Bootstrap 5.
+  description: Open Source UI Components library built on top of Bootstrap 6.
   image: https://coreui.io/bootstrap/docs/images/coreui-social.jpg
   twitter: core_ui
   author: CoreUI


### PR DESCRIPTION
The docs tree carried both major numbers at once: 105 page titles and the site description still read "Bootstrap 5", while pages added later (the utilities split) already read "Bootstrap 6". Within a single section two sibling pages advertised different majors.

Every occurrence changed here is the product name, not a version reference:

- 105 `title:` lines across `components/`, `forms/`, `utilities/`, `layout/`, `content/`, `helpers/`
- 2 `description:` lines (`forms/range-slider`, `forms/stepper`)
- 5 prose mentions (`forms/chip-input`, `forms/range-slider`, `forms/stepper`, `components/calendar` ×2)
- the site description in `docs/src/data/config.yml`

Left untouched, because they are genuine version references, not the product name:

- `getting-started/introduction` — "Bootstrap 3 & 4 LTS"
- `utilities/flex` — the Bootstrap 4 media-object link
- `getting-started/download` — the hard-coded `v5.8.0`, a separate defect handled on its own

Gate: `npm run docs-build` green, 172 pages, no broken links.