### PR TITLE
docs: correct the class names that are simply wrong

### DIFF
--- a/docs/src/content/docs/components/header.mdx
+++ b/docs/src/content/docs/components/header.mdx
@@ -41,7 +41,7 @@ Here's an example of all the sub-components included in a responsive header.
     <button class="header-toggler" type="button">
       <span class="header-toggler-icon"></span>
     </button>
-    <ul class="header-nav mr-auto">
+    <ul class="header-nav me-auto">
       <li class="nav-item active">
         <a class="nav-link" href="#">Home <span class="visually-hidden">(current)</span></a>
       </li>
@@ -191,9 +191,7 @@ Input groups work, too:
 <Example code={`<header class="header">
     <form class="d-flex">
       <div class="input-group">
-        <div class="input-group-prepend">
-          <span class="input-group-text" id="basic-addon1">@</span>
-        </div>
+        <span class="input-group-text" id="basic-addon1">@</span>
         <input type="text" class="form-control" placeholder="Username" aria-label="Username" aria-describedby="basic-addon1">
       </div>
     </form>

--- a/docs/src/content/docs/components/tooltips.mdx
+++ b/docs/src/content/docs/components/tooltips.mdx
@@ -46,7 +46,7 @@ You can enable tooltips using JavaScript or data attributes. Here's how to initi
 
 Hover your cursor over the links below to see tooltips:
 
-<Example class="tooltip-demo" sandboxJsId="enable-tooltips" html={[`<p class="muted">`, `  Sample text to illustrate <a href="#" data-coreui-toggle="tooltip" title="Default tooltip">inline links</a> accompanied by tooltips. This serves purely as filler, lacking substance. The content here merely simulates <a href="#" data-coreui-toggle="tooltip" title="Another tooltip">genuine text</a> presence. All of this is to demonstrate how <a href="#" data-coreui-toggle="tooltip" title="Another one here too">tooltips</a> would appear in actual scenarios. Hopefully, you have now observed how these link tooltips function effectively in practice, ready to be used on your own website or project.`, `</p>`]} />
+<Example class="tooltip-demo" sandboxJsId="enable-tooltips" html={[`<p class="text-muted">`, `  Sample text to illustrate <a href="#" data-coreui-toggle="tooltip" title="Default tooltip">inline links</a> accompanied by tooltips. This serves purely as filler, lacking substance. The content here merely simulates <a href="#" data-coreui-toggle="tooltip" title="Another tooltip">genuine text</a> presence. All of this is to demonstrate how <a href="#" data-coreui-toggle="tooltip" title="Another one here too">tooltips</a> would appear in actual scenarios. Hopefully, you have now observed how these link tooltips function effectively in practice, ready to be used on your own website or project.`, `</p>`]} />
 
 <Callout color="warning">
 You can choose to use either `title` or `data-coreui-title` in your HTML. If you opt for `title,` the plugin will automatically change it to `data-coreui-title` upon rendering the element.

--- a/docs/src/content/docs/forms/stepper.mdx
+++ b/docs/src/content/docs/forms/stepper.mdx
@@ -21,23 +21,23 @@ A simple multi-step form built with the Bootstrap Stepper. Each step displays fo
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step" data-coreui-target="#step-1">
           <span class="stepper-step-indicator">1</span>
-          <span class="stepper-step-label">Step 1</span>
+          <span>Step 1</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step" data-coreui-target="#step-2">
           <span class="stepper-step-indicator">2</span>
-          <span class="stepper-step-label">Step 2</span>
+          <span>Step 2</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step" data-coreui-target="#step-3">
           <span class="stepper-step-indicator">3</span>
-          <span class="stepper-step-label">Step 3</span>
+          <span>Step 3</span>
         </button>
       </li>
     </ol>
-    <div class="stepper-content">
+    <div>
       <div class="stepper-pane" id="step-1">
         <form class="row g-3 mb-4">
           <div class="col-md-4">
@@ -131,19 +131,19 @@ Display step indicators vertically above labels using the `.vertical` modifier. 
       <li class="stepper-step vertical">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step">
           <span class="stepper-step-indicator">1</span>
-          <span class="stepper-step-label">Step 1</span>
+          <span>Step 1</span>
         </button>
       </li>
       <li class="stepper-step vertical">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">2</span>
-          <span class="stepper-step-label">Step 2</span>
+          <span>Step 2</span>
         </button>
       </li>
       <li class="stepper-step vertical">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">3</span>
-          <span class="stepper-step-label">Step 3</span>
+          <span>Step 3</span>
         </button>
       </li>
     </ol>
@@ -158,7 +158,7 @@ Use the `.stepper-vertical` class to build a full vertical stepper, where both i
       <li class="stepper-step">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step">
           <span class="stepper-step-indicator">1</span>
-          <span class="stepper-step-label">Step 1</span>
+          <span>Step 1</span>
         </button>
         <div class="stepper-step-content">
           <div class="py-3">
@@ -195,7 +195,7 @@ Use the `.stepper-vertical` class to build a full vertical stepper, where both i
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">2</span>
-          <span class="stepper-step-label">Step 2</span>
+          <span>Step 2</span>
         </button>
         <div class="stepper-step-content">
           <div class="py-3">
@@ -233,7 +233,7 @@ Use the `.stepper-vertical` class to build a full vertical stepper, where both i
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">3</span>
-          <span class="stepper-step-label">Step 3</span>
+          <span>Step 3</span>
         </button>
         <div class="stepper-step-content">
           <div class="pt-3">
@@ -279,19 +279,19 @@ Use a Linear Bootstrap Stepper when you need a guided and controlled experience,
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">1</span>
-          <span class="stepper-step-label">Step 1</span>
+          <span>Step 1</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step">
           <span class="stepper-step-indicator">2</span>
-          <span class="stepper-step-label">Step 2</span>
+          <span>Step 2</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">3</span>
-          <span class="stepper-step-label">Step 3</span>
+          <span>Step 3</span>
         </button>
       </li>
     </ol>
@@ -314,19 +314,19 @@ Use a Non-linear Bootstrap Stepper when users should have full control over navi
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">1</span>
-          <span class="stepper-step-label">Step 1</span>
+          <span>Step 1</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step">
           <span class="stepper-step-indicator">2</span>
-          <span class="stepper-step-label">Step 2</span>
+          <span>Step 2</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">3</span>
-          <span class="stepper-step-label">Step 3</span>
+          <span>Step 3</span>
         </button>
       </li>
     </ol>
@@ -349,17 +349,17 @@ This example shows a stepper with native browser validation enabled:
       <li class="stepper-step">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step" data-coreui-target="#validation-step-1">
           <span class="stepper-step-indicator">1</span>
-          <span class="stepper-step-label">Account</span>
+          <span>Account</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step" data-coreui-target="#validation-step-2">
           <span class="stepper-step-indicator">2</span>
-          <span class="stepper-step-label">Profile</span>
+          <span>Profile</span>
         </button>
       </li>
     </ol>
-    <div class="stepper-content">
+    <div>
       <div class="stepper-pane active show" id="validation-step-1">
         <form class="row g-3 mb-4">
           <div class="col-md-6">
@@ -411,17 +411,17 @@ To disable native browser styles validation and turn on custom styles, add the `
       <li class="stepper-step">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step" data-coreui-target="#novalidate-step-1">
           <span class="stepper-step-indicator">1</span>
-          <span class="stepper-step-label">Account</span>
+          <span>Account</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step" data-coreui-target="#novalidate-step-2">
           <span class="stepper-step-indicator">2</span>
-          <span class="stepper-step-label">Profile</span>
+          <span>Profile</span>
         </button>
       </li>
     </ol>
-    <div class="stepper-content">
+    <div>
       <div class="stepper-pane active show" id="novalidate-step-1">
         <form class="row g-3 mb-4" novalidate>
           <div class="col-md-6">
@@ -473,17 +473,17 @@ To completely skip form validation and allow free navigation between steps, add 
       <li class="stepper-step">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step" data-coreui-target="#skip-step-1">
           <span class="stepper-step-indicator">1</span>
-          <span class="stepper-step-label">Account</span>
+          <span>Account</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step" data-coreui-target="#skip-step-2">
           <span class="stepper-step-indicator">2</span>
-          <span class="stepper-step-label">Profile</span>
+          <span>Profile</span>
         </button>
       </li>
     </ol>
-    <div class="stepper-content">
+    <div>
       <div class="stepper-pane active show" id="skip-step-1">
         <form class="row g-3 mb-4">
           <div class="col-md-6">

--- a/docs/src/content/docs/forms/stepper.mdx
+++ b/docs/src/content/docs/forms/stepper.mdx
@@ -21,23 +21,23 @@ A simple multi-step form built with the Bootstrap Stepper. Each step displays fo
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step" data-coreui-target="#step-1">
           <span class="stepper-step-indicator">1</span>
-          <span>Step 1</span>
+          <span class="stepper-step-label">Step 1</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step" data-coreui-target="#step-2">
           <span class="stepper-step-indicator">2</span>
-          <span>Step 2</span>
+          <span class="stepper-step-label">Step 2</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step" data-coreui-target="#step-3">
           <span class="stepper-step-indicator">3</span>
-          <span>Step 3</span>
+          <span class="stepper-step-label">Step 3</span>
         </button>
       </li>
     </ol>
-    <div>
+    <div class="stepper-content">
       <div class="stepper-pane" id="step-1">
         <form class="row g-3 mb-4">
           <div class="col-md-4">
@@ -131,19 +131,19 @@ Display step indicators vertically above labels using the `.vertical` modifier. 
       <li class="stepper-step vertical">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step">
           <span class="stepper-step-indicator">1</span>
-          <span>Step 1</span>
+          <span class="stepper-step-label">Step 1</span>
         </button>
       </li>
       <li class="stepper-step vertical">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">2</span>
-          <span>Step 2</span>
+          <span class="stepper-step-label">Step 2</span>
         </button>
       </li>
       <li class="stepper-step vertical">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">3</span>
-          <span>Step 3</span>
+          <span class="stepper-step-label">Step 3</span>
         </button>
       </li>
     </ol>
@@ -158,7 +158,7 @@ Use the `.stepper-vertical` class to build a full vertical stepper, where both i
       <li class="stepper-step">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step">
           <span class="stepper-step-indicator">1</span>
-          <span>Step 1</span>
+          <span class="stepper-step-label">Step 1</span>
         </button>
         <div class="stepper-step-content">
           <div class="py-3">
@@ -195,7 +195,7 @@ Use the `.stepper-vertical` class to build a full vertical stepper, where both i
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">2</span>
-          <span>Step 2</span>
+          <span class="stepper-step-label">Step 2</span>
         </button>
         <div class="stepper-step-content">
           <div class="py-3">
@@ -233,7 +233,7 @@ Use the `.stepper-vertical` class to build a full vertical stepper, where both i
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">3</span>
-          <span>Step 3</span>
+          <span class="stepper-step-label">Step 3</span>
         </button>
         <div class="stepper-step-content">
           <div class="pt-3">
@@ -279,19 +279,19 @@ Use a Linear Bootstrap Stepper when you need a guided and controlled experience,
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">1</span>
-          <span>Step 1</span>
+          <span class="stepper-step-label">Step 1</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step">
           <span class="stepper-step-indicator">2</span>
-          <span>Step 2</span>
+          <span class="stepper-step-label">Step 2</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">3</span>
-          <span>Step 3</span>
+          <span class="stepper-step-label">Step 3</span>
         </button>
       </li>
     </ol>
@@ -314,19 +314,19 @@ Use a Non-linear Bootstrap Stepper when users should have full control over navi
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">1</span>
-          <span>Step 1</span>
+          <span class="stepper-step-label">Step 1</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step">
           <span class="stepper-step-indicator">2</span>
-          <span>Step 2</span>
+          <span class="stepper-step-label">Step 2</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step">
           <span class="stepper-step-indicator">3</span>
-          <span>Step 3</span>
+          <span class="stepper-step-label">Step 3</span>
         </button>
       </li>
     </ol>
@@ -349,17 +349,17 @@ This example shows a stepper with native browser validation enabled:
       <li class="stepper-step">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step" data-coreui-target="#validation-step-1">
           <span class="stepper-step-indicator">1</span>
-          <span>Account</span>
+          <span class="stepper-step-label">Account</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step" data-coreui-target="#validation-step-2">
           <span class="stepper-step-indicator">2</span>
-          <span>Profile</span>
+          <span class="stepper-step-label">Profile</span>
         </button>
       </li>
     </ol>
-    <div>
+    <div class="stepper-content">
       <div class="stepper-pane active show" id="validation-step-1">
         <form class="row g-3 mb-4">
           <div class="col-md-6">
@@ -411,17 +411,17 @@ To disable native browser styles validation and turn on custom styles, add the `
       <li class="stepper-step">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step" data-coreui-target="#novalidate-step-1">
           <span class="stepper-step-indicator">1</span>
-          <span>Account</span>
+          <span class="stepper-step-label">Account</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step" data-coreui-target="#novalidate-step-2">
           <span class="stepper-step-indicator">2</span>
-          <span>Profile</span>
+          <span class="stepper-step-label">Profile</span>
         </button>
       </li>
     </ol>
-    <div>
+    <div class="stepper-content">
       <div class="stepper-pane active show" id="novalidate-step-1">
         <form class="row g-3 mb-4" novalidate>
           <div class="col-md-6">
@@ -473,17 +473,17 @@ To completely skip form validation and allow free navigation between steps, add 
       <li class="stepper-step">
         <button type="button" class="stepper-step-button active" data-coreui-toggle="step" data-coreui-target="#skip-step-1">
           <span class="stepper-step-indicator">1</span>
-          <span>Account</span>
+          <span class="stepper-step-label">Account</span>
         </button>
       </li>
       <li class="stepper-step">
         <button type="button" class="stepper-step-button" data-coreui-toggle="step" data-coreui-target="#skip-step-2">
           <span class="stepper-step-indicator">2</span>
-          <span>Profile</span>
+          <span class="stepper-step-label">Profile</span>
         </button>
       </li>
     </ol>
-    <div>
+    <div class="stepper-content">
       <div class="stepper-pane active show" id="skip-step-1">
         <form class="row g-3 mb-4">
           <div class="col-md-6">

--- a/docs/src/content/docs/helpers/icon-link.mdx
+++ b/docs/src/content/docs/helpers/icon-link.mdx
@@ -81,7 +81,7 @@ Customize the icon link Sass variables to modify all icon link styles across you
 
 Modify icon links with any of [our link utilities](/utilities/link/) for modifying underline color and offset.
 
-<Example code={`<a class="icon-link icon-link-hover link-success link-underline-success link-underline-opacity-25" href="#">
+<Example code={`<a class="icon-link icon-link-hover theme-success link-underline-success link-underline-opacity-25" href="#">
     Icon link
     <svg xmlns="http://www.w3.org/2000/svg" class="icon" viewBox="0 0 16 16" aria-hidden="true">
       <path d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8z"/>

--- a/docs/src/content/docs/helpers/stacks.mdx
+++ b/docs/src/content/docs/helpers/stacks.mdx
@@ -6,10 +6,6 @@ description: "Shorthand helpers that build on top of our flexbox utilities to ma
 
 Stacks offer a shortcut for applying a number of flexbox properties to quickly and easily create layouts in Bootstrap. All credit for the concept and implementation goes to the open source [Pylon project](https://almonk.github.io/pylon/).
 
-<Callout color="warning">
-**Heads up!** Support for gap utilities with flexbox isn't available in Safari prior to 14.5, so consider verifying your intended browser support. Grid layout should have no issues. [Read more](https://caniuse.com/flexbox-gap).
-</Callout>
-
 ## Vertical
 
 Use `.vstack` to create vertical layouts. Stacked items are full-width by default. Use `.gap-*` utilities to add space between items.

--- a/docs/src/content/docs/utilities/background.mdx
+++ b/docs/src/content/docs/utilities/background.mdx
@@ -38,15 +38,9 @@ Five neutral surfaces run from the page background to the deepest panel. The num
 
 By adding a `.bg-gradient` class, a linear gradient is added as background image to the backgrounds. This gradient starts with a semi-transparent white which fades out to the bottom.
 
-Do you need a gradient in your custom CSS? Just add `background-image: var(gradient);`.
+Do you need a gradient in your custom CSS? Read the token: `background-image: var(--cui-gradient);`.
 
-<div class="p-3 mb-2 text-bg-primary bg-gradient">.bg-primary.bg-gradient</div>
-<div class="p-3 mb-2 text-bg-secondary bg-gradient">.bg-secondary.bg-gradient</div>
-<div class="p-3 mb-2 text-bg-success bg-gradient">.bg-success.bg-gradient</div>
-<div class="p-3 mb-2 text-bg-danger bg-gradient">.bg-danger.bg-gradient</div>
-<div class="p-3 mb-2 text-bg-warning bg-gradient">.bg-warning.bg-gradient</div>
-<div class="p-3 mb-2 text-bg-info bg-gradient">.bg-info.bg-gradient</div>
-<div class="p-3 mb-2 bg-black bg-gradient text-white">.bg-black.bg-gradient</div>
+<Example code={[`<div class="p-3 mb-2 text-bg-primary bg-gradient">.bg-primary.bg-gradient</div>`, `<div class="p-3 mb-2 text-bg-secondary bg-gradient">.bg-secondary.bg-gradient</div>`, `<div class="p-3 mb-2 text-bg-success bg-gradient">.bg-success.bg-gradient</div>`, `<div class="p-3 mb-2 text-bg-danger bg-gradient">.bg-danger.bg-gradient</div>`, `<div class="p-3 mb-2 text-bg-warning bg-gradient">.bg-warning.bg-gradient</div>`, `<div class="p-3 mb-2 text-bg-info bg-gradient">.bg-info.bg-gradient</div>`, `<div class="p-3 mb-2 bg-black bg-gradient text-white">.bg-black.bg-gradient</div>`]} />
 
 ## Opacity
 

--- a/docs/src/content/docs/utilities/colors.mdx
+++ b/docs/src/content/docs/utilities/colors.mdx
@@ -24,7 +24,7 @@ Colorize text with color utilities. To colorize a link, give it a [theme class](
 ]} />
 
 <Callout color="warning">
-**Deprecation:** With the addition of `.text-opacity-*` utilities and CSS variables for text utilities, `.text-black-50` and `.text-white-50` are deprecated as of v4.1.0. They'll be removed in v6.0.0.
+**Deprecation:** `.text-black-50` and `.text-white-50` still ship, but `.text-opacity-*` composes with any text color and is the spelling to reach for. Write `.text-black.text-opacity-50` instead.
 </Callout>
 
 ## Foreground ladder


### PR DESCRIPTION
Audit items §3.1, §3.2, §4.2 and §5b.1, plus three pre-v5 classes the class sweep on #893 turned up.

Every name was checked against `dist/css/coreui.css` — and, where the answer mattered, against the **v5** stylesheet too, so a genuine regression is not papered over as a docs typo. That check changed two verdicts; both are below.

| Page | Was | Now |
| --- | --- | --- |
| `helpers/icon-link` | `.link-success` — 0 in CSS since link colour moved to the theme (#876) | `.theme-success`; Reboot resolves a link's colour from `--cui-theme-fg`, which `utilities/link` already documents |
| `helpers/stacks` | callout: flexbox `gap` unsupported before Safari 14.5 | removed — our floor is Safari 17.5 |
| `utilities/background` | `background-image: var(gradient);` | `var(--cui-gradient)` — the old form is not a valid declaration |
| `utilities/background` | seven `.bg-gradient` demos as bare `<div>`s | wrapped in `<Example>`, so code shows beside the swatches |
| `utilities/colors` | "`.text-black-50` and `.text-white-50` … will be removed in v6.0.0" | both are emitted and keeping them was deliberate; the callout points at `.text-opacity-*` instead of promising a removal that did not happen |
| `components/header` | `.mr-auto`, `.input-group-prepend` | `.me-auto`; the addon is a direct child of `.input-group` |
| `components/tooltips` | `.muted` (a v3 class) | `.text-muted` |

## Deliberately kept: three names on `forms/stepper`

An earlier revision of this branch deleted `.stepper-step-label` (21 uses) and `.stepper-content` (4) as dead classes. **That is reverted** — please do not re-flag them.

Neither matches a rule today, but that makes them an open question rather than a typo. The stylesheet emits `.stepper-step-content` **and** `.stepper-step-indicator-text` while the docs say `.stepper-step-label`, so either the label slot has no style yet or the docs are using a name the build does not produce. Deleting the class settles that silently, and in the direction that loses the slot. Tracked in `TODO.md` as a decision per class, with the measured vocabulary on both sides.

Upstream is not the source of names here: their stepper is a static progress indicator (`stepper`, `stepper-horizontal`, `stepper-item`, `stepper-overflow`), ours is a wizard, and the two vocabularies do not overlap — the slug stays ours (decision F).

`.stepper-action` was never touched by this branch. It appears only as `data-coreui-stepper-action`, an attribute the plugin reads (`js/src/stepper.ts:42`); §5.4 of the audit lists it as an undocumented class, which is a mistake.

## Why the other removals are not the same case

Each one replaces a name that has a working equivalent, rather than a slot of ours with no style:

- `.mr-auto` → `.me-auto` and `.muted` → `.text-muted` — pre-v5 spellings of utilities that still exist.
- `.link-success` — removed on purpose in #876; `utilities/link` already teaches `.theme-*`.
- `.input-group-prepend` — not an unstyled slot but a v4 **wrapper**, and keeping it is actively wrong now: `.input-group` styles its children with the direct-child combinator and rounds them with `> :not(:last-child, …)`, so an addon nested one level deeper stops matching those rules.

## One audit verdict corrected — a code regression, not a docs bug

§5b.1 lists `.form-multi-select-lg` / `-sm` as dead classes on `forms/multi-select`. True of v6 — but **v5 emits both**, and so it does for `.autocomplete-lg` / `-sm`. Every other form family kept its sizes (`.chip-input-*`, `.form-control-*`, `.form-select-*`, `.input-group-*`, `.form-otp-*`, `.rating-*`), so this is an oversight in the v6 rewrite, not a decision.

`forms/multi-select.mdx` and `forms/autocomplete.mdx` are therefore **untouched here** — deleting their Sizing sections would have hidden the regression. Recorded in the audit for a call.

## Gate

`npm run docs-build` green, 172 pages, no broken links.