### PR TITLE
fix(Button)!: stop button labels from wrapping

### DIFF
--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -226,23 +226,23 @@ Visually, these toggle buttons are identical to the [checkbox toggle buttons](/f
 
 Add `data-coreui-toggle="button"` to toggle a button's `active` state. Also add `aria-pressed` so assistive technologies announce the control as a toggle button. Use `aria-pressed="false"` for the default state. If you're pre-toggling a button, add the `.active` class **and** `aria-pressed="true"`.
 
-<Example code={`<div class="d-flex gap-1 mb-3">
+<Example code={`<div class="d-flex flex-wrap gap-1 mb-3">
     <button type="button" class="btn" data-coreui-toggle="button" aria-pressed="false">Toggle button</button>
     <button type="button" class="btn active" data-coreui-toggle="button" aria-pressed="true">Active toggle button</button>
     <button type="button" class="btn" disabled data-coreui-toggle="button" aria-pressed="false">Disabled toggle button</button>
   </div>
-  <div class="d-flex gap-1">
+  <div class="d-flex flex-wrap gap-1">
     <button type="button" class="btn-solid theme-primary" data-coreui-toggle="button" aria-pressed="false">Toggle button</button>
     <button type="button" class="btn-solid theme-primary active" data-coreui-toggle="button" aria-pressed="true">Active toggle button</button>
     <button type="button" class="btn-solid theme-primary" disabled data-coreui-toggle="button" aria-pressed="false">Disabled toggle button</button>
   </div>`} />
 
-<Example code={`<div class="d-flex gap-1 mb-3">
+<Example code={`<div class="d-flex flex-wrap gap-1 mb-3">
     <a href="#" class="btn" role="button" data-coreui-toggle="button" aria-pressed="false">Toggle link</a>
     <a href="#" class="btn active" role="button" data-coreui-toggle="button" aria-pressed="true">Active toggle link</a>
     <a class="btn disabled" aria-disabled="true" role="button" data-coreui-toggle="button" aria-pressed="false">Disabled toggle link</a>
   </div>
-  <div class="d-flex gap-1">
+  <div class="d-flex flex-wrap gap-1">
     <a href="#" class="btn-solid theme-primary" role="button" data-coreui-toggle="button" aria-pressed="false">Toggle link</a>
     <a href="#" class="btn-solid theme-primary active" role="button" data-coreui-toggle="button" aria-pressed="true">Active toggle link</a>
     <a class="btn-solid theme-primary disabled" aria-disabled="true" role="button" data-coreui-toggle="button" aria-pressed="false">Disabled toggle link</a>

--- a/docs/src/content/docs/components/collapse.mdx
+++ b/docs/src/content/docs/components/collapse.mdx
@@ -24,7 +24,7 @@ Click the buttons below to show and hide another element via class changes:
 
 You can use a link with the `href` attribute, or a button with the `data-coreui-target` attribute. In both samples, the `data-coreui-toggle="collapse""` is required.
 
-<Example code={`<p class="d-inline-flex gap-1">
+<Example code={`<p class="d-inline-flex flex-wrap gap-1">
     <a class="btn-solid theme-primary" data-coreui-toggle="collapse" href="#collapseExample" role="button" aria-expanded="false" aria-controls="collapseExample">
       Link with href
     </a>
@@ -64,7 +64,7 @@ Please note that while the example below has a `min-height` set to avoid excessi
 A `<button>` or `<a>` can show and hide multiple elements by referencing them with a selector in its `href` or `data-coreui-target` attribute.
 Multiple `<button>` or `<a>` can show and hide an element if they each reference it with their `href` or `data-coreui-target` attribute
 
-<Example code={`<p class="d-inline-flex gap-1">
+<Example code={`<p class="d-inline-flex flex-wrap gap-1">
     <a class="btn-solid theme-primary" data-coreui-toggle="collapse" href="#multiCollapseExample1" role="button" aria-expanded="false" aria-controls="multiCollapseExample1">Toggle first element</a>
     <button class="btn-solid theme-primary" type="button" data-coreui-toggle="collapse" data-coreui-target="#multiCollapseExample2" aria-expanded="false" aria-controls="multiCollapseExample2">Toggle second element</button>
     <button class="btn-solid theme-primary" type="button" data-coreui-toggle="collapse" data-coreui-target=".multi-collapse" aria-expanded="false" aria-controls="multiCollapseExample1 multiCollapseExample2">Toggle both elements</button>

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1151,6 +1151,28 @@ adornment in the library — so the button needs no icon markup at all:
   CSS that positioned button content with `display`, `line-height` or margins
   needs a second look; the caret of a `.dropdown-toggle` now takes its distance
   from the gap instead of its own margin.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **A button label no longer wraps.** `--cui-btn-white-space` is `nowrap`. In v5
+  `$btn-white-space` was `null`, so no declaration was emitted at all and a long
+  label broke onto a second line, leaving the button taller than the ones beside
+  it — while the variable's own comment told you to set `nowrap`, which is to say
+  the default was the one nobody wanted. A long label now keeps the button one
+  line tall and makes it wider instead.
+
+  It is still a token, so the old behaviour is one declaration away — on a single
+  button, on a theme, or globally:
+
+  ```css
+  .btn-that-wraps { --cui-btn-white-space: normal; }
+  :root { --cui-btn-white-space: normal; }
+  ```
+
+  In Sass, `$btn-white-space: normal`. The token is declared on `.btn` itself, so
+  an override has to reach the button — setting it on an ancestor is not enough.
+
+  Look at rows that hold several buttons: a flex row without `.flex-wrap` grows
+  wider now instead of taller, so add it where the group should break onto a
+  second line rather than push the layout out.
 - **`.btn-icon` (new).** A button that holds nothing but an icon: no padding,
   and its width follows its height, so it stays square at every size.
 - **A variant is a shape, the colour is a theme.** `.btn-solid`, `.btn-outline`,

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -13,7 +13,7 @@
 @use "../config" as *;
 
 // scss-docs-start btn-variables
-$btn-white-space:             inherit !default; // Set to `nowrap` to prevent text wrapping
+$btn-white-space:             nowrap !default; // Set to `normal` to let button text wrap
 
 $btn-color:                   var(--#{$prefix}fg-body) !default;
 $btn-bg:                      var(--#{$prefix}bg-4) !default;

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -13,7 +13,7 @@
 @use "../config" as *;
 
 // scss-docs-start btn-variables
-$btn-white-space:             null !default; // Set to `nowrap` to prevent text wrapping
+$btn-white-space:             inherit !default; // Set to `nowrap` to prevent text wrapping
 
 $btn-color:                   var(--#{$prefix}fg-body) !default;
 $btn-bg:                      var(--#{$prefix}bg-4) !default;


### PR DESCRIPTION
§5.2 of the docs parity audit — which turned out to be two things: a token that was never declared, and a default worth changing while we are in a major.

## The defect

```
dist/css/coreui.css:4753    white-space: var(--cui-btn-white-space);
grep -c -- '--cui-btn-white-space:' dist/css/coreui.css   → 0
```

One read, no fallback, zero declarations. `$btn-white-space` was `null`, and a null map value makes Sass drop the declaration rather than emit it — the `defaults()` trap already written up in `CLAUDE.md`. So the declaration was invalid at computed-value time on every `.btn`, and the token appeared in the button's CSS variables table while never appearing in the stylesheet or in developer tools.

## The default changes too — this is the breaking part

The token is now **`nowrap`**.

| | value | what a long label did |
| --- | --- | --- |
| v5 (`$btn-white-space: null`) | nothing emitted | broke onto a second line, leaving that button taller than its neighbours |
| v6 before this PR | read, never declared | the same, via an invalid declaration |
| v6 after | `nowrap` | stays on one line, the button gets wider |

Our own v5 comment on that variable read *"Set to `nowrap` to prevent text wrapping"* — the default was the one we were telling everybody to override. The comment now points the other way.

It stays a token, so the old behaviour is one declaration away, per instance, per theme or globally — `--cui-btn-white-space: normal`, or `$btn-white-space: normal` in Sass. Worth knowing, and now written in the migration guide: the token is declared **on `.btn` itself**, so an override has to reach the button; setting it on an ancestor loses to that declaration.

`migration/v6.mdx` carries the entry, marked Breaking. This is a visible change of default appearance, not a bug fix.

## Does `nowrap` break the examples? Measured, not eyeballed

This is the real risk of the change, and the reason Bootstrap 5 left the variable `null`. All **181 built pages** were loaded at **1280, 768 and 400 px**, and each page's `scrollWidth` compared against the same page with every button forced back to `white-space: normal`. Only a positive delta is caused by this change.

- **1280 px and 768 px: zero pages.**
- **400 px: exactly two.** `components/buttons` grew 400 → 514 px, `components/collapse` 400 → 571 px.

Both were rows of buttons in a flex container with no `flex-wrap` (`d-flex gap-1`, `d-inline-flex gap-1`), so a label that stopped wrapping widened the row past the viewport instead. `.flex-wrap` on those five rows is the correct pairing rather than a patch: with labels held on one line, the **group** should break, not the text — and `buttons.mdx` already used `<Example class="d-flex flex-wrap gap-2">` elsewhere for exactly this.

Re-running the same measurement after the fix: **zero pages on all three widths.**

A note on the probe, because the first version of it was worthless: overriding the token on `:root` changes nothing, since it is declared on `.btn` and a direct declaration beats an inherited one. It reported "0 buttons wrap anywhere", which looked like good news. Setting the override inline on each element instead found 29 wrapping buttons at 400 px and 12 at 1280 px.

## Seven more empty tokens — not fixed here

The sweep that found this one found others: declared empty (`--x: ;`) and read with no fallback, so they resolve to nothing exactly as this one did — `--cui-form-feedback-font-style`, `--cui-form-feedback-tooltip-line-height`, `--cui-nav-link-font-size`, `--cui-nav-link-font-weight`, `--cui-modal-footer-bg`, `--cui-tooltip-margin`. (`--cui-dropdown-box-shadow` is declared empty but never read, so it is harmless.) Left out deliberately: one decision covering six components, recorded in the audit.

## Gates

`npx stylelint scss/buttons/_button.scss` clean · `npm run css` · `npm run docs-build` green, 172 pages, no broken links · bundlewatch PASS on a freshly built `dist` (`coreui.css` 64.91KB < 66KB, `coreui.bundle.min.js` 76.84KB < 77KB) · pre-push gate green.

Heads-up unrelated to this PR: `coreui.bundle.min.js` is at 76.84KB against a 77KB ceiling — 0.16KB of headroom, so the next JS PR will trip it.