### PR TITLE
docs(content): give the figures page a structure and a way in

### DIFF
--- a/docs/src/content/docs/content/figures.mdx
+++ b/docs/src/content/docs/content/figures.mdx
@@ -4,16 +4,20 @@ name: "Figures"
 description: "Documentation and examples for displaying related images and text with the figure component in Bootstrap."
 ---
 
-Anytime you need to display a piece of content—like an image with an optional caption, consider using a `<figure>`.
+Anytime you need to display a piece of content—like an image with an optional caption, consider using a `<figure>`. For images without a caption, see [Images](/content/images/).
 
-Use the included `.figure`, `.figure-img` and `.figure-caption` classes to provide some baseline styles for the HTML5 `<figure>` and `<figcaption>` elements. Images in figures have no explicit size, so be sure to add the `.img-fluid` class to your `<img />` to make it responsive.
+## Basic example
+
+Use the included `.figure`, `.figure-img` and `.figure-caption` classes to provide some baseline styles for the HTML5 `<figure>` and `<figcaption>` elements. `.figure` is an `inline-block`, so it shrinks to the width of the image and the caption lines up with it. Images in figures have no explicit size, so be sure to add the `.img-fluid` class to your `<img />` to make it responsive.
 
 <Example code={`<figure class="figure">
     <svg class="docs-placeholder-img figure-img img-fluid rounded" width="400" height="300" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="" preserveAspectRatio="xMidYMid slice" focusable="false"><title></title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
     <figcaption class="figure-caption">A caption for the above image.</figcaption>
   </figure>`} />
 
-Aligning the figure's caption is easy with our [text utilities](/utilities/text-alignment/).
+## Aligning the caption
+
+Aligning the figure's caption is easy with our [text utilities](/utilities/text-alignment/). Because the figure is only as wide as its image, the caption aligns against the image rather than the page.
 
 <Example code={`<figure class="figure">
     <svg class="docs-placeholder-img figure-img img-fluid rounded" width="400" height="300" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="" preserveAspectRatio="xMidYMid slice" focusable="false"><title></title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>

--- a/docs/src/content/docs/content/images.mdx
+++ b/docs/src/content/docs/content/images.mdx
@@ -8,7 +8,7 @@ otherFrameworks:
 
 ## Responsive images
 
-Images in CoreUI for Bootstrap are made responsive with `.img-fluid`. This applies `max-width: 100%;` and `height: auto;` to the image so that it scales with the parent element.
+Images in CoreUI for Bootstrap are made responsive with `.img-fluid`. This applies `max-width: 100%;` and `height: auto;` to the image so that it scales with the parent element. To pair an image with a caption, see [Figures](/content/figures/).
 
 <Example code={`<svg class="docs-placeholder-img docs-placeholder-img-lg img-fluid" width="100%" height="250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Responsive image" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Responsive image</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Responsive image</text></svg>`} />
 


### PR DESCRIPTION
Decision E from the docs parity audit. The decision settled the granularity question — `content/figures` stays a page of its own — and left its content to be reviewed. Reviewing it against `content/images` turned up two problems that are about the page rather than its examples.

**No section headings.** The page was prose, two examples, then `## Customizing`. Nothing its body covers reached the table of contents, so a reader landing on the page got a contents list with a single entry that is not about figures. Its two subjects now have names: `## Basic example` and `## Aligning the caption`.

**Nothing linked to it.** `grep -rn 'content/figures' docs/src` returned exactly one hit — the sidebar entry. `content/images`, the page about images, never mentioned figures, although a figure is an image with a caption. That is the cost of keeping the page separate, and it is what makes the separation work once fixed. The two pages now point at each other.

**The examples are accurate.** Checked against the build rather than assumed:

- `.figure`, `.figure-img`, `.figure-caption` are all emitted
- `.figure` is `display: inline-block`, not a flex container, so `.text-end` on the caption genuinely aligns it against the image

Both prose passages now say that, because it is the part a reader cannot infer from the markup — and it is also why there is no "reverse alignment" example here: that one depends on the figure being a flex container, which ours is not.

Gate: `npm run docs-build` green, 172 pages, no broken links.