### PR TITLE
docs(components): color every component with a theme class

### DIFF
--- a/docs/src/content/docs/components/accordion.mdx
+++ b/docs/src/content/docs/components/accordion.mdx
@@ -145,8 +145,8 @@ They work on an exclusive accordion too: the HTML Standard forbids leaving more 
 
 Both return a promise that settles once the items have finished moving.
 
-<Example code={`<button class="btn btn-primary mb-3" type="button" id="accordionExpandAll">Expand all</button>
-  <button class="btn btn-secondary mb-3" type="button" id="accordionCollapseAll">Collapse all</button>
+<Example code={`<button class="btn-solid theme-primary mb-3" type="button" id="accordionExpandAll">Expand all</button>
+  <button class="btn-solid theme-secondary mb-3" type="button" id="accordionCollapseAll">Collapse all</button>
   <div class="accordion" id="accordionToggleAll">
     <details class="accordion-item" name="accordionToggleAll" open>
       <summary class="accordion-header">Accordion Item #1</summary>

--- a/docs/src/content/docs/components/alerts.mdx
+++ b/docs/src/content/docs/components/alerts.mdx
@@ -11,24 +11,24 @@ import alertLive from './snippets/alert-live.js?raw'
 
 ## Examples
 
-Bootstrap alerts can accommodate text of any length and feature an optional close button. To style an alert, apply one of the required contextual classes (e.g., .alert-success). For inline dismissal, utilize the [alerts JavaScript plugin](#dismissing).
+Bootstrap alerts can accommodate text of any length and feature an optional close button. `.alert` on its own is a neutral alert; the colour comes from a [`.theme-*` class](/customize/components/#theme-variants), which may sit on the alert or on any element above it. For inline dismissal, utilize the [alerts JavaScript plugin](#dismissing).
 
-<Example code={`<div class="alert alert-primary" role="alert">
+<Example code={`<div class="alert theme-primary" role="alert">
     Here's a straightforward example of a primary alert—take a look!
   </div>
-  <div class="alert alert-secondary" role="alert">
+  <div class="alert theme-secondary" role="alert">
     Here's a straightforward example of a secondary alert—take a look!
   </div>
-  <div class="alert alert-success" role="alert">
+  <div class="alert theme-success" role="alert">
     Here's a straightforward example of a success alert—take a look!
   </div>
-  <div class="alert alert-danger" role="alert">
+  <div class="alert theme-danger" role="alert">
     Here's a straightforward example of a danger alert—take a look!
   </div>
-  <div class="alert alert-warning" role="alert">
+  <div class="alert theme-warning" role="alert">
     Here's a straightforward example of a warning alert—take a look!
   </div>
-  <div class="alert alert-info" role="alert">
+  <div class="alert theme-info" role="alert">
     Here's a straightforward example of an info alert—take a look!
   </div>`} />
 
@@ -43,7 +43,7 @@ Relying on color to convey meaning creates a visual cue that assistive technolog
 Click the button below to show an alert (initially hidden with inline styles), then dismiss (and destroy) it using the built-in close button.
 
 <Example code={`<div id="liveAlertPlaceholder"></div>
-  <button type="button" class="btn btn-primary" id="liveAlertBtn">Show alert with message</button>`} sandboxJs={alertLive} />
+  <button type="button" class="btn-solid theme-primary" id="liveAlertBtn">Show alert with message</button>`} sandboxJs={alertLive} />
 
 The JavaScript below initiates our live alert demo:
 
@@ -52,22 +52,22 @@ The JavaScript below initiates our live alert demo:
 ### Link color
 
 Utilize the `.alert-link` utility class to instantly create matching colored links within any alert.
-<Example code={`<div class="alert alert-primary" role="alert">
+<Example code={`<div class="alert theme-primary" role="alert">
     Here's a straightforward example of a primary alert with <a href="#" class="alert-link">an example link</a>. Take a look!
   </div>
-  <div class="alert alert-secondary" role="alert">
+  <div class="alert theme-secondary" role="alert">
     Here's a straightforward example of a secondary alert with <a href="#" class="alert-link">an example link</a>. Take a look!
   </div>
-  <div class="alert alert-success" role="alert">
+  <div class="alert theme-success" role="alert">
     Here's a straightforward example of a success alert with <a href="#" class="alert-link">an example link</a>. Take a look!
   </div>
-  <div class="alert alert-danger" role="alert">
+  <div class="alert theme-danger" role="alert">
     Here's a straightforward example of a danger alert with <a href="#" class="alert-link">an example link</a>. Take a look!
   </div>
-  <div class="alert alert-warning" role="alert">
+  <div class="alert theme-warning" role="alert">
     Here's a straightforward example of a warning alert with <a href="#" class="alert-link">an example link</a>. Take a look!
   </div>
-  <div class="alert alert-info" role="alert">
+  <div class="alert theme-info" role="alert">
     Here's a straightforward example of an info alert with <a href="#" class="alert-link">an example link</a>. Take a look!
   </div>`} />
 
@@ -75,7 +75,7 @@ Utilize the `.alert-link` utility class to instantly create matching colored lin
 
 Bootstrap alerts can also include additional HTML elements such as headings, paragraphs, and dividers. The alert lays its children out in a row, so wrap them in a [`.vstack`](/helpers/stacks/) to keep them stacked.
 
-<Example code={`<div class="alert alert-success" role="alert">
+<Example code={`<div class="alert theme-success" role="alert">
     <div class="vstack">
       <h4 class="alert-heading">Great job! </h4>
       <p>Awesome! You've successfully read this crucial alert message. This example text will be slightly longer to demonstrate how spacing in an alert interacts with this type of content.</p>
@@ -88,7 +88,7 @@ Bootstrap alerts can also include additional HTML elements such as headings, par
 
 Put an icon straight into the alert — it lays its children out in a row and spaces them with `--cui-alert-gap`, so no flexbox utilities are needed. Use [CoreUI Icons](https://coreui.io/icons/) or any inline SVG.
 
-<Example code={`<div class="alert alert-primary" role="alert">
+<Example code={`<div class="alert theme-primary" role="alert">
     <svg class="flex-shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 512 512">
       <rect width="32" height="176" x="240" y="176" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
       <rect width="32" height="32" x="240" y="384" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
@@ -101,7 +101,7 @@ Put an icon straight into the alert — it lays its children out in a row and sp
 
 Different kinds of alert usually call for different icons. Put the matching SVG straight into each one. To reuse a single icon many times across a page, define it once as a symbol — see [Icons](/icons/).
 
-<Example code={`<div class="alert alert-primary" role="alert">
+<Example code={`<div class="alert theme-primary" role="alert">
     <svg class="flex-shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 512 512" role="img" aria-label="Info:">
       <rect width="34.924" height="34.924" x="256" y="95.998" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
       <path fill="var(--ci-primary-color, currentColor)" d="M16,496H496V16H16ZM48,48H464V464H48Z" class="ci-primary"/>
@@ -111,7 +111,7 @@ Different kinds of alert usually call for different icons. Put the matching SVG 
       A straightforward alert with an icon
     </div>
   </div>
-  <div class="alert alert-success" role="alert">
+  <div class="alert theme-success" role="alert">
     <svg class="flex-shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 512 512" role="img" aria-label="Success:">
       <path fill="var(--ci-primary-color, currentColor)" d="M426.072,86.928A238.75,238.75,0,0,0,88.428,424.572,238.75,238.75,0,0,0,426.072,86.928ZM257.25,462.5c-114,0-206.75-92.748-206.75-206.75S143.248,49,257.25,49,464,141.748,464,255.75,371.252,462.5,257.25,462.5Z" class="ci-primary"/>
       <polygon fill="var(--ci-primary-color, currentColor)" points="221.27 305.808 147.857 232.396 125.23 255.023 221.27 351.063 388.77 183.564 366.142 160.937 221.27 305.808" class="ci-primary"/>
@@ -120,7 +120,7 @@ Different kinds of alert usually call for different icons. Put the matching SVG 
       A straightforward success alert with an icon
     </div>
   </div>
-  <div class="alert alert-warning" role="alert">
+  <div class="alert theme-warning" role="alert">
     <svg class="flex-shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 512 512" role="img" aria-label="Warning:">
       <rect width="32" height="176" x="240" y="176" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
       <rect width="32" height="32" x="240" y="384" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
@@ -130,7 +130,7 @@ Different kinds of alert usually call for different icons. Put the matching SVG 
       A straightforward warning alert with an icon
     </div>
   </div>
-  <div class="alert alert-danger" role="alert">
+  <div class="alert theme-danger" role="alert">
     <svg class="flex-shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 512 512" role="img" aria-label="Danger:">
       <rect width="32" height="176" x="240" y="176" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
       <rect width="32" height="32" x="240" y="384" fill="var(--ci-primary-color, currentColor)" class="ci-primary"/>
@@ -147,7 +147,7 @@ Different kinds of alert usually call for different icons. Put the matching SVG 
 
 Add `.alert-solid` for a high-contrast alert. The background takes the theme color and the text takes the color that reads on it, so a yellow alert gets dark text and a dark one gets light text without you picking either.
 
-<Example code={getData('theme-colors').map((c) => `<div class="alert alert-solid alert-${c.name}" role="alert">
+<Example code={getData('theme-colors').map((c) => `<div class="alert alert-solid theme-${c.name}" role="alert">
     Here's a straightforward example of solid ${c.name} alert—take a look!
   </div>`)} />
 
@@ -164,7 +164,7 @@ Using the JavaScript plugin, you can remove any alert.
 
 You can observe this in action with a live demonstration:
 
-<Example code={`<div class="alert alert-warning" role="alert">
+<Example code={`<div class="alert theme-warning" role="alert">
     Wow, you might want to take a look at some of the fields listed below.
     <button type="button" class="btn-close" data-coreui-dismiss="alert" aria-label="Close"></button>
   </div>`} />
@@ -241,6 +241,25 @@ myAlert.addEventListener('closed.coreui.alert', event => {
   // document.getElementById('...').focus()
 })
 ```
+
+## Deprecated markup
+
+<DeprecatedIn version="6.0.0" />
+
+The v5 spelling — `.alert` with a colour modifier — still works and renders identically. Each colour class is generated from the same theme map as the class it replaces, so `.alert-primary` *is* `.alert.theme-primary`. They are removed in v7.
+
+<Example code={getData('theme-colors').map((c) => `<div class="alert alert-${c.name}" role="alert">
+    Here's a straightforward example of a ${c.name} alert—take a look!
+  </div>`)} />
+
+```diff
+- <div class="alert alert-success" role="alert">Saved</div>
++ <div class="alert theme-success" role="alert">Saved</div>
+```
+
+The rewrite buys two things the modifier cannot. A theme colour set on a wrapper reaches every alert inside it, and a colour of your own works the moment you define its theme tokens, with no Sass to compile.
+
+See the [v6 migration guide](/migration/v6/) for the full picture.
 
 ## Customizing
 

--- a/docs/src/content/docs/components/badge.mdx
+++ b/docs/src/content/docs/components/badge.mdx
@@ -34,7 +34,7 @@ Badges adapt to the `font-size` of the parent element, down to a floor that keep
 
 Badges can be used as part of links or buttons to provide a counter.
 
-<Example code={`<button type="button" class="btn btn-primary">
+<Example code={`<button type="button" class="btn-solid theme-primary">
     Notifications <span class="badge theme-danger">4</span>
   </button>`} />
 
@@ -46,7 +46,7 @@ Unless the context is clear, consider including additional context with a visual
 
 Use utilities to modify a `.badge` and position it in the corner of a link or button.
 
-<Example code={`<button type="button" class="btn btn-primary position-relative">
+<Example code={`<button type="button" class="btn-solid theme-primary position-relative">
     Inbox
     <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill theme-danger">
       99+
@@ -56,7 +56,7 @@ Use utilities to modify a `.badge` and position it in the corner of a link or bu
 
 You can also replace the `.badge` class with a few more utilities without a count for a more generic indicator.
 
-<Example code={`<button type="button" class="btn btn-primary position-relative">
+<Example code={`<button type="button" class="btn-solid theme-primary position-relative">
     Profile
     <span class="position-absolute top-0 start-100 translate-middle p-2 bg-danger border border-secondary rounded-circle">
       <span class="visually-hidden">New alerts</span>

--- a/docs/src/content/docs/components/button-group.mdx
+++ b/docs/src/content/docs/components/button-group.mdx
@@ -11,9 +11,9 @@ otherFrameworks:
 Wrap a series of buttons with `.btn` in `.btn-group`. Add on optional JavaScript radio and checkbox style behavior with [our buttons plugin](/components/buttons/#button-plugin).
 
 <Example code={`<div class="btn-group" role="group" aria-label="Basic example">
-    <button type="button" class="btn btn-primary">Left</button>
-    <button type="button" class="btn btn-primary">Middle</button>
-    <button type="button" class="btn btn-primary">Right</button>
+    <button type="button" class="btn-solid theme-primary">Left</button>
+    <button type="button" class="btn-solid theme-primary">Middle</button>
+    <button type="button" class="btn-solid theme-primary">Right</button>
   </div>`} />
 
 <Callout color="info">
@@ -27,25 +27,25 @@ Besides, groups and toolbars should be provided an understandable label, as most
 These classes can also be added to groups of links, as an alternative to the [`.nav` navigation components](/components/nav/).
 
 <Example code={`<div class="btn-group">
-    <a href="#" class="btn btn-primary active" aria-current="page">Active link</a>
-    <a href="#" class="btn btn-primary">Link</a>
-    <a href="#" class="btn btn-primary">Link</a>
+    <a href="#" class="btn-solid theme-primary active" aria-current="page">Active link</a>
+    <a href="#" class="btn-solid theme-primary">Link</a>
+    <a href="#" class="btn-solid theme-primary">Link</a>
   </div>`} />
 
 ## Mixed styles
 
 <Example code={`<div class="btn-group" role="group" aria-label="Basic mixed styles example">
-    <button type="button" class="btn btn-danger">Left</button>
-    <button type="button" class="btn btn-warning">Middle</button>
-    <button type="button" class="btn btn-success">Right</button>
+    <button type="button" class="btn-solid theme-danger">Left</button>
+    <button type="button" class="btn-solid theme-warning">Middle</button>
+    <button type="button" class="btn-solid theme-success">Right</button>
   </div>`} />
 
 ## Outlined styles
 
 <Example code={`<div class="btn-group" role="group" aria-label="Basic outlined example">
-    <button type="button" class="btn btn-outline-primary">Left</button>
-    <button type="button" class="btn btn-outline-primary">Middle</button>
-    <button type="button" class="btn btn-outline-primary">Right</button>
+    <button type="button" class="btn-outline theme-primary">Left</button>
+    <button type="button" class="btn-outline theme-primary">Middle</button>
+    <button type="button" class="btn-outline theme-primary">Right</button>
   </div>`} />
 
 ## Checkbox and radio button groups
@@ -53,34 +53,34 @@ These classes can also be added to groups of links, as an alternative to the [`.
 Combine button-like [checkbox](/forms/checkbox/#toggle-buttons) and [radio](/forms/radio/#toggle-buttons) toggle buttons into a seamless looking button group.
 
 <Example code={`<div class="btn-group" role="group" aria-label="Basic checkbox toggle button group">
-    <label class="btn btn-outline-primary btn-check">
+    <label class="btn-outline theme-primary btn-check">
       <input type="checkbox" autocomplete="off">
       Checkbox 1
     </label>
 
-    <label class="btn btn-outline-primary btn-check">
+    <label class="btn-outline theme-primary btn-check">
       <input type="checkbox" autocomplete="off">
       Checkbox 2
     </label>
 
-    <label class="btn btn-outline-primary btn-check">
+    <label class="btn-outline theme-primary btn-check">
       <input type="checkbox" autocomplete="off">
       Checkbox 3
     </label>
   </div>`} />
 
 <Example code={`<div class="btn-group" role="group" aria-label="Basic radio toggle button group">
-    <label class="btn btn-outline-primary btn-check">
+    <label class="btn-outline theme-primary btn-check">
       <input type="radio" name="btnradio" checked autocomplete="off">
       Radio 1
     </label>
 
-    <label class="btn btn-outline-primary btn-check">
+    <label class="btn-outline theme-primary btn-check">
       <input type="radio" name="btnradio" autocomplete="off">
       Radio 2
     </label>
 
-    <label class="btn btn-outline-primary btn-check">
+    <label class="btn-outline theme-primary btn-check">
       <input type="radio" name="btnradio" autocomplete="off">
       Radio 3
     </label>
@@ -92,18 +92,18 @@ Join sets of button groups into button toolbars for more complicated components.
 
 <Example code={`<div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
     <div class="btn-group me-2" role="group" aria-label="First group">
-      <button type="button" class="btn btn-primary">1</button>
-      <button type="button" class="btn btn-primary">2</button>
-      <button type="button" class="btn btn-primary">3</button>
-      <button type="button" class="btn btn-primary">4</button>
+      <button type="button" class="btn-solid theme-primary">1</button>
+      <button type="button" class="btn-solid theme-primary">2</button>
+      <button type="button" class="btn-solid theme-primary">3</button>
+      <button type="button" class="btn-solid theme-primary">4</button>
     </div>
     <div class="btn-group me-2" role="group" aria-label="Second group">
-      <button type="button" class="btn btn-secondary">5</button>
-      <button type="button" class="btn btn-secondary">6</button>
-      <button type="button" class="btn btn-secondary">7</button>
+      <button type="button" class="btn-solid theme-secondary">5</button>
+      <button type="button" class="btn-solid theme-secondary">6</button>
+      <button type="button" class="btn-solid theme-secondary">7</button>
     </div>
     <div class="btn-group" role="group" aria-label="Third group">
-      <button type="button" class="btn btn-info">8</button>
+      <button type="button" class="btn-solid theme-info">8</button>
     </div>
   </div>`} />
 
@@ -111,10 +111,10 @@ Feel free to combine input groups with button groups in your toolbars. Similar t
 
 <Example code={`<div class="btn-toolbar mb-3" role="toolbar" aria-label="Toolbar with button groups">
     <div class="btn-group me-2" role="group" aria-label="First group">
-      <button type="button" class="btn btn-outline-secondary">1</button>
-      <button type="button" class="btn btn-outline-secondary">2</button>
-      <button type="button" class="btn btn-outline-secondary">3</button>
-      <button type="button" class="btn btn-outline-secondary">4</button>
+      <button type="button" class="btn-outline theme-secondary">1</button>
+      <button type="button" class="btn-outline theme-secondary">2</button>
+      <button type="button" class="btn-outline theme-secondary">3</button>
+      <button type="button" class="btn-outline theme-secondary">4</button>
     </div>
     <div class="input-group">
       <div class="input-group-text" id="btnGroupAddon">@</div>
@@ -124,10 +124,10 @@ Feel free to combine input groups with button groups in your toolbars. Similar t
 
   <div class="btn-toolbar justify-content-between" role="toolbar" aria-label="Toolbar with button groups">
     <div class="btn-group" role="group" aria-label="First group">
-      <button type="button" class="btn btn-outline-secondary">1</button>
-      <button type="button" class="btn btn-outline-secondary">2</button>
-      <button type="button" class="btn btn-outline-secondary">3</button>
-      <button type="button" class="btn btn-outline-secondary">4</button>
+      <button type="button" class="btn-outline theme-secondary">1</button>
+      <button type="button" class="btn-outline theme-secondary">2</button>
+      <button type="button" class="btn-outline theme-secondary">3</button>
+      <button type="button" class="btn-outline theme-secondary">4</button>
     </div>
     <div class="input-group">
       <div class="input-group-text" id="btnGroupAddon2">@</div>
@@ -140,21 +140,21 @@ Feel free to combine input groups with button groups in your toolbars. Similar t
 Alternatively, of implementing button sizing classes to each button in a group, add `.btn-group-*` to all `.btn-group`, including each one when nesting multiple groups.
 
 <Example code={`<div class="btn-group btn-group-lg" role="group" aria-label="Large button group">
-    <button type="button" class="btn btn-outline-primary">Left</button>
-    <button type="button" class="btn btn-outline-primary">Middle</button>
-    <button type="button" class="btn btn-outline-primary">Right</button>
+    <button type="button" class="btn-outline theme-primary">Left</button>
+    <button type="button" class="btn-outline theme-primary">Middle</button>
+    <button type="button" class="btn-outline theme-primary">Right</button>
   </div>
   <br>
   <div class="btn-group" role="group" aria-label="Default button group">
-    <button type="button" class="btn btn-outline-primary">Left</button>
-    <button type="button" class="btn btn-outline-primary">Middle</button>
-    <button type="button" class="btn btn-outline-primary">Right</button>
+    <button type="button" class="btn-outline theme-primary">Left</button>
+    <button type="button" class="btn-outline theme-primary">Middle</button>
+    <button type="button" class="btn-outline theme-primary">Right</button>
   </div>
   <br>
   <div class="btn-group btn-group-sm" role="group" aria-label="Small button group">
-    <button type="button" class="btn btn-outline-primary">Left</button>
-    <button type="button" class="btn btn-outline-primary">Middle</button>
-    <button type="button" class="btn btn-outline-primary">Right</button>
+    <button type="button" class="btn-outline theme-primary">Left</button>
+    <button type="button" class="btn-outline theme-primary">Middle</button>
+    <button type="button" class="btn-outline theme-primary">Right</button>
   </div>`} />
 
 ## Nesting
@@ -162,11 +162,11 @@ Alternatively, of implementing button sizing classes to each button in a group, 
 Put a `.btn-group` inside another `.btn-group` when you need dropdown menus combined with a series of buttons.
 
 <Example code={`<div class="btn-group" role="group" aria-label="Button group with nested dropdown">
-    <button type="button" class="btn btn-primary">1</button>
-    <button type="button" class="btn btn-primary">2</button>
+    <button type="button" class="btn-solid theme-primary">1</button>
+    <button type="button" class="btn-solid theme-primary">2</button>
 
     <div class="btn-group" role="group">
-      <button type="button" class="btn btn-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+      <button type="button" class="btn-solid theme-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
         Dropdown
       </button>
       <ul class="dropdown-menu">
@@ -182,17 +182,17 @@ Create a set of buttons that appear vertically stacked rather than horizontally.
 
 <Example code={`<div class="docs-example">
     <div class="btn-group-vertical" role="group" aria-label="Vertical button group">
-      <button type="button" class="btn btn-primary">Button</button>
-      <button type="button" class="btn btn-primary">Button</button>
-      <button type="button" class="btn btn-primary">Button</button>
-      <button type="button" class="btn btn-primary">Button</button>
+      <button type="button" class="btn-solid theme-primary">Button</button>
+      <button type="button" class="btn-solid theme-primary">Button</button>
+      <button type="button" class="btn-solid theme-primary">Button</button>
+      <button type="button" class="btn-solid theme-primary">Button</button>
     </div>
   </div>`} />
 
 <Example code={`<div class="docs-example">
     <div class="btn-group-vertical" role="group" aria-label="Vertical button group">
       <div class="btn-group" role="group">
-        <button id="btnGroupVerticalDrop1" type="button" class="btn btn-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+        <button id="btnGroupVerticalDrop1" type="button" class="btn-solid theme-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
           Dropdown
         </button>
         <ul class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop1">
@@ -200,10 +200,10 @@ Create a set of buttons that appear vertically stacked rather than horizontally.
           <li><a class="dropdown-item" href="#">Dropdown link</a></li>
         </ul>
       </div>
-      <button type="button" class="btn btn-primary">Button</button>
-      <button type="button" class="btn btn-primary">Button</button>
+      <button type="button" class="btn-solid theme-primary">Button</button>
+      <button type="button" class="btn-solid theme-primary">Button</button>
       <div class="btn-group dropstart" role="group">
-        <button id="btnGroupVerticalDrop2" type="button" class="btn btn-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+        <button id="btnGroupVerticalDrop2" type="button" class="btn-solid theme-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
           Dropdown
         </button>
         <ul class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop2">
@@ -212,7 +212,7 @@ Create a set of buttons that appear vertically stacked rather than horizontally.
         </ul>
       </div>
       <div class="btn-group dropend" role="group">
-        <button id="btnGroupVerticalDrop3" type="button" class="btn btn-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+        <button id="btnGroupVerticalDrop3" type="button" class="btn-solid theme-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
           Dropdown
         </button>
         <ul class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop3">
@@ -221,7 +221,7 @@ Create a set of buttons that appear vertically stacked rather than horizontally.
         </ul>
       </div>
       <div class="btn-group dropup" role="group">
-        <button id="btnGroupVerticalDrop4" type="button" class="btn btn-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+        <button id="btnGroupVerticalDrop4" type="button" class="btn-solid theme-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
           Dropdown
         </button>
         <ul class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop4">
@@ -234,15 +234,15 @@ Create a set of buttons that appear vertically stacked rather than horizontally.
 
   <div class="docs-example">
     <div class="btn-group-vertical" role="group" aria-label="Vertical radio toggle button group">
-      <label class="btn btn-outline-danger btn-check">
+      <label class="btn-outline theme-danger btn-check">
         <input type="radio" name="vbtn-radio" checked autocomplete="off">
         Radio 1
       </label>
-      <label class="btn btn-outline-danger btn-check">
+      <label class="btn-outline theme-danger btn-check">
         <input type="radio" name="vbtn-radio" autocomplete="off">
         Radio 2
       </label>
-      <label class="btn btn-outline-danger btn-check">
+      <label class="btn-outline theme-danger btn-check">
         <input type="radio" name="vbtn-radio" autocomplete="off">
         Radio 3
       </label>
@@ -250,15 +250,15 @@ Create a set of buttons that appear vertically stacked rather than horizontally.
   </div>`} />
 
 <Example code={`<div class="btn-group-vertical" role="group" aria-label="Vertical radio toggle button group">
-    <label class="btn btn-outline-danger btn-check">
+    <label class="btn-outline theme-danger btn-check">
       <input type="radio" name="vbtn-radio2" checked autocomplete="off">
       Radio 1
     </label>
-    <label class="btn btn-outline-danger btn-check">
+    <label class="btn-outline theme-danger btn-check">
       <input type="radio" name="vbtn-radio2" autocomplete="off">
       Radio 2
     </label>
-    <label class="btn btn-outline-danger btn-check">
+    <label class="btn-outline theme-danger btn-check">
       <input type="radio" name="vbtn-radio2" autocomplete="off">
       Radio 3
     </label>

--- a/docs/src/content/docs/components/card.mdx
+++ b/docs/src/content/docs/components/card.mdx
@@ -23,7 +23,7 @@ Below is an example of a basic card with mixed content and a fixed width. Cards 
     <div class="card-body">
       <h5 class="card-title">Card title</h5>
       <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
-      <a href="#" class="btn btn-primary">Go somewhere</a>
+      <a href="#" class="btn-solid theme-primary">Go somewhere</a>
     </div>
   </div>`} />
 
@@ -142,7 +142,7 @@ Add an optional header and/or footer within a card.
     <div class="card-body">
       <h5 class="card-title">Special title treatment</h5>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-      <a href="#" class="btn btn-primary">Go somewhere</a>
+      <a href="#" class="btn-solid theme-primary">Go somewhere</a>
     </div>
   </div>`} />
 
@@ -153,7 +153,7 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
     <div class="card-body">
       <h5 class="card-title">Special title treatment</h5>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-      <a href="#" class="btn btn-primary">Go somewhere</a>
+      <a href="#" class="btn-solid theme-primary">Go somewhere</a>
     </div>
   </div>`} />
 
@@ -176,7 +176,7 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
     <div class="card-body">
       <h5 class="card-title">Special title treatment</h5>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-      <a href="#" class="btn btn-primary">Go somewhere</a>
+      <a href="#" class="btn-solid theme-primary">Go somewhere</a>
     </div>
     <div class="card-footer fg-2">
       2 days ago
@@ -197,7 +197,7 @@ Using the grid, wrap cards in columns and rows as needed.
         <div class="card-body">
           <h5 class="card-title">Special title treatment</h5>
           <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-          <a href="#" class="btn btn-primary">Go somewhere</a>
+          <a href="#" class="btn-solid theme-primary">Go somewhere</a>
         </div>
       </div>
     </div>
@@ -206,7 +206,7 @@ Using the grid, wrap cards in columns and rows as needed.
         <div class="card-body">
           <h5 class="card-title">Special title treatment</h5>
           <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-          <a href="#" class="btn btn-primary">Go somewhere</a>
+          <a href="#" class="btn-solid theme-primary">Go somewhere</a>
         </div>
       </div>
     </div>
@@ -220,7 +220,7 @@ Use some of [available sizing utilities](/utilities/width/) to rapidly set a car
     <div class="card-body">
       <h5 class="card-title">Card title</h5>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-      <a href="#" class="btn btn-primary">Button</a>
+      <a href="#" class="btn-solid theme-primary">Button</a>
     </div>
   </div>
 
@@ -228,7 +228,7 @@ Use some of [available sizing utilities](/utilities/width/) to rapidly set a car
     <div class="card-body">
       <h5 class="card-title">Card title</h5>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-      <a href="#" class="btn btn-primary">Button</a>
+      <a href="#" class="btn-solid theme-primary">Button</a>
     </div>
   </div>`} />
 
@@ -240,7 +240,7 @@ Use custom CSS in your stylesheets or as inline styles to set a width.
     <div class="card-body">
       <h5 class="card-title">Special title treatment</h5>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-      <a href="#" class="btn btn-primary">Go somewhere</a>
+      <a href="#" class="btn-solid theme-primary">Go somewhere</a>
     </div>
   </div>`} />
 
@@ -254,7 +254,7 @@ You can instantly change the text arrangement of any card—in its whole or spec
     <div class="card-body">
       <h5 class="card-title">Special title treatment</h5>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-      <a href="#" class="btn btn-primary">Go somewhere</a>
+      <a href="#" class="btn-solid theme-primary">Go somewhere</a>
     </div>
   </div>
 
@@ -262,7 +262,7 @@ You can instantly change the text arrangement of any card—in its whole or spec
     <div class="card-body">
       <h5 class="card-title">Special title treatment</h5>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-      <a href="#" class="btn btn-primary mx-auto">Go somewhere</a>
+      <a href="#" class="btn-solid theme-primary mx-auto">Go somewhere</a>
     </div>
   </div>
 
@@ -270,7 +270,7 @@ You can instantly change the text arrangement of any card—in its whole or spec
     <div class="card-body">
       <h5 class="card-title">Special title treatment</h5>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-      <a href="#" class="btn btn-primary ms-auto">Go somewhere</a>
+      <a href="#" class="btn-solid theme-primary ms-auto">Go somewhere</a>
     </div>
   </div>`} />
 
@@ -295,7 +295,7 @@ Add some navigation to a card's header (or block) with CoreUI for Bootstrap's [n
     <div class="card-body">
       <h5 class="card-title">Special title treatment</h5>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-      <a href="#" class="btn btn-primary">Go somewhere</a>
+      <a href="#" class="btn-solid theme-primary">Go somewhere</a>
     </div>
   </div>`} />
 
@@ -318,7 +318,7 @@ This works with `.nav-pills` as well.
     <div class="card-body">
       <h5 class="card-title">Special title treatment</h5>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-      <a href="#" class="btn btn-primary">Go somewhere</a>
+      <a href="#" class="btn-solid theme-primary">Go somewhere</a>
     </div>
   </div>`} />
 

--- a/docs/src/content/docs/components/chip.mdx
+++ b/docs/src/content/docs/components/chip.mdx
@@ -95,24 +95,24 @@ Add `.chip-img` for an image like an avatar or use our avatar component.
       Chip with avatar 2
     </span>
     <span class="chip">
-      <span class="avatar bg-primary text-white">L</span>
+      <span class="avatar theme-primary">L</span>
       Chip with avatar 3
     </span>
     <span class="chip">
-      <span class="avatar text-bg-success">L</span>
+      <span class="avatar theme-success">L</span>
       Chip with avatar 4
     </span>
   </div>`} />
 
 ## Variants
 
-Apply `.chip-*` classes to color your chips. Chips are subtle by default as this allows for a clear, themed active state.
+Colour a chip with a [`.theme-*` class](/customize/components/#theme-variants), on the chip itself or on any element above it. Chips are subtle by default as this allows for a clear, themed active state.
 
-<Example code={[`<div class="d-flex flex-wrap gap-1">`, ...getData('theme-colors').map((c) => `<span class="chip chip-${c.name} chip-clickable" tabindex="0">${c.title} chip</span>
-    <span class="chip chip-${c.name} active" tabindex="0">${c.title} chip</span>`), ``, `</div>`]} />
+<Example code={[`<div class="d-flex flex-wrap gap-1">`, ...getData('theme-colors').map((c) => `<span class="chip theme-${c.name} chip-clickable" tabindex="0">${c.title} chip</span>
+    <span class="chip theme-${c.name} active" tabindex="0">${c.title} chip</span>`), ``, `</div>`]} />
 
-<Example code={[`<div class="d-flex flex-wrap gap-1">`, ...getData('theme-colors').map((c) => `<span class="chip chip-outline chip-clickable chip-${c.name}" tabindex="0">${c.title} chip</span>
-    <span class="chip chip-outline chip-${c.name} active" tabindex="0">${c.title} chip</span>`), ``, `</div>`]} />
+<Example code={[`<div class="d-flex flex-wrap gap-1">`, ...getData('theme-colors').map((c) => `<span class="chip chip-outline chip-clickable theme-${c.name}" tabindex="0">${c.title} chip</span>
+    <span class="chip chip-outline theme-${c.name} active" tabindex="0">${c.title} chip</span>`), ``, `</div>`]} />
 
 ### Active state
 
@@ -121,10 +121,10 @@ Add `.active` to make chips use the solid appearance (bg/contrast). This is usef
 <Example code={`<div class="d-flex flex-wrap gap-1">
     <span class="chip">Default</span>
     <span class="chip active">Active</span>
-    <span class="chip chip-primary">Primary</span>
-    <span class="chip chip-primary active">Active</span>
-    <span class="chip chip-success">Success</span>
-    <span class="chip chip-success active">Active</span>
+    <span class="chip theme-primary">Primary</span>
+    <span class="chip theme-primary active">Active</span>
+    <span class="chip theme-success">Success</span>
+    <span class="chip theme-success active">Active</span>
   </div>`} />
 
 ## Sizes
@@ -146,7 +146,7 @@ Use `.chip-sm` or `.chip-lg` for different sizes.
       Small with avatar
     </span>
     <span class="chip chip-sm">
-      <span class="avatar bg-primary text-white">L</span>
+      <span class="avatar theme-primary">L</span>
       Small with avatar 2
     </span>
     <span class="chip chip-sm">
@@ -175,7 +175,7 @@ Use `.chip-sm` or `.chip-lg` for different sizes.
       Default with avatar
     </span>
     <span class="chip">
-      <span class="avatar bg-primary text-white">L</span>
+      <span class="avatar theme-primary">L</span>
       Default with avatar1
     </span>
     <span class="chip">
@@ -204,7 +204,7 @@ Use `.chip-sm` or `.chip-lg` for different sizes.
       Large with avatar
     </span>
     <span class="chip chip-lg">
-      <span class="avatar bg-primary text-white">L</span>
+      <span class="avatar theme-primary">L</span>
       Large with avatar 2
     </span>
     <span class="chip chip-lg">
@@ -352,6 +352,23 @@ The Bootstrap Chip component follows WAI-ARIA patterns for interactive widgets, 
 - `aria-disabled="true"` is applied to disabled chips that carry a role; a role-less chip conveys the state through the `disabled` class and its removed interactivity.
 - Each `.chip-remove` button includes an accessible label via `ariaRemoveLabel`.
 - Use descriptive `aria-label` attributes on chip containers when the chip component group has a meaningful role (e.g., "Applied filters").
+
+## Deprecated markup
+
+<DeprecatedIn version="6.0.0" />
+
+The v5 spelling — `.chip` with a colour modifier — still works and renders identically. Each colour class is generated from the same theme map as the class it replaces, so `.chip-primary` *is* `.chip.theme-primary`. They are removed in v7.
+
+<Example code={[`<div class="d-flex flex-wrap gap-1">`, ...getData('theme-colors').map((c) => `<span class="chip chip-${c.name}">${c.title} chip</span>`), ``, `</div>`]} />
+
+```diff
+- <span class="chip chip-success">Done</span>
++ <span class="chip theme-success">Done</span>
+```
+
+The rewrite buys two things the modifier cannot. A theme colour set on a chip set reaches every chip inside it, and a colour of your own works the moment you define its theme tokens, with no Sass to compile.
+
+See the [v6 migration guide](/migration/v6/) for the full picture.
 
 ## Customizing
 

--- a/docs/src/content/docs/components/collapse.mdx
+++ b/docs/src/content/docs/components/collapse.mdx
@@ -25,10 +25,10 @@ Click the buttons below to show and hide another element via class changes:
 You can use a link with the `href` attribute, or a button with the `data-coreui-target` attribute. In both samples, the `data-coreui-toggle="collapse""` is required.
 
 <Example code={`<p class="d-inline-flex gap-1">
-    <a class="btn btn-primary" data-coreui-toggle="collapse" href="#collapseExample" role="button" aria-expanded="false" aria-controls="collapseExample">
+    <a class="btn-solid theme-primary" data-coreui-toggle="collapse" href="#collapseExample" role="button" aria-expanded="false" aria-controls="collapseExample">
       Link with href
     </a>
-    <button class="btn btn-primary" type="button" data-coreui-toggle="collapse" data-coreui-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
+    <button class="btn-solid theme-primary" type="button" data-coreui-toggle="collapse" data-coreui-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
       Button with data-coreui-target
     </button>
   </p>
@@ -47,7 +47,7 @@ Please note that while the example below has a `min-height` set to avoid excessi
 </Callout>
 
 <Example code={`<p>
-    <button class="btn btn-primary" type="button" data-coreui-toggle="collapse" data-coreui-target="#collapseWidthExample" aria-expanded="false" aria-controls="collapseWidthExample">
+    <button class="btn-solid theme-primary" type="button" data-coreui-toggle="collapse" data-coreui-target="#collapseWidthExample" aria-expanded="false" aria-controls="collapseWidthExample">
       Toggle width collapse
     </button>
   </p>
@@ -65,9 +65,9 @@ A `<button>` or `<a>` can show and hide multiple elements by referencing them wi
 Multiple `<button>` or `<a>` can show and hide an element if they each reference it with their `href` or `data-coreui-target` attribute
 
 <Example code={`<p class="d-inline-flex gap-1">
-    <a class="btn btn-primary" data-coreui-toggle="collapse" href="#multiCollapseExample1" role="button" aria-expanded="false" aria-controls="multiCollapseExample1">Toggle first element</a>
-    <button class="btn btn-primary" type="button" data-coreui-toggle="collapse" data-coreui-target="#multiCollapseExample2" aria-expanded="false" aria-controls="multiCollapseExample2">Toggle second element</button>
-    <button class="btn btn-primary" type="button" data-coreui-toggle="collapse" data-coreui-target=".multi-collapse" aria-expanded="false" aria-controls="multiCollapseExample1 multiCollapseExample2">Toggle both elements</button>
+    <a class="btn-solid theme-primary" data-coreui-toggle="collapse" href="#multiCollapseExample1" role="button" aria-expanded="false" aria-controls="multiCollapseExample1">Toggle first element</a>
+    <button class="btn-solid theme-primary" type="button" data-coreui-toggle="collapse" data-coreui-target="#multiCollapseExample2" aria-expanded="false" aria-controls="multiCollapseExample2">Toggle second element</button>
+    <button class="btn-solid theme-primary" type="button" data-coreui-toggle="collapse" data-coreui-target=".multi-collapse" aria-expanded="false" aria-controls="multiCollapseExample1 multiCollapseExample2">Toggle both elements</button>
   </p>
   <div class="row">
     <div class="col">
@@ -91,7 +91,7 @@ Multiple `<button>` or `<a>` can show and hide an element if they each reference
 By default a collapsed area is removed from the layout, which also removes it from what the browser's find-in-page can search. Set `data-coreui-hidden-until-found="true"` on the collapsible element to hide it with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden) instead: the content stays laid out but invisible, so searching the page finds it, and the browser expands the area to show the match.
 
 <Example code={`<p>
-    <button class="btn btn-primary" type="button" data-coreui-toggle="collapse" data-coreui-target="#collapseFindable" aria-expanded="false" aria-controls="collapseFindable">
+    <button class="btn-solid theme-primary" type="button" data-coreui-toggle="collapse" data-coreui-target="#collapseFindable" aria-expanded="false" aria-controls="collapseFindable">
       Toggle findable content
     </button>
   </p>

--- a/docs/src/content/docs/components/dialog.mdx
+++ b/docs/src/content/docs/components/dialog.mdx
@@ -33,15 +33,15 @@ Toggle a dialog by clicking the button below.
     <p>This is a native dialog element. It uses the browser's built-in modal behavior for accessibility and focus management.</p>
   </div>
   <div class="dialog-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="dialog">Close</button>
-    <button type="button" class="btn btn-primary">Save changes</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="dialog">Close</button>
+    <button type="button" class="btn-solid theme-primary">Save changes</button>
   </div>
 </dialog>
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialog">`, `  Open dialog`, `</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialog">`, `  Open dialog`, `</button>`]} />
 
 ```html
-<button type="button" class="btn btn-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialog">
+<button type="button" class="btn-solid theme-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialog">
   Open dialog
 </button>
 
@@ -54,8 +54,8 @@ Toggle a dialog by clicking the button below.
     <p>This is a native dialog element.</p>
   </div>
   <div class="dialog-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="dialog">Close</button>
-    <button type="button" class="btn btn-primary">Save changes</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="dialog">Close</button>
+    <button type="button" class="btn-solid theme-primary">Save changes</button>
   </div>
 </dialog>
 ```
@@ -84,7 +84,7 @@ Dialogs fade in and out by default. Add `.dialog-slide-down` to slide in from ab
   </div>
 </dialog>
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialogSlideDown">Slide down</button>`, `<button type="button" class="btn btn-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialogSlideUp">Slide up</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialogSlideDown">Slide down</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialogSlideUp">Slide up</button>`]} />
 
 ```html
 <dialog class="dialog dialog-slide-down">...</dialog>
@@ -106,12 +106,12 @@ When backdrop is set to `static`, the dialog will not close when clicking outsid
     <p>I will not close if you click outside of me. Don't even try to press escape key.</p>
   </div>
   <div class="dialog-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="dialog">Close</button>
-    <button type="button" class="btn btn-primary">Understood</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="dialog">Close</button>
+    <button type="button" class="btn-solid theme-primary">Understood</button>
   </div>
 </dialog>
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialogStatic">`, `  Launch static backdrop dialog`, `</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialogStatic">`, `  Launch static backdrop dialog`, `</button>`]} />
 
 ## Scrolling long content
 
@@ -128,12 +128,12 @@ Add `.dialog-scrollable` — the header and footer stay fixed while the dialog b
     <p>This content should appear at the bottom after you scroll.</p>
   </div>
   <div class="dialog-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="dialog">Close</button>
-    <button type="button" class="btn btn-primary">Save changes</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="dialog">Close</button>
+    <button type="button" class="btn-solid theme-primary">Save changes</button>
   </div>
 </dialog>
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialogScrollable">`, `  Launch scrollable dialog`, `</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialogScrollable">`, `  Launch scrollable dialog`, `</button>`]} />
 
 ```html
 <dialog class="dialog dialog-scrollable">
@@ -154,7 +154,7 @@ When a trigger sits inside an open dialog, the component swaps to the target dia
       Show a second dialog and hide this one with the button below.
     </div>
     <div class="dialog-footer">
-      <button class="btn btn-primary" data-coreui-target="#exampleDialogToggle2" data-coreui-toggle="dialog">Open second dialog</button>
+      <button class="btn-solid theme-primary" data-coreui-target="#exampleDialogToggle2" data-coreui-toggle="dialog">Open second dialog</button>
     </div>
   </dialog>
   <dialog class="dialog" id="exampleDialogToggle2" aria-labelledby="exampleDialogToggleLabel2">
@@ -166,10 +166,10 @@ When a trigger sits inside an open dialog, the component swaps to the target dia
       Hide this dialog and show the first with the button below.
     </div>
     <div class="dialog-footer">
-      <button class="btn btn-primary" data-coreui-target="#exampleDialogToggle" data-coreui-toggle="dialog">Back to first</button>
+      <button class="btn-solid theme-primary" data-coreui-target="#exampleDialogToggle" data-coreui-toggle="dialog">Back to first</button>
     </div>
   </dialog>
-  <button class="btn btn-primary" data-coreui-target="#exampleDialogToggle" data-coreui-toggle="dialog">Open first dialog</button>`} />
+  <button class="btn-solid theme-primary" data-coreui-target="#exampleDialogToggle" data-coreui-toggle="dialog">Open first dialog</button>`} />
 
 ## Non-modal dialogs
 
@@ -185,7 +185,7 @@ Set the `modal` option to `false` to show the dialog without the top layer — n
   </div>
 </dialog>
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialogNonModal">`, `  Open non-modal dialog`, `</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialogNonModal">`, `  Open non-modal dialog`, `</button>`]} />
 
 ```html
 <dialog class="dialog" id="myDialog" data-coreui-modal="false">

--- a/docs/src/content/docs/components/drawer.mdx
+++ b/docs/src/content/docs/components/drawer.mdx
@@ -26,10 +26,10 @@ Toggle a drawer by clicking the button below.
   </div>
 </dialog>
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawer">`, `  Open drawer`, `</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawer">`, `  Open drawer`, `</button>`]} />
 
 ```html
-<button type="button" class="btn btn-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawer">
+<button type="button" class="btn-solid theme-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawer">
   Open drawer
 </button>
 
@@ -94,7 +94,7 @@ Drawers can slide in from any edge of the viewport — apply one of the placemen
   </div>
 </dialog>
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawerEnd">Right drawer</button>`, `<button type="button" class="btn btn-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawerTop">Top drawer</button>`, `<button type="button" class="btn btn-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawerBottom">Bottom drawer</button>`, `<button type="button" class="btn btn-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawerFullscreen">Fullscreen drawer</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawerEnd">Right drawer</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawerTop">Top drawer</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawerBottom">Bottom drawer</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawerFullscreen">Fullscreen drawer</button>`]} />
 
 ## Variants
 
@@ -112,7 +112,7 @@ Add `.drawer-translucent` for a frosted-glass panel that blurs the content behin
   </div>
 </dialog>
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawerTranslucent">Translucent drawer</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawerTranslucent">Translucent drawer</button>`]} />
 
 ### Sheet
 
@@ -128,7 +128,7 @@ Combine `.drawer-bottom` with `.drawer-sheet` for a flush-to-edge bottom sheet w
   </div>
 </dialog>
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawerSheet">Bottom sheet</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="drawer" data-coreui-target="#exampleDrawerSheet">Bottom sheet</button>`]} />
 
 ### Fit content
 
@@ -138,7 +138,7 @@ Add `.drawer-fit-content` to a `.drawer-start`/`.drawer-end` drawer to keep the 
 
 The page scroll is blocked while a drawer is open. Set `scroll: true` to open the drawer non-modally instead — the page stays interactive and scrollable. A visible backdrop requires the top layer, so `backdrop: true` (the default) takes precedence over `scroll: true` for the page-interactivity part.
 
-<Example code={`<button class="btn btn-primary" type="button" data-coreui-toggle="drawer" data-coreui-target="#drawerScrolling">Enable body scrolling</button>
+<Example code={`<button class="btn-solid theme-primary" type="button" data-coreui-toggle="drawer" data-coreui-target="#drawerScrolling">Enable body scrolling</button>
 
   <dialog class="drawer drawer-start" data-coreui-scroll="true" data-coreui-backdrop="false" id="drawerScrolling" aria-labelledby="drawerScrollingLabel">
     <div class="drawer-header">
@@ -154,7 +154,7 @@ The page scroll is blocked while a drawer is open. Set `scroll: true` to open th
 
 When the backdrop is set to `static`, the drawer will remain open when clicking outside of it.
 
-<Example code={`<button class="btn btn-primary" type="button" data-coreui-toggle="drawer" data-coreui-target="#drawerStatic">
+<Example code={`<button class="btn-solid theme-primary" type="button" data-coreui-toggle="drawer" data-coreui-target="#drawerStatic">
     Toggle static drawer
   </button>
 
@@ -174,7 +174,7 @@ When the backdrop is set to `static`, the drawer will remain open when clicking 
 
 Responsive drawer classes hide content in a drawer below a specified breakpoint and render it inline above it. For example, `.drawer-lg` acts as a drawer below the `lg` breakpoint and displays the content inline above it.
 
-<Example code={`<button class="btn btn-primary d-lg-none" type="button" data-coreui-toggle="drawer" data-coreui-target="#drawerResponsive" aria-controls="drawerResponsive">Toggle drawer</button>
+<Example code={`<button class="btn-solid theme-primary d-lg-none" type="button" data-coreui-toggle="drawer" data-coreui-target="#drawerResponsive" aria-controls="drawerResponsive">Toggle drawer</button>
 
   <div class="alert alert-info d-none d-lg-block">Resize your browser to show the responsive drawer toggle.</div>
 

--- a/docs/src/content/docs/components/dropdowns.mdx
+++ b/docs/src/content/docs/components/dropdowns.mdx
@@ -33,7 +33,7 @@ Bind the dropdown's toggle and the dropdown menu inside `.dropdown`, or differen
 Each single `.btn` can be changed into a dropdown toggle with small changes. Here's how you can put them to work with either `<button>` elements:
 
 <Example code={`<div class="dropdown">
-    <button class="btn btn-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button class="btn-solid theme-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
       Dropdown button
     </button>
     <ul class="dropdown-menu">
@@ -46,7 +46,7 @@ Each single `.btn` can be changed into a dropdown toggle with small changes. Her
 And with `<a>` elements:
 
 <Example code={`<div class="dropdown">
-    <a class="btn btn-secondary dropdown-toggle" href="#" role="button" data-coreui-toggle="dropdown" aria-expanded="false">
+    <a class="btn-solid theme-secondary dropdown-toggle" href="#" role="button" data-coreui-toggle="dropdown" aria-expanded="false">
       Dropdown link
     </a>
 
@@ -59,12 +59,12 @@ And with `<a>` elements:
 
 The best part is you can do this with any button variant, too:
 
-<Example html={[`<div class="btn-group">`, `  <button type="button" class="btn btn-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">Primary</button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">Secondary</button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn btn-success dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">Success</button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn btn-info dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">Info</button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn btn-warning dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">Warning</button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn btn-danger dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">Danger</button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`]} />
+<Example html={[`<div class="btn-group">`, `  <button type="button" class="btn-solid theme-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">Primary</button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">Secondary</button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn-solid theme-success dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">Success</button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn-solid theme-info dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">Info</button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn-solid theme-warning dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">Warning</button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn-solid theme-danger dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">Danger</button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`]} />
 
 ```html
 <!-- Example single danger button -->
 <div class="btn-group">
-  <button type="button" class="btn btn-danger dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+  <button type="button" class="btn-solid theme-danger dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
     Action
   </button>
   <ul class="dropdown-menu">
@@ -83,13 +83,13 @@ Similarly, create split button dropdowns with virtually the same markup as singl
 
 We use this extra class to reduce the horizontal `padding` on either side of the caret by 25% and remove the `margin-left` that's attached for normal button dropdowns. Those additional changes hold the caret centered in the split button and implement a more properly sized hit area next to the main button.
 
-<Example html={[`<div class="btn-group">`, `  <button type="button" class="btn btn-primary">Primary</button>`, `  <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn btn-secondary">Secondary</button>`, `  <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn btn-success">Success</button>`, `  <button type="button" class="btn btn-success dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn btn-info">Info</button>`, `  <button type="button" class="btn btn-info dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn btn-warning">Warning</button>`, `  <button type="button" class="btn btn-warning dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn btn-danger">Danger</button>`, `  <button type="button" class="btn btn-danger dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`]} />
+<Example html={[`<div class="btn-group">`, `  <button type="button" class="btn-solid theme-primary">Primary</button>`, `  <button type="button" class="btn-solid theme-primary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn-solid theme-secondary">Secondary</button>`, `  <button type="button" class="btn-solid theme-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn-solid theme-success">Success</button>`, `  <button type="button" class="btn-solid theme-success dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn-solid theme-info">Info</button>`, `  <button type="button" class="btn-solid theme-info dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn-solid theme-warning">Warning</button>`, `  <button type="button" class="btn-solid theme-warning dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`, `<div class="btn-group">`, `  <button type="button" class="btn-solid theme-danger">Danger</button>`, `  <button type="button" class="btn-solid theme-danger dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div><!-- /btn-group -->`]} />
 
 ```html
 <!-- Example split danger button -->
 <div class="btn-group">
-  <button type="button" class="btn btn-danger">Action</button>
-  <button type="button" class="btn btn-danger dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
+  <button type="button" class="btn-solid theme-danger">Action</button>
+  <button type="button" class="btn-solid theme-danger dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
     <span class="visually-hidden">Toggle Dropdown</span>
   </button>
   <ul class="dropdown-menu">
@@ -106,12 +106,12 @@ We use this extra class to reduce the horizontal `padding` on either side of the
 
 Button dropdowns work with buttons of all sizes, including default and split dropdown buttons.
 
-<Example html={[`<div class="btn-group">`, `  <button class="btn btn-secondary btn-lg dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">`, `    Large button`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`, `<div class="btn-group">`, `  <button type="button" class="btn btn-lg btn-secondary">Large split button</button>`, `  <button type="button" class="btn btn-lg btn-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`]} />
+<Example html={[`<div class="btn-group">`, `  <button class="btn-solid theme-secondary btn-lg dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">`, `    Large button`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`, `<div class="btn-group">`, `  <button type="button" class="btn-solid theme-secondary btn-lg">Large split button</button>`, `  <button type="button" class="btn-solid theme-secondary btn-lg dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`]} />
 
 ```html
 <!-- Large button groups (default and split) -->
 <div class="btn-group">
-  <button class="btn btn-secondary btn-lg dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
+  <button class="btn-solid theme-secondary btn-lg dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
     Large button
   </button>
   <ul class="dropdown-menu">
@@ -119,10 +119,10 @@ Button dropdowns work with buttons of all sizes, including default and split dro
   </ul>
 </div>
 <div class="btn-group">
-  <button class="btn btn-secondary btn-lg" type="button">
+  <button class="btn-solid theme-secondary btn-lg" type="button">
     Large split button
   </button>
-  <button type="button" class="btn btn-lg btn-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
+  <button type="button" class="btn-solid theme-secondary btn-lg dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
     <span class="visually-hidden">Toggle Dropdown</span>
   </button>
   <ul class="dropdown-menu">
@@ -131,11 +131,11 @@ Button dropdowns work with buttons of all sizes, including default and split dro
 </div>
 ```
 
-<Example html={[`<div class="btn-group">`, `  <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">`, `    Small button`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`, `<div class="btn-group">`, `  <button type="button" class="btn btn-sm btn-secondary">Small split button</button>`, `  <button type="button" class="btn btn-sm btn-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`]} />
+<Example html={[`<div class="btn-group">`, `  <button class="btn-solid theme-secondary btn-sm dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">`, `    Small button`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`, `<div class="btn-group">`, `  <button type="button" class="btn-solid theme-secondary btn-sm">Small split button</button>`, `  <button type="button" class="btn-solid theme-secondary btn-sm dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`]} />
 
 ```html
 <div class="btn-group">
-  <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
+  <button class="btn-solid theme-secondary btn-sm dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
     Small button
   </button>
   <ul class="dropdown-menu">
@@ -143,10 +143,10 @@ Button dropdowns work with buttons of all sizes, including default and split dro
   </ul>
 </div>
 <div class="btn-group">
-  <button class="btn btn-secondary btn-sm" type="button">
+  <button class="btn-solid theme-secondary btn-sm" type="button">
     Small split button
   </button>
-  <button type="button" class="btn btn-sm btn-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
+  <button type="button" class="btn-solid theme-secondary btn-sm dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
     <span class="visually-hidden">Toggle Dropdown</span>
   </button>
   <ul class="dropdown-menu">
@@ -160,7 +160,7 @@ Button dropdowns work with buttons of all sizes, including default and split dro
 Opt into darker dropdowns to match a dark navbar or custom style by adding `.dropdown-menu-dark` onto an existing `.dropdown-menu`. No changes are required to the dropdown items.
 
 <Example code={`<div class="dropdown">
-    <button class="btn btn-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button class="btn-solid theme-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
       Dropdown button
     </button>
     <ul class="dropdown-menu dropdown-menu-dark">
@@ -183,7 +183,7 @@ And putting it to use in a navbar:
       <div class="collapse navbar-collapse" id="navbarNavDarkDropdown">
         <ul class="navbar-nav">
           <li class="nav-item dropdown">
-            <button class="btn btn-inverse dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+            <button class="btn-solid theme-inverse dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
               Dropdown
             </button>
             <ul class="dropdown-menu dropdown-menu-dark">
@@ -209,7 +209,7 @@ Directions are mirrored when using CoreUI in RTL, meaning `.dropstart` will appe
 Make the dropdown menu centered below the toggle with `.dropdown-center` on the parent element.
 
 <Example code={`<div class="dropdown-center">
-    <button class="btn btn-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button class="btn-solid theme-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
       Centered dropdown
     </button>
     <ul class="dropdown-menu">
@@ -223,12 +223,12 @@ Make the dropdown menu centered below the toggle with `.dropdown-center` on the 
 
 Trigger dropdown menus above elements by adding `.dropup` to the parent element.
 
-<Example html={[`<div class="btn-group dropup">`, `  <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">`, `    Dropup`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`, `<div class="btn-group dropup">`, `  <button type="button" class="btn btn-secondary">`, `    Split dropup`, `  </button>`, `  <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`]} />
+<Example html={[`<div class="btn-group dropup">`, `  <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">`, `    Dropup`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`, `<div class="btn-group dropup">`, `  <button type="button" class="btn-solid theme-secondary">`, `    Split dropup`, `  </button>`, `  <button type="button" class="btn-solid theme-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropdown</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`]} />
 
 ```html
 <!-- Default dropup button -->
 <div class="btn-group dropup">
-  <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+  <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
     Dropup
   </button>
   <ul class="dropdown-menu">
@@ -238,10 +238,10 @@ Trigger dropdown menus above elements by adding `.dropup` to the parent element.
 
 <!-- Split dropup button -->
 <div class="btn-group dropup">
-  <button type="button" class="btn btn-secondary">
+  <button type="button" class="btn-solid theme-secondary">
     Split dropup
   </button>
-  <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
+  <button type="button" class="btn-solid theme-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
     <span class="visually-hidden">Toggle Dropdown</span>
   </button>
   <ul class="dropdown-menu">
@@ -255,7 +255,7 @@ Trigger dropdown menus above elements by adding `.dropup` to the parent element.
 Make the dropup menu centered above the toggle with `.dropup-center` on the parent element.
 
 <Example code={`<div class="dropup-center dropup">
-    <button class="btn btn-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button class="btn-solid theme-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
       Centered dropup
     </button>
     <ul class="dropdown-menu">
@@ -269,12 +269,12 @@ Make the dropup menu centered above the toggle with `.dropup-center` on the pare
 
 Trigger dropdown menus at the right of the elements by adding `.dropend` to the parent element.
 
-<Example html={[`<div class="btn-group dropend">`, `  <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">`, `    Dropend`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`, `<div class="btn-group dropend">`, `  <button type="button" class="btn btn-secondary">`, `    Split dropend`, `  </button>`, `  <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropend</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`]} />
+<Example html={[`<div class="btn-group dropend">`, `  <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">`, `    Dropend`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`, `<div class="btn-group dropend">`, `  <button type="button" class="btn-solid theme-secondary">`, `    Split dropend`, `  </button>`, `  <button type="button" class="btn-solid theme-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropend</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`]} />
 
 ```html
 <!-- Default dropend button -->
 <div class="btn-group dropend">
-  <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+  <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
     Dropend
   </button>
   <ul class="dropdown-menu">
@@ -284,10 +284,10 @@ Trigger dropdown menus at the right of the elements by adding `.dropend` to the 
 
 <!-- Split dropend button -->
 <div class="btn-group dropend">
-  <button type="button" class="btn btn-secondary">
+  <button type="button" class="btn-solid theme-secondary">
     Split dropend
   </button>
-  <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
+  <button type="button" class="btn-solid theme-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
     <span class="visually-hidden">Toggle Dropend</span>
   </button>
   <ul class="dropdown-menu">
@@ -300,12 +300,12 @@ Trigger dropdown menus at the right of the elements by adding `.dropend` to the 
 
 Trigger dropdown menus at the left of the elements by adding `.dropstart` to the parent element.
 
-<Example html={[`<div class="btn-group dropstart">`, `  <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">`, `    Dropstart`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`, `<div class="btn-group dropstart">`, `  <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropstart</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `  <button type="button" class="btn btn-secondary">`, `    Split dropstart`, `  </button>`, `</div>`]} />
+<Example html={[`<div class="btn-group dropstart">`, `  <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">`, `    Dropstart`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`, `<div class="btn-group dropstart">`, `  <button type="button" class="btn-solid theme-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">`, `    <span class="visually-hidden">Toggle Dropstart</span>`, `  </button>`, `  <ul class="dropdown-menu">`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `  <button type="button" class="btn-solid theme-secondary">`, `    Split dropstart`, `  </button>`, `</div>`]} />
 
 ```html
 <!-- Default dropstart button -->
 <div class="btn-group dropstart">
-  <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+  <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
     Dropstart
   </button>
   <ul class="dropdown-menu">
@@ -315,13 +315,13 @@ Trigger dropdown menus at the left of the elements by adding `.dropstart` to the
 
 <!-- Split dropstart button -->
 <div class="btn-group dropstart">
-  <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
+  <button type="button" class="btn-solid theme-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
     <span class="visually-hidden">Toggle Dropstart</span>
   </button>
   <ul class="dropdown-menu">
     <!-- Dropdown menu links -->
   </ul>
-  <button type="button" class="btn btn-secondary">
+  <button type="button" class="btn-solid theme-secondary">
     Split dropstart
   </button>
 </div>
@@ -332,7 +332,7 @@ Trigger dropdown menus at the left of the elements by adding `.dropstart` to the
 You can use `<a>` or `<button>` elements as dropdown items.
 
 <Example code={`<div class="dropdown">
-    <button class="btn btn-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button class="btn-solid theme-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
       Dropdown
     </button>
     <ul class="dropdown-menu">
@@ -380,7 +380,7 @@ By default, a dropdown menu is automatically positioned 100% from the top and al
 </Callout>
 
 <Example code={`<div class="btn-group">
-    <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
       Right-aligned menu example
     </button>
     <ul class="dropdown-menu dropdown-menu-end">
@@ -397,7 +397,7 @@ If you want to use responsive alignment, disable dynamic positioning by adding t
 To align **right** the dropdown menu with the given breakpoint or larger, add `.dropdown-menu{-sm|-md|-lg|-xl|-xxl}-end`.
 
 <Example code={`<div class="btn-group">
-    <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" aria-expanded="false">
       Left-aligned but right aligned when large screen
     </button>
     <ul class="dropdown-menu dropdown-menu-lg-end">
@@ -410,7 +410,7 @@ To align **right** the dropdown menu with the given breakpoint or larger, add `.
 To align **left** the dropdown menu with the given breakpoint or larger, add `.dropdown-menu-end` and `.dropdown-menu{-sm|-md|-lg|-xl|-xxl}-start`.
 
 <Example code={`<div class="btn-group">
-    <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" aria-expanded="false">
       Right-aligned but left aligned when large screen
     </button>
     <ul class="dropdown-menu dropdown-menu-end dropdown-menu-lg-start">
@@ -427,7 +427,7 @@ Note that you don't need to add a `data-coreui-display="static"` attribute to dr
 Taking most of the options shown above, here's a small kitchen sink demo of various dropdown alignment options in one place.
 
 <Example code={`<div class="btn-group">
-    <button class="btn btn-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button class="btn-solid theme-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">
       Dropdown
     </button>
     <ul class="dropdown-menu">
@@ -438,7 +438,7 @@ Taking most of the options shown above, here's a small kitchen sink demo of vari
   </div>
 
   <div class="btn-group">
-    <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
       Right-aligned menu
     </button>
     <ul class="dropdown-menu dropdown-menu-end">
@@ -449,7 +449,7 @@ Taking most of the options shown above, here's a small kitchen sink demo of vari
   </div>
 
   <div class="btn-group">
-    <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" aria-expanded="false">
       Left-aligned, right-aligned lg
     </button>
     <ul class="dropdown-menu dropdown-menu-lg-end">
@@ -460,7 +460,7 @@ Taking most of the options shown above, here's a small kitchen sink demo of vari
   </div>
 
   <div class="btn-group">
-    <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" aria-expanded="false">
       Right-aligned, left-aligned lg
     </button>
     <ul class="dropdown-menu dropdown-menu-end dropdown-menu-lg-start">
@@ -471,7 +471,7 @@ Taking most of the options shown above, here's a small kitchen sink demo of vari
   </div>
 
   <div class="btn-group dropstart">
-    <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
       Dropstart
     </button>
     <ul class="dropdown-menu">
@@ -482,7 +482,7 @@ Taking most of the options shown above, here's a small kitchen sink demo of vari
   </div>
 
   <div class="btn-group dropend">
-    <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
       Dropend
     </button>
     <ul class="dropdown-menu">
@@ -493,7 +493,7 @@ Taking most of the options shown above, here's a small kitchen sink demo of vari
   </div>
 
   <div class="btn-group dropup">
-    <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
       Dropup
     </button>
     <ul class="dropdown-menu">
@@ -562,7 +562,7 @@ Put a form within a dropdown menu, or make it into a dropdown menu, and use [mar
           </label>
         </div>
       </div>
-      <button type="submit" class="btn btn-primary">Sign in</button>
+      <button type="submit" class="btn-solid theme-primary">Sign in</button>
     </form>
     <div class="dropdown-divider"></div>
     <a class="dropdown-item" href="#">New around here? Sign up</a>
@@ -570,7 +570,7 @@ Put a form within a dropdown menu, or make it into a dropdown menu, and use [mar
   </div>`} />
 
 <Example code={`<div class="dropdown">
-    <button type="button" class="btn btn-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false" data-coreui-auto-close="outside">
+    <button type="button" class="btn-solid theme-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false" data-coreui-auto-close="outside">
       Dropdown form
     </button>
     <form class="dropdown-menu p-4">
@@ -590,7 +590,7 @@ Put a form within a dropdown menu, or make it into a dropdown menu, and use [mar
           </label>
         </div>
       </div>
-      <button type="submit" class="btn btn-primary">Sign in</button>
+      <button type="submit" class="btn-solid theme-primary">Sign in</button>
     </form>
   </div>`} />
 
@@ -600,7 +600,7 @@ Use `data-coreui-offset` or `data-coreui-reference` to change the location of th
 
 <Example code={`<div class="d-flex">
     <div class="dropdown me-1">
-      <button type="button" class="btn btn-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false" data-coreui-offset="10,20">
+      <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false" data-coreui-offset="10,20">
         Offset
       </button>
       <ul class="dropdown-menu">
@@ -610,8 +610,8 @@ Use `data-coreui-offset` or `data-coreui-reference` to change the location of th
       </ul>
     </div>
     <div class="btn-group">
-      <button type="button" class="btn btn-secondary">Reference</button>
-      <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false" data-coreui-reference="parent">
+      <button type="button" class="btn-solid theme-secondary">Reference</button>
+      <button type="button" class="btn-solid theme-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false" data-coreui-reference="parent">
         <span class="visually-hidden">Toggle Dropdown</span>
       </button>
       <ul class="dropdown-menu">
@@ -629,7 +629,7 @@ Use `data-coreui-offset` or `data-coreui-reference` to change the location of th
 By default, the dropdown menu is closed when clicking inside or outside the dropdown menu. You can use the `autoClose` option to change this behavior of the dropdown.
 
 <Example code={`<div class="btn-group">
-    <button class="btn btn-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" data-coreui-auto-close="true" aria-expanded="false">
+    <button class="btn-solid theme-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" data-coreui-auto-close="true" aria-expanded="false">
       Default dropdown
     </button>
     <ul class="dropdown-menu">
@@ -640,7 +640,7 @@ By default, the dropdown menu is closed when clicking inside or outside the drop
   </div>
 
   <div class="btn-group">
-    <button class="btn btn-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" data-coreui-auto-close="inside" aria-expanded="false">
+    <button class="btn-solid theme-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" data-coreui-auto-close="inside" aria-expanded="false">
       Clickable inside
     </button>
     <ul class="dropdown-menu">
@@ -651,7 +651,7 @@ By default, the dropdown menu is closed when clicking inside or outside the drop
   </div>
 
   <div class="btn-group">
-    <button class="btn btn-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" data-coreui-auto-close="outside" aria-expanded="false">
+    <button class="btn-solid theme-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" data-coreui-auto-close="outside" aria-expanded="false">
       Clickable outside
     </button>
     <ul class="dropdown-menu">
@@ -662,7 +662,7 @@ By default, the dropdown menu is closed when clicking inside or outside the drop
   </div>
 
   <div class="btn-group">
-    <button class="btn btn-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" data-coreui-auto-close="false" aria-expanded="false">
+    <button class="btn-solid theme-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" data-coreui-auto-close="false" aria-expanded="false">
       Manual close
     </button>
     <ul class="dropdown-menu">

--- a/docs/src/content/docs/components/header.mdx
+++ b/docs/src/content/docs/components/header.mdx
@@ -65,7 +65,7 @@ Here's an example of all the sub-components included in a responsive header.
     </ul>
     <form class="d-flex">
       <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-      <button class="btn btn-outline-success" type="submit">Search</button>
+      <button class="btn-outline theme-success" type="submit">Search</button>
     </form>
   </header>`} />
 
@@ -172,7 +172,7 @@ Place various form controls and components within a header with `.d-flex`.
 <Example code={`<header class="header">
     <form class="d-flex">
       <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-      <button class="btn btn-outline-success" type="submit">Search</button>
+      <button class="btn-outline theme-success" type="submit">Search</button>
     </form>
   </header>`} />
 
@@ -182,7 +182,7 @@ Immediate children elements in `.header` use flex layout and will default to `ju
     <a class="header-brand">Header</a>
     <form class="d-flex">
       <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-      <button class="btn btn-outline-success" type="submit">Search</button>
+      <button class="btn-outline theme-success" type="submit">Search</button>
     </form>
   </header>`} />
 
@@ -203,8 +203,8 @@ Various buttons are supported as part of these header forms, too. This is also a
 
 <Example code={`<header class="header">
     <form class="d-flex">
-      <button class="btn btn-outline-success" type="button">Main button</button>
-      <button class="btn btn-sm btn-outline-secondary" type="button">Smaller button</button>
+      <button class="btn-outline theme-success" type="button">Main button</button>
+      <button class="btn-outline theme-secondary btn-sm" type="button">Smaller button</button>
     </form>
   </header>`} />
 

--- a/docs/src/content/docs/components/jumbotron.mdx
+++ b/docs/src/content/docs/components/jumbotron.mdx
@@ -13,7 +13,7 @@ The jumbotron component is dropped in version v4 as it can be replicated with ut
     <p class="lead">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
     <hr class="my-4">
     <p>It uses utility classes for typography and spacing to space content out within the larger container.</p>
-    <a class="btn btn-primary btn-lg" href="#" role="button">Learn more</a>
+    <a class="btn-solid theme-primary btn-lg" href="#" role="button">Learn more</a>
   </div>`} />
 
 ## Full-width Bootstrap jumbotron
@@ -34,14 +34,14 @@ The jumbotron component is dropped in version v4 as it can be replicated with ut
       <div class="h-100 p-5 bg-black text-white rounded-3" data-coreui-theme="dark">
         <h2>Change the background</h2>
         <p>Swap the background-color utility and add a <code>.text-*</code> color utility to mix up the jumbotron look. Then, mix and match with additional component themes and more.</p>
-        <button class="btn btn-outline-inverse" type="button">Example button</button>
+        <button class="btn-outline theme-inverse" type="button">Example button</button>
       </div>
     </div>
     <div class="col-md-6">
       <div class="h-100 p-5 bg-3 border rounded-3">
         <h2>Add borders</h2>
         <p>Or, keep it light and add a border for some added definition to the boundaries of your content. Be sure to look under the hood at the source HTML here as we've adjusted the alignment and sizing of both column's content for equal-height.</p>
-        <button class="btn btn-outline-secondary" type="button">Example button</button>
+        <button class="btn-outline theme-secondary" type="button">Example button</button>
       </div>
     </div>
   </div>`} />

--- a/docs/src/content/docs/components/list-group.mdx
+++ b/docs/src/content/docs/components/list-group.mdx
@@ -104,21 +104,21 @@ These work great with custom content as well.
         <div class="fw-bold">Subheading</div>
         Content for list item
       </div>
-      <span class="badge text-bg-primary rounded-pill">14</span>
+      <span class="badge theme-primary rounded-pill">14</span>
     </li>
     <li class="list-group-item d-flex justify-content-between align-items-start">
       <div class="ms-2 me-auto">
         <div class="fw-bold">Subheading</div>
         Content for list item
       </div>
-      <span class="badge text-bg-primary rounded-pill">14</span>
+      <span class="badge theme-primary rounded-pill">14</span>
     </li>
     <li class="list-group-item d-flex justify-content-between align-items-start">
       <div class="ms-2 me-auto">
         <div class="fw-bold">Subheading</div>
         Content for list item
       </div>
-      <span class="badge text-bg-primary rounded-pill">14</span>
+      <span class="badge theme-primary rounded-pill">14</span>
     </li>
   </ol>`} />
 
@@ -138,13 +138,13 @@ The responsive variants measure the nearest [query container](/utilities/contain
 
 ## Contextual classes
 
-Use contextual classes to style list items with a stateful background and color.
+Colour a list item with a [`.theme-*` class](/customize/components/#theme-variants). It works on the item, on the `.list-group` above it, or on both — an item's own theme wins over the one it inherits.
 
-<Example code={[`<ul class="list-group">`, `<li class="list-group-item">A simple default list group item</li>`, ...getData('theme-colors').map((c) => `<li class="list-group-item list-group-item-${c.name}">A simple ${c.name} list group item</li>`), ``, `</ul>`]} />
+<Example code={[`<ul class="list-group">`, `<li class="list-group-item">A simple default list group item</li>`, ...getData('theme-colors').map((c) => `<li class="list-group-item theme-${c.name}">A simple ${c.name} list group item</li>`), ``, `</ul>`]} />
 
 Contextual classes also work with `.list-group-item-action`. Note the addition of the hover styles here not present in the previous example. Also supported is the `.active` state; apply it to indicate an active selection on a contextual list group item.
 
-<Example code={[`<div class="list-group">`, `<a href="#" class="list-group-item list-group-item-action">A simple default list group item</a>`, ...getData('theme-colors').map((c) => `<a href="#" class="list-group-item list-group-item-action list-group-item-${c.name}">A simple ${c.name} list group item</a>`), ``, `</div>`]} />
+<Example code={[`<div class="list-group">`, `<a href="#" class="list-group-item list-group-item-action">A simple default list group item</a>`, ...getData('theme-colors').map((c) => `<a href="#" class="list-group-item list-group-item-action theme-${c.name}">A simple ${c.name} list group item</a>`), ``, `</div>`]} />
 
 <Callout color="info">
 ##### Conveying meaning to assistive technologies
@@ -159,15 +159,15 @@ Add badges to any list group item to show unread counts, activity, and more with
 <Example code={`<ul class="list-group">
     <li class="list-group-item d-flex justify-content-between align-items-center">
       A list item
-      <span class="badge text-bg-primary rounded-pill">14</span>
+      <span class="badge theme-primary rounded-pill">14</span>
     </li>
     <li class="list-group-item d-flex justify-content-between align-items-center">
       A second list item
-      <span class="badge text-bg-primary rounded-pill">2</span>
+      <span class="badge theme-primary rounded-pill">2</span>
     </li>
     <li class="list-group-item d-flex justify-content-between align-items-center">
       A third list item
-      <span class="badge text-bg-primary rounded-pill">1</span>
+      <span class="badge theme-primary rounded-pill">1</span>
     </li>
   </ul>`} />
 
@@ -399,6 +399,23 @@ tabElms.forEach(tabElm => {
 })
 ```
 
+## Deprecated markup
+
+<DeprecatedIn version="6.0.0" />
+
+The v5 spelling — `.list-group-item` with a colour modifier — still works and renders identically. Each colour class is generated from the same theme map as the class it replaces, so `.list-group-item-primary` *is* `.list-group-item.theme-primary`. They are removed in v7.
+
+<Example code={[`<ul class="list-group">`, ...getData('theme-colors').map((c) => `<li class="list-group-item list-group-item-${c.name}">A simple ${c.name} list group item</li>`), ``, `</ul>`]} />
+
+```diff
+- <li class="list-group-item list-group-item-success">Done</li>
++ <li class="list-group-item theme-success">Done</li>
+```
+
+The rewrite buys two things the modifier cannot. A theme colour set on the `.list-group` reaches every item inside it, and a colour of your own works the moment you define its theme tokens, with no Sass to compile.
+
+See the [v6 migration guide](/migration/v6/) for the full picture.
+
 ## Customizing
 
 ### CSS variables
@@ -417,9 +434,9 @@ Sass variables set these defaults at build time and are removed in v7. The CSS v
 
 ### SASS loop
 
-Loop that generates the [contextual variant classes](#contextual-classes) for
-`.list-group-item`s. Each class sets the generic `--cui-theme-*` tokens, which the
-item, its `.active` state and `.list-group-item-action` read directly. Putting
-[`.theme-{color}`](/customize/theme/) on a list group colors it the same way.
+Loop that generates the [deprecated colour classes](#deprecated-markup) for
+`.list-group-item`s. Each class sets the same generic `--cui-theme-*` tokens that
+`.theme-{color}` sets, which is why the two spellings render identically — the item,
+its `.active` state and `.list-group-item-action` all read those tokens directly.
 
 <ScssDocs file="scss/_list-group.scss" capture="list-group-modifiers" />

--- a/docs/src/content/docs/components/loading-buttons.mdx
+++ b/docs/src/content/docs/components/loading-buttons.mdx
@@ -11,9 +11,9 @@ otherFrameworks:
 
 Create basic Bootstrap Loading Buttons with different styles: primary, outline, and ghost. These buttons show a loading state when clicked.
 
-<Example pro code={`<button type="button" class="btn btn-primary" data-coreui-timeout="2000" data-coreui-toggle="loading-button">Submit</button>
-  <button type="button" class="btn btn-outline-primary" data-coreui-toggle="loading-button">Submit</button>
-  <button type="button" class="btn btn-ghost-primary" data-coreui-toggle="loading-button">Submit</button>`} />
+<Example pro code={`<button type="button" class="btn-solid theme-primary" data-coreui-timeout="2000" data-coreui-toggle="loading-button">Submit</button>
+  <button type="button" class="btn-outline theme-primary" data-coreui-toggle="loading-button">Submit</button>
+  <button type="button" class="btn-ghost theme-primary" data-coreui-toggle="loading-button">Submit</button>`} />
 
 ## Spinners
 
@@ -21,17 +21,17 @@ Create basic Bootstrap Loading Buttons with different styles: primary, outline, 
 
 The default option. Use loading buttons with a border spinner to indicate loading status.
 
-<Example pro code={`<button type="button" class="btn btn-info" data-coreui-toggle="loading-button">Submit</button>
-  <button type="button" class="btn btn-outline-success" data-coreui-toggle="loading-button">Submit</button>
-  <button type="button" class="btn btn-ghost-warning" data-coreui-toggle="loading-button">Submit</button>`} />
+<Example pro code={`<button type="button" class="btn-solid theme-info" data-coreui-toggle="loading-button">Submit</button>
+  <button type="button" class="btn-outline theme-success" data-coreui-toggle="loading-button">Submit</button>
+  <button type="button" class="btn-ghost theme-warning" data-coreui-toggle="loading-button">Submit</button>`} />
 
 ### Grow
 
 Switch to a grow spinner for Bootstrap loading buttons by adding `data-coreui-spinner-type="grow"`.
 
-<Example pro code={`<button type="button" class="btn btn-info" data-coreui-spinner-type="grow" data-coreui-toggle="loading-button">Submit</button>
-  <button type="button" class="btn btn-outline-success" data-coreui-spinner-type="grow" data-coreui-toggle="loading-button">Submit</button>
-  <button type="button" class="btn btn-ghost-warning" data-coreui-spinner-type="grow" data-coreui-toggle="loading-button">Submit</button>`} />
+<Example pro code={`<button type="button" class="btn-solid theme-info" data-coreui-spinner-type="grow" data-coreui-toggle="loading-button">Submit</button>
+  <button type="button" class="btn-outline theme-success" data-coreui-spinner-type="grow" data-coreui-toggle="loading-button">Submit</button>
+  <button type="button" class="btn-ghost theme-warning" data-coreui-spinner-type="grow" data-coreui-toggle="loading-button">Submit</button>`} />
 
 ## Usage
 
@@ -40,7 +40,7 @@ Switch to a grow spinner for Bootstrap loading buttons by adding `data-coreui-sp
 Add `data-coreui-toggle="loading-button"` to a `button` element.
 
 ```html
-<button type="button" class="btn btn-primary" data-coreui-toggle="loading-button">Submit</button>
+<button type="button" class="btn-solid theme-primary" data-coreui-toggle="loading-button">Submit</button>
 ```
 
 ### Via JavaScript
@@ -48,7 +48,7 @@ Add `data-coreui-toggle="loading-button"` to a `button` element.
 Call the loading button via JavaScript:
 
 ```html
-<div class="btn btn-primary btn-loading"></div>
+<div class="btn-solid theme-primary btn-loading"></div>
 ```
 
 ```js

--- a/docs/src/content/docs/components/menu.mdx
+++ b/docs/src/content/docs/components/menu.mdx
@@ -10,7 +10,7 @@ description: "The Menu component toggles contextual overlays with submenus, cont
 
 Toggle menus with buttons whenever possible. Here’s an example using a CoreUI button:
 
-<Example code={`<button class="btn btn-primary" type="button" data-coreui-toggle="menu" aria-expanded="false">
+<Example code={`<button class="btn-solid theme-primary" type="button" data-coreui-toggle="menu" aria-expanded="false">
     Toggle menu
   </button>
   <div class="menu">
@@ -29,7 +29,7 @@ While `<button>` is the recommended control for a menu toggle, there might be si
 
 Use [button groups](/components/button-group/) to create split button menus where the menu is displayed when a secondary button is clicked. Give that second button `.menu-toggle-split`, which narrows its padding so the pair reads as one control.
 
-<Example code={`<a class="btn btn-primary" href="#" role="button" data-coreui-toggle="menu" aria-expanded="false">
+<Example code={`<a class="btn-solid theme-primary" href="#" role="button" data-coreui-toggle="menu" aria-expanded="false">
     Toggle menu
   </a>
   <div class="menu">
@@ -39,8 +39,8 @@ Use [button groups](/components/button-group/) to create split button menus wher
   </div>
 
   <div class="btn-group">
-    <button type="button" class="btn btn-secondary">Split</button>
-    <button type="button" class="btn btn-secondary menu-toggle-split" data-coreui-toggle="menu" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary">Split</button>
+    <button type="button" class="btn-solid theme-secondary menu-toggle-split" data-coreui-toggle="menu" aria-expanded="false">
       <svg class="icon" viewBox="0 0 512 512" aria-hidden="true"><path d="M256 144a64 64 0 1 0-64-64 64.07 64.07 0 0 0 64 64m0-96a32 32 0 1 1-32 32 32.036 32.036 0 0 1 32-32m0 320a64 64 0 1 0 64 64 64.07 64.07 0 0 0-64-64m0 96a32 32 0 1 1 32-32 32.036 32.036 0 0 1-32 32m0-272a64 64 0 1 0 64 64 64.07 64.07 0 0 0-64-64m0 96a32 32 0 1 1 32-32 32.036 32.036 0 0 1-32 32"></path></svg>
       <span class="visually-hidden">Toggle menu</span>
     </button>
@@ -58,7 +58,7 @@ Use [button groups](/components/button-group/) to create split button menus wher
 Opt into darker menus to match a dark navbar or custom style by adding `data-coreui-theme="dark"` onto the toggle element or a parent.
 
 <Example code={`<div data-coreui-theme="dark">
-    <button class="btn btn-secondary" type="button" data-coreui-toggle="menu" aria-expanded="false">
+    <button class="btn-solid theme-secondary" type="button" data-coreui-toggle="menu" aria-expanded="false">
       Menu button
     </button>
     <div class="menu">
@@ -77,7 +77,7 @@ And putting it to use in a navbar:
       <a class="navbar-brand" href="#">Navbar</a>
       <ul class="navbar-nav">
         <li class="nav-item" data-coreui-theme="dark">
-          <button class="btn btn-secondary" data-coreui-toggle="menu" aria-expanded="false">
+          <button class="btn-solid theme-secondary" data-coreui-toggle="menu" aria-expanded="false">
             Menu
           </button>
           <div class="menu">
@@ -94,7 +94,7 @@ And putting it to use in a navbar:
 
 Blur and saturate the background of menus to create a translucent effect with `.menu-translucent`.
 
-<Example code={`<button class="btn btn-secondary" type="button" data-coreui-toggle="menu" aria-expanded="false">
+<Example code={`<button class="btn-solid theme-secondary" type="button" data-coreui-toggle="menu" aria-expanded="false">
     Menu button
   </button>
   <div class="menu menu-translucent">
@@ -104,7 +104,7 @@ Blur and saturate the background of menus to create a translucent effect with `.
     <a class="menu-item" href="#">Menu item</a>
     <a class="menu-item" href="#">Menu item</a>
     <hr class="menu-divider">
-    <a class="menu-item text-danger" href="#">Danger menu item</a>
+    <a class="menu-item theme-danger" href="#">Danger menu item</a>
   </div>`} />
 
 ## Placement
@@ -117,7 +117,7 @@ Use `data-coreui-placement` on the toggle element to control where the menu appe
 All placements support `-start` and `-end` alignment modifiers (e.g., `bottom-start`, `end-end`).
 
 <Example code={`<div class="btn-group">
-    <button type="button" class="btn btn-secondary" data-coreui-toggle="menu" data-coreui-placement="top-start" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary" data-coreui-toggle="menu" data-coreui-placement="top-start" aria-expanded="false">
       Top start
     </button>
     <div class="menu">
@@ -126,7 +126,7 @@ All placements support `-start` and `-end` alignment modifiers (e.g., `bottom-st
     </div>
   </div>
   <div class="btn-group">
-    <button type="button" class="btn btn-secondary" data-coreui-toggle="menu" data-coreui-placement="end" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary" data-coreui-toggle="menu" data-coreui-placement="end" aria-expanded="false">
       End (logical)
     </button>
     <div class="menu">
@@ -145,7 +145,7 @@ For example, `data-coreui-placement="bottom-start md:bottom-end lg:end-start"` w
 - Switch to `bottom-end` at the `md` breakpoint
 - Switch to `right-start` at the `lg` breakpoint
 
-<Example class="d-flex flex-column flex-lg-row gap-2" code={`<button class="btn btn-secondary" type="button" data-coreui-toggle="menu" data-coreui-placement="bottom-start md:bottom-end" aria-expanded="false">
+<Example class="d-flex flex-column flex-lg-row gap-2" code={`<button class="btn-solid theme-secondary" type="button" data-coreui-toggle="menu" data-coreui-placement="bottom-start md:bottom-end" aria-expanded="false">
     Bottom start → md:bottom-end
   </button>
   <div class="menu">
@@ -153,7 +153,7 @@ For example, `data-coreui-placement="bottom-start md:bottom-end lg:end-start"` w
     <a class="menu-item" href="#">Another action</a>
   </div>
 
-  <button class="btn btn-secondary" type="button" data-coreui-toggle="menu" data-coreui-placement="bottom lg:right" aria-expanded="false">
+  <button class="btn-solid theme-secondary" type="button" data-coreui-toggle="menu" data-coreui-placement="bottom lg:right" aria-expanded="false">
     Bottom → lg:right
   </button>
   <div class="menu">
@@ -161,7 +161,7 @@ For example, `data-coreui-placement="bottom-start md:bottom-end lg:end-start"` w
     <a class="menu-item" href="#">Another action</a>
   </div>
 
-  <button class="btn btn-secondary" type="button" data-coreui-toggle="menu" data-coreui-placement="top-end md:right-start xl:bottom-start" aria-expanded="false">
+  <button class="btn-solid theme-secondary" type="button" data-coreui-toggle="menu" data-coreui-placement="top-end md:right-start xl:bottom-start" aria-expanded="false">
     Multi-breakpoint
   </button>
   <div class="menu">
@@ -216,19 +216,19 @@ Add `.disabled` to items in the menu to style them as disabled.
 
 ### Variants
 
-Use our color utilities to tint individual menu items - the classic CoreUI idiom, with no extra component API involved.
+Colour an individual item with a [`.theme-*` class](/customize/components/#theme-variants). The item reads the theme's foreground while at rest and swaps to the theme's fill with a contrasting label once it is `.active`, so one class covers both states.
 
 <Example class="hstack gap-3" code={`<div class="menu show position-static">
-    <a class="menu-item text-primary" href="#">Primary link</a>
-    <a class="menu-item text-secondary" href="#">Secondary link</a>
-    <a class="menu-item text-success" href="#">Success link</a>
-    <a class="menu-item text-danger" href="#">Danger link</a>
+    <a class="menu-item theme-primary" href="#">Primary link</a>
+    <a class="menu-item theme-secondary" href="#">Secondary link</a>
+    <a class="menu-item theme-success" href="#">Success link</a>
+    <a class="menu-item theme-danger" href="#">Danger link</a>
   </div>
   <div class="menu show position-static">
-    <a class="menu-item active text-primary" href="#">Primary link</a>
-    <a class="menu-item active text-secondary" href="#">Secondary link</a>
-    <a class="menu-item active text-success" href="#">Success link</a>
-    <a class="menu-item active text-danger" href="#">Danger link</a>
+    <a class="menu-item active theme-primary" href="#">Primary link</a>
+    <a class="menu-item active theme-secondary" href="#">Secondary link</a>
+    <a class="menu-item active theme-success" href="#">Success link</a>
+    <a class="menu-item active theme-danger" href="#">Danger link</a>
   </div>`} />
 
 ### Icons
@@ -249,7 +249,7 @@ Add `.menu-item-icon` directly to an `<svg>` to add an icon slot to menu items.
       Cut
     </button>
     <hr class="menu-divider">
-    <button class="menu-item text-danger" type="button">
+    <button class="menu-item theme-danger" type="button">
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="menu-item-icon" viewBox="0 0 16 16">
         <path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5M11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1zm1.958 1-.846 10.58a1 1 0 0 1-.997.92h-6.23a1 1 0 0 1-.997-.92L3.042 3.5zm-7.487 1a.5.5 0 0 1 .528.47l.5 8.5a.5.5 0 0 1-.998.06L5 5.03a.5.5 0 0 1 .47-.53Zm5.058 0a.5.5 0 0 1 .47.53l-.5 8.5a.5.5 0 1 1-.998-.06l.5-8.5a.5.5 0 0 1 .528-.47M8 4.5a.5.5 0 0 1 .5.5v8.5a.5.5 0 0 1-1 0V5a.5.5 0 0 1 .5-.5"/>
       </svg>
@@ -280,7 +280,7 @@ Use `.menu-item-content` for a flex column layout and `.menu-item-description` f
 
 Add `.selected` to a `.menu-item` to indicate the current selection.
 
-<Example code={`<button class="btn btn-secondary" type="button" data-coreui-toggle="menu" aria-expanded="false">Select status</button>
+<Example code={`<button class="btn-solid theme-secondary" type="button" data-coreui-toggle="menu" aria-expanded="false">Select status</button>
   <div class="menu">
     <button class="menu-item selected" type="button">
       <span class="menu-item-content">
@@ -298,7 +298,7 @@ Add `.selected` to a `.menu-item` to indicate the current selection.
     </button>
   </div>
 
-  <button class="btn btn-secondary" type="button" data-coreui-toggle="menu" aria-expanded="false">Select status</button>
+  <button class="btn-solid theme-secondary" type="button" data-coreui-toggle="menu" aria-expanded="false">Select status</button>
   <div class="menu">
     <button class="menu-item" type="button">
       Default menu item
@@ -373,9 +373,9 @@ Put a form within a menu, or make it into a menu, and use [spacing utilities](/u
         <label for="checkLabel">Example new checkbox</label>
       </div>
       <div class="vstack gap-2">
-        <button type="submit" class="btn btn-primary">Sign in</button>
-        <a class="btn btn-ghost-secondary" href="#">New around here? Sign up</a>
-        <a class="btn btn-ghost-secondary" href="#">Forgot password?</a>
+        <button type="submit" class="btn-solid theme-primary">Sign in</button>
+        <a class="btn-ghost theme-secondary" href="#">New around here? Sign up</a>
+        <a class="btn-ghost theme-secondary" href="#">Forgot password?</a>
       </div>
     </form>
   </div>`} />
@@ -403,7 +403,7 @@ Create nested menus with the `.submenu` wrapper class. Submenus support hover an
 
 Wrap a `.menu-item` trigger and a nested `.menu` inside a `.submenu` element.
 
-<Example code={`<button class="btn btn-secondary" type="button" data-coreui-toggle="menu" aria-expanded="false">
+<Example code={`<button class="btn-solid theme-secondary" type="button" data-coreui-toggle="menu" aria-expanded="false">
     Submenus
   </button>
   <div class="menu">
@@ -438,7 +438,7 @@ Wrap a `.menu-item` trigger and a nested `.menu` inside a `.submenu` element.
 
 Submenus can be nested to multiple levels. Each level opens to the side and flips direction when there’s not enough viewport space.
 
-<Example code={`<button class="btn btn-secondary" type="button" data-coreui-toggle="menu" aria-expanded="false">
+<Example code={`<button class="btn-solid theme-secondary" type="button" data-coreui-toggle="menu" aria-expanded="false">
     Multi-level menu
   </button>
   <div class="menu">
@@ -466,7 +466,7 @@ Use `data-coreui-offset` or `data-coreui-reference` to change the location of th
 
 <Example code={`<div class="d-flex">
     <div class="me-1">
-      <button type="button" class="btn btn-secondary" data-coreui-toggle="menu" aria-expanded="false" data-coreui-offset="10,20">
+      <button type="button" class="btn-solid theme-secondary" data-coreui-toggle="menu" aria-expanded="false" data-coreui-offset="10,20">
         Offset
       </button>
       <div class="menu">
@@ -476,8 +476,8 @@ Use `data-coreui-offset` or `data-coreui-reference` to change the location of th
       </div>
     </div>
     <div class="btn-group">
-      <button type="button" class="btn btn-secondary">Reference</button>
-      <button type="button" class="btn btn-secondary menu-toggle-split" data-coreui-toggle="menu" aria-expanded="false" data-coreui-reference="parent">
+      <button type="button" class="btn-solid theme-secondary">Reference</button>
+      <button type="button" class="btn-solid theme-secondary menu-toggle-split" data-coreui-toggle="menu" aria-expanded="false" data-coreui-reference="parent">
         <svg class="icon" viewBox="0 0 512 512" aria-hidden="true"><path d="M256 144a64 64 0 1 0-64-64 64.07 64.07 0 0 0 64 64m0-96a32 32 0 1 1-32 32 32.036 32.036 0 0 1 32-32m0 320a64 64 0 1 0 64 64 64.07 64.07 0 0 0-64-64m0 96a32 32 0 1 1 32-32 32.036 32.036 0 0 1-32 32m0-272a64 64 0 1 0 64 64 64.07 64.07 0 0 0-64-64m0 96a32 32 0 1 1 32-32 32.036 32.036 0 0 1-32 32"></path></svg>
         <span class="visually-hidden">Toggle Menu</span>
       </button>
@@ -498,7 +498,7 @@ By default, the menu is closed when clicking inside or outside the menu. You can
 Regardless of the `autoClose` setting, pressing <kbd>Esc</kbd> while focus is within the menu (its toggle or items) closes the menu and returns focus to the toggle.
 
 <Example class="d-flex flex-wrap gap-2" code={`<div class="btn-group">
-    <button class="btn btn-secondary" type="button" data-coreui-toggle="menu" data-coreui-auto-close="true" aria-expanded="false">
+    <button class="btn-solid theme-secondary" type="button" data-coreui-toggle="menu" data-coreui-auto-close="true" aria-expanded="false">
       Default menu
     </button>
     <div class="menu">
@@ -509,7 +509,7 @@ Regardless of the `autoClose` setting, pressing <kbd>Esc</kbd> while focus is wi
   </div>
 
   <div class="btn-group">
-    <button class="btn btn-secondary" type="button" data-coreui-toggle="menu" data-coreui-auto-close="inside" aria-expanded="false">
+    <button class="btn-solid theme-secondary" type="button" data-coreui-toggle="menu" data-coreui-auto-close="inside" aria-expanded="false">
       Clickable inside
     </button>
     <div class="menu">
@@ -520,7 +520,7 @@ Regardless of the `autoClose` setting, pressing <kbd>Esc</kbd> while focus is wi
   </div>
 
   <div class="btn-group">
-    <button class="btn btn-secondary" type="button" data-coreui-toggle="menu" data-coreui-auto-close="outside" aria-expanded="false">
+    <button class="btn-solid theme-secondary" type="button" data-coreui-toggle="menu" data-coreui-auto-close="outside" aria-expanded="false">
       Clickable outside
     </button>
     <div class="menu">
@@ -531,7 +531,7 @@ Regardless of the `autoClose` setting, pressing <kbd>Esc</kbd> while focus is wi
   </div>
 
   <div class="btn-group">
-    <button class="btn btn-secondary" type="button" data-coreui-toggle="menu" data-coreui-auto-close="false" aria-expanded="false">
+    <button class="btn-solid theme-secondary" type="button" data-coreui-toggle="menu" data-coreui-auto-close="false" aria-expanded="false">
       Manual close
     </button>
     <div class="menu">

--- a/docs/src/content/docs/components/modal.mdx
+++ b/docs/src/content/docs/components/modal.mdx
@@ -45,7 +45,7 @@ Keep reading for demos and usage guidelines.
 
 Below is a _static_ modal example (meaning it is open and rendered in place). Included are the modal header, modal body (required for `padding`), and modal footer (optional). We ask that you include modal headers with dismiss actions whenever possible, or provide another explicit dismiss action.
 
-<Example class="bg-3" html={[`<dialog class="modal modal-instant position-static" open>`, `  <div class="modal-header">`, `    <h5 class="modal-title">Modal title</h5>`, `    <button type="button" class="btn-close" aria-label="Close"></button>`, `  </div>`, `  <div class="modal-body">`, `    <p>Modal body text goes here.</p>`, `  </div>`, `  <div class="modal-footer">`, `    <button type="button" class="btn btn-secondary">Close</button>`, `    <button type="button" class="btn btn-primary">Save changes</button>`, `  </div>`, `</dialog>`]} />
+<Example class="bg-3" html={[`<dialog class="modal modal-instant position-static" open>`, `  <div class="modal-header">`, `    <h5 class="modal-title">Modal title</h5>`, `    <button type="button" class="btn-close" aria-label="Close"></button>`, `  </div>`, `  <div class="modal-body">`, `    <p>Modal body text goes here.</p>`, `  </div>`, `  <div class="modal-footer">`, `    <button type="button" class="btn-solid theme-secondary">Close</button>`, `    <button type="button" class="btn-solid theme-primary">Save changes</button>`, `  </div>`, `</dialog>`]} />
 
 ```html
 <dialog class="modal">
@@ -57,8 +57,8 @@ Below is a _static_ modal example (meaning it is open and rendered in place). In
     <p>Modal body text goes here.</p>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
-    <button type="button" class="btn btn-primary">Save changes</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
+    <button type="button" class="btn-solid theme-primary">Save changes</button>
   </div>
 </dialog>
 ```
@@ -76,16 +76,16 @@ Toggle a working modal demo by clicking the button below. It will slide down and
     <p>Woo-hoo, you're reading this text in a modal!</p>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
-    <button type="button" class="btn btn-primary">Save changes</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
+    <button type="button" class="btn-solid theme-primary">Save changes</button>
   </div>
 </dialog>
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalLive">`, `  Launch demo modal`, `</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalLive">`, `  Launch demo modal`, `</button>`]} />
 
 ```html
 <!-- Button trigger modal -->
-<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModal">
+<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModal">
   Launch demo modal
 </button>
 
@@ -99,8 +99,8 @@ Toggle a working modal demo by clicking the button below. It will slide down and
     ...
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
-    <button type="button" class="btn btn-primary">Save changes</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
+    <button type="button" class="btn-solid theme-primary">Save changes</button>
   </div>
 </dialog>
 ```
@@ -118,16 +118,16 @@ When backdrop is set to static, the modal will not close when clicking outside o
     <p>I will not close if you click outside of me. Don't even try to press escape key.</p>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
-    <button type="button" class="btn btn-primary">Understood</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
+    <button type="button" class="btn-solid theme-primary">Understood</button>
   </div>
 </dialog>
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#staticBackdropLive">`, `  Launch static backdrop modal`, `</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#staticBackdropLive">`, `  Launch static backdrop modal`, `</button>`]} />
 
 ```html
 <!-- Button trigger modal -->
-<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#staticBackdrop">
+<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#staticBackdrop">
   Launch static backdrop modal
 </button>
 
@@ -141,8 +141,8 @@ When backdrop is set to static, the modal will not close when clicking outside o
     ...
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
-    <button type="button" class="btn btn-primary">Understood</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
+    <button type="button" class="btn-solid theme-primary">Understood</button>
   </div>
 </dialog>
 ```
@@ -162,12 +162,12 @@ When modals become too long for the user's viewport or device, add `.modal-scrol
     <p>This content should appear at the bottom after you scroll.</p>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
-    <button type="button" class="btn btn-primary">Save changes</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
+    <button type="button" class="btn-solid theme-primary">Save changes</button>
   </div>
 </dialog>
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalScrollable">`, `  Launch demo modal`, `</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalScrollable">`, `  Launch demo modal`, `</button>`]} />
 
 ```html
 <!-- Scrollable modal -->
@@ -191,23 +191,23 @@ Modals are vertically and horizontally centered by the browser — the v5 `.moda
   </div>
   <div class="modal-body">
     <h5>Popover in a modal</h5>
-    <p>This <button class="btn btn-secondary" data-coreui-toggle="popover" title="Popover title" data-coreui-content="Popover body content is set in this attribute." data-coreui-container="#exampleModalPopovers">button</button> triggers a popover on click.</p>
+    <p>This <button class="btn-solid theme-secondary" data-coreui-toggle="popover" title="Popover title" data-coreui-content="Popover body content is set in this attribute." data-coreui-container="#exampleModalPopovers">button</button> triggers a popover on click.</p>
     <hr />
     <h5>Tooltips in a modal</h5>
     <p><a href="#" data-coreui-toggle="tooltip" title="Tooltip" data-coreui-container="#exampleModalPopovers">This link</a> and <a href="#" data-coreui-toggle="tooltip" title="Tooltip" data-coreui-container="#exampleModalPopovers">that link</a> have tooltips on hover.</p>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
-    <button type="button" class="btn btn-primary">Save changes</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
+    <button type="button" class="btn-solid theme-primary">Save changes</button>
   </div>
 </dialog>
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalPopovers">`, `  Launch demo modal`, `</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalPopovers">`, `  Launch demo modal`, `</button>`]} />
 
 ```html
 <div class="modal-body">
   <h5>Popover in a modal</h5>
-  <p>This <button class="btn btn-secondary" data-coreui-toggle="popover" title="Popover title" data-coreui-content="Popover body content is set in this attribute." data-coreui-container="#myModal">button</button> triggers a popover on click.</p>
+  <p>This <button class="btn-solid theme-secondary" data-coreui-toggle="popover" title="Popover title" data-coreui-content="Popover body content is set in this attribute." data-coreui-container="#myModal">button</button> triggers a popover on click.</p>
   <hr>
   <h5>Tooltips in a modal</h5>
   <p><a href="#" data-coreui-toggle="tooltip" title="Tooltip" data-coreui-container="#myModal">This link</a> and <a href="#" data-coreui-toggle="tooltip" title="Tooltip" data-coreui-container="#myModal">that link</a> have tooltips on hover.</p>
@@ -252,12 +252,12 @@ Utilize the Bootstrap grid system within a modal by nesting `.container-fluid` w
     </div>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
-    <button type="button" class="btn btn-primary">Save changes</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
+    <button type="button" class="btn-solid theme-primary">Save changes</button>
   </div>
 </dialog>
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#gridSystemModal">`, `  Launch demo modal`, `</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#gridSystemModal">`, `  Launch demo modal`, `</button>`]} />
 
 ```html
 <div class="modal-body">
@@ -296,9 +296,9 @@ Have a bunch of buttons that all trigger the same modal with slightly different 
 
 Below is a live demo followed by example HTML and JavaScript. For more information, [read the modal events docs](#events) for details on `relatedTarget`.
 
-<Example code={`<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModal" data-coreui-whatever="@mdo">Open modal for @mdo</button>
-  <button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModal" data-coreui-whatever="@fat">Open modal for @fat</button>
-  <button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModal" data-coreui-whatever="@getbootstrap">Open modal for @getbootstrap</button>
+<Example code={`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModal" data-coreui-whatever="@mdo">Open modal for @mdo</button>
+  <button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModal" data-coreui-whatever="@fat">Open modal for @fat</button>
+  <button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModal" data-coreui-whatever="@getbootstrap">Open modal for @getbootstrap</button>
 
   <dialog class="modal" id="exampleModal" aria-labelledby="exampleModalLabel">
     <div class="modal-header">
@@ -318,8 +318,8 @@ Below is a live demo followed by example HTML and JavaScript. For more informati
       </form>
     </div>
     <div class="modal-footer">
-      <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
-      <button type="button" class="btn btn-primary">Send message</button>
+      <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
+      <button type="button" class="btn-solid theme-primary">Send message</button>
     </div>
   </dialog>`} sandboxJs={varyingModalContent} />
 
@@ -338,7 +338,7 @@ Toggle between multiple modals with some clever placement of the `data-coreui-ta
       Show a second modal and hide this one with the button below.
     </div>
     <div class="modal-footer">
-      <button class="btn btn-primary" data-coreui-target="#exampleModalToggle2" data-coreui-toggle="modal">Open second modal</button>
+      <button class="btn-solid theme-primary" data-coreui-target="#exampleModalToggle2" data-coreui-toggle="modal">Open second modal</button>
     </div>
   </dialog>
   <dialog class="modal" id="exampleModalToggle2" aria-labelledby="exampleModalToggleLabel2">
@@ -350,10 +350,10 @@ Toggle between multiple modals with some clever placement of the `data-coreui-ta
       Hide this modal and show the first with the button below.
     </div>
     <div class="modal-footer">
-      <button class="btn btn-primary" data-coreui-target="#exampleModalToggle" data-coreui-toggle="modal">Back to first</button>
+      <button class="btn-solid theme-primary" data-coreui-target="#exampleModalToggle" data-coreui-toggle="modal">Back to first</button>
     </div>
   </dialog>
-  <button class="btn btn-primary" data-coreui-target="#exampleModalToggle" data-coreui-toggle="modal">Open first modal</button>`} />
+  <button class="btn-solid theme-primary" data-coreui-target="#exampleModalToggle" data-coreui-toggle="modal">Open first modal</button>`} />
 
 ### Non-modal mode
 
@@ -402,7 +402,7 @@ Modals have three optional sizes, available via modifier classes to be placed on
 
 Our default modal without modifier class constitutes the "medium" size modal.
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalXl">Extra large modal</button>`, `<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalLg">Large modal</button>`, `<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalSm">Small modal</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalXl">Extra large modal</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalLg">Large modal</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalSm">Small modal</button>`]} />
 
 ```html
 <dialog class="modal modal-xl">...</dialog>
@@ -453,7 +453,7 @@ Another override is the option to pop up a modal that covers the user viewport, 
 | `.modal-fullscreen-xl-down` | `1200px` |
 | `.modal-fullscreen-xxl-down` | `1400px` |
 
-<Example html={[`<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreen">Full screen</button>`, `<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenSm">Full screen below sm</button>`, `<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenMd">Full screen below md</button>`, `<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenLg">Full screen below lg</button>`, `<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenXl">Full screen below xl</button>`, `<button type="button" class="btn btn-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenXxl">Full screen below xxl</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreen">Full screen</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenSm">Full screen below sm</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenMd">Full screen below md</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenLg">Full screen below lg</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenXl">Full screen below xl</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenXxl">Full screen below xxl</button>`]} />
 
 ```html
 <!-- Full screen modal -->
@@ -471,7 +471,7 @@ Another override is the option to pop up a modal that covers the user viewport, 
     ...
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
   </div>
 </dialog>
 
@@ -484,7 +484,7 @@ Another override is the option to pop up a modal that covers the user viewport, 
     ...
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
   </div>
 </dialog>
 
@@ -497,7 +497,7 @@ Another override is the option to pop up a modal that covers the user viewport, 
     ...
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
   </div>
 </dialog>
 
@@ -510,7 +510,7 @@ Another override is the option to pop up a modal that covers the user viewport, 
     ...
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
   </div>
 </dialog>
 
@@ -523,7 +523,7 @@ Another override is the option to pop up a modal that covers the user viewport, 
     ...
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
   </div>
 </dialog>
 
@@ -536,7 +536,7 @@ Another override is the option to pop up a modal that covers the user viewport, 
     ...
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal">Close</button>
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
   </div>
 </dialog>
 

--- a/docs/src/content/docs/components/navbar.mdx
+++ b/docs/src/content/docs/components/navbar.mdx
@@ -67,7 +67,7 @@ Here's an example of all the sub-components included in a responsive light-theme
         </ul>
         <form class="d-flex" role="search">
           <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-          <button class="btn btn-outline-success" type="submit">Search</button>
+          <button class="btn-outline theme-success" type="submit">Search</button>
         </form>
       </div>
     </div>
@@ -216,7 +216,7 @@ Place various form controls and components within a navbar:
     <div class="container-fluid">
       <form class="d-flex" role="search">
         <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-        <button class="btn btn-outline-success" type="submit">Search</button>
+        <button class="btn-outline theme-success" type="submit">Search</button>
       </form>
     </div>
   </nav>`} />
@@ -228,7 +228,7 @@ Immediate child elements of `.navbar` use flex layout and will default to `justi
       <a class="navbar-brand">Navbar</a>
       <form class="d-flex" role="search">
         <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-        <button class="btn btn-outline-success" type="submit">Search</button>
+        <button class="btn-outline theme-success" type="submit">Search</button>
       </form>
     </div>
   </nav>`} />
@@ -248,8 +248,8 @@ Various buttons are supported as part of these navbar forms, too. This is also a
 
 <Example code={`<nav class="navbar bg-3">
     <form class="container-fluid justify-content-start">
-      <button class="btn btn-outline-success me-2" type="button">Main button</button>
-      <button class="btn btn-sm btn-outline-secondary" type="button">Smaller button</button>
+      <button class="btn-outline theme-success me-2" type="button">Main button</button>
+      <button class="btn-outline theme-secondary btn-sm" type="button">Smaller button</button>
     </form>
   </nav>`} />
 
@@ -300,7 +300,7 @@ Prefer `data-coreui-theme="dark"` over `.navbar-dark`: it sets a component-speci
 
 Navbar themes are easier than ever thanks to CoreUI for Bootstrap's combination of Sass and CSS variables. The default is our "light navbar" for use with light background colors, but you can also apply `data-coreui-theme="dark"` for dark background colors. Then, customize with `.bg-*` utilities.
 
-<Example html={[`<nav class="navbar navbar-expand-lg bg-3 border-bottom" data-coreui-theme="dark">`, `  <div class="container-fluid">`, `    <a class="navbar-brand" href="#">Navbar</a>`, `    <button class="navbar-toggler" type="button" data-coreui-toggle="collapse" data-coreui-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">`, `      <span class="navbar-toggler-icon"></span>`, `    </button>`, `    <div class="collapse navbar-collapse" id="navbarColor01">`, `      <ul class="navbar-nav me-auto mb-2 mb-lg-0">`, `        <li class="nav-item">`, `          <a class="nav-link active" aria-current="page" href="#">Home</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">Features</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">Pricing</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">About</a>`, `        </li>`, `      </ul>`, `      <form class="d-flex" role="search">`, `        <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">`, `        <button class="btn btn-outline-inverse" type="submit">Search</button>`, `      </form>`, `  </div>`, `  </div>`, `</nav>`, ``, `<nav class="navbar navbar-expand-lg bg-primary" data-coreui-theme="dark">`, `  <div class="container-fluid">`, `    <a class="navbar-brand" href="#">Navbar</a>`, `    <button class="navbar-toggler" type="button" data-coreui-toggle="collapse" data-coreui-target="#navbarColor02" aria-controls="navbarColor02" aria-expanded="false" aria-label="Toggle navigation">`, `      <span class="navbar-toggler-icon"></span>`, `    </button>`, `    <div class="collapse navbar-collapse" id="navbarColor02">`, `      <ul class="navbar-nav me-auto mb-2 mb-lg-0">`, `        <li class="nav-item">`, `          <a class="nav-link active" aria-current="page" href="#">Home</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">Features</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">Pricing</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">About</a>`, `        </li>`, `      </ul>`, `      <form class="d-flex" role="search">`, `        <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">`, `        <button class="btn btn-outline-inverse" type="submit">Search</button>`, `      </form>`, `  </div>`, `    </div>`, `</nav>`, ``, `<nav class="navbar navbar-expand-lg" style="background-color: #e3f2fd;" data-coreui-theme="light">`, `  <div class="container-fluid">`, `    <a class="navbar-brand" href="#">Navbar</a>`, `    <button class="navbar-toggler" type="button" data-coreui-toggle="collapse" data-coreui-target="#navbarColor03" aria-controls="navbarColor03" aria-expanded="false" aria-label="Toggle navigation">`, `      <span class="navbar-toggler-icon"></span>`, `    </button>`, `    <div class="collapse navbar-collapse" id="navbarColor03">`, `      <ul class="navbar-nav me-auto mb-2 mb-lg-0">`, `        <li class="nav-item">`, `          <a class="nav-link active" aria-current="page" href="#">Home</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">Features</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">Pricing</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">About</a>`, `        </li>`, `      </ul>`, `      <form class="d-flex" role="search">`, `        <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">`, `        <button class="btn btn-outline-primary" type="submit">Search</button>`, `      </form>`, `    </div>`, `    </div>`, `</nav>`]} />
+<Example html={[`<nav class="navbar navbar-expand-lg bg-3 border-bottom" data-coreui-theme="dark">`, `  <div class="container-fluid">`, `    <a class="navbar-brand" href="#">Navbar</a>`, `    <button class="navbar-toggler" type="button" data-coreui-toggle="collapse" data-coreui-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">`, `      <span class="navbar-toggler-icon"></span>`, `    </button>`, `    <div class="collapse navbar-collapse" id="navbarColor01">`, `      <ul class="navbar-nav me-auto mb-2 mb-lg-0">`, `        <li class="nav-item">`, `          <a class="nav-link active" aria-current="page" href="#">Home</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">Features</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">Pricing</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">About</a>`, `        </li>`, `      </ul>`, `      <form class="d-flex" role="search">`, `        <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">`, `        <button class="btn-outline theme-inverse" type="submit">Search</button>`, `      </form>`, `  </div>`, `  </div>`, `</nav>`, ``, `<nav class="navbar navbar-expand-lg bg-primary" data-coreui-theme="dark">`, `  <div class="container-fluid">`, `    <a class="navbar-brand" href="#">Navbar</a>`, `    <button class="navbar-toggler" type="button" data-coreui-toggle="collapse" data-coreui-target="#navbarColor02" aria-controls="navbarColor02" aria-expanded="false" aria-label="Toggle navigation">`, `      <span class="navbar-toggler-icon"></span>`, `    </button>`, `    <div class="collapse navbar-collapse" id="navbarColor02">`, `      <ul class="navbar-nav me-auto mb-2 mb-lg-0">`, `        <li class="nav-item">`, `          <a class="nav-link active" aria-current="page" href="#">Home</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">Features</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">Pricing</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">About</a>`, `        </li>`, `      </ul>`, `      <form class="d-flex" role="search">`, `        <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">`, `        <button class="btn-outline theme-inverse" type="submit">Search</button>`, `      </form>`, `  </div>`, `    </div>`, `</nav>`, ``, `<nav class="navbar navbar-expand-lg" style="background-color: #e3f2fd;" data-coreui-theme="light">`, `  <div class="container-fluid">`, `    <a class="navbar-brand" href="#">Navbar</a>`, `    <button class="navbar-toggler" type="button" data-coreui-toggle="collapse" data-coreui-target="#navbarColor03" aria-controls="navbarColor03" aria-expanded="false" aria-label="Toggle navigation">`, `      <span class="navbar-toggler-icon"></span>`, `    </button>`, `    <div class="collapse navbar-collapse" id="navbarColor03">`, `      <ul class="navbar-nav me-auto mb-2 mb-lg-0">`, `        <li class="nav-item">`, `          <a class="nav-link active" aria-current="page" href="#">Home</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">Features</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">Pricing</a>`, `        </li>`, `        <li class="nav-item">`, `          <a class="nav-link" href="#">About</a>`, `        </li>`, `      </ul>`, `      <form class="d-flex" role="search">`, `        <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">`, `        <button class="btn-outline theme-primary" type="submit">Search</button>`, `      </form>`, `    </div>`, `    </div>`, `</nav>`]} />
 
 ```html
 <nav class="navbar bg-3 border-bottom" data-coreui-theme="dark">
@@ -430,7 +430,7 @@ Here's an example navbar using `.navbar-nav-scroll` with `style="--cui-scroll-he
         </ul>
         <form class="d-flex" role="search">
           <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-          <button class="btn btn-outline-success" type="submit">Search</button>
+          <button class="btn-outline theme-success" type="submit">Search</button>
         </form>
       </div>
     </div>
@@ -472,7 +472,7 @@ With no `.navbar-brand` shown at the smallest breakpoint:
         </ul>
         <form class="d-flex" role="search">
           <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-          <button class="btn btn-outline-success" type="submit">Search</button>
+          <button class="btn-outline theme-success" type="submit">Search</button>
         </form>
       </div>
     </div>
@@ -500,7 +500,7 @@ With a brand name shown on the left and toggler on the right:
         </ul>
         <form class="d-flex" role="search">
           <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-          <button class="btn btn-outline-success" type="submit">Search</button>
+          <button class="btn-outline theme-success" type="submit">Search</button>
         </form>
       </div>
     </div>
@@ -528,7 +528,7 @@ With a toggler on the left and brand name on the right:
         </ul>
         <form class="d-flex" role="search">
           <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-          <button class="btn btn-outline-success" type="submit">Search</button>
+          <button class="btn-outline theme-success" type="submit">Search</button>
         </form>
       </div>
     </div>
@@ -595,7 +595,7 @@ In the example below, to create an offcanvas navbar that is always collapsed acr
           </ul>
           <form class="d-flex" role="search">
             <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-            <button class="btn btn-outline-success" type="submit">Search</button>
+            <button class="btn-outline theme-success" type="submit">Search</button>
           </form>
         </div>
       </dialog>
@@ -653,7 +653,7 @@ When using offcanvas in a dark navbar, be aware that you may need to have a dark
           </ul>
           <form class="d-flex" role="search">
             <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-            <button class="btn btn-success" type="submit">Search</button>
+            <button class="btn-solid theme-success" type="submit">Search</button>
           </form>
         </div>
       </dialog>

--- a/docs/src/content/docs/components/offcanvas.mdx
+++ b/docs/src/content/docs/components/offcanvas.mdx
@@ -49,10 +49,10 @@ Utilize the buttons below to toggle the visibility of an offcanvas element using
 
 You can employ a link with the `href` attribute or a button featuring the `data-coreui-target` attribute. In both instances, including `data-coreui-toggle="offcanvas"` is necessary.
 
-<Example code={`<a class="btn btn-primary" data-coreui-toggle="offcanvas" href="#offcanvasExample" role="button" aria-controls="offcanvasExample">
+<Example code={`<a class="btn-solid theme-primary" data-coreui-toggle="offcanvas" href="#offcanvasExample" role="button" aria-controls="offcanvasExample">
     Link with href
   </a>
-  <button class="btn btn-primary" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasExample" aria-controls="offcanvasExample">
+  <button class="btn-solid theme-primary" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasExample" aria-controls="offcanvasExample">
     Button with data-coreui-target
   </button>
 
@@ -66,7 +66,7 @@ You can employ a link with the `href` attribute or a button featuring the `data-
         Some text as a placeholder. In real life, you can have the elements you have chosen, like text, images, lists, etc.
       </div>
       <div class="dropdown mt-3">
-        <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-coreui-toggle="dropdown">
+        <button class="btn-solid theme-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-coreui-toggle="dropdown">
           Dropdown button
         </button>
         <ul class="dropdown-menu">
@@ -82,7 +82,7 @@ You can employ a link with the `href` attribute or a button featuring the `data-
 
 The `<body>` element's scrolling is disabled when the Bootstrap offcanvas and its backdrop are visible. Utilize the `data-coreui-scroll` attribute to allow scrolling on the `<body>` — the offcanvas then opens non-modally, so the rest of the page also stays interactive.
 
-<Example code={`<button class="btn btn-primary" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasScrolling" aria-controls="offcanvasScrolling">Enable body scrolling</button>
+<Example code={`<button class="btn-solid theme-primary" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasScrolling" aria-controls="offcanvasScrolling">Enable body scrolling</button>
 
   <dialog class="offcanvas offcanvas-start" data-coreui-scroll="true" data-coreui-backdrop="false" id="offcanvasScrolling" aria-labelledby="offcanvasScrollingLabel">
     <div class="offcanvas-header">
@@ -99,7 +99,7 @@ The `<body>` element's scrolling is disabled when the Bootstrap offcanvas and it
 
 You can also enable `<body>` scrolling with a visible backdrop.
 
-<Example code={`<button class="btn btn-primary" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasWithBothOptions" aria-controls="offcanvasWithBothOptions">Enable both scrolling & backdrop</button>
+<Example code={`<button class="btn-solid theme-primary" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasWithBothOptions" aria-controls="offcanvasWithBothOptions">Enable both scrolling & backdrop</button>
 
   <dialog class="offcanvas offcanvas-start" data-coreui-scroll="true" id="offcanvasWithBothOptions" aria-labelledby="offcanvasWithBothOptionsLabel">
     <div class="offcanvas-header">
@@ -114,7 +114,7 @@ You can also enable `<body>` scrolling with a visible backdrop.
 ### Static backdrop
 
 When the backdrop is set to static, the Bootstrap offcanvas will remain open when clicking outside of it.
-<Example code={`<button class="btn btn-primary" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#staticBackdrop" aria-controls="staticBackdrop">
+<Example code={`<button class="btn-solid theme-primary" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#staticBackdrop" aria-controls="staticBackdrop">
     Toggle static offcanvas
   </button>
 
@@ -156,7 +156,7 @@ Attention! Dark variants for components are no longer supported as of v5.3.0 due
 
 Responsive offcanvas classes hide content that is outside the viewport from a specified breakpoint and lower. Above that breakpoint, the content will behave normally. For example, `.offcanvas-lg` hides content in an offcanvas below the `lg` breakpoint, but displays the content above the `lg` breakpoint.
 
-<Example code={`<button class="btn btn-primary d-lg-none" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasResponsive" aria-controls="offcanvasResponsive">Toggle offcanvas</button>
+<Example code={`<button class="btn-solid theme-primary d-lg-none" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasResponsive" aria-controls="offcanvasResponsive">Toggle offcanvas</button>
 
   <div class="alert alert-info d-none d-lg-block">Resize your browser to show the responsive offcanvas toggle.</div>
 
@@ -190,7 +190,7 @@ Offcanvas components do not have a default position; therefore, you need to appl
 
 Feel free to experiment with the top, right, and bottom examples below.
 
-<Example code={`<button class="btn btn-primary" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasTop" aria-controls="offcanvasTop">Toggle top offcanvas</button>
+<Example code={`<button class="btn-solid theme-primary" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasTop" aria-controls="offcanvasTop">Toggle top offcanvas</button>
 
   <dialog class="offcanvas offcanvas-top" id="offcanvasTop" aria-labelledby="offcanvasTopLabel">
     <div class="offcanvas-header">
@@ -202,7 +202,7 @@ Feel free to experiment with the top, right, and bottom examples below.
     </div>
   </dialog>`} />
 
-<Example code={`<button class="btn btn-primary" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasRight" aria-controls="offcanvasRight">Toggle right offcanvas</button>
+<Example code={`<button class="btn-solid theme-primary" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasRight" aria-controls="offcanvasRight">Toggle right offcanvas</button>
 
   <dialog class="offcanvas offcanvas-end" id="offcanvasRight" aria-labelledby="offcanvasRightLabel">
     <div class="offcanvas-header">
@@ -214,7 +214,7 @@ Feel free to experiment with the top, right, and bottom examples below.
     </div>
   </dialog>`} />
 
-<Example code={`<button class="btn btn-primary" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasBottom" aria-controls="offcanvasBottom">Toggle bottom offcanvas</button>
+<Example code={`<button class="btn-solid theme-primary" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasBottom" aria-controls="offcanvasBottom">Toggle bottom offcanvas</button>
 
   <dialog class="offcanvas offcanvas-bottom" id="offcanvasBottom" aria-labelledby="offcanvasBottomLabel">
     <div class="offcanvas-header">

--- a/docs/src/content/docs/components/placeholders.mdx
+++ b/docs/src/content/docs/components/placeholders.mdx
@@ -15,7 +15,7 @@ Bootstrap placeholders can enhance your application's user experience. They're b
 ## Example
 
 In the example below, we use the Bootstrap card component and modify it with placeholders to form a "loading card." The size and proportions remain consistent between the two.
-<Example class="docs-example-placeholder-cards d-flex justify-content-around" html={[`<div class="card">`, `  <svg class="docs-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>`, `  <div class="card-body">`, `    <h5 class="card-title">Bootstrap card title</h5>`, `    <p class="card-text">Some brief example text to expand on the card title and form most of the card's content.</p>`, `    <a href="#" class="btn btn-primary">Go somewhere</a>`, `  </div>`, `</div>`, ``, `<div class="card" aria-hidden="true">`, `  <svg class="docs-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>`, `  <div class="card-body">`, `    <div class="h5 card-title placeholder-glow">`, `      <span class="placeholder col-6"></span>`, `    </div>`, `    <p class="card-text placeholder-glow">`, `      <span class="placeholder col-7"></span>`, `      <span class="placeholder col-4"></span>`, `      <span class="placeholder col-4"></span>`, `      <span class="placeholder col-6"></span>`, `      <span class="placeholder col-8"></span>`, `    </p>`, `    <a class="btn btn-primary disabled placeholder col-6" aria-disabled="true"></a>`, `  </div>`, `</div>`]} />
+<Example class="docs-example-placeholder-cards d-flex justify-content-around" html={[`<div class="card">`, `  <svg class="docs-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>`, `  <div class="card-body">`, `    <h5 class="card-title">Bootstrap card title</h5>`, `    <p class="card-text">Some brief example text to expand on the card title and form most of the card's content.</p>`, `    <a href="#" class="btn-solid theme-primary">Go somewhere</a>`, `  </div>`, `</div>`, ``, `<div class="card" aria-hidden="true">`, `  <svg class="docs-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>`, `  <div class="card-body">`, `    <div class="h5 card-title placeholder-glow">`, `      <span class="placeholder col-6"></span>`, `    </div>`, `    <p class="card-text placeholder-glow">`, `      <span class="placeholder col-7"></span>`, `      <span class="placeholder col-4"></span>`, `      <span class="placeholder col-4"></span>`, `      <span class="placeholder col-6"></span>`, `      <span class="placeholder col-8"></span>`, `    </p>`, `    <a class="btn-solid theme-primary disabled placeholder col-6" aria-disabled="true"></a>`, `  </div>`, `</div>`]} />
 
 ```html
 <div class="card">
@@ -24,7 +24,7 @@ In the example below, we use the Bootstrap card component and modify it with pla
   <div class="card-body">
     <h5 class="card-title">Bootstrap card title</h5>
     <p class="card-text">Some brief example text to expand on the card title and form most of the card's content.</p>
-    <a href="#" class="btn btn-primary">Go somewhere</a>
+    <a href="#" class="btn-solid theme-primary">Go somewhere</a>
   </div>
 </div>
 
@@ -41,7 +41,7 @@ In the example below, we use the Bootstrap card component and modify it with pla
       <span class="placeholder col-6"></span>
       <span class="placeholder col-8"></span>
     </p>
-    <a class="btn btn-primary disabled placeholder col-6" aria-disabled="true"></a>
+    <a class="btn-solid theme-primary disabled placeholder col-6" aria-disabled="true"></a>
   </div>
 </div>
 ```
@@ -56,7 +56,7 @@ To ensure the `height` is maintained, we style `.btn`s with `::before`. This pat
     <span class="placeholder col-6"></span>
   </p>
 
-  <a class="btn btn-primary disabled placeholder col-4" aria-disabled="true"></a>`} />
+  <a class="btn-solid theme-primary disabled placeholder col-4" aria-disabled="true"></a>`} />
 
 <Callout color="info">
 Using `aria-hidden="true"` simply tells screen readers to ignore the element. The actual *loading* behavior of the placeholder depends on how authors implement and style the placeholder, as well as how they update it. Some JavaScript may be necessary to *toggle* the placeholder's state and notify AT users of the change.

--- a/docs/src/content/docs/components/popovers.mdx
+++ b/docs/src/content/docs/components/popovers.mdx
@@ -60,22 +60,22 @@ We use JavaScript similar to the snippet above to render the following live popo
 You can choose to use either `title` or `data-coreui-title` in your HTML. If you opt for `title,` the plugin will automatically change it to `data-coreui-title` upon rendering the element.
 </Callout>
 
-<Example code={`<button type="button" class="btn btn-lg btn-danger" data-coreui-toggle="popover" title="Popover title" data-coreui-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>`} sandboxJs={popoverLive} />
+<Example code={`<button type="button" class="btn-solid theme-danger btn-lg" data-coreui-toggle="popover" title="Popover title" data-coreui-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>`} sandboxJs={popoverLive} />
 
 ### Four directions
 
 Four options are available: top, right, bottom, and left aligned. Directions are mirrored when using CoreUI in RTL.
 
-<Example code={`<button type="button" class="btn btn-secondary" data-coreui-container="body" data-coreui-toggle="popover" data-coreui-placement="top" data-coreui-content="Top popover">
+<Example code={`<button type="button" class="btn-solid theme-secondary" data-coreui-container="body" data-coreui-toggle="popover" data-coreui-placement="top" data-coreui-content="Top popover">
     Popover on top
   </button>
-  <button type="button" class="btn btn-secondary" data-coreui-container="body" data-coreui-toggle="popover" data-coreui-placement="right" data-coreui-content="Right popover">
+  <button type="button" class="btn-solid theme-secondary" data-coreui-container="body" data-coreui-toggle="popover" data-coreui-placement="right" data-coreui-content="Right popover">
     Popover on right
   </button>
-  <button type="button" class="btn btn-secondary" data-coreui-container="body" data-coreui-toggle="popover" data-coreui-placement="bottom" data-coreui-content="Bottom popover">
+  <button type="button" class="btn-solid theme-secondary" data-coreui-container="body" data-coreui-toggle="popover" data-coreui-placement="bottom" data-coreui-content="Bottom popover">
     Popover on bottom
   </button>
-  <button type="button" class="btn btn-secondary" data-coreui-container="body" data-coreui-toggle="popover" data-coreui-placement="left" data-coreui-content="Left popover">
+  <button type="button" class="btn-solid theme-secondary" data-coreui-container="body" data-coreui-toggle="popover" data-coreui-placement="left" data-coreui-content="Left popover">
     Popover on left
   </button>`} sandboxJs={popoverDirections} />
 
@@ -95,7 +95,7 @@ const popover = new coreui.Popover(document.querySelector('.example-popover'), {
 
 You can customize the appearance of popovers using [CSS variables](#variables). We set a custom class with `data-coreui-custom-class="custom-popover"` to scope our custom appearance and use it to override some of the local CSS variables.
 <ScssDocs file="@docs/_component-examples.scss" capture="custom-popovers" />
-<Example code={`<button type="button" class="btn btn-secondary"
+<Example code={`<button type="button" class="btn-solid theme-secondary"
           data-coreui-toggle="popover" data-coreui-placement="right"
           data-coreui-custom-class="custom-popover"
           data-coreui-title="Custom popover"
@@ -115,7 +115,7 @@ A shown popover can also be dismissed by pressing the <kbd>Escape</kbd> key. As 
 For proper cross-browser and cross-platform behavior, you must use the `<a>` tag, _not_ the `<button>` tag, and you also must include a [`tabindex`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute.
 </Callout>
 
-<Example code={`<a tabindex="0" class="btn btn-lg btn-danger" role="button" data-coreui-toggle="popover" data-coreui-trigger="focus" title="Dismissible popover" data-coreui-content="And here's some amazing content. It's very engaging. Right?">Dismissible popover</a>`} />
+<Example code={`<a tabindex="0" class="btn-solid theme-danger btn-lg" role="button" data-coreui-toggle="popover" data-coreui-trigger="focus" title="Dismissible popover" data-coreui-content="And here's some amazing content. It's very engaging. Right?">Dismissible popover</a>`} />
 
 ```js
 const popover = new coreui.Popover(document.querySelector('.popover-dismiss'), {
@@ -130,7 +130,7 @@ Elements with the `disabled` attribute aren't interactive, meaning users cannot 
 For disabled popover triggers, you may also prefer `data-coreui-trigger="hover focus"` so that the popover appears as immediate visual feedback to your users as they may not expect to _click_ on a disabled element.
 
 <Example code={`<span class="d-inline-block" tabindex="0" data-coreui-toggle="popover" data-coreui-trigger="hover focus" data-coreui-content="Disabled popover">
-    <button class="btn btn-primary" type="button" disabled>Disabled button</button>
+    <button class="btn-solid theme-primary" type="button" disabled>Disabled button</button>
   </span>`} />
 
 ## Usage

--- a/docs/src/content/docs/components/progress.mdx
+++ b/docs/src/content/docs/components/progress.mdx
@@ -62,26 +62,28 @@ We only set a `height` value on the `.progress`, so if you change that value the
 
 ## Backgrounds
 
-Use background utility classes to change the appearance of individual progress bars.
+Colour a bar with a [`.theme-*` class](/customize/components/#theme-variants). The bar reads both the theme's fill and the contrast colour that reads on it, so a label stays legible whichever colour you pick.
 
 <Example code={`<div class="progress">
-    <div class="progress-bar bg-success" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="progress-bar theme-success" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
   </div>
   <div class="progress">
-    <div class="progress-bar bg-info" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="progress-bar theme-info" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>
   </div>
   <div class="progress">
-    <div class="progress-bar bg-warning" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="progress-bar theme-warning" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
   </div>
   <div class="progress">
-    <div class="progress-bar bg-danger" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="progress-bar theme-danger" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
   </div>`} />
 
-Or use a [theme class](/customize/components/#theme-variants) — the bar reads the theme's colors, including the label's contrast color:
+The class works one level up as well — put it on the `.progress` and every bar inside follows.
 
 <Example code={`<div class="progress theme-success">
     <div class="progress-bar" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100">50%</div>
   </div>`} />
+
+A [`.bg-*` utility](/utilities/background/) still paints a bar, but it sets the fill alone — the label keeps the default foreground colour rather than the one that reads on the fill.
 
 ## Multiple bars
 
@@ -89,8 +91,8 @@ Include multiple progress bars in a progress component if you need.
 
 <Example code={`<div class="progress">
     <div class="progress-bar" role="progressbar" style="width: 15%" aria-valuenow="15" aria-valuemin="0" aria-valuemax="100"></div>
-    <div class="progress-bar bg-success" role="progressbar" style="width: 30%" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100"></div>
-    <div class="progress-bar bg-info" role="progressbar" style="width: 20%" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="progress-bar theme-success" role="progressbar" style="width: 30%" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="progress-bar theme-info" role="progressbar" style="width: 20%" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100"></div>
   </div>`} />
 
 ## Striped
@@ -101,16 +103,16 @@ Add `.progress-bar-striped` to any `.progress-bar` to apply a stripe via CSS gra
     <div class="progress-bar progress-bar-striped" role="progressbar" style="width: 10%" aria-valuenow="10" aria-valuemin="0" aria-valuemax="100"></div>
   </div>
   <div class="progress">
-    <div class="progress-bar progress-bar-striped bg-success" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="progress-bar progress-bar-striped theme-success" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
   </div>
   <div class="progress">
-    <div class="progress-bar progress-bar-striped bg-info" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="progress-bar progress-bar-striped theme-info" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>
   </div>
   <div class="progress">
-    <div class="progress-bar progress-bar-striped bg-warning" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="progress-bar progress-bar-striped theme-warning" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
   </div>
   <div class="progress">
-    <div class="progress-bar progress-bar-striped bg-danger" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="progress-bar progress-bar-striped theme-danger" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
   </div>`} />
 
 ## Animated stripes
@@ -135,10 +137,10 @@ Related bars need no component of their own — [stacks](/helpers/stacks/) and [
     <span class="fg-2 small flex-shrink-0" style="width: 100px">Title</span>
     <div class="vstack gap-1">
       <div class="progress" style="height: 4px">
-        <div class="progress-bar bg-info" role="progressbar" style="width: 34%" aria-valuenow="34" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar theme-info" role="progressbar" style="width: 34%" aria-valuenow="34" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
       <div class="progress" style="height: 4px">
-        <div class="progress-bar bg-danger" role="progressbar" style="width: 78%" aria-valuenow="78" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar theme-danger" role="progressbar" style="width: 78%" aria-valuenow="78" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
     </div>
   </div>
@@ -146,13 +148,13 @@ Related bars need no component of their own — [stacks](/helpers/stacks/) and [
     <span class="fg-2 small flex-shrink-0" style="width: 100px">Title</span>
     <div class="vstack gap-1">
       <div class="progress" style="height: 4px">
-        <div class="progress-bar bg-info" role="progressbar" style="width: 56%" aria-valuenow="56" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar theme-info" role="progressbar" style="width: 56%" aria-valuenow="56" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
       <div class="progress" style="height: 4px">
-        <div class="progress-bar bg-danger" role="progressbar" style="width: 94%" aria-valuenow="94" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar theme-danger" role="progressbar" style="width: 94%" aria-valuenow="94" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
       <div class="progress" style="height: 4px">
-        <div class="progress-bar bg-success" role="progressbar" style="width: 67%" aria-valuenow="67" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar theme-success" role="progressbar" style="width: 67%" aria-valuenow="67" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
     </div>
   </div>`} />
@@ -166,7 +168,7 @@ Or stack a header above the bar, with the value pushed to the end by `.ms-auto`:
       <div class="ms-auto fw-bold">43%</div>
     </div>
     <div class="progress" style="height: 4px">
-      <div class="progress-bar bg-warning" role="progressbar" style="width: 43%" aria-valuenow="43" aria-valuemin="0" aria-valuemax="100"></div>
+      <div class="progress-bar theme-warning" role="progressbar" style="width: 43%" aria-valuenow="43" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
   </div>`} />
 
@@ -178,7 +180,7 @@ Or stack a header above the bar, with the value pushed to the end by `.ms-auto`:
       <div class="fg-2 small">(56%)</div>
     </div>
     <div class="progress" style="height: 4px">
-      <div class="progress-bar bg-success" role="progressbar" style="width: 56%" aria-valuenow="56" aria-valuemin="0" aria-valuemax="100"></div>
+      <div class="progress-bar theme-success" role="progressbar" style="width: 56%" aria-valuenow="56" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
   </div>`} />
 

--- a/docs/src/content/docs/components/sidebar.mdx
+++ b/docs/src/content/docs/components/sidebar.mdx
@@ -53,7 +53,7 @@ Below is a more complete sidebar example shown by default on desktop devices. It
           </g>
         </svg>
       </div>
-      <button class="btn btn-ghost btn-sm d-sidebar-narrow-none d-flex" type="button" data-coreui-toggle="unfoldable">
+      <button class="btn-ghost btn-sm d-sidebar-narrow-none d-flex" type="button" data-coreui-toggle="unfoldable">
         <i class="icon icon-lg cil-sidebar-open d-sidebar-narrow-unfoldable"></i>
         <i class="icon icon-lg cil-sidebar-close d-sidebar-narrow-unfoldable-none"></i>
       </button>
@@ -73,7 +73,7 @@ Below is a more complete sidebar example shown by default on desktop devices. It
       <li class="nav-item">
         <a class="nav-link" href="#">
           <i class="nav-icon cil-layers"></i> With badge
-          <span class="badge bg-primary ms-auto">NEW</span>
+          <span class="badge theme-primary ms-auto">NEW</span>
         </a>
       </li>
       <li class="nav-item nav-group show">
@@ -148,7 +148,7 @@ Below is a more complete sidebar example shown by default on desktop devices. It
     </ul>
     <div class="sidebar-footer">
       <div class="dropdown dropend w-100">
-        <a class="btn btn-ghost w-100 d-flex gap-2 p-1 align-items-center" href="#" role="button" data-coreui-toggle="dropdown" aria-expanded="false">
+        <a class="btn-ghost w-100 d-flex gap-2 p-1 align-items-center" href="#" role="button" data-coreui-toggle="dropdown" aria-expanded="false">
           <div class="avatar avatar-md">
             <img class="avatar-img rounded" src="/assets/img/avatars/7.jpg" alt="user@email.com">
           </div>
@@ -259,7 +259,7 @@ Use `.d-sidebar-narrow-unfoldable` and `.d-sidebar-narrow-unfoldable-none` to co
       <li class="nav-item">
         <a class="nav-link" href="#">
           <i class="nav-icon cil-speedometer"></i> With badge
-          <span class="badge bg-primary ms-auto">NEW</span>
+          <span class="badge theme-primary ms-auto">NEW</span>
         </a>
       </li>
       <li class="nav-item nav-group show">
@@ -490,7 +490,7 @@ Change the appearance of sidebars with the `.sidebar-dark` class.
       <li class="nav-item">
         <a class="nav-link" href="#">
           <i class="nav-icon cil-speedometer"></i> With badge
-          <span class="badge bg-primary ms-auto">NEW</span>
+          <span class="badge theme-primary ms-auto">NEW</span>
         </a>
       </li>
       <li class="nav-item nav-group show">

--- a/docs/src/content/docs/components/spinners.mdx
+++ b/docs/src/content/docs/components/spinners.mdx
@@ -141,20 +141,20 @@ Add `.spinner-rotate` to any element to spin it at the same speed as `.spinner-b
 
 Use spinners within buttons to indicate an action is currently processing or taking place. You may also swap the text out of the spinner element and utilize button text as needed.
 
-<Example code={`<button class="btn btn-primary" type="button" disabled>
+<Example code={`<button class="btn-solid theme-primary" type="button" disabled>
     <span class="spinner-border" aria-hidden="true"></span>
     <span class="visually-hidden" role="status">Loading...</span>
   </button>
-  <button class="btn btn-primary" type="button" disabled>
+  <button class="btn-solid theme-primary" type="button" disabled>
     <span class="spinner-border" aria-hidden="true"></span>
     <span role="status">Loading...</span>
   </button>`} />
 
-<Example code={`<button class="btn btn-primary" type="button" disabled>
+<Example code={`<button class="btn-solid theme-primary" type="button" disabled>
     <span class="spinner-grow" aria-hidden="true"></span>
     <span class="visually-hidden" role="status">Loading...</span>
   </button>
-  <button class="btn btn-primary" type="button" disabled>
+  <button class="btn-solid theme-primary" type="button" disabled>
     <span class="spinner-grow" aria-hidden="true"></span>
     <span role="status">Loading...</span>
   </button>`} />

--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -59,7 +59,7 @@ Click the button below to display a toast (positioned with our utilities in the 
     </div>
   </div>
 
-  <button type="button" class="btn btn-primary" id="liveToastBtn">Show live toast</button>`} sandboxJs={liveToast} />
+  <button type="button" class="btn-solid theme-primary" id="liveToastBtn">Show live toast</button>`} sandboxJs={liveToast} />
 
 We use the following JavaScript to trigger our live toast demo:
 
@@ -130,8 +130,8 @@ Alternatively, you can also add additional controls and components to toasts.
     <div class="toast-body">
       Hello, world! This is a toast message.
       <div class="mt-2 pt-2 border-top">
-        <button type="button" class="btn btn-primary btn-sm">Take action</button>
-        <button type="button" class="btn btn-secondary btn-sm" data-coreui-dismiss="toast">Close</button>
+        <button type="button" class="btn-solid theme-primary btn-sm">Take action</button>
+        <button type="button" class="btn-solid theme-secondary btn-sm" data-coreui-dismiss="toast">Close</button>
       </div>
     </div>
   </div>`} />

--- a/docs/src/content/docs/components/tooltips.mdx
+++ b/docs/src/content/docs/components/tooltips.mdx
@@ -60,7 +60,7 @@ Feel free to personalize the look of your tooltips with [CSS variables](#variabl
 
 <ScssDocs file="@docs/_component-examples.scss" capture="custom-tooltip" />
 
-<Example class="tooltip-demo" sandboxJsId="enable-tooltips" code={`<button type="button" class="btn btn-outline"
+<Example class="tooltip-demo" sandboxJsId="enable-tooltips" code={`<button type="button" class="btn-outline"
           data-coreui-toggle="tooltip" data-coreui-placement="top"
           data-coreui-custom-class="custom-tooltip"
           data-coreui-title="This top tooltip is themed via CSS variables.">
@@ -71,10 +71,10 @@ Feel free to personalize the look of your tooltips with [CSS variables](#variabl
 
 Bootstrap Tooltips support multiple placements: top, right, bottom, and left. The default is top. Directions are mirrored when using CoreUI in RTL. To change placement, use the `data-coreui-placement` attribute:
 
-<Example class="tooltip-demo" sandboxJsId="enable-tooltips" code={`<button type="button" class="btn btn-outline" data-coreui-toggle="tooltip" data-coreui-placement="top" title="Tooltip on top">Tooltip on top</button>
-  <button type="button" class="btn btn-outline" data-coreui-toggle="tooltip" data-coreui-placement="right" title="Tooltip on right">Tooltip on right</button>
-  <button type="button" class="btn btn-outline" data-coreui-toggle="tooltip" data-coreui-placement="bottom" title="Tooltip on bottom">Tooltip on bottom</button>
-  <button type="button" class="btn btn-outline" data-coreui-toggle="tooltip" data-coreui-placement="left" title="Tooltip on left">Tooltip on left</button>`} />
+<Example class="tooltip-demo" sandboxJsId="enable-tooltips" code={`<button type="button" class="btn-outline" data-coreui-toggle="tooltip" data-coreui-placement="top" title="Tooltip on top">Tooltip on top</button>
+  <button type="button" class="btn-outline" data-coreui-toggle="tooltip" data-coreui-placement="right" title="Tooltip on right">Tooltip on right</button>
+  <button type="button" class="btn-outline" data-coreui-toggle="tooltip" data-coreui-placement="bottom" title="Tooltip on bottom">Tooltip on bottom</button>
+  <button type="button" class="btn-outline" data-coreui-toggle="tooltip" data-coreui-placement="left" title="Tooltip on left">Tooltip on left</button>`} />
 
 ### Tooltips with HTML Content
 
@@ -82,7 +82,7 @@ Bootstrap Tooltips support HTML content, allowing you to insert styled elements 
 
 To enable this, set the `data-coreui-html="true"` attribute and include valid HTML in the title attribute. Be mindful of security when injecting dynamic content.
 
-<Example class="tooltip-demo" sandboxJsId="enable-tooltips" code={`<button type="button" class="btn btn-outline" data-coreui-toggle="tooltip" data-coreui-html="true" title="<em>Tooltip</em> <u>with</u> <b>HTML</b>">
+<Example class="tooltip-demo" sandboxJsId="enable-tooltips" code={`<button type="button" class="btn-outline" data-coreui-toggle="tooltip" data-coreui-html="true" title="<em>Tooltip</em> <u>with</u> <b>HTML</b>">
     Tooltip with HTML
   </button>`} />
 
@@ -156,7 +156,7 @@ A shown tooltip can be dismissed by pressing the <kbd>Escape</kbd> key, helping 
 Elements that have the `disabled` attribute are non-interactive, which prevents users from focusing, hovering, or clicking on them to display a tooltip (or popover). To address this, consider triggering the tooltip from a surrounding `<div>` or `<span>`, preferably making it keyboard-focusable by using `tabindex="0"`.
 
 <Example class="tooltip-demo" sandboxJsId="enable-tooltips" code={`<span class="d-inline-block" tabindex="0" data-coreui-toggle="tooltip" title="Disabled tooltip">
-    <button class="btn btn-primary" type="button" disabled>Disabled button</button>
+    <button class="btn-solid theme-primary" type="button" disabled>Disabled button</button>
   </span>`} />
 
 ### Options


### PR DESCRIPTION
Closes the colour half of the components section. `buttons` had already moved to `.theme-*` with the v5 spelling closed off in a deprecated section, while 25 other pages still spelled colour as a per-component modifier — `btn btn-primary`, `alert-success`, `list-group-item-warning`, `chip-primary`. Two sibling pages disagreed on how a colour is applied.

## What changed

| Pages | Change |
| --- | --- |
| 21 pages | `btn btn-primary` and its outline/ghost/size variants become `btn-solid theme-primary`, the spelling `buttons` documents |
| `alerts`, `list-group`, `chip` | the component's own colour modifier becomes `.theme-*`; the v5 spelling moves into a new `## Deprecated markup` section rather than disappearing |
| `progress` | bars read the theme's fill **and** its contrast colour, so a label stays legible; `.bg-*` painted the fill alone and is now called out as such |
| `menu` | an item's colour becomes a theme class, which also gives `.active` the themed fill instead of only tinting the text |
| `chip`, `sidebar` | avatars and badges take the theme rather than a `bg-*`/`text-white` pair, which also picks the readable foreground |

Each new `## Deprecated markup` section carries `<DeprecatedIn version="6.0.0" />`, a live example of the old spelling, a `diff` block, and the reason the rewrite is worth it — a theme on a wrapper reaches every child, and a colour of your own needs no Sass.

## Deliberately left alone

Checked against `dist/css/coreui.css` and `scss/`, not assumed:

- `.avatar-status` reads no theme slot — `.bg-*` is the only thing that colours the status dot
- `.spinner-border` / `.spinner-grow` paint from `currentColor`, so the text colour utilities stay the documented mechanism
- `.card`, `.toast` and `.offcanvas` backgrounds read their own token, not a theme slot, so `.text-bg-*` keeps doing something no theme class can
- the four `btn btn-*` occurrences on `buttons` — they *are* the deprecated example
- `navbar`'s `bg-primary` — the navbar background is not a theme slot either

## Gate

`npm run docs-build` green, 172 pages, no broken links. Every class name introduced was verified against `dist/css/coreui.css` by extracting each `class="…"` attribute on every component page and diffing it against the selectors the stylesheet emits.

That same sweep turned up three dead pre-v5 classes that are **not** touched here, to keep this diff about colour: `.mr-auto` and `.input-group-prepend` on `components/header`, and `.muted` on `components/tooltips`.