### PR TITLE
docs(getting-started): make the bundler guides run as printed

### DIFF
--- a/docs/src/content/docs/getting-started/introduction.mdx
+++ b/docs/src/content/docs/getting-started/introduction.mdx
@@ -244,7 +244,7 @@ For improved cross-browser rendering, we use [Reboot](/content/reboot/) to corre
 Stay up to date on the development of CoreUI and reach out to the community with these helpful resources.
 
 - Read and subscribe to [The Official CoreUI Blog](https://coreui.io/blog/).
-- Ask questions and explore [our GitHub Discussions]the official Community).
+- Ask questions and explore [our GitHub Discussions](https://github.com/coreui/coreui/discussions).
 - Discuss, ask questions, and more on [the community Discord](https://discord.gg/TsFcCgkG).
 
 You can also follow [@core_ui on X (Twitter)](https://x.com/core_ui).

--- a/docs/src/content/docs/getting-started/javascript.mdx
+++ b/docs/src/content/docs/getting-started/javascript.mdx
@@ -53,14 +53,14 @@ To fix this, you can use an `importmap` to resolve the arbitrary module names to
   </head>
   <body>
     <h1>Hello, modularity!</h1>
-    <button id="popoverButton" type="button" class="btn btn-primary btn-lg" data-coreui-toggle="popover" title="ESM in Browser" data-coreui-content="Bang!">Custom popover</button>
+    <button id="popoverButton" type="button" class="btn-solid theme-primary btn-lg" data-coreui-toggle="popover" title="ESM in Browser" data-coreui-content="Bang!">Custom popover</button>
 
     <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1/dist/es-module-shims.min.js" crossorigin="anonymous"></script>
     <script type="importmap">
     {
       "imports": {
         "@floating-ui/dom": "[[config:cdn.floating_ui_esm]]",
-        "coreui": "https://cdn.jsdelivr.net/npm/coreui@5.8.0/dist/js/coreui.esm.min.js"
+        "@coreui/coreui": "https://cdn.jsdelivr.net/npm/@coreui/coreui@[[config:current_version]]/dist/js/coreui.esm.min.js"
       }
     }
     </script>

--- a/docs/src/content/docs/getting-started/parcel.mdx
+++ b/docs/src/content/docs/getting-started/parcel.mdx
@@ -14,6 +14,8 @@ We're building a Parcel project with CoreUI from scratch, so there are some prer
    npm init -y
    ```
 
+   Delete the `"main": "index.js"` line from that fresh `package.json`. Parcel reads `main` as a library build target, and with it present the build stops before it starts (*Target "main" declares an output file path of "index.js" which does not match the compiled bundle type "html"*).
+
 2. **Install Parcel.** Unlike our Webpack guide, there's only a single build tool dependency here. Parcel will automatically install language transformers (like Sass) as it detects them. We use `--save-dev` to signal that this dependency is only for development use and not for production.
 
    ```sh
@@ -40,7 +42,7 @@ We've already created the `my-project` folder and initialized npm. Now we'll als
 
 ```sh
 mkdir {src,src/js,src/scss}
-touch src/index.html src/js/main.js src/scss/styles.scss
+touch .sassrc src/index.html src/js/main.js src/scss/styles.scss
 ```
 
 When you're done, your complete project should look like this:
@@ -53,6 +55,7 @@ my-project/
 │   ├── scss/
 │   │   └── styles.scss
 │   └── index.html
+├── .sassrc
 ├── package-lock.json
 └── package.json
 ```
@@ -78,13 +81,13 @@ With dependencies installed and our project folder ready for us to start coding,
      <body>
        <div class="container py-4 px-3 mx-auto">
          <h1>Hello, CoreUI and Parcel!</h1>
-         <button class="btn btn-primary">Primary button</button>
+         <button class="btn-solid theme-primary">Primary button</button>
        </div>
      </body>
    </html>
    ```
 
-   We're including a little bit of CoreUI styling here with the `div class="container"` and `<button>` so that we see when CoreUI's CSS is loaded by Webpack.
+   We're including a little bit of CoreUI styling here with the `div class="container"` and `<button>` so that we see when CoreUI's CSS is loaded by Parcel.
 
    Parcel will automatically detect we're using Sass and install the [Sass Parcel plugin](https://parceljs.org/languages/sass/) to support it. However, if you wish, you can also manually run `npm i --save-dev @parcel/transformer-sass`.
 
@@ -111,28 +114,41 @@ In the next and final section to this guide, we'll import all of CoreUI's CSS an
 
 ## Import CoreUI
 
-Importing CoreUI into Parcel requires two imports, one into our `styles.scss` and one into our `main.js`.
+Importing CoreUI into Parcel takes one line of Sass config and two imports, one into our `styles.scss` and one into our `main.js`.
 
-1. **Import CoreUI's CSS.** Add the following to `src/scss/styles.scss` to import all of CoreUI's source Sass.
+1. **Point the Sass transformer at `node_modules`.** Unlike Vite and Webpack, Parcel's Sass transformer resolves imports relative to the file only — a package path finds nothing on its own, whether or not you prefix it with `~`. Create a `.sassrc` next to `package.json` so package paths resolve:
+
+   ```json
+   {
+     "includePaths": ["node_modules"]
+   }
+   ```
+
+2. **Import CoreUI's CSS.** Add the following to `src/scss/styles.scss` to import all of CoreUI's source Sass.
 
    ```scss
    // Use all of CoreUI's CSS
-   @use "~@coreui/coreui/scss/coreui";
-
-   // Or use all of CoreUI PRO's CSS
-   @use "~@coreui/coreui-pro/scss/coreui";
+   @use "@coreui/coreui/scss/coreui";
    ```
 
+   PRO users import the PRO package instead. Import **one** of the two — importing both emits the whole stylesheet twice.
+
+   ```scss
+   @use "@coreui/coreui-pro/scss/coreui";
+   ```
 
    *You can also import our stylesheets individually if you want. [Read our Sass import docs](/customize/sass/#importing) for details.*
 
-2. **Import CoreUI's JS.** Add the following to `src/js/main.js` to import all of CoreUI's JS. Floating UI will be imported automatically through CoreUI.
+3. **Import CoreUI's JS.** Add the following to `src/js/main.js` to import all of CoreUI's JS. Floating UI will be imported automatically through CoreUI.
 
    ```js
    // Import all of CoreUI's JS
    import * as coreui from '@coreui/coreui'
+   ```
 
-   // Or import all of CoreUI PRO's JS
+   PRO users import the PRO package instead. Again, pick one — two `import * as coreui` statements in the same file bind the same name twice and the file will not parse.
+
+   ```js
    import * as coreui from '@coreui/coreui-pro'
    ```
 
@@ -147,6 +163,6 @@ Importing CoreUI into Parcel requires two imports, one into our `styles.scss` an
 
    *[Read our JavaScript docs](/getting-started/javascript/) for more information on how to use CoreUI's plugins.*
 
-3. **And you're done! 🎉** With CoreUI's source Sass and JS fully loaded, your local development server should now look like this.
+4. **And you're done! 🎉** With CoreUI's source Sass and JS fully loaded, your local development server should now look like this.
 
    Now you can start adding any CoreUI components you want to use.

--- a/docs/src/content/docs/getting-started/vite.mdx
+++ b/docs/src/content/docs/getting-started/vite.mdx
@@ -70,13 +70,11 @@ At this point, everything is in the right place, but Vite won't work because we 
 
 With dependencies installed and our project folder ready for us to start coding, we can now configure Vite and run our project locally.
 
-1. **Open `vite.config.js` in your editor.** Since it's blank, we'll need to add some boilerplate config to it so we can start our server. This part of the config tells Vite where to look for our project's JavaScript and how the development server should behave (pulling from the `src` folder with hot reload).
+1. **Open `vite.config.js` in your editor.** Since it's blank, we'll need to add some boilerplate config to it so we can start our server. This is the whole config the guide needs: it tells Vite where to look for our project's JavaScript and which port the development server should use. `root` is resolved relative to the config file, so there is nothing to import.
 
    ```js
-   import { resolve } from 'path'
-
    export default {
-     root: resolve(__dirname, 'src'),
+     root: 'src',
      server: {
        port: 8080
      }
@@ -96,7 +94,7 @@ With dependencies installed and our project folder ready for us to start coding,
      <body>
        <div class="container py-4 px-3 mx-auto">
          <h1>Hello, CoreUI and Vite!</h1>
-         <button class="btn btn-primary">Primary button</button>
+         <button class="btn-solid theme-primary">Primary button</button>
        </div>
        <script type="module" src="./js/main.js"></script>
      </body>
@@ -128,41 +126,22 @@ In the next and final section to this guide, we’ll import all of CoreUI’s CS
 
 ## Import CoreUI
 
-1. **Set up CoreUI's Sass import in `vite.config.js`.** Your configuration file is now complete and should match the snippet below. The only new part here is the `resolve` section—we use this to add an alias to our source files inside `node_modules` to keep imports as simple as possible.
-
-   ```js
-   import { resolve } from 'path'
-
-   export default {
-     root: path.resolve(__dirname, 'src'),
-     resolve: {
-       alias: {
-         '~coreui': resolve(__dirname, 'node_modules/@coreui/coreui'),
-         // for CoreUI PRO users
-         // '~coreui': resolve(__dirname, 'node_modules/@coreui/coreui-pro'),
-       }
-     },
-     server: {
-       port: 8080,
-       hot: true
-     }
-   }
-   ```
-
-2. **Now, let's import CoreUI's CSS.** Add the following to `src/scss/styles.scss` to import all of CoreUI's source Sass.
+1. **Now, let's import CoreUI's CSS.** Add the following to `src/scss/styles.scss` to import all of CoreUI's source Sass. Vite resolves the package name through `node_modules`, so no alias and no configuration are needed — `vite.config.js` stays exactly as you left it in the previous section.
 
    ```scss
    // Use all of CoreUI's CSS
-   @use "~@coreui/coreui/scss/coreui";
-
-   // Or use all of CoreUI PRO's CSS
-   @use "~@coreui/coreui-pro/scss/coreui";
+   @use "@coreui/coreui/scss/coreui";
    ```
 
+   PRO users import the PRO package instead. Import **one** of the two — importing both emits the whole stylesheet twice.
+
+   ```scss
+   @use "@coreui/coreui-pro/scss/coreui";
+   ```
 
    *You can also import our stylesheets individually if you want. [Read our Sass import docs](/customize/sass/#importing) for details.*
 
-3. **Next we load the CSS and import CoreUI's JavaScript.** Add the following to `src/js/main.js` to load the CSS and import all of CoreUI's JS. Floating UI will be imported automatically through CoreUI.
+2. **Next we load the CSS and import CoreUI's JavaScript.** Add the following to `src/js/main.js` to load the CSS and import all of CoreUI's JS. Floating UI will be imported automatically through CoreUI.
 
    ```js
    // Import our custom CSS
@@ -170,22 +149,25 @@ In the next and final section to this guide, we’ll import all of CoreUI’s CS
 
    // Import all of CoreUI's JS
    import * as coreui from '@coreui/coreui'
+   ```
 
-   // Or import all of CoreUI PRO's JS
+   PRO users import the PRO package instead. Again, pick one — two `import * as coreui` statements in the same file bind the same name twice and the file will not parse.
+
+   ```js
    import * as coreui from '@coreui/coreui-pro'
    ```
 
    You can also import JavaScript plugins individually as needed to keep bundle sizes down:
 
    ```js
-   import Alert from '@coreui/coreui/js/dist/alert';
+   import Alert from '@coreui/coreui/js/dist/alert'
 
    // or, specify which plugins you need:
-   import { Tooltip, Toast, Popover } from '@coreui/coreui';
+   import { Tooltip, Toast, Popover } from '@coreui/coreui'
    ```
 
    *[Read our JavaScript docs](/getting-started/javascript/) for more information on how to use CoreUI's plugins.*
 
-4. **And you're done! 🎉** With CoreUI's source Sass and JS fully loaded, your local development server should now look like this.
+3. **And you're done! 🎉** With CoreUI's source Sass and JS fully loaded, your local development server should now look like this.
 
    Now you can start adding any CoreUI components you want to use.

--- a/docs/src/content/docs/getting-started/webpack.mdx
+++ b/docs/src/content/docs/getting-started/webpack.mdx
@@ -14,6 +14,8 @@ We're building a Webpack project with CoreUI from scratch, so there are some pre
    npm init -y
    ```
 
+   Current npm versions write `"type": "commonjs"` into that fresh `package.json`. Delete that line. Our `src/js/main.js` is written with `import`, and under `"type": "commonjs"` Webpack refuses to parse it (*'import' and 'export' may appear only with 'sourceType: module'*). With no `type` field, Webpack detects the module system per file, so the ESM source and the CommonJS `webpack.config.js` below both work.
+
 2. **Install Webpack.** Next we need to install our Webpack development dependencies: `webpack` for the core of Webpack, `webpack-cli` so we can run Webpack commands from the terminal, and `webpack-dev-server` so we can run a local development server. We use `--save-dev` to signal that these dependencies are only for development use and not for production.
 
    ```sh
@@ -103,7 +105,7 @@ With dependencies installed and our project folder ready for us to start coding,
      <body>
        <div class="container py-4 px-3 mx-auto">
          <h1>Hello, CoreUI and Webpack!</h1>
-         <button class="btn btn-primary">Primary button</button>
+         <button class="btn-solid theme-primary">Primary button</button>
        </div>
        <script src="./main.js"></script>
      </body>
@@ -186,16 +188,18 @@ Importing CoreUI into Webpack requires the loaders we installed in the first sec
 
    Here's a recap of why we need all these loaders. `style-loader` injects the CSS into a `<style>` element in the `<head>` of the HTML page, `css-loader` helps with using `@import` and `url()`, `postcss-loader` is required for Autoprefixer, and `sass-loader` allows us to use Sass.
 
-2. **Now, let's import CoreUI's CSS.** Add the following to `src/scss/styles.scss` to import all of CoreUI's source Sass.
+2. **Now, let's import CoreUI's CSS.** Add the following to `src/scss/styles.scss` to import all of CoreUI's source Sass. `sass-loader` resolves the package name through `node_modules`, so the path needs no `~` prefix and no alias.
 
    ```scss
    // Use all of CoreUI's CSS
-   @use "~@coreui/coreui/scss/coreui";
-
-   // Or use all of CoreUI PRO's CSS
-   @use "~@coreui/coreui-pro/scss/coreui";
+   @use "@coreui/coreui/scss/coreui";
    ```
 
+   PRO users import the PRO package instead. Import **one** of the two — importing both emits the whole stylesheet twice.
+
+   ```scss
+   @use "@coreui/coreui-pro/scss/coreui";
+   ```
 
    *You can also import our stylesheets individually if you want. [Read our Sass import docs](/customize/sass/#importing) for details.*
 
@@ -207,8 +211,11 @@ Importing CoreUI into Webpack requires the loaders we installed in the first sec
 
    // Import all of CoreUI's JS
    import * as coreui from '@coreui/coreui'
+   ```
 
-   // Or import all of CoreUI PRO's JS
+   PRO users import the PRO package instead. Again, pick one — two `import * as coreui` statements in the same file bind the same name twice and the file will not parse.
+
+   ```js
    import * as coreui from '@coreui/coreui-pro'
    ```
 


### PR DESCRIPTION
Decision I from the docs parity audit. Every one of the three bundler tutorials failed if you typed it out. Each fix was **reproduced** against a scratch project first, then re-verified by replaying the corrected guide from `npm init` to a green build.

## Reproduced failures

| Guide | Typed as printed, you get |
| --- | --- |
| Vite | `ReferenceError: path is not defined` — the finished config calls `path.resolve(...)` while importing `{ resolve }` |
| Vite | `[sass] Can't find stylesheet to import` — the config aliases `~coreui`, the stylesheet asks for `~@coreui/coreui/scss/coreui`; no alias matches |
| Webpack | `Module parse failed: 'import' and 'export' may appear only with 'sourceType: module'` — `npm init -y` now writes `"type": "commonjs"` |
| Parcel | `Target "main" declares an output file path of "index.js" which does not match the compiled bundle type "html"` |
| Parcel | `Can't find stylesheet to import` — for the package path **and** for the `~` prefix |
| all three | `SyntaxError` on two `import * as coreui` statements binding the same name |
| all three | free + PRO `@use` both active, emitting the whole stylesheet twice |

## What the fixes are

- **Vite** resolves the package name through `node_modules` by itself, so the whole `resolve.alias` block is gone, and `root: 'src'` removes the `path` import (and with it the Vite warning about ESM syntax in a config loaded as CommonJS).
- **Webpack**: step 1 now says to drop the `"type": "commonjs"` line, which leaves the ESM source and the CommonJS `webpack.config.js` both working. `sass-loader` resolves the package name directly, so the `~` prefix is gone.
- **Parcel** was the surprise. Its Sass transformer resolves relative to the file only — the package path fails, and so does `~`. Neither the current guide nor the "just drop the tilde" fix works here; it needs a `.sassrc` with `includePaths`, which the guide never mentioned. It also needs `"main"` removed from `package.json`. Both are now steps, with the `.sassrc` in the project tree.
- Every free/PRO pair is one active line with the PRO variant shown as the alternative.

## Also on this branch

- `getting-started/javascript` — the import map bound the key `coreui` while the script imported `@coreui/coreui`, so the example threw the exact error the section exists to teach you to fix. The key now matches, the package name is the real one (`@coreui/coreui`, not `coreui`), and the pinned `5.8.0` reads `[[config:current_version]]`.
- `getting-started/introduction` — `[our GitHub Discussions]the official Community).` rendered as literal text. It is not a link, so the build's link checker had nothing to catch.
- Sample-page buttons use the current spelling.

## Verification

Replayed each corrected guide from scratch against the published `@coreui/coreui`:

```
### VITE:     ✓ built in 1.58s
### WEBPACK:  webpack 5.109.2 compiled successfully in 1558 ms
### PARCEL:   ✨ Built in 3.06s
```

`npm run docs-build` green, 172 pages, no broken links.

**Not touched here:** `getting-started/download.mdx`, even though the audit lists two of its defects under this decision. It is the one file decisions I and J share, and keeping it out of this branch keeps the two PRs from conflicting — its fixes ship with J.