### PR TITLE
docs: document the classes the stylesheet already ships

### DIFF
--- a/docs/src/content/docs/components/button-group.mdx
+++ b/docs/src/content/docs/components/button-group.mdx
@@ -137,7 +137,7 @@ Feel free to combine input groups with button groups in your toolbars. Similar t
 
 ## Sizing
 
-Alternatively, of implementing button sizing classes to each button in a group, add `.btn-group-*` to all `.btn-group`, including each one when nesting multiple groups.
+Alternatively, of implementing button sizing classes to each button in a group, add `.btn-group-*` to all `.btn-group`, including each one when nesting multiple groups. The sizes are `.btn-group-xs`, `.btn-group-sm` and `.btn-group-lg` — the same ladder the buttons themselves use.
 
 <Example code={`<div class="btn-group btn-group-lg" role="group" aria-label="Large button group">
     <button type="button" class="btn btn-outline-primary">Left</button>
@@ -152,6 +152,12 @@ Alternatively, of implementing button sizing classes to each button in a group, 
   </div>
   <br>
   <div class="btn-group btn-group-sm" role="group" aria-label="Small button group">
+    <button type="button" class="btn btn-outline-primary">Left</button>
+    <button type="button" class="btn btn-outline-primary">Middle</button>
+    <button type="button" class="btn btn-outline-primary">Right</button>
+  </div>
+  <br>
+  <div class="btn-group btn-group-xs" role="group" aria-label="Extra small button group">
     <button type="button" class="btn btn-outline-primary">Left</button>
     <button type="button" class="btn btn-outline-primary">Middle</button>
     <button type="button" class="btn btn-outline-primary">Right</button>

--- a/docs/src/content/docs/components/drawer.mdx
+++ b/docs/src/content/docs/components/drawer.mdx
@@ -134,6 +134,20 @@ Combine `.drawer-bottom` with `.drawer-sheet` for a flush-to-edge bottom sheet w
 
 Add `.drawer-fit-content` to a `.drawer-start`/`.drawer-end` drawer to keep the panel only as tall as its content.
 
+### Footer
+
+Add a `.drawer-footer` below the `.drawer-body` for the panel's actions. It is a flex row that wraps and keeps its children spaced and vertically centered, so a row of buttons needs no utilities.
+
+<Example html={[`<div class="drawer-footer">`, `  <button type="button" class="btn-outline theme-secondary" data-coreui-dismiss="drawer">Close</button>`, `  <button type="button" class="btn-solid theme-primary">Save changes</button>`, `</div>`]} />
+
+### No backdrop
+
+Add `.drawer-no-backdrop` to hide the backdrop while keeping the drawer modal — the panel still takes the top layer and traps focus, but nothing dims the page behind it.
+
+### Instant
+
+Add `.drawer-instant` to a drawer that should appear and disappear at once, with no slide and no backdrop fade. It is the same opt-out that [`.alert-instant`](/components/alerts/#dismissing) provides, and it applies to both directions.
+
 ## Body scrolling
 
 The page scroll is blocked while a drawer is open. Set `scroll: true` to open the drawer non-modally instead — the page stays interactive and scrollable. A visible backdrop requires the top layer, so `backdrop: true` (the default) takes precedence over `scroll: true` for the page-interactivity part.

--- a/docs/src/content/docs/components/offcanvas.mdx
+++ b/docs/src/content/docs/components/offcanvas.mdx
@@ -130,6 +130,10 @@ When the backdrop is set to static, the Bootstrap offcanvas will remain open whe
     </div>
   </dialog>`} />
 
+### Instant
+
+Add `.offcanvas-instant` to an offcanvas that should appear and disappear at once, with no slide and no backdrop fade — the same opt-out `.drawer-instant` provides for drawers.
+
 ## Dark offcanvas
 
 <AddedIn version="4.2.6" />

