### PR TITLE
docs(forms): show every control inside a form field

### DIFF
--- a/docs/src/content/docs/forms/autocomplete.mdx
+++ b/docs/src/content/docs/forms/autocomplete.mdx
@@ -34,6 +34,21 @@ A straightforward demonstration of how to implement a basic Bootstrap Autocomple
     data-coreui-value="React.js"
   ></div>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example pro code={`<div class="form-field">
+    <label for="autocompleteField" class="form-label">Framework</label>
+    <div
+      data-coreui-toggle="autocomplete"
+      data-coreui-id="autocompleteField"
+      data-coreui-options="Angular, Bootstrap, React.js, Vue.js"
+      data-coreui-placeholder="Search frameworks..."
+    ></div>
+    <div class="form-text">Start typing to filter the list.</div>
+  </div>`} />
+
 ## Data source
 
 Learn how to populate the autocomplete component with data from various sources, including arrays and objects, for dynamic content integration.

--- a/docs/src/content/docs/forms/checkbox.mdx
+++ b/docs/src/content/docs/forms/checkbox.mdx
@@ -111,9 +111,9 @@ A checkbox with no label text is the input on its own. Give it an accessible nam
 
 <Example code={`<input class="check" type="checkbox" id="checkboxNoLabel" value="" aria-label="...">`} />
 
-## Description
+## With form field
 
