### PR TITLE
docs(pickers): document the option that names the control

### DIFF
--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -364,6 +364,7 @@ attributes work on the picker element too.
 | --- | --- | --- | --- |
 | `allowList` | object | `SVGAllowlist` | Allowlist used when sanitizing the icon markup. |
 | `ariaCleanerLabel` | string | `'Clear the value'` | Accessible label of the cleaner button. |
+| `ariaLabel` | string | `'Date input'` | Accessible name of the field. It lands on the `role="group"` container the sections sit in, so it names the whole control rather than one part of it. |
 | `ariaToggleLabel` | string | `'Toggle the calendar'` | Accessible label of the indicator button. |
 | `cleaner` | boolean | `true` | Renders a button that clears the value. It appears only once the field holds one. |
 | `cleanerIcon` | string | cross SVG | Inline SVG rendered by the component (sanitized). |

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -285,6 +285,7 @@ attributes work on the picker element too.
 | --- | --- | --- | --- |
 | `allowList` | object | `SVGAllowlist` | Allowlist used when sanitizing icon markup. |
 | `ariaCleanerLabel` | string | `'Clear the value'` | Accessible label of the cleaner button. |
+| `ariaLabel` | string | `'Date input'` | Accessible name of the fields. It lands on the `role="group"` container the sections sit in. **Both the start and the end field receive it**, so give each range its own name and expect the two halves to announce alike. |
 | `ariaToggleLabel` | string | `'Toggle the calendar'` | Accessible label of the indicator button. |
 | `cleaner` | boolean | `true` | Renders a button that clears the value. It appears only once the field holds one. |
 | `cleanerIcon` | string | cross SVG | Inline SVG rendered by the component (sanitized). |

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -145,6 +145,7 @@ Options belonging to the inner [calendar](/components/calendar/#options) or
 | --- | --- | --- | --- |
 | `allowList` | object | `SVGAllowlist` | Allowlist used when sanitizing the icon markup. |
 | `ariaCleanerLabel` | string | `'Clear the value'` | Accessible label of the cleaner button. |
+| `ariaLabel` | string | `'Date and time input'` | Accessible name of the field. It lands on the `role="group"` container the sections sit in, so it names the whole control rather than one part of it. |
 | `ariaToggleLabel` | string | `'Toggle the calendar'` | Accessible label of the indicator button. |
 | `cleaner` | boolean | `true` | Renders a button that clears the value. It appears only once the field holds one. |
 | `cleanerIcon` | string | cross SVG | Inline SVG rendered by the component (sanitized). |

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -198,6 +198,7 @@ forwarded by name, so their data attributes work on the picker element too.
 | --- | --- | --- | --- |
 | `allowList` | object | `SVGAllowlist` | Allowlist used when sanitizing the icon markup. |
 | `ariaCleanerLabel` | string | `'Clear the value'` | Accessible label of the cleaner button. |
+| `ariaLabel` | string | `'Time input'` | Accessible name of the field. It lands on the `role="group"` container the sections sit in, so it names the whole control rather than one part of it. |
 | `ariaToggleLabel` | string | `'Toggle the time selection'` | Accessible label of the indicator button. |
 | `cleaner` | boolean | `true` | Renders a button that clears the value. It appears only once the field holds one. |
 | `cleanerIcon` | string | cross SVG | Inline SVG rendered by the component (sanitized). |


### PR DESCRIPTION
The four pickers mount on a `<div>`, so `<label for>` has nothing to point at and the accessible name has to come from the component. `ariaLabel` already provides it — and it was in none of the four Options tables. The pages documented `ariaCleanerLabel` and `ariaToggleLabel`, the names of the two buttons, while the name of the field itself could only be found by knowing it was there.

## Verified in a browser, not read off the source

The option is not declared in any picker's `Default`. It works because `_forwardConfig` passes any key the inner primitive knows about, and `_typeCheckConfig` validates the keys it knows rather than rejecting the ones it does not. That is a thin thread to hang an accessibility feature on, so it was measured against the built bundle:

| picker | programmatic | `data-coreui-aria-label` | default | lands on |
| --- | --- | --- | --- | --- |
| DatePicker | ✓ | ✓ | `Date input` | `<div role="group">` |
| DateRangePicker | ✓ | ✓ | `Date input` | `<div role="group">` ×2 |
| DateTimePicker | ✓ | ✓ | `Date and time input` | `<div role="group">` |
| TimePicker | ✓ | ✓ | `Time input` | `<div role="group">` |

The structure underneath is sound: each section is separately named (`Month`, `Day`, `Year`, `Hour`, `Minute`, `AM/PM`) and both buttons carry their own labels. Only the documentation was missing.

## One defect found on the way, not fixed here

`DateRangePicker` applies the same name to **both** fields:

```
grupa 1: aria-label="Booking dates"   .form-control.form-date-time
grupa 2: aria-label="Booking dates"   .form-control.form-date-time
```

Someone moving from the start date to the end date hears the identical name twice, with nothing to tell them which is which. The range picker's row warns about it; the fix belongs in the component — probably a suffix per half, or a second option — and is a call rather than a cleanup.

## Verification

`npm run docs-build` — 173 pages, exit 0, no broken links; rows confirmed in the rendered HTML rather than the source.