--- a/docs/src/content/docs/components/progress.mdx
+++ b/docs/src/content/docs/components/progress.mdx
@@ -93,6 +93,30 @@ Include multiple progress bars in a progress component if you need.
     <div class="progress-bar bg-info" role="progressbar" style="width: 20%" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100"></div>
   </div>`} />
 
+## Stacked
+
+`.progress-bar`s inside one `.progress` share a single track. To give each segment its own track and rounded ends, wrap several `.progress` elements in a `.progress-stacked` — it is a flex row, and each child keeps the width you give it.
+
+<Example code={`<div class="progress-stacked">
+    <div class="progress" role="progressbar" aria-label="Segment one" aria-valuenow="15" aria-valuemin="0" aria-valuemax="100" style="width: 15%">
+      <div class="progress-bar"></div>
+    </div>
+    <div class="progress" role="progressbar" aria-label="Segment two" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100" style="width: 30%">
+      <div class="progress-bar theme-success"></div>
+    </div>
+    <div class="progress" role="progressbar" aria-label="Segment three" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="width: 20%">
+      <div class="progress-bar theme-info"></div>
+    </div>
+  </div>`} />
+
+## On a colored surface
+
+Add `.progress-white` to draw the bar in the current text color and the track as a faint tint of it. That way a progress bar sitting on a solid or brand-colored surface takes its colors from the text around it rather than needing a color of its own.
+
+<Example class="p-3 text-bg-primary" code={`<div class="progress progress-white">
+    <div class="progress-bar" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>
+  </div>`} />
+
 ## Striped
 
 Add `.progress-bar-striped` to any `.progress-bar` to apply a stripe via CSS gradient over the progress bar's background color.

--- a/docs/src/content/docs/utilities/overflow.mdx
+++ b/docs/src/content/docs/utilities/overflow.mdx
@@ -15,6 +15,24 @@ Adjust the `overflow` property on the fly with four default values and classes. 
 <div class="overflow-scroll">...</div>
 ```
 
+## Overflow on one axis
+
+The same four values are generated per axis as `.overflow-x-*` and `.overflow-y-*`, which set `overflow-x` and `overflow-y` on their own. Use them when only one direction should scroll or clip.
+
+<Example class="d-md-flex" html={[`<div class="overflow-x-scroll p-3 mb-3 mb-md-0 me-md-3 bg-4" style="max-width: 260px; max-height: 100px;">`, `  This is an example of using <code>.overflow-x-scroll</code>, so this content scrolls horizontally and is clipped vertically.`, `</div>`, `<div class="overflow-y-scroll p-3 bg-4" style="max-width: 260px; max-height: 100px;">`, `  This is an example of using <code>.overflow-y-scroll</code>, so this content scrolls vertically and is clipped horizontally.`, `</div>`]} />
+
+```html
+<div class="overflow-x-auto">...</div>
+<div class="overflow-x-hidden">...</div>
+<div class="overflow-x-visible">...</div>
+<div class="overflow-x-scroll">...</div>
+
+<div class="overflow-y-auto">...</div>
+<div class="overflow-y-hidden">...</div>
+<div class="overflow-y-visible">...</div>
+<div class="overflow-y-scroll">...</div>
+```
+
 Using Sass variables, you may customize the overflow utilities by changing the `$overflows` variable in `_utilities.scss`.
 
 ## Customizing


### PR DESCRIPTION
Audit items §4.3 and §5.4. A capability with no docs is unfinished, and these were shipping unmentioned.

| Page | Class | What it does |
| --- | --- | --- |
| `utilities/overflow` | `.overflow-x-*`, `.overflow-y-*` (8) | the same four values per axis. The page did not contain the string `overflow-x` **once** |
| `components/button-group` | `.btn-group-xs` | comes out of the same `$button-sizes` loop as `sm` and `lg`; the Sizing section showed only large/default/small |
| `components/progress` | `.progress-stacked` | each segment gets its own track and rounded ends instead of sharing one |
| `components/progress` | `.progress-white` | bar in `currentcolor`, track as a tint of it — for a bar on a solid or brand-colored surface |
| `components/drawer` | `.drawer-footer` | the action row below the body; a flex row that wraps and centers, so buttons need no utilities |
| `components/drawer` | `.drawer-no-backdrop` | modal drawer with nothing dimming the page |
| `components/drawer` | `.drawer-instant` | no slide, no backdrop fade, both directions |
| `components/offcanvas` | `.offcanvas-instant` | the same opt-out |

## Four names from the audit list are deliberately left undocumented

§5.4 also lists `.dialog-nonmodal`, `.dialog-swap-in`, `.dialog-static` and `.drawer-static` as classes we ship without documenting. They are not author-facing — **the plugin owns them**:

- `js/src/dialog.ts:85,161` adds and removes `.dialog-nonmodal` and `.dialog-swap-in`
- `js/src/dialog-base.ts:207` — `_triggerBackdropTransition()` adds `${NAME}-static` for the length of one transition to play the bounce, then removes it

Their behaviour is already documented where it belongs: as the `backdrop: static` and `modal: false` options, each with a live example. Writing them up as classes would have invited people to set state the plugin manages.

That distinction is the same one §5b.1 drew for `.chip-input-label` — a name in the stylesheet or the JS is not automatically public API, and the two directions have to be told apart before anything is written.

## Gate

`npm run docs-build` green, 172 pages, no broken links. Every class named in the new copy was checked against `dist/css/coreui.css`.