### PR TITLE
docs: stop documenting a build and defaults we do not have

### DIFF
--- a/docs/src/content/docs/customize/color-modes.mdx
+++ b/docs/src/content/docs/customize/color-modes.mdx
@@ -58,6 +58,8 @@ For example, to change the color mode of a dropdown menu, add `data-coreui-theme
 
 - Almost every global color is declared once, as a native [`light-dark()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) pair, so there is no second set of dark declarations to keep in sync. The `data-coreui-theme="dark"` selector only has to declare `color-scheme: dark` and every pair — plus the native form widgets — follows. The exceptions are values `light-dark()` cannot hold: the colors baked into embedded SVGs (the select chevron, the switch knob) and filters keep their own dark rule.
 
+  Note that `light-dark()` is the *mechanism*, not the switch. `:root` declares `color-scheme: light` outright rather than `light dark`, so a pair resolves to its light value until something sets `color-scheme: dark` — which, in practice, means the `data-coreui-theme` attribute. The operating system preference does not reach the pairs on its own; see [Building with Sass](#building-with-sass) for the media-query build if that is what you want.
+
 ## Usage
 
 ### Enable dark mode

--- a/docs/src/content/docs/customize/options.mdx
+++ b/docs/src/content/docs/customize/options.mdx
@@ -18,6 +18,7 @@ You can find and customize these variables for key global options in CoreUI for 
 | `$enable-reduced-motion`       | `true` (default) or `false`        | Enables the [`prefers-reduced-motion` media query](/getting-started/accessibility/#reduced-motion), which suppresses certain animations/transitions based on the users' browser/operating system preferences. |
 | `$enable-grid-classes`         | `true` (default) or `false`        | Enables the generation of CSS classes for the grid system (e.g. `.row`, `.col-md-1`, etc.). |
 | `$enable-container-classes`    | `true` (default) or `false`        | Enables the generation of CSS classes for layout containers. (New in v4.2.6) |
+| `$enable-cssgrid`              | `true` (default) or `false`        | Enables the generation of the [CSS Grid layout](/layout/css-grid/) classes (e.g. `.grid`, `.g-col-6`). |
 | `$enable-caret`                | `true` (default) or `false`        | Enables pseudo element caret on `.dropdown-toggle`. |
 | `$enable-button-pointers`      | `true` (default) or `false`        | Add "hand" cursor to non-disabled button elements. |
 | `$enable-validation-icons`     | `true` (default) or `false`        | Enables `background-image` icons within textual inputs and some custom forms for validation states. |
@@ -26,5 +27,5 @@ You can find and customize these variables for key global options in CoreUI for 
 | `$enable-deprecated-form-check` | `true` (default) or `false`       | Keeps the v5 form check spelling — `.form-check`, `.form-check-input`, `.form-check-label`, `.form-check-inline`, `.form-switch` — as aliases of [`.form-field`](/forms/field/), [`.check`](/forms/checkbox/), [`.radio`](/forms/radio/) and [`.switch`](/forms/switch/). Set to `false` once your markup has moved; that removes every `.form-check*` selector and takes 455 bytes gzip off the stylesheet. Removed in v7. |
 | `$enable-important-utilities`  | `true` or `false` (default)        | Adds the `!important` suffix to utility classes. Off since v6: utilities are emitted in the last [cascade layer](/migration/v6/#cascade-layers), so they already beat every component. Turn it on if your own CSS sits outside a layer and has to lose to utilities — unlayered styles beat every layer. |
 | `$enable-smooth-scroll`        | `true` (default) or `false`        | Applies `scroll-behavior: smooth` globally, except for users asking for reduced motion through [`prefers-reduced-motion` media query](/getting-started/accessibility/#reduced-motion) |
-| `$enable-ltr`                  | `false` or `false` (default)       | Enables Left-to-Right |
+| `$enable-ltr`                  | `true` (default) or `false`        | Enables Left-to-Right |
 | `$enable-rtl`                  | `true` (default) or `false`        | Enables Right-to-Left |

--- a/docs/src/content/docs/getting-started/build-tools.mdx
+++ b/docs/src/content/docs/getting-started/build-tools.mdx
@@ -5,19 +5,19 @@ description: "Learn how to use CoreUI for Bootstrap included npm scripts to buil
 
 ## Tooling setup
 
-CoreUI for Bootstrap uses [npm scripts](https://docs.npmjs.com/misc/scripts/) for its build system. Our [package.json](https://github.com/coreui/coreui/blob/v5.8.0/package.json) includes convenient methods for working with the framework, including compiling code, running tests, and more.
+CoreUI for Bootstrap uses [npm scripts](https://docs.npmjs.com/misc/scripts/) for its build system. Our [package.json](https://github.com/coreui/coreui/blob/v[[config:current_version]]/package.json) includes convenient methods for working with the framework, including compiling code, running tests, and more.
 
 To use our build system and run our documentation locally, you'll need a copy of CoreUI's source files and Node. Follow these steps and you should be ready to rock:
 
 1. [Download and install Node.js](https://nodejs.org/en/download/), which we use to manage our dependencies.
-2. Either [download CoreUI's sources](https://github.com/coreui/coreui/archive/v5.8.0.zip) or fork [CoreUI's repository](https://github.com/coreui/coreui).
-3. Navigate to the root `/coreui` directory and run `npm install` to install our local dependencies listed in [package.json](https://github.com/coreui/coreui/blob/v5.8.0/package.json).
+2. Either [download CoreUI's sources](https://github.com/coreui/coreui/archive/v[[config:current_version]].zip) or fork [CoreUI's repository](https://github.com/coreui/coreui).
+3. Navigate to the root `/coreui` directory and run `npm install` to install our local dependencies listed in [package.json](https://github.com/coreui/coreui/blob/v[[config:current_version]]/package.json).
 
 When completed, you'll be able to run the various commands provided from the command line.
 
 ## Using npm scripts
 
-Our [package.json](https://github.com/coreui/coreui/blob/v5.8.0/package.json) includes numerous tasks for developing the project. Run `npm run` to see all the npm scripts in your terminal. **Primary tasks include:**
+Our [package.json](https://github.com/coreui/coreui/blob/v[[config:current_version]]/package.json) includes numerous tasks for developing the project. Run `npm run` to see all the npm scripts in your terminal. **Primary tasks include:**
 
 | Task | Description |
 | --- | --- |
@@ -36,11 +36,7 @@ Dart Sass uses a rounding precision of 10 and for efficiency reasons does not al
 
 CoreUI for Bootstrap uses [Autoprefixer](https://github.com/postcss/autoprefixer) (included in our build process) to automatically add vendor prefixes to some CSS properties at build time. Doing so saves us time and code by allowing us to write key parts of our CSS a single time while eliminating the need for vendor mixins like those found in v3.
 
-We maintain the list of browsers supported through Autoprefixer in a separate file within our GitHub repository. See [.browserslistrc](https://github.com/coreui/coreui/blob/v5.8.0/.browserslistrc) for details.
-
-## RTLCSS
-
-CoreUI for Bootstrap uses [RTLCSS](https://rtlcss.com/) to process compiled CSS and convert them to RTL – basically replacing horizontal direction aware properties (eg. `padding-left`) with their opposite. It allows us only write our CSS a single time and make minor tweaks using RTLCSS [control](https://rtlcss.com/learn/usage-guide/control-directives/) and [value](https://rtlcss.com/learn/usage-guide/value-directives/) directives.
+We maintain the list of browsers supported through Autoprefixer in a separate file within our GitHub repository. See [.browserslistrc](https://github.com/coreui/coreui/blob/v[[config:current_version]]/.browserslistrc) for details.
 
 ## Local documentation
 

--- a/docs/src/content/docs/getting-started/download.mdx
+++ b/docs/src/content/docs/getting-started/download.mdx
@@ -5,25 +5,25 @@ description: "Download CoreUI for Bootstrap to get the compiled CSS and JavaScri
 
 ## Compiled CSS and JS
 
-Download ready-to-use compiled code for **CoreUI for Bootstrap v5.8.0** to easily drop into your project, which includes:
+Download ready-to-use compiled code for **CoreUI for Bootstrap v[[config:current_version]]** to easily drop into your project, which includes:
 
 - Compiled and minified CSS bundles (see [CSS files comparison](/getting-started/contents/#css-files))
 - Compiled and minified JavaScript plugins (see [JS files comparison](/getting-started/contents/#js-files))
 
 This doesn't include documentation, source files, or any optional JavaScript dependencies like Floating UI.
 
-<a href="https://github.com/coreui/coreui/releases/download/v5.8.0/coreui-5.8.0-dist.zip" class="btn btn-primary" onclick="ga('send', 'event', 'Getting started', 'Download', 'Download Bootstrap');">Download</a>
+<a href="https://github.com/coreui/coreui/releases/download/v[[config:current_version]]/coreui-[[config:current_version]]-dist.zip" class="btn-solid theme-primary">Download</a>
 
 ## Source files
 
 Compile CoreUI for Bootstrap with your own asset pipeline by downloading our source Sass, JavaScript, and documentation files. This option requires some additional tooling:
 
-- Sass compiler (Libsass or Ruby Sass is supported) for compiling your CSS.
+- [Dart Sass](https://sass-lang.com/dart-sass) for compiling your CSS.
 - [Autoprefixer](https://github.com/postcss/autoprefixer) for CSS vendor prefixing
 
 Should you require [build tools](/getting-started/build-tools/#tooling-setup), they are included for developing CoreUI for Bootstrap and its docs, but they're likely unsuitable for your own purposes.
 
-<a href="https://github.com/coreui/coreui/archive/v5.8.0.zip" class="btn btn-primary" onclick="ga('send', 'event', 'Getting started', 'Download', 'Download source');">Download source</a>
+<a href="https://github.com/coreui/coreui/archive/v[[config:current_version]].zip" class="btn-solid theme-primary">Download source</a>
 
 ## CDN via jsDelivr
 
@@ -108,5 +108,5 @@ bun add @coreui/coreui-pro
 You can also install and manage CoreUI's Sass and JavaScript using [Composer](https://getcomposer.org/):
 
 ```sh
-composer require coreui/coreui:5.8.0
+composer require coreui/coreui:[[config:current_version]]
 ```


### PR DESCRIPTION
Decision J from the docs parity audit, plus the rest of §2.6. Four places described a state the v6 tree is not in.

## `## RTLCSS` — a tool this build does not have

The section explained how RTLCSS converts the compiled CSS into a separate RTL stylesheet. Measured:

- `grep -rn 'rtlcss' package.json build/` → nothing
- `dist/css` → no `*.rtl.css`
- `getting-started/rtl` already says: *"There is no separate RTL stylesheet any more"* — the compiled CSS carries both directions and reacts to `dir="rtl"`

Section removed.

## Seven hard-coded `v5.8.0` references

The download button, the source archive, the Composer constraint, and the `package.json` / `.browserslistrc` links on `build-tools` all pinned a version two releases behind. They now read `[[config:current_version]]`, so they follow whatever `build/generate-sri.mjs` writes on release. Verified in the build output: the page renders `CoreUI for Bootstrap v5.9.0`.

## Two more on the download page

- The source-files prerequisite offered *"Libsass or Ruby Sass"*, both of which `build-tools` calls deprecated one page over. It now names Dart Sass.
- Both download buttons carried `onclick="ga('send', 'event', …)"` — a Universal Analytics call that stopped existing in 2023 and throws `ga is not defined` on click. Removed (0 left in the built page).

## `customize/options` — a wrong default and a missing flag

`$enable-ltr` was listed as ``` `false` or `false` (default) ``` — wrong in both halves; `scss/_config.scss:31` sets `true`.

Rather than fix just that row, I cross-checked the whole table against the flags the Sass actually defines, in both directions:

- **wrong default:** `$enable-ltr` only
- **defined but undocumented:** `$enable-cssgrid` (default `true`) — added in source order
- **documented but not in `_config.scss`:** `$enable-smooth-scroll` — *not* a defect; it is real, it just lives in `scss/content/_reboot.scss`
- the other seventeen rows match

## `customize/color-modes` — two true sentences that read as a contradiction

The page said colors are `light-dark()` pairs that follow `color-scheme`, then six paragraphs later that the mode *"does not automatically toggle"*. Both statements are correct, which is what makes the pair confusing.

The resolution is in `scss/_root.scss:347`: `:root` declares `color-scheme: light` outright, not `light dark`. A pair therefore stays on its light value until something sets `color-scheme: dark`, which in practice means the `data-coreui-theme` attribute. `light-dark()` is the mechanism, not the switch. The first passage now says that and points at the media-query build for readers who want the OS preference honoured.

## Gate

`npm run docs-build` green, 172 pages, no broken links.

**Note on scope:** `getting-started/download.mdx` is the one file decisions I and J share — the audit lists its `ga(` handlers under I and its `v5.8.0` pins under J. All of its fixes ship here so the two PRs do not conflict.