### PR TITLE
refactor(Alert, Badge, Avatar)!: make a component's own colour tokens reachable

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -27,13 +27,13 @@ $alert-tokens: () !default;
 // scss-docs-start alert-css-vars
 $alert-tokens: defaults(
   (
-    --#{$prefix}alert-bg: transparent,
+    --#{$prefix}alert-bg: var(--#{$prefix}theme-bg-subtle, transparent),
     --#{$prefix}alert-padding-x: #{$alert-padding-x},
     --#{$prefix}alert-padding-y: #{$alert-padding-y},
     --#{$prefix}alert-gap: #{$alert-gap},
     --#{$prefix}alert-margin-bottom: #{$alert-margin-bottom},
-    --#{$prefix}alert-color: inherit,
-    --#{$prefix}alert-border-color: transparent,
+    --#{$prefix}alert-color: var(--#{$prefix}theme-fg-emphasis, inherit),
+    --#{$prefix}alert-border-color: var(--#{$prefix}theme-border, transparent),
     --#{$prefix}alert-border-width: #{$alert-border-width},
     --#{$prefix}alert-border-radius: #{$alert-border-radius},
     --#{$prefix}alert-link-color: inherit,
@@ -67,9 +67,9 @@ $alert-variants: (
     align-items: start;
     padding: var(--#{$prefix}alert-padding-y) var(--#{$prefix}alert-padding-x);
     margin-bottom: var(--#{$prefix}alert-margin-bottom);
-    color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}alert-color));
-    background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}alert-bg));
-    border: var(--#{$prefix}alert-border-width) solid var(--#{$prefix}theme-border, var(--#{$prefix}alert-border-color));
+    color: var(--#{$prefix}alert-color);
+    background-color: var(--#{$prefix}alert-bg);
+    border: var(--#{$prefix}alert-border-width) solid var(--#{$prefix}alert-border-color);
     @include border-radius(var(--#{$prefix}alert-border-radius));
 
     // scss-docs-start alert-transition
@@ -130,10 +130,6 @@ $alert-variants: (
           --#{$prefix}alert-#{$property}: var(--#{$prefix}theme-#{$value});
         }
       }
-
-      color: var(--#{$prefix}alert-color);
-      background-color: var(--#{$prefix}alert-bg);
-      border-color: var(--#{$prefix}alert-border-color);
     }
   }
   // scss-docs-end alert-modifiers

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -33,8 +33,9 @@ $alert-tokens: defaults(
     --#{$prefix}alert-gap: #{$alert-gap},
     --#{$prefix}alert-margin-bottom: #{$alert-margin-bottom},
     --#{$prefix}alert-color: var(--#{$prefix}theme-fg-emphasis, inherit),
-    --#{$prefix}alert-border-color: var(--#{$prefix}theme-border, transparent),
+    --#{$prefix}alert-border-color: var(--#{$prefix}theme-border, var(--#{$prefix}border-color)),
     --#{$prefix}alert-border-width: #{$alert-border-width},
+    --#{$prefix}alert-border: var(--#{$prefix}alert-border-width) solid var(--#{$prefix}alert-border-color),
     --#{$prefix}alert-border-radius: #{$alert-border-radius},
     --#{$prefix}alert-link-color: inherit,
     --#{$prefix}alert-transition-property: #{$alert-transition-property},
@@ -69,7 +70,7 @@ $alert-variants: (
     margin-bottom: var(--#{$prefix}alert-margin-bottom);
     color: var(--#{$prefix}alert-color);
     background-color: var(--#{$prefix}alert-bg);
-    border: var(--#{$prefix}alert-border-width) solid var(--#{$prefix}alert-border-color);
+    border: var(--#{$prefix}alert-border);
     @include border-radius(var(--#{$prefix}alert-border-radius));
 
     // scss-docs-start alert-transition

--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -48,8 +48,8 @@ $avatar-tokens: () !default;
 $avatar-tokens: defaults(
   (
     --#{$prefix}avatar-size: #{$avatar-size},
-    --#{$prefix}avatar-color: #{$avatar-color},
-    --#{$prefix}avatar-bg: #{$avatar-bg},
+    --#{$prefix}avatar-color: var(--#{$prefix}theme-contrast, #{$avatar-color}),
+    --#{$prefix}avatar-bg: var(--#{$prefix}theme-bg, #{$avatar-bg}),
     --#{$prefix}avatar-border-radius: #{$avatar-border-radius},
     --#{$prefix}avatar-status-size: #{$avatar-status-size},
     --#{$prefix}avatar-status-border-radius: #{$avatar-status-border-radius},
@@ -83,9 +83,9 @@ $avatar-variants: (
     // Declared as a fallback rather than a token, so the derived size is the
     // default and an explicit one still wins.
     font-size: var(--#{$prefix}avatar-font-size, calc(var(--#{$prefix}avatar-size) * #{$avatar-font-size-ratio}));
-    color: var(--#{$prefix}theme-contrast, var(--#{$prefix}avatar-color));
+    color: var(--#{$prefix}avatar-color);
     vertical-align: middle;
-    background-color: var(--#{$prefix}theme-bg, var(--#{$prefix}avatar-bg));
+    background-color: var(--#{$prefix}avatar-bg);
     @include border-radius(var(--#{$prefix}avatar-border-radius));
     @include transition($avatar-transition);
   }

--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -55,7 +55,7 @@ $badge-tokens: defaults(
     --#{$prefix}badge-padding-y: #{$badge-padding-y},
     --#{$prefix}badge-font-size: clamp(#{$badge-font-size-floor}, #{$badge-font-size}, #{$badge-font-size}),
     --#{$prefix}badge-font-weight: #{$badge-font-weight},
-    --#{$prefix}badge-color: #{$badge-color},
+    --#{$prefix}badge-color: var(--#{$prefix}theme-contrast, #{$badge-color}),
     --#{$prefix}badge-bg: #{$badge-bg},
     --#{$prefix}badge-border-width: #{$badge-border-width},
     --#{$prefix}badge-border-color: #{$badge-border-color},
@@ -95,7 +95,7 @@ $badge-variants: (
     font-size: var(--#{$prefix}badge-font-size);
     font-weight: var(--#{$prefix}badge-font-weight);
     line-height: 1;
-    color: var(--#{$prefix}theme-contrast, var(--#{$prefix}badge-color));
+    color: var(--#{$prefix}badge-color);
     text-align: center;
     text-decoration: none;
     white-space: nowrap;


### PR DESCRIPTION
Reconnaissance on one component, so the shape can be judged before the same change is made in eighteen more.

## The defect

`.alert` read the theme slot first and its own token only as a fallback:

```scss
color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}alert-color));
```

`--cui-alert-color` is documented as the way to recolour an alert. It did nothing whenever the element also carried a theme class — which is the common case, since that is how alerts are coloured. The generic name beat the specific one.

Now the theme fallback lives in the token's default value and the property reads the token plainly:

```scss
--#{$prefix}alert-color: var(--#{$prefix}theme-fg-emphasis, inherit);
color: var(--#{$prefix}alert-color);
```

## The border gets one token, and a real default

`border` was composed at the point of use with the style written into the rule — `var(--alert-border-width) solid var(--alert-border-color)`. **Nothing in the library declares a border-style token; `solid` is hardcoded in forty such rules.** A project wanting a dashed alert had to override the whole `border` property and lose the token-driven width and colour with it. It is now `--cui-alert-border`, composed from the parts, so either level is reachable: the whole border, or just its colour.

The colour also falls back to `--cui-border-color` instead of `transparent`. An alert with no theme class rendered as padded text with no boundary; it now draws the same neutral line as every other bordered surface. **This is the one visual change in the PR** — themed alerts are untouched, because their `--cui-theme-border` always resolves and the fallback never fires.

## It also deletes a workaround

`.alert-solid` set its tokens and then re-declared `color`, `background-color` and `border-color` — not redundancy, but the only way to overpower the base rule. Setting the tokens is now enough. Every future variant is three lines shorter, and none of them has to know about this.

## Measured, not argued

Computed styles in Chromium against the built stylesheet, before and after:

| case | before → after |
| --- | --- |
| `.alert` | border `transparent` → `rgb(219, 223, 230)` — the intended change |
| `.alert-primary` | identical |
| `.alert-success` | identical |
| `.alert-primary.alert-solid` | identical |
| `.alert-solid` | identical |
| `.alert-primary` + `--cui-alert-color: red` | **ignored → red** |
| `.alert` + `--cui-alert-bg` (control) | works → works |
| `.alert-primary` + `--cui-alert-border: 3px dashed blue` | **ignored → applied** |
| `.alert-primary` + `--cui-alert-border-color` | **ignored → applied** |

Every themed case renders to the same values. Three tokens that were silently ignored now apply, and the plain alert gains the border described above.

Not adopted, and worth a separate call: `--cui-alert-bg` still falls back to `transparent`, where the reference implementation uses a subtle surface. That would give a plain alert a background as well — the same kind of decision as the border, but a louder one.

The compiled diff is three token defaults, three simplified reads and three deleted lines — nothing else moved.

## Why this is marked breaking

A project that set `--cui-alert-*` on a themed alert saw it ignored and will now see it take effect.

## Scope beyond this PR

The same inversion is in eighteen more files — `_list-group` and `_card` 11 each, `_pagination` and `_nav` 9, `_stepper` 7, `_toasts` and `_menu` 5, down to two apiece in the form controls. Same mechanical edit, but each needs its own before/after measurement, since a component whose variant relies on the current order would change appearance rather than keep it. That is the point of doing one first.

## Gates

`npx stylelint scss/_alert.scss` clean · bundlewatch PASS (`coreui.css` 65.27KB < 66KB) · full pre-push gate green.

Note for the reviewer: the visual suite passes, but it covers only the field components — there is no alert screenshot, so its green says nothing about this change. The Chromium measurement above is the evidence.

---

## Scope, measured — the sweep does not generalise

The first read of this said the same inversion belonged in eighteen more files. Measuring says otherwise, and the reason is worth writing down.

A sweep over the compiled stylesheet found every `property: var(--cui-theme-X, var(--cui-Y))` and asked **where `--cui-Y` is declared**. Three different shapes hide behind one grep:

| shape | count | verdict |
| --- | --- | --- |
| the fallback target is a **global** token (`--cui-fg-body`, `--cui-border-color`, `--cui-primary`, `--cui-focus-ring-color`) | most of them | **correct already** — this reads "the theme slot, else the page default". Nothing is shadowed |
| the component token is declared on a **wrapper** and read by a child — `--cui-list-group-color` on `.list-group` read by `.list-group-item`, `--cui-pagination-*` on `.pagination` read by `.page-link`, `--cui-card-cap-*` on `.card` read by `.card-header` | 105 reads | **must stay inverted.** Moving the fallback resolves it on the wrapper, so a theme class on the child stops working |
| the component declares and reads the token on the **same element** | alert, badge, avatar | the case this PR fixes |

Bootstrap v6 makes the same distinction rather than applying one shape everywhere: their alert carries the fallback in the token, their progress keeps the inverted read — because their `--bs-progress-bar-bg` also lives on the wrapper.

The middle row is not theory. The first attempt at this branch included `.progress`, and the probe caught `.progress-bar.theme-danger` rendering indigo instead of red: the token had been resolved on `.progress`, where `theme-danger` was not set. That component was reverted.

## Evidence

27 class combinations measured in Chromium against the built stylesheet, before and after — including regression checks on the components deliberately **not** changed (`progress-bar.theme-danger`, `list-group-item.theme-primary`, `card-header.theme-info`, `nav-link`, `page-link`).

**23 of 27 identical.** The four differences are the plain alert gaining its border, and `--cui-alert-color`, `--cui-badge-color`, `--cui-avatar-bg` taking effect on a themed element where they were previously ignored.

Gates: `stylelint` clean on all three files · bundlewatch PASS (65.26KB < 66KB) · `docs-build` 173 pages, no broken links.
