### PR TITLE
docs(forms): stop advertising Password Input and OTP Input as PRO

### DIFF
--- a/docs/src/content/docs/forms/otp-input.mdx
+++ b/docs/src/content/docs/forms/otp-input.mdx
@@ -1,5 +1,4 @@
 ---
-pro: true
 title: "Bootstrap 5 One Time Password (OTP) Input"
 name: "One Time Password (OTP) Input"
 description: "Create secure and user-friendly one-time password input fields with automatic navigation, paste support, validation, and customizable options for modern authentication flows."

--- a/docs/src/content/docs/forms/password-input.mdx
+++ b/docs/src/content/docs/forms/password-input.mdx
@@ -1,5 +1,4 @@
 ---
-pro: true
 title: "Bootstrap 5 Password Input"
 name: "Password Input"
 description: "Enhance your password input fields in Bootstrap with custom styles, sizing options, toggle visibility button, and more."

--- a/docs/src/data/sidebar.yml
+++ b/docs/src/data/sidebar.yml
@@ -162,14 +162,8 @@
         text: PRO
     - title: OTP Input
       to: /forms/otp-input/
-      badge:
-        color: danger
-        text: PRO
     - title: Password Input
       to: /forms/password-input/
-      badge:
-        color: danger
-        text: PRO
     - title: Radio
       to: /forms/radio/
     - title: Range


### PR DESCRIPTION
Password Input and OTP Input move to the free edition in v6 (recorded in the workspace free/pro split note). The pages describe v6, not the road to it, so they must stop selling two components that ship for free.

## Changes

- `forms/password-input.mdx` — `pro: true` dropped from frontmatter.
- `forms/otp-input.mdx` — `pro: true` dropped from frontmatter.
- `docs/src/data/sidebar.yml` — PRO badge removed from both entries.

## What `pro:` actually controls

I traced every read of the field before touching it. Page-level `pro: true` drives exactly two things, both in the engine `Shell.astro`:

1. Renders the "part of CoreUI PRO" upsell banner above the lead.
2. **Suppresses Carbon Ads** — `showAds = Boolean(ads?.code) && !pro`.

So these two pages stop being an upsell and start being ad-supported in the same move. That is the intended consequence of calling them free, but it is a visible change worth naming.

It does **not** affect sitemap, robots, SEO meta, `llms.txt`, `llms-full.txt`, per-page `.md`, or DocSearch — none of those read the field. Sidebar badges are authored by hand and are not derived from frontmatter, which is why they need the separate edit.

## What is deliberately NOT changed

The inline `<Example pro>` props stay. Despite the name, that prop is an unrelated mechanism: it selects which npm package the runnable sandbox installs (`@coreui/coreui-pro` vs `@coreui/coreui`). The code still lives only in `@coreui/coreui-pro` — the tree has not been cut yet — so flipping it would point every example on both pages at a package that does not contain the component. It flips when the split happens, not now.

## Verification

`npm run docs-build` green (172 pages, no broken links), then asserted against the built HTML with an untouched control page:

| page | PRO banner | Carbon Ads |
| --- | --- | --- |
| `forms/password-input` | gone | now shown |
| `forms/otp-input` | gone | now shown |
| `forms/multi-select` (control) | still there | still suppressed |