### PR TITLE
fix(DateRangePicker): give each half of the range its own name

### DIFF
--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -285,7 +285,7 @@ attributes work on the picker element too.
 | --- | --- | --- | --- |
 | `allowList` | object | `SVGAllowlist` | Allowlist used when sanitizing icon markup. |
 | `ariaCleanerLabel` | string | `'Clear the value'` | Accessible label of the cleaner button. |
-| `ariaLabel` | string | `'Date input'` | Accessible name of the fields. It lands on the `role="group"` container the sections sit in. **Both the start and the end field receive it**, so give each range its own name and expect the two halves to announce alike. |
+| `ariaLabels` | array | `['Start date', 'End date']` | Accessible name of each field, in order. Both halves are the same control, so naming them apart is what tells a screen reader which end of the range it is on. A shorter array leaves the remaining field on its default. |
 | `ariaToggleLabel` | string | `'Toggle the calendar'` | Accessible label of the indicator button. |
 | `cleaner` | boolean | `true` | Renders a button that clears the value. It appears only once the field holds one. |
 | `cleanerIcon` | string | cross SVG | Inline SVG rendered by the component (sanitized). |

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -71,6 +71,7 @@ const DEFAULT_SEPARATOR_ICON_RTL: string = '<svg xmlns="http://www.w3.org/2000/s
 type DateRangePickerConfig = {
   allowList: SanitizerAllowList
   ariaCleanerLabel: string
+  ariaLabels: string[]
   ariaToggleLabel: string
   cleaner: boolean
   cleanerIcon: string
@@ -97,6 +98,7 @@ type DateRangePickerConfig = {
 const Default: DateRangePickerConfig = {
   allowList: SVGAllowlist,
   ariaCleanerLabel: 'Clear the value',
+  ariaLabels: ['Start date', 'End date'],
   ariaToggleLabel: 'Toggle the calendar',
   cleaner: true,
   cleanerIcon: CLEANER_ICON,
@@ -123,6 +125,7 @@ const Default: DateRangePickerConfig = {
 const DefaultType: Record<string, string> = {
   allowList: 'object',
   ariaCleanerLabel: 'string',
+  ariaLabels: 'array',
   ariaToggleLabel: 'string',
   cleaner: 'boolean',
   cleanerIcon: 'string',
@@ -326,10 +329,18 @@ class DateRangePicker extends BaseComponent {
     return isRtl ? this._config.separatorIconRtl : this._config.separatorIcon
   }
 
-  _createInput(date: Date | null, name: string): any {
+  // Both halves are the same primitive, so without a name of its own each would
+  // announce identically and give no clue which end of the range it is.
+  _ariaLabel(index: number): string {
+    const labels = this._config.ariaLabels
+    return (Array.isArray(labels) && labels[index]) || (Default.ariaLabels as string[])[index]
+  }
+
+  _createInput(date: Date | null, name: string, ariaLabel: string): any {
     const inputEl = document.createElement('div')
 
     const input = new DateInput(inputEl, this._forwardConfig(DateInput, {
+      ariaLabel,
       date,
       disabled: this._config.disabled,
       locale: this._config.locale,
@@ -354,7 +365,7 @@ class DateRangePicker extends BaseComponent {
       inputGroup.classList.add(`${CLASS_NAME_FORM_CONTROL}-${this._config.size}`)
     }
 
-    const start = this._createInput(this._config.startDate, this._config.startName)
+    const start = this._createInput(this._config.startDate, this._config.startName, this._ariaLabel(0))
     this._startInput = start.input
     this._startInputElement = start.inputEl
     inputGroup.append(start.inputEl)
@@ -365,7 +376,7 @@ class DateRangePicker extends BaseComponent {
     separator.innerHTML = this._sanitizeIcon(this._resolveSeparatorIcon())
     inputGroup.append(separator)
 
-    const end = this._createInput(this._config.endDate, this._config.endName)
+    const end = this._createInput(this._config.endDate, this._config.endName, this._ariaLabel(1))
     this._endInput = end.input
     this._endInputElement = end.inputEl
     inputGroup.append(end.inputEl)


### PR DESCRIPTION
Stacked on #911 — merge that first, then this.

## The defect

Both fields of the range are the same primitive, and both received the same accessible name: `Date input` twice by default, and whatever `ariaLabel` was set to twice otherwise.

```
grupa 1: aria-label="Booking dates"   .form-control.form-date-time
grupa 2: aria-label="Booking dates"   .form-control.form-date-time
```

Someone moving from the start date to the end date heard the identical name and had nothing to tell them which end they were on. Everything else was already right — each section inside is separately named (`Month`, `Day`, `Year`) and both buttons carry their own labels.

## The fix

`ariaLabels` names the two fields in order, defaulting to `Start date` and `End date`, so the control is correct before anyone configures it.

**The array is the shape Range Slider already uses** for the same problem — a control whose parts each need a name (`ariaLabels: string[] | null`, read by index). A pair of single-purpose options would have invented a second pattern for a problem this library had already solved once.

It also stays translatable: each entry is a whole string. A shared name with a suffix glued on reads acceptably in English and falls apart in languages that inflect or reorder.

## Measured on the built bundle

| | result |
| --- | --- |
| default | `Start date` · `End date` |
| `ariaLabels: ['Zameldowanie', 'Wymeldowanie']` | both applied |
| short array `['Tylko pierwszy']` | first applied, second falls back to its default |
| `data-coreui-aria-labels='["Od","Do"]'` | both applied |

The short-array case matters: dropping a name would be worse than the bug being fixed, so a missing entry falls back rather than emptying the label.

## Docs

The `ariaLabel` row #911 adds to this page warned about the shared name. That warning is now false, so the row is replaced by `ariaLabels`.

## Verification

`npx eslint js/src/date-range-picker.ts` clean · `npm run js-test-unit` 3237 passed / 61 files · `npm run docs-build` 173 pages, no broken links · full pre-push gate green.
