### PR TITLE
docs(PasswordStrength): say what the weights are for

### DIFF
--- a/docs/src/content/docs/forms/password-strength.mdx
+++ b/docs/src/content/docs/forms/password-strength.mdx
@@ -284,7 +284,27 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 | `userInputs` | array, function | `[]` | Values to penalize a password for containing, or a function returning them. |
 | `weights` | object | see below | Points the built-in scorer awards per rule. Ignored when `scorer` is set. |
 
-Default `weights`: `minLength`, `extraLength`, `longPassword`, `lowercase`, `uppercase`, `numbers`, `special` and `multipleSpecial`, each `1`.
+Each key in `weights` is one rule the built-in scorer checks, and its value is what a pass is worth. Set a rule to `0` to stop it counting — useful when a policy does not ask for that class of character and a meter demanding it would only mislead. Raise a value to make one rule outweigh the others.
+
+| Rule | Passes when the password |
+| --- | --- |
+| `minLength` | reaches `minLength` characters |
+| `extraLength` | reaches `minLength` + 4 |
+| `longPassword` | reaches 16 |
+| `lowercase` / `uppercase` / `numbers` | contains one |
+| `special` | contains a symbol |
+| `multipleSpecial` | contains two or more symbols |
+
+Every rule defaults to `1`, so out of the box the score is a count of rules passed, measured against `thresholds`.
+
+```js
+// Do not ask for an uppercase letter, and reward real length instead
+new coreui.PasswordStrength(element, {
+  weights: { uppercase: 0, longPassword: 3 }
+})
+```
+
+Three of the eight rules measure length and two measure symbols, so a short password dense with symbols can outscore a long passphrase. That is the composition problem the callout above describes; `scorer` is the way out of it, not these numbers.
 
 ### Methods
 


### PR DESCRIPTION
The option table pointed at a line that transcribed the config: eight rule names and the value `1` next to each. It named nothing a reader could act on — not what the rules check, not why anyone would change them.

Each key is now shown as the rule it stands for, with the two things worth knowing:

- **`0` stops a rule counting** — what a project reaches for when its policy does not ask for that class of character, and a meter demanding it would only mislead;
- **a higher value makes one rule outweigh the rest.**

```js
// Do not ask for an uppercase letter, and reward real length instead
new coreui.PasswordStrength(element, {
  weights: { uppercase: 0, longPassword: 3 }
})
```

## The closing sentence is the point

Three of the eight rules measure length and two measure symbols, so a short password dense with symbols can outscore a long passphrase. That is stated plainly rather than left for the reader to derive, and it points at `scorer` as the way out — instead of implying these numbers can be tuned into a real estimator. It sits under the callout that already says the built-in scorer is a UX hint and cites NIST SP 800-63B against composition rules, so the page now argues the same thing in both places.

The option itself stays. It has a real use, and dropping it would leave us behind a component that documents `uppercase: 0` as a supported way to relax a criterion.

## Verification

`npm run docs-build` — 173 pages, exit 0, no broken links. Checked the rendered HTML rather than the source: `_site/forms/password-strength/index.html` carries the `0` guidance and the closing paragraph. Full pre-push gate green.
