### PR TITLE
docs(forms): point Sizing at the frame for Autocomplete and Multi Select

### DIFF
--- a/docs/src/content/docs/forms/autocomplete.mdx
+++ b/docs/src/content/docs/forms/autocomplete.mdx
@@ -171,10 +171,10 @@ Add the `data-coreui-disabled="true"` attribute to disable the component:
 
 ## Sizing
 
-You may also choose from small and large auto completes to match our similarly sized text inputs.
+The frame carries the size. Add `.form-control-sm` or `.form-control-lg` to the element you initialize — it becomes the `.form-control-group`, so the field matches our similarly sized text inputs.
 
 <Example pro class="d-flex flex-column gap-3" code={`<div 
-    class="autocomplete-lg"
+    class="form-control-lg"
     data-coreui-cleaner="true"
     data-coreui-highlight-options-on-search="true"
     data-coreui-indicator="true"
@@ -195,7 +195,7 @@ You may also choose from small and large auto completes to match our similarly s
     data-coreui-toggle="autocomplete"
   ></div>
   <div 
-    class="autocomplete-sm"
+    class="form-control-sm"
     data-coreui-cleaner="true"
     data-coreui-highlight-options-on-search="true"
     data-coreui-indicator="true"

--- a/docs/src/content/docs/forms/multi-select.mdx
+++ b/docs/src/content/docs/forms/multi-select.mdx
@@ -383,11 +383,11 @@ We use the following JavaScript to set up our multi-select:
 
 ## Sizing
 
-You may also choose from small and large multi selects to match our similarly sized text inputs.
+The frame carries the size. Add `.form-control-sm` or `.form-control-lg` to the `<select>` — the component copies the element's classes onto the `.form-control-group` it builds, so the field matches our similarly sized text inputs.
 
 <Example pro code={`<div class="row">
     <div class="col-md-6">
-      <select id="multiple-select-counter-lg" class="form-multi-select-lg mb-3" data-coreui-multi-select data-coreui-selection-type="counter" data-coreui-search="true">
+      <select id="multiple-select-counter-lg" class="form-control-lg mb-3" data-coreui-multi-select data-coreui-selection-type="counter" data-coreui-search="true">
         <option value="0">Angular</option>
         <option value="1">Bootstrap</option>
         <option value="2">React.js</option>
@@ -398,7 +398,7 @@ You may also choose from small and large multi selects to match our similarly si
           <option value="6">Node.js</option>
         </optgroup>
       </select>
-      <select id="multiple-select-counter-sm" class="form-multi-select-sm" data-coreui-multi-select data-coreui-selection-type="counter" data-coreui-search="true">
+      <select id="multiple-select-counter-sm" class="form-control-sm" data-coreui-multi-select data-coreui-selection-type="counter" data-coreui-search="true">
         <option value="0">Angular</option>
         <option value="1">Bootstrap</option>
         <option value="2">React.js</option>
@@ -411,7 +411,7 @@ You may also choose from small and large multi selects to match our similarly si
       </select>
     </div>
     <div class="col-md-6">
-      <select id="multiple-select-tags-lg" class="form-multi-select-lg mb-3" data-coreui-multi-select data-coreui-selection-type="tags" data-coreui-search="true">
+      <select id="multiple-select-tags-lg" class="form-control-lg mb-3" data-coreui-multi-select data-coreui-selection-type="tags" data-coreui-search="true">
         <option value="0">Angular</option>
         <option value="1">Bootstrap</option>
         <option value="2">React.js</option>
@@ -422,7 +422,7 @@ You may also choose from small and large multi selects to match our similarly si
           <option value="6">Node.js</option>
         </optgroup>
       </select>
-      <select id="multiple-select-tags-sm" class="form-multi-select-sm" data-coreui-multi-select data-coreui-selection-type="tags" data-coreui-search="true">
+      <select id="multiple-select-tags-sm" class="form-control-sm" data-coreui-multi-select data-coreui-selection-type="tags" data-coreui-search="true">
         <option value="0">Angular</option>
         <option value="1">Bootstrap</option>
         <option value="2">React.js</option>


### PR DESCRIPTION
Both `forms/autocomplete` and `forms/multi-select` taught size classes the build does not emit — `.autocomplete-lg/-sm` and `.form-multi-select-lg/-sm`. Every example in those two `## Sizing` sections therefore rendered at the default size, and a reader copying the snippet got nothing.

This is not a missing feature. `build/class-api-removals.json` already records the move for all four names: *"The frame is the size surface now: put `.form-control-sm` / `.form-control-lg` on the `.form-control-group`. The family-named class declared its tokens on the component root, where the frame's own declarations shadowed them - it never had an effect in v6."* The docs were the only thing left pointing at the old surface.

## What the frame does

`.form-control-group` is the element that declares the `--cui-control-*` block, and `.form-control-group.form-control-sm` / `.form-control-lg` reset that block wholesale — `min-height`, `padding-y`, `padding-x`, `font-size`, `border-radius`, plus the icon and action sizes.

Where the class goes differs per component, and the pages now say which:

- **Autocomplete** — the element you initialize *becomes* the frame, so the class goes straight on it.
- **Multi Select** — the component copies the `<select>`'s classes onto the frame it generates, so the class goes on the `<select>`.

## Changes

- `forms/autocomplete.mdx` — two example classes swapped, prose names the mechanism.
- `forms/multi-select.mdx` — four example classes swapped, prose names the mechanism.

Docs only; no SCSS or JS touched.

## Verification

- `npm run docs-build` — green, 172 pages, no broken links.
- Pre-push CI gate (lint → build → bundlewatch → tests) — green.