### PR TITLE
feat(FormControlGroup): add .form-control-text for static adornments

### DIFF
--- a/docs/src/content/docs/forms/form-control-group.mdx
+++ b/docs/src/content/docs/forms/form-control-group.mdx
@@ -38,6 +38,7 @@ result reads as a single field rather than a row of parts.
 | `.form-control-group` | The frame. |
 | `.form-control` | The editable inside it. |
 | `.form-control-icon` | Decoration — an icon and nothing more. It ignores pointer events, and can sit in the group on its own or inside an action. |
+| `.form-control-text` | Static text in the frame — a prefix or suffix like `https://`, `@` or `.00`. Inert and unselectable, so a click lands in the input and a drag over the field does not pick it up. |
 | `.form-control-action` | An interactive adornment: a real `<button>`. Give it an `aria-label`; it may hold a `.form-control-icon`. |
 | `.form-control-cleaner` | The action that clears the value. Styled like an action; showing and hiding it is the component's job, since only it knows whether the control holds a value. |
 
@@ -52,6 +53,44 @@ button's colour, which is how a validation state reaches it.
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path d="M.293.293a1 1 0 011.414 0L8 6.586 14.293.293a1 1 0 111.414 1.414L9.414 8l6.293 6.293a1 1 0 01-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 01-1.414-1.414L6.586 8 .293 1.707a1 1 0 010-1.414z"/></svg>
       </span>
     </button>
+  </div>`} />
+
+## Static text
+
+<AddedIn version="6.0.0" />
+
+Use `.form-control-text` for a fixed prefix or suffix that labels the value
+rather than changing it — a scheme, a unit, a currency. It is inert: pointer
+events pass through to the input, and the text cannot be selected, so
+double-clicking to select the value never catches the adornment instead.
+
+Which side it lands on is decided by where you put it, because the group is a
+flex row and follows DOM order. Write it before the input for a prefix, after
+for a suffix — there is no separate class for the end.
+
+<Example code={`<div class="form-control-group mb-3">
+    <span class="form-control-text">https://</span>
+    <input type="text" class="form-control" placeholder="example.com" aria-label="Website address">
+  </div>
+  <div class="form-control-group mb-3">
+    <span class="form-control-text">@</span>
+    <input type="text" class="form-control" placeholder="username" aria-label="Username">
+  </div>
+  <div class="form-control-group">
+    <span class="form-control-text">$</span>
+    <input type="text" class="form-control" placeholder="0" aria-label="Amount">
+    <span class="form-control-text">.00</span>
+  </div>`} />
+
+It combines with the other parts, and dims with the group when the field is
+disabled:
+
+<Example code={`<div class="form-control-group">
+    <span class="form-control-icon">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"/></svg>
+    </span>
+    <span class="form-control-text">USD</span>
+    <input type="text" class="form-control" value="1250" disabled aria-label="Amount">
   </div>`} />
 
 ## Sizing

--- a/scss/forms/_form-control-group.scss
+++ b/scss/forms/_form-control-group.scss
@@ -13,6 +13,7 @@ $form-control-group-icon-size:        1rem !default;
 $form-control-group-icon-size-sm:     .875rem !default;
 $form-control-group-icon-size-lg:     1.25rem !default;
 $form-control-group-icon-color:       var(--#{$prefix}fg-3) !default;
+$form-control-group-text-color:       var(--#{$prefix}fg-3) !default;
 $form-control-group-action-size:      1.5rem !default;
 $form-control-group-action-size-sm:   1.25rem !default;
 $form-control-group-action-size-lg:   1.75rem !default;
@@ -44,6 +45,7 @@ $form-control-group-tokens: defaults(
     --#{$prefix}control-group-gap: #{$form-control-group-gap},
     --#{$prefix}control-group-icon-size: #{$form-control-group-icon-size},
     --#{$prefix}control-group-icon-color: #{$form-control-group-icon-color},
+    --#{$prefix}control-group-text-color: #{$form-control-group-text-color},
     --#{$prefix}control-group-action-size: #{$form-control-group-action-size},
     --#{$prefix}control-group-action-color: #{$form-control-group-action-color},
     --#{$prefix}control-group-action-hover-color: #{$form-control-group-action-hover-color},
@@ -122,7 +124,8 @@ $form-control-group-tokens: defaults(
 
       > .form-control-action,
       > .form-control-cleaner,
-      > .form-control-icon {
+      > .form-control-icon,
+      > .form-control-text {
         pointer-events: none;
         opacity: var(--#{$prefix}control-group-disabled-opacity);
       }
@@ -168,6 +171,13 @@ $form-control-group-tokens: defaults(
       width: var(--#{$prefix}control-group-icon-size);
       height: var(--#{$prefix}control-group-icon-size);
     }
+  }
+
+  .form-control-text {
+    flex: 0 0 auto;
+    color: var(--#{$prefix}control-group-text-color);
+    pointer-events: none;
+    user-select: none;
   }
 
   .form-control-action,


### PR DESCRIPTION
The group could hold an icon (`.form-control-icon`), an interactive adornment (`.form-control-action`) and a cleaner (`.form-control-cleaner`) — but nothing for **fixed text**: `https://`, `@`, `.00`, `USD`.

With no class for it, the only way to put text in the frame was to abuse `.form-control-icon`. That class is styled for artwork — it sizes its `> svg` child and paints with the icon colour — so text placed in it inherited a colour meant for decoration and none of the metrics it needed.

## What this adds

`.form-control-text`, the missing inert part:

- `flex: 0 0 auto` — holds its width, matching how the other adornments sit in the row.
- `color: var(--cui-control-group-text-color)` — a new token.
- `pointer-events: none` — a click on the prefix lands in the input.
- `user-select: none` — double-clicking to select the value cannot catch `https://` instead, and dragging across the field does not lift the adornment into the selection.

It also joins the group's disabled block alongside the other adornments, so a disabled field dims as a whole instead of leaving the static text at full strength.

## Design decisions

**Its own colour token, not the icon's.** `--cui-control-group-text-color` defaults to the same `--cui-fg-3` as the icon, so nothing changes visually. But a prefix that *labels the value* and an icon that *decorates the field* are separate customization surfaces; sharing one token would mean restyling one silently moves the other. The token is declared on `.form-control-group` and read on the child, so it resolves normally and appears in the documented CSS-variable list.

**No end modifier.** `.form-control-group` is a flex row, so DOM order already decides the side: write the text before the input for a prefix, after it for a suffix. A separate class for the end would be a second way to express something the markup states, and the two could disagree.

## Docs

Same PR, per the "new class is not finished without docs" rule:

- New row in the **Parts** table on `forms/form-control-group`.
- New **Static text** section with `https://`, `@`, `$ … .00` examples, plus one showing it combined with an icon in a disabled field.

## Verification

- `npx stylelint scss/forms/_form-control-group.scss` — clean.
- `npm run css` — compiles; token verified declared once on the group and read once on the child in `dist/css/coreui.css`.
- `npm run css-test-class-api` — passed.
- `npm run docs-build` — green, 172 pages, no broken links.
- `npm run bundlewatch` — PASS on all 14 bundles (`coreui.css` 64.95KB < 66KB, `coreui.min.css` 59.99KB < 61KB). No ceiling raise needed.