### PR TITLE
chore(deps): bump @coreui/astro-docs to 0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@astrojs/mdx": "^7.0.4",
         "@babel/core": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
-        "@coreui/astro-docs": "^0.1.7",
+        "@coreui/astro-docs": "^0.1.9",
         "@eslint/markdown": "^7.5.1",
         "@popperjs/core": "^2.11.8",
         "@rollup/plugin-babel": "^7.1.0",
@@ -2187,9 +2187,9 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.7.tgz",
-      "integrity": "sha512-Cp/auWb7/915Y2JGU9a65yHIP4NZYiPCypwKMDPRKWFE5KPJqZXn6Y089XrVLFsAIJU3n6biZaJWBHfONc9krg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.9.tgz",
+      "integrity": "sha512-gNxj5Lakojwxog6LnLroX0J7so3gKZSilenNv4B7viQ1ERbA+Qkc5at+dfCzdNU8wJQU7yx1FUKChLsel9fNcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@astrojs/mdx": "^7.0.4",
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
-    "@coreui/astro-docs": "^0.1.7",
+    "@coreui/astro-docs": "^0.1.9",
     "@eslint/markdown": "^7.5.1",
     "@popperjs/core": "^2.11.8",
     "@rollup/plugin-babel": "^7.1.0",


### PR DESCRIPTION
Rolls the docs engine pin from 0.1.7 to 0.1.9.

Utility pages can now declare a class family in their frontmatter (`utility: "ratio"`) and get a Class/Styles table generated from the compiled `dist/css/coreui.css` instead of describing the classes in prose. No page in this repo declares it yet, so nothing changes visually here — the capability is now available to use.

The 100-900 palette grid on `customize/color` renders as a styled grid instead of plain swatches.

Verified: `npm run docs-build` — 133 pages, no broken links.