### PR TITLE
docs(forms): one name per repeated section, and the tokens input-group already ships

### DIFF
--- a/docs/src/content/docs/components/avatar.mdx
+++ b/docs/src/content/docs/components/avatar.mdx
@@ -79,8 +79,7 @@ Make avatars square by using the `.rounded-0` class, removing any rounded edges 
   <div class="avatar rounded-0 theme-secondary">CUI</div>
   <div class="avatar rounded-0 theme-warning">CUI</div>`} />
 
-## Sizes
-
+## Sizing
 Adjust the size of avatars using the `.avatar-sm`, `.avatar-md`, `.avatar-lg`, and `.avatar-xl` classes for larger or smaller versions.
 <Example code={`<div class="avatar avatar-xl">CUI</div>
   <div class="avatar avatar-lg">CUI</div>

--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -129,8 +129,7 @@ With a theme colour the text takes it, and the fill that appears on hover takes 
 
 <Example code={getData('theme-colors').map((c) => `<button type="button" class="btn-subtle theme-${c.name}">${c.title}</button>`)} />
 
-## Sizes
-
+## Sizing
 Larger or smaller buttons? Add `.btn-xs`, `.btn-sm` or `.btn-lg` for additional sizes.
 
 <Example code={`<button type="button" class="btn-solid theme-primary btn-lg">Large button</button>
@@ -163,8 +162,7 @@ You can even roll your own custom sizing with CSS variables:
 
 <Example code={getData('theme-colors').map((c) => `<button type="button" class="btn-solid theme-${c.name} rounded-0">${c.title}</button>`)} />
 
-## Disabled state
-
+## Disabled
 Add the `disabled` boolean attribute to any `<button>` element to make buttons look inactive. Disabled button has `pointer-events: none` applied to, disabling hover and active states from triggering.
 
 <Example code={`<button type="button" class="btn-solid theme-primary btn-lg" disabled>Primary button</button>

--- a/docs/src/content/docs/components/chip.mdx
+++ b/docs/src/content/docs/components/chip.mdx
@@ -127,8 +127,7 @@ Add `.active` to make chips use the solid appearance (bg/contrast). This is usef
     <span class="chip chip-success active">Active</span>
   </div>`} />
 
-## Sizes
-
+## Sizing
 Use `.chip-sm` or `.chip-lg` for different sizes.
 
 <Example code={`<div class="d-flex flex-wrap gap-1 mb-3">

--- a/docs/src/content/docs/components/close-button.mdx
+++ b/docs/src/content/docs/components/close-button.mdx
@@ -12,8 +12,7 @@ Provide an option to dismiss or close a component with `.btn-close`. The icon is
 
 <Example code={`<button type="button" class="btn-close" aria-label="Close"></button>`} />
 
-## Disabled state
-
+## Disabled
 Disabled close buttons change their `opacity`. We've also applied `pointer-events: none` and `user-select: none` to preventing hover and active states from triggering.
 
 <Example code={`<button type="button" class="btn-close" disabled aria-label="Close"></button>`} />

--- a/docs/src/content/docs/forms/autocomplete.mdx
+++ b/docs/src/content/docs/forms/autocomplete.mdx
@@ -163,8 +163,7 @@ Apply validation styling to indicate input validity.
 
 <Example pro code={`<div data-coreui-toggle="autocomplete" data-coreui-options="Angular, Bootstrap, React.js, Vue.js" data-coreui-placeholder="Invalid autocomplete..." data-coreui-invalid="true"></div>`} />
 
-## Disabled state
-
+## Disabled
 Add the `data-coreui-disabled="true"` attribute to disable the component:
 
 <Example pro code={`<div data-coreui-toggle="autocomplete" data-coreui-disabled="true" data-coreui-options="" data-coreui-placeholder="Disabled autocomplete..." ></div>`} />

--- a/docs/src/content/docs/forms/checkbox.mdx
+++ b/docs/src/content/docs/forms/checkbox.mdx
@@ -81,8 +81,7 @@ There is no inline modifier: the control is an inline element, so a row is a fle
     </div>
   </div>`} />
 
-## Sizes
-
+## Sizing
 `.check-sm` and `.check-lg` size the whole row — the box, its label, and the space they sit in. Each sets one font size: the box is `1em`, so it follows, and so does the alignment margin, which is computed from the line. Nothing needs re-tuning per size, and a size of your own is one custom property.
 
 <Example code={`<div class="d-flex align-items-start gap-3">

--- a/docs/src/content/docs/forms/chip-input.mdx
+++ b/docs/src/content/docs/forms/chip-input.mdx
@@ -74,8 +74,7 @@ The JavaScript below initializes the example:
 
 <Code code={chipVariants} lang="js" />
 
-## Sizes
-
+## Sizing
 Use `chip-input-sm` and `chip-input-lg` to match surrounding form controls. Default size is provided by `.chip-input` without a size modifier.
 
 <Example code={`<div class="chip-input chip-input-sm mb-3" data-coreui-chip-input data-coreui-placeholder="Add small tag...">

--- a/docs/src/content/docs/forms/input-group.mdx
+++ b/docs/src/content/docs/forms/input-group.mdx
@@ -289,6 +289,16 @@ Input groups include support for custom selects and custom file inputs. Browser 
 
 ## Customizing
 
+### CSS variables
+
+The addon declares its own tokens on `.input-group-text`, so a single addon can be repainted or resized without a modifier class. `.input-group` itself declares none — it is a layout wrapper.
+
+<ScssDocs file="scss/forms/_input-group.scss" capture="input-group-tokens" />
+
+```html
+<span class="input-group-text" style="--cui-input-group-addon-bg: var(--cui-bg-1);">@</span>
+```
+
 ### SASS variables
 
 <DeprecatedIn version="6.0.0" />

--- a/docs/src/content/docs/forms/layout.mdx
+++ b/docs/src/content/docs/forms/layout.mdx
@@ -271,7 +271,7 @@ You can then remix that once again with size-specific column classes.
 
 ## Inline forms
 
-Use the `.row-cols-*` classes to create responsive horizontal layouts. By adding [gutter modifier classes](/layout/gutters/), we'll have gutters in horizontal and vertical directions. On narrow mobile viewports, the `.col-12` helps stack the form controls and more. The `.align-items-center` aligns the form elements to the middle, making the `.form-checkbox` align properly.
+Use the `.row-cols-*` classes to create responsive horizontal layouts. By adding [gutter modifier classes](/layout/gutters/), we'll have gutters in horizontal and vertical directions. On narrow mobile viewports, the `.col-12` helps stack the form controls and more. The `.align-items-center` aligns the form elements to the middle, making the `.form-check` align properly.
 
 <Example code={`<form class="row row-cols-lg-auto g-3 align-items-center">
     <div class="col-12">

--- a/docs/src/content/docs/forms/multi-select.mdx
+++ b/docs/src/content/docs/forms/multi-select.mdx
@@ -574,7 +574,7 @@ myMutliSelect.addEventListener('changed.coreui.multi-select', event => {
 
 ### CSS variables
 
-MultiSelects use local CSS variables on `.multi-select` for enhanced real-time customization.
+MultiSelects use local CSS variables on `.form-multi-select` for enhanced real-time customization.
 
 <ScssDocs file="scss/forms/_form-multi-select.scss" capture="form-multi-select-css-vars" />
 

--- a/docs/src/content/docs/forms/number-input.mdx
+++ b/docs/src/content/docs/forms/number-input.mdx
@@ -52,8 +52,7 @@ on the input would put the margin inside the border.
 <Example pro code={`<input type="number" class="form-control form-control-sm mb-3" value="3" aria-label="Quantity" data-coreui-toggle="number-input">
   <input type="number" class="form-control form-control-lg" value="3" aria-label="Quantity" data-coreui-toggle="number-input">`} />
 
-## Disabled state
-
+## Disabled
 <Example pro code={`<input type="number" class="form-control" value="3" aria-label="Quantity" disabled data-coreui-toggle="number-input">`} />
 
 ## Inside your own group

--- a/docs/src/content/docs/forms/otp-input.mdx
+++ b/docs/src/content/docs/forms/otp-input.mdx
@@ -234,8 +234,7 @@ One-time password input supports different sizes. You may choose from small, nor
     </div>
   </div>`} />
 
-## Disabled state
-
+## Disabled
 Disable the entire one-time password input by adding the `data-coreui-disabled="true"` attribute.
 
 <Example pro code={`<label class="form-label">Disabled OTP input</label>

--- a/docs/src/content/docs/forms/password-input.mdx
+++ b/docs/src/content/docs/forms/password-input.mdx
@@ -30,8 +30,7 @@ Bootstrap Password Input supports different sizes using Bootstrap's sizing utili
   <input type="password" class="form-control" placeholder="Default password input" data-coreui-toggle="password-input">
   <input type="password" class="form-control form-control-sm" placeholder="Small password input" data-coreui-toggle="password-input">`} />
 
-## Disabled state
-
+## Disabled
 To make a Bootstrap Password Input non-interactive, add the `disabled` attribute to the `<input />` and the toggle `<button>`.
 
 <Example pro code={`<input type="password" class="form-control" placeholder="Disabled password input" disabled data-coreui-toggle="password-input">

--- a/docs/src/content/docs/forms/radio.mdx
+++ b/docs/src/content/docs/forms/radio.mdx
@@ -76,8 +76,7 @@ There is no inline modifier: the control is an inline element, so a row is a fle
     </div>
   </div>`} />
 
-## Sizes
-
+## Sizing
 `.radio-sm` and `.radio-lg` size the whole row — the box, its label, and the space they sit in. Each sets one font size: the box is `1em`, so it follows, and so does the alignment margin, which is computed from the line. Nothing needs re-tuning per size, and a size of your own is one custom property.
 
 <Example code={`<div class="d-flex align-items-start gap-3">

--- a/docs/src/content/docs/forms/rating.mdx
+++ b/docs/src/content/docs/forms/rating.mdx
@@ -71,8 +71,7 @@ For custom messages, provide a comma-separated list of tooltips corresponding to
 
 <Example pro code={`<div data-coreui-toggle="rating" data-coreui-tooltips="Very bad, Bad, Meh, Good, Very good" data-coreui-value="3"></div>`} />
 
-## Sizes
-
+## Sizing
 Larger or smaller rating component? Add `data-coreui-size="lg"` or `data-coreui-size="sm"` for additional sizes.
 
 <Example pro code={`<div data-coreui-size="sm" data-coreui-toggle="rating" data-coreui-value="3"></div>

--- a/docs/src/content/docs/forms/switch.mdx
+++ b/docs/src/content/docs/forms/switch.mdx
@@ -36,8 +36,7 @@ Add `role="switch"` to convey the nature of the control to assistive technologie
     <label for="flexSwitchCheckCheckedDisabled">Disabled checked switch checkbox input</label>
   </div>`} />
 
-## Sizes
-
+## Sizing
 `.switch-sm`, `.switch-lg` and `.switch-xl` size the whole row — the track, its thumb, and the label beside it — the way [`.check-sm`](/forms/checkbox/#sizes) and [`.radio-lg`](/forms/radio/#sizes) do.
 
 Each sets **one** custom property. The track's width follows its height through the aspect ratio, the thumb follows the height minus the padding, and the alignment margin is computed from the line — so nothing needs re-tuning per size.

--- a/docs/src/content/docs/utilities/border-radius.mdx
+++ b/docs/src/content/docs/utilities/border-radius.mdx
@@ -21,8 +21,7 @@ Add classes to an element to easily round its corners.
   <svg class="docs-placeholder-img rounded-start-pill" width="75" height="75" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Example left rounded pill image" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Example left rounded pill image</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
   <svg class="docs-placeholder-img rounded-5 rounded-top-0" width="75" height="75" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Example extra large bottom rounded image" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Example extra large bottom rounded image</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>`} />
 
-## Sizes
-
+## Sizing
 Use the scaling classes for larger or smaller rounded corners. Sizes range from `0` to `5` including `circle` and `pill`, and can be configured by modifying the utilities API.
 
 <Example class="docs-example-rounded-utils" code={`<svg class="docs-placeholder-img rounded-0" width="75" height="75" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Example non-rounded image" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Example non-rounded image</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>


### PR DESCRIPTION
From closing out the `forms/` batch (§5b) — the part of the audit that had only been done mechanically. These are the findings that were ready to fix; the rest are recorded in the audit for a decision.

## One name per repeated section

Sibling pages carried two names for the same section:

| | count | pages |
| --- | --- | --- |
| `## Sizing` | 14 | date-input, form-control, input-group, otp-input, select, … |
| `## Sizes` | 5 | checkbox, chip-input, radio, rating, switch |
| `## Disabled` | 16 | |
| `## Disabled state` | 4 | autocomplete, number-input, otp-input, password-input |

The split runs along component families, not along any difference in content. That is not cosmetic for the same reason `## Customizing` was not (#884): the heading is the anchor in the URL and the section name the docs MCP reads, so two pages documenting the same thing were addressable two different ways.

Normalized tree-wide to the majority spelling — 9 × `## Sizes`, 6 × `## Disabled state`. No page linked to either anchor, so nothing needed repointing.

## A section that was referred to but did not exist

`forms/input-group`'s `## Customizing` held only `### SASS variables`, and its deprecation note reads *"The CSS variables above reach the same values"* — pointing at nothing.

The tokens are real: `.input-group-text` declares ten of them (`dist/css/coreui.css:4171`), and `scss/forms/_input-group.scss` already carries the `input-group-tokens` block for the docs to cite. The section now leads `## Customizing`, per the convention that runtime tokens come before build-time knobs, and names the element that carries them — `.input-group` declares none, it is a layout wrapper.

## Two class names in prose

- `forms/layout`: *"making the `.form-checkbox` align properly"* — no such class is emitted; the example uses `.form-check`.
- `forms/multi-select`: *"local CSS variables on `.multi-select`"* — they are declared on `.form-multi-select` (`dist/css/coreui.css:3841`), which is also what the `<ScssDocs>` block under the sentence shows.

## Gate

`npm run docs-build` green, 172 pages, no broken links.