-[`.form-field`](/forms/field/) puts a description under the label and keeps validation feedback in the right place.
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
 
 <Example code={`<div class="form-field">
     <input class="check" type="checkbox" value="" id="fieldCheck">

--- a/docs/src/content/docs/forms/chip-input.mdx
+++ b/docs/src/content/docs/forms/chip-input.mdx
@@ -98,13 +98,13 @@ Start with just the input and let users add chips as they type.
 
 <Example code={`<div class="chip-input" data-coreui-chip-input data-coreui-name="tags" data-coreui-placeholder="Start typing tags..."></div>`} />
 
-## With label
+## With form field
 
-Use a standard form label for accessibility.
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place. The label goes inside the container as `.chip-input-label` — that is the one the component points at the text input it builds.
 
-<Example code={`<div class="mb-3">
-    <label class="form-label" for="techStackInput">Tech stack</label>
+<Example code={`<div class="form-field">
     <div class="chip-input" data-coreui-chip-input data-coreui-name="techStack" data-coreui-placeholder="Add package...">
+      <label class="chip-input-label" for="techStackInput">Tech stack</label>
       <span class="chip">Vue</span>
       <span class="chip">Vite</span>
     </div>

--- a/docs/src/content/docs/forms/date-input.mdx
+++ b/docs/src/content/docs/forms/date-input.mdx
@@ -28,6 +28,16 @@ By default, the section order and separators are derived from the user's locale,
 <Example pro code={`<label class="form-label" id="basicDateInputLabel">Delivery date</label>
   <div class="form-control form-date-time" data-coreui-date-input data-coreui-name="delivery-date"></div>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example pro code={`<div class="form-field">
+    <span class="form-label">Delivery date</span>
+    <div class="form-control form-date-time" data-coreui-date-input data-coreui-name="delivery-date"></div>
+    <div class="form-text">We deliver on working days only.</div>
+  </div>`} />
+
 ## Formats
 
 Set an explicit format with the `data-coreui-format` attribute. The parser accepts both dayjs/moment-style tokens (`DD`, `MM`, `YYYY`, `YY`) and date-fns/Unicode-style tokens (`dd`, `MM`, `yyyy`, `yy`), plus `ww` for ISO week numbers and `q` (numeric) or `QQQ` (`Q1`–`Q4`) for quarters, so you can reuse the format strings from the date library you already use. Any other character becomes a literal separator — a fixed, non-editable part of the mask — and text wrapped in single quotes is always a literal, even when it contains token letters (`'Week' ww` renders `Week 29`; escape a quote by doubling it, `''`).

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -148,6 +148,16 @@ to the year automatically.
     </div>
   </div>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example pro code={`<div class="form-field">
+    <span class="form-label">Delivery date</span>
+    <div data-coreui-locale="en-US" data-coreui-toggle="date-picker"></div>
+    <div class="form-text">We deliver on working days only.</div>
+  </div>`} />
+
 ## Sizing
 
 Set heights using the `data-coreui-size` attribute like `data-coreui-size="lg"`

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -110,6 +110,16 @@ The field masks narrow to quarter and year sections (`Q1 2026`).
     </div>
   </div>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example pro code={`<div class="form-field">
+    <span class="form-label">Reporting period</span>
+    <div data-coreui-locale="en-US" data-coreui-toggle="date-range-picker"></div>
+    <div class="form-text">Both dates are included in the report.</div>
+  </div>`} />
+
 ## Sizing
 
 <Example pro code={`<div class="row mb-3">

--- a/docs/src/content/docs/forms/date-time-input.mdx
+++ b/docs/src/content/docs/forms/date-time-input.mdx
@@ -22,6 +22,16 @@ Use an empty container with `data-coreui-date-time-input` to create a masked dat
 <Example pro code={`<label class="form-label">Appointment</label>
   <div class="form-control form-date-time" data-coreui-date-time-input data-coreui-name="appointment"></div>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example pro code={`<div class="form-field">
+    <span class="form-label">Appointment</span>
+    <div class="form-control form-date-time" data-coreui-date-time-input data-coreui-name="appointment"></div>
+    <div class="form-text">Local time, in your own time zone.</div>
+  </div>`} />
+
 ## Formats
 
 Combine [date tokens](/forms/date-input/#formats) and [time tokens](/forms/time-input/#formats) in one format string — including text month tokens (`MMM`, `MMMM`) with [letter matching](/forms/date-input/#month-names) and the AM/PM section.

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -58,6 +58,16 @@ keeps the day — so the popup does not auto-close.
     </div>
   </div>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example pro code={`<div class="form-field">
+    <span class="form-label">Appointment</span>
+    <div data-coreui-locale="en-US" data-coreui-toggle="date-time-picker"></div>
+    <div class="form-text">Local time, in your own time zone.</div>
+  </div>`} />
+
 ## Sizing
 
 <Example pro code={`<div class="row mb-3">

--- a/docs/src/content/docs/forms/form-control-group.mdx
+++ b/docs/src/content/docs/forms/form-control-group.mdx
@@ -147,6 +147,21 @@ the group when there is no single control to disable.
   assembled from parts inside a single frame.
 </Callout>
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example code={`<div class="form-field">
+    <label for="formControlGroupField" class="form-label">Search</label>
+    <div class="form-control-group">
+      <span class="form-control-icon">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M479.6 399.716l-81.084-81.084-62.368-25.767A175.014 175.014 0 0 0 368 192c0-97.047-78.953-176-176-176S16 94.953 16 192s78.953 176 176 176a175.034 175.034 0 0 0 101.619-32.377l25.7 62.2L400.4 479.6a56 56 0 1 0 79.2-79.884ZM48 192c0-79.4 64.6-144 144-144s144 64.6 144 144-64.6 144-144 144S48 271.4 48 192Zm408.971 264.284a24.028 24.028 0 0 1-33.942 0l-76.572-76.572-23.894-57.835 57.835 23.894 76.573 76.572a24.028 24.028 0 0 1 0 33.941Z"/></svg>
+      </span>
+      <input type="search" class="form-control" id="formControlGroupField" placeholder="Search…">
+    </div>
+    <div class="form-text">Searches titles and body text.</div>
+  </div>`} />
+
 ## Where it is used
 
 Every CoreUI field component builds on it, which is why they all size, focus

--- a/docs/src/content/docs/forms/form-control.mdx
+++ b/docs/src/content/docs/forms/form-control.mdx
@@ -18,6 +18,16 @@ otherFrameworks:
     <textarea class="form-control" id="exampleFormControlTextarea1" rows="3"></textarea>
   </div>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example code={`<div class="form-field">
+    <label for="formControlField" class="form-label">Email address</label>
+    <input type="email" class="form-control" id="formControlField" placeholder="name@example.com">
+    <div class="form-text">We'll never share your email with anyone else.</div>
+  </div>`} />
+
 ## Sizing
 
 Set heights using classes like `.form-control-lg` and `.form-control-sm`.

--- a/docs/src/content/docs/forms/input-group.mdx
+++ b/docs/src/content/docs/forms/input-group.mdx
@@ -43,6 +43,19 @@ Place one add-on or button on either side of an input. You may also place one on
     <textarea class="form-control" aria-label="With textarea"></textarea>
   </div>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example code={`<div class="form-field">
+    <label for="inputGroupField" class="form-label">Your vanity URL</label>
+    <div class="input-group">
+      <span class="input-group-text">https://example.com/users/</span>
+      <input type="text" class="form-control" id="inputGroupField">
+    </div>
+    <div class="form-text">Choose a unique name for your profile.</div>
+  </div>`} />
+
 ## Wrapping
 
 Input groups wrap by default via `flex-wrap: wrap` in order to accommodate custom form field validation within an input group. You may disable this with `.flex-nowrap`.

--- a/docs/src/content/docs/forms/multi-select.mdx
+++ b/docs/src/content/docs/forms/multi-select.mdx
@@ -41,6 +41,21 @@ A straightforward demonstration of how to implement a basic Bootstrap Multi Sele
     </optgroup>
   </select>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example pro code={`<div class="form-field">
+    <label for="multiSelectField" class="form-label">Technologies</label>
+    <select id="multiSelectField" data-coreui-multi-select multiple>
+      <option value="0">Angular</option>
+      <option value="1">Bootstrap</option>
+      <option value="2">React.js</option>
+      <option value="3">Vue.js</option>
+    </select>
+    <div class="form-text">Pick every technology you work with.</div>
+  </div>`} />
+
 ## Data source
 
 Learn how to populate the multi-select component with data from various sources, including arrays and objects, for dynamic content integration.

--- a/docs/src/content/docs/forms/number-input.mdx
+++ b/docs/src/content/docs/forms/number-input.mdx
@@ -22,6 +22,16 @@ adds the buttons — you write neither the frame, the buttons nor their icons.
 
 <Example pro code={`<input type="number" class="form-control" value="3" aria-label="Quantity" data-coreui-toggle="number-input">`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example pro code={`<div class="form-field">
+    <label for="numberInputField" class="form-label">Quantity</label>
+    <input type="number" class="form-control" id="numberInputField" value="3" data-coreui-toggle="number-input">
+    <div class="form-text">Up to ten items per order.</div>
+  </div>`} />
+
 ## Min, max and step
 
 `min`, `max` and `step` are the native attributes — the component does not

--- a/docs/src/content/docs/forms/otp-input.mdx
+++ b/docs/src/content/docs/forms/otp-input.mdx
@@ -20,6 +20,23 @@ Use the `form-otp` wrapper with `data-coreui-toggle="otp"` to create an one-time
     <input class="form-otp-control">
   </div>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example pro code={`<div class="form-field">
+    <span class="form-label">Verification code</span>
+    <div class="form-otp" data-coreui-toggle="otp" data-coreui-name="otpField">
+      <input class="form-otp-control">
+      <input class="form-otp-control">
+      <input class="form-otp-control">
+      <input class="form-otp-control">
+      <input class="form-otp-control">
+      <input class="form-otp-control">
+    </div>
+    <div class="form-text">We sent it to your phone a moment ago.</div>
+  </div>`} />
+
 ## One-time password types
 
 The one-time password input supports different input types for various use cases.

--- a/docs/src/content/docs/forms/password-input.mdx
+++ b/docs/src/content/docs/forms/password-input.mdx
@@ -21,6 +21,16 @@ toggle — you write neither the frame, the button nor its icon.
     <input type="password" class="form-control" id="examplePasswordInput2" placeholder="Enter your password" value="Top secret" data-coreui-toggle="password-input">
   </div>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example pro code={`<div class="form-field">
+    <label for="passwordInputField" class="form-label">Password</label>
+    <input type="password" class="form-control" id="passwordInputField" placeholder="Enter your password" data-coreui-toggle="password-input">
+    <div class="form-text">At least 12 characters.</div>
+  </div>`} />
+
 ## Sizing variants
 
 Bootstrap Password Input supports different sizes using Bootstrap's sizing utilities like `.form-control-lg` and `.form-control-sm`.

--- a/docs/src/content/docs/forms/password-strength.mdx
+++ b/docs/src/content/docs/forms/password-strength.mdx
@@ -223,6 +223,17 @@ The built-in scorer returns `0` when the password contains any of these values
 (three characters or more, case-insensitive). A custom scorer receives the same
 list as its second argument and decides for itself — zxcvbn takes it directly.
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place. The meter is a child of the field like any other, so it picks up the same gap.
+
+<Example pro code={`<div class="form-field">
+    <label for="strengthField" class="form-label">Password</label>
+    <input type="password" class="form-control" id="strengthField" data-coreui-toggle="password-input" placeholder="Type a password…">
+    <div data-coreui-toggle="password-strength" data-coreui-input="#strengthField"></div>
+    <div class="form-text">At least 12 characters.</div>
+  </div>`} />
+
 ## Accessibility
 
 - The segmented bar is `aria-hidden`, because it carries no information the

--- a/docs/src/content/docs/forms/radio.mdx
+++ b/docs/src/content/docs/forms/radio.mdx
@@ -106,7 +106,7 @@ A radio with no label text is the input on its own. Give it an accessible name s
 
 <Example code={`<input class="radio" type="radio" name="radioNoLabel" id="radioNoLabel1" value="" aria-label="...">`} />
 
-## With a form field
+## With form field
 
 Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place. Nest one `.form-field` per radio inside an outer one to give the whole group a shared label.
 

--- a/docs/src/content/docs/forms/range-slider.mdx
+++ b/docs/src/content/docs/forms/range-slider.mdx
@@ -36,6 +36,16 @@ Create a simple range slider with default settings.
 
 <Example pro code={`<div data-coreui-toggle="range-slider" data-coreui-value="50"></div>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example pro code={`<div class="form-field">
+    <span class="form-label">Budget</span>
+    <div data-coreui-toggle="range-slider" data-coreui-value="25, 75" data-coreui-aria-labels='["Minimum budget", "Maximum budget"]'></div>
+    <div class="form-text">Monthly spend, in thousands.</div>
+  </div>`} />
+
 ## Multiple handles
 
 Enable multiple handles to allow the selection of a range or/and multiple values.

--- a/docs/src/content/docs/forms/range.mdx
+++ b/docs/src/content/docs/forms/range.mdx
@@ -15,6 +15,16 @@ Create custom `<input type="range" />` controls with `.form-range`. The track (t
 <Example code={`<label for="customRange1" class="form-label">Example range</label>
   <input type="range" class="form-range" id="customRange1">`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example code={`<div class="form-field">
+    <label for="rangeField" class="form-label">Volume</label>
+    <input type="range" class="form-range" id="rangeField">
+    <div class="form-text">Applies to notification sounds only.</div>
+  </div>`} />
+
 ## Disabled
 
 Add the `disabled` boolean attribute on an input to give it a grayed out appearance and remove pointer events.

--- a/docs/src/content/docs/forms/rating.mdx
+++ b/docs/src/content/docs/forms/rating.mdx
@@ -18,6 +18,16 @@ Embed the Rating component in your HTML by using a `div` with `data-coreui-toggl
 
 <Example pro code={`<div data-coreui-toggle="rating" data-coreui-value="3"></div>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example pro code={`<div class="form-field">
+    <span class="form-label" id="ratingFieldLabel">Overall rating</span>
+    <div data-coreui-toggle="rating" data-coreui-value="3" aria-labelledby="ratingFieldLabel"></div>
+    <div class="form-text">Tell us how the delivery went.</div>
+  </div>`} />
+
 ## Allow clear
 
 Enable users to clear their selected rating by clicking on the current rating again. This functionality is activated by setting `data-coreui-allow-clear="true"`.

--- a/docs/src/content/docs/forms/select.mdx
+++ b/docs/src/content/docs/forms/select.mdx
@@ -17,6 +17,21 @@ A `<select>` takes `.form-control`, the same class as every other form control â
     <option value="3">Three</option>
   </select>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example code={`<div class="form-field">
+    <label for="selectField" class="form-label">Country</label>
+    <select class="form-control" id="selectField">
+      <option selected>Choose oneâ€¦</option>
+      <option value="1">United States</option>
+      <option value="2">Canada</option>
+      <option value="3">United Kingdom</option>
+    </select>
+    <div class="form-text">We ship to these three for now.</div>
+  </div>`} />
+
 ## Sizing
 
 `.form-control-sm` and `.form-control-lg` size a select exactly as they size a text input.

--- a/docs/src/content/docs/forms/switch.mdx
+++ b/docs/src/content/docs/forms/switch.mdx
@@ -66,15 +66,13 @@ Any other size is that one property:
 
 The proportion is a Sass variable, `$switch-aspect-ratio`, so a squarer or longer track is set once for every size.
 
-## Description
+## With form field
 
 Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
 
 <Example code={`<div class="form-field">
-    <div class="form-field">
     <input class="switch" type="checkbox" role="switch" id="fieldSwitch">
     <label for="fieldSwitch">Email notifications</label>
-  </div>
     <div class="form-text">Turn this off and we will only contact you about your account.</div>
   </div>`} />
 

--- a/docs/src/content/docs/forms/time-input.mdx
+++ b/docs/src/content/docs/forms/time-input.mdx
@@ -22,6 +22,16 @@ Use an empty container with `data-coreui-time-input` to create a masked time fie
 <Example pro code={`<label class="form-label">Meeting time</label>
   <div class="form-control form-date-time" data-coreui-time-input data-coreui-name="meeting-time"></div>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example pro code={`<div class="form-field">
+    <span class="form-label">Meeting time</span>
+    <div class="form-control form-date-time" data-coreui-time-input data-coreui-name="meeting-time"></div>
+    <div class="form-text">Local time, in your own time zone.</div>
+  </div>`} />
+
 ## Formats
 
 Set an explicit format with the `data-coreui-format` attribute: `HH`/`H` for the 23-hour cycle, `hh`/`h` for the 12-hour cycle, `mm` for minutes, `ss` for seconds, and `A`/`a` for the day period. Type `a` or `p` in the AM/PM section to switch it, or use the arrow keys.

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -56,6 +56,16 @@ child. Buttons act through `data-coreui-picker-action` (`now`, `clear`, `reset`,
     </div>
   </div>`} />
 
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example pro code={`<div class="form-field">
+    <span class="form-label">Meeting time</span>
+    <div data-coreui-locale="en-US" data-coreui-toggle="time-picker"></div>
+    <div class="form-text">Local time, in your own time zone.</div>
+  </div>`} />
+
 ## Sizing
 
 <Example pro code={`<div class="row mb-3">


### PR DESCRIPTION
## What this changes

Every control page under `forms/` now has a **`## With form field`** section: the control composed with its label and description in a single `.form-field` block. Until now that composition was documented only on `/forms/field/`, so a reader on the control page saw the control alone and had to leave the page to find out how to assemble the thing they actually needed.

- **21 pages gain the section**: autocomplete, date input, date picker, date range picker, date time input, date time picker, form control, form control group, input group, multi select, number input, OTP input, password input, password strength, range, range slider, rating, select, time input, time picker, and chip input (whose `With label` section became this one).
- **3 pages already had it under different headings** — checkbox and switch called it `Description`, radio called it `With a form field`. All three now use the same heading and the same opening sentence as the other 21, so a future change to `.form-field` is one mechanical pass instead of 24 separate decisions.

Section shape is identical everywhere: heading, one sentence naming what `.form-field` does with a link to `/forms/field/`, one example. No page repeats what the field page explains.

## Defects fixed on the way

- **`switch.mdx`** nested a second `.form-field` inside the first and left the description outside it. In the two-column layout that put the description in the control column instead of under the label.
- **`chip-input.mdx`** pointed a `.form-label` at `for="techStackInput"`, an id no element carries. The component only wires a `.chip-input-label` **inside** the container to the text input it builds, so the label named nothing.

## Labelling rule applied

- Control with a labelable target (native input/select, or a component that accepts an id such as autocomplete's `data-coreui-id`) → `<label for>`.
- Control whose root is a `<div>` → `<span class="form-label">`, because `for` has nothing valid to point at.
- Rating exposes `role="radiogroup"`, so it is named with `aria-labelledby`.

## Deliberately skipped

`field` (the page being linked to), `overview`, `layout`, `validation` and `stepper` are not control pages. `floating-labels` is skipped on purpose: the pattern exists to put the label inside the control, so pairing it with a separate field label would contradict the page.

## Verification

- `npm run docs-build` — green, 173 pages, broken-link checker clean.
- Every class used in the new examples confirmed present in `dist/css/coreui.css`. `.chip-input-label` is the one exception and is correct: it is a JS-only selector with no CSS rules, already used across that page.
- `/forms/field/` link and the `#with-form-field` anchor confirmed in the built HTML on all 24 pages.
- vnu HTML validation green via the pre-push gate.