### PR TITLE
docs: document the accessibility options that already work

### DIFF
--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -146,10 +146,14 @@ Options belonging to the inner [calendar](/components/calendar/#options) or
 | `allowList` | object | `SVGAllowlist` | Allowlist used when sanitizing the icon markup. |
 | `ariaCleanerLabel` | string | `'Clear the value'` | Accessible label of the cleaner button. |
 | `ariaLabel` | string | `'Date and time input'` | Accessible name of the field. It lands on the `role="group"` container the sections sit in, so it names the whole control rather than one part of it. |
+| `ariaSelectHoursLabel` | string | `'Select hours'` | Accessible name of the hours select in the panel. |
+| `ariaSelectMeridiemLabel` | string | `'Select AM/PM'` | Accessible name of the AM/PM select in the panel. |
+| `ariaSelectMinutesLabel` | string | `'Select minutes'` | Accessible name of the minutes select in the panel. |
+| `ariaSelectSecondsLabel` | string | `'Select seconds'` | Accessible name of the seconds select in the panel. |
 | `ariaToggleLabel` | string | `'Toggle the calendar'` | Accessible label of the indicator button. |
+| `calendarOptions` | object | `{}` | Programmatic escape hatch for calendar options. |
 | `cleaner` | boolean | `true` | Renders a button that clears the value. It appears only once the field holds one. |
 | `cleanerIcon` | string | cross SVG | Inline SVG rendered by the component (sanitized). |
-| `calendarOptions` | object | `{}` | Programmatic escape hatch for calendar options. |
 | `container` | string, element, false | `false` | Teleport target for the dropdown. |
 | `date` | date, string, null | `null` | Initial value (date **and** time). |
 | `disabled` | boolean | `false` | Disables the field and the popup. |

--- a/docs/src/content/docs/forms/multi-select.mdx
+++ b/docs/src/content/docs/forms/multi-select.mdx
@@ -498,6 +498,7 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 | --- | --- | --- | --- |
 | `allowList` | object | `DefaultAllowlist` | Object containing allowed tags and attributes for HTML sanitization when using custom templates. |
 | `ariaCleanerLabel`| string | `Clear all selections` | A string that provides an accessible label for the cleaner button. This label is read by screen readers to describe the action associated with the button. |
+| `ariaIndicatorLabel` | string | `'Toggle visibility of options menu'` | Accessible label of the indicator button. |
 | `ariaSearchLabel`| string | `Search` | Accessible label for the search input (when `search` is enabled). |
 | `ariaTagDeleteLabel`| string | `Remove` | Accessible label prefix for a tag's delete button (selection type `tags`). The selected option's text is appended, so screen readers announce e.g. "Remove Angular". |
 | `cleaner`| boolean | `true` | Enables selection cleaner element. |
@@ -528,8 +529,8 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 | `selectAllLabel` | string | `'Select all'` | Sets the select all button label shown until everything is selected. The button is a toggle: it shows `selectAllLabel` (and selects all) until everything is selected, then shows `deselectAllLabel` (and deselects all). |
 | `selectAllMode` | string | `'all'` | Scope of the built-in select all button: `'all'` toggles every option (ignoring the search filter), `'filtered'` toggles only the search-filtered options. With no active filter both behave the same. |
 | `selectAllStyle` | string | `'checkbox'` | Sets the select all button style: `'checkbox'` or `'text'`. With `'checkbox'` (and `multiple`), the built-in select all button shows a tri-state checkbox indicator (`none` / `all` / `indeterminate`) reflecting the overall selection, and clicking it toggles between selecting and deselecting all. |
-| `selectionLimit` | number, null | `null` | Sets the maximum number of selectable options. The select all button stays enabled and selects up to the limit (firing the `selectionLimit` event), then toggles to deselect all once the limit is reached. |
 | `selectFilteredLabel` | string | `'Select filtered'` | Label shown instead of `selectAllLabel` when `selectAllMode: 'filtered'` and a search filter narrows the list, so the button reads as acting on the filtered options rather than the whole list. |
+| `selectionLimit` | number, null | `null` | Sets the maximum number of selectable options. The select all button stays enabled and selects up to the limit (firing the `selectionLimit` event), then toggles to deselect all once the limit is reached. |
 | `selectionType` | string | `'tags'` | Sets the selection style: `'chips'`, `'counter'`, `'tags'` or `'text'`. Selections render as [Chip](/components/chip/) components — `'tags'` and `'chips'` are the same thing, kept as synonyms. |
 | `selectionTypeCounterText` | string | `'item(s) selected'` | Sets the counter selection label.	|
 | `valid` | boolean | `false` | Toggle the valid state for the component. |

--- a/docs/src/content/docs/forms/range-slider.mdx
+++ b/docs/src/content/docs/forms/range-slider.mdx
@@ -190,6 +190,7 @@ Please note that for security reasons, the `sanitize`, `sanitizeFn`, and `allowL
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `allowList` | object | [Default value](/getting-started/javascript#sanitizer) |  Defines the set of permitted HTML tags and attributes that can safely appear in the tooltip content when HTML content is passedd. This helps maintain control over the output and prevent injection of malicious code. |
+| `ariaLabels` | array, null | `null` | Accessible name of each handle, in order. Handles are otherwise indistinguishable to a screen reader, so a slider with more than one wants this. A shorter array leaves the remaining handles unnamed. |
 | `clickableLabels` | boolean | `true` | Enables or disables the ability to click on labels to set slider values. |
 | `disabled` | boolean | `false` | Disables the slider, making it non-interactive and grayed out. |
 | `distance` | number | `0` | Sets the minimum distance between multiple slider handles. |
@@ -197,14 +198,14 @@ Please note that for security reasons, the `sanitize`, `sanitizeFn`, and `allowL
 | `max` | number | `100` | Defines the maximum value of the slider. |
 | `min` | number | `0` | Defines the minimum value of the slider. |
 | `name` | array, string, null | `null` | Sets the name attribute for each slider input. |
+| `sanitize` | boolean | `true` | Controls whether HTML content in the tooltip should be sanitized before rendering. Strongly recommended to leave enabled unless you’re fully managing the content and trust its source. |
+| `sanitizeFn` | null, function | `null` | You can define your own custom sanitization logic by passing a function here. Ideal if you want to use a specialized HTML sanitizer or integrate with existing security tool. |
 | `step` | number, string | `1` | Specifies the increment step for slider values. |
 | `tooltips` | boolean | `true` | Enables or disables tooltips that display current slider values. |
 | `tooltipsFormat` | function, null | `null` | Provides a custom formatting function for tooltip values. |
 | `track` | boolean, 'fill' | `'fill'` | Controls the visual representation of the slider's track. When set to `'fill'`, the track is dynamically filled based on the slider's value(s). Setting it to `false` disables the filled track. |
 | `value` | array, number | `0` | Sets the initial value(s) of the slider. |
 | `vertical` | boolean | `false` | Rotates the slider to a vertical orientation. |
-| `sanitize` | boolean | `true` | Controls whether HTML content in the tooltip should be sanitized before rendering. Strongly recommended to leave enabled unless you’re fully managing the content and trust its source. |
-| `sanitizeFn` | null, function | `null` | You can define your own custom sanitization logic by passing a function here. Ideal if you want to use a specialized HTML sanitizer or integrate with existing security tool. |
 
 ### Methods
 

--- a/docs/src/content/docs/forms/rating.mdx
+++ b/docs/src/content/docs/forms/rating.mdx
@@ -164,6 +164,7 @@ Note that for security reasons the `sanitize`, `sanitizeFn`, and `allowList` opt
 | `activeIcon` | object, string, null | `null` | The default icon to display when the item is selected. |
 | `allowClear` | boolean | `false` | Enables the clearing upon clicking the selected item again. |
 | `allowList` | object | [Default value](/getting-started/javascript/#sanitizer) |  Object which contains allowed attributes and tags. |
+| `ariaLabel` | function | `` (value, itemCount) => `${value} of ${itemCount}` `` | Accessible name of each item, built from its value and the total. |
 | `disabled` | boolean | `false` | Toggle the disabled state for the component. |
 | `highlightOnlySelected` | boolean | `false` | If enabled, only the currently selected icon will be visibly highlighted. |
 | `icon` | object, string, null | `null` | The default icon to display when the item is not selected. |
@@ -171,11 +172,11 @@ Note that for security reasons the `sanitize`, `sanitizeFn`, and `allowList` opt
 | `name` | string | `null` | The name attribute of the radio input elements. |
 | `precision` | number | `1` | Minimum increment value change allowed. |
 | `readOnly` | boolean | `false` | Toggle the readonly state for the component. |
+| `sanitize` | boolean | `true` |  Enable or disable the sanitization. If activated `activeIcon`, and `icon` options will be sanitized. |
+| `sanitizeFn` | null, function | `null` |  Here you can supply your own sanitize function. This can be useful if you prefer to use a dedicated library to perform sanitization. |
 | `size` | `'sm'`, `'lg'` | `null` | Size the component small or large. |
 | `tooltips` | array, boolean, object | `false` | Enable tooltips with default values or set specific labels for each icon. |
 | `value` | number, null | `null` |  The default `value` of component. |
-| `sanitize` | boolean | `true` |  Enable or disable the sanitization. If activated `activeIcon`, and `icon` options will be sanitized. |
-| `sanitizeFn` | null, function | `null` |  Here you can supply your own sanitize function. This can be useful if you prefer to use a dedicated library to perform sanitization. |
 
 ### Methods
 

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -199,6 +199,10 @@ forwarded by name, so their data attributes work on the picker element too.
 | `allowList` | object | `SVGAllowlist` | Allowlist used when sanitizing the icon markup. |
 | `ariaCleanerLabel` | string | `'Clear the value'` | Accessible label of the cleaner button. |
 | `ariaLabel` | string | `'Time input'` | Accessible name of the field. It lands on the `role="group"` container the sections sit in, so it names the whole control rather than one part of it. |
+| `ariaSelectHoursLabel` | string | `'Select hours'` | Accessible name of the hours select in the panel. |
+| `ariaSelectMeridiemLabel` | string | `'Select AM/PM'` | Accessible name of the AM/PM select in the panel. |
+| `ariaSelectMinutesLabel` | string | `'Select minutes'` | Accessible name of the minutes select in the panel. |
+| `ariaSelectSecondsLabel` | string | `'Select seconds'` | Accessible name of the seconds select in the panel. |
 | `ariaToggleLabel` | string | `'Toggle the time selection'` | Accessible label of the indicator button. |
 | `cleaner` | boolean | `true` | Renders a button that clears the value. It appears only once the field holds one. |
 | `cleanerIcon` | string | cross SVG | Inline SVG rendered by the component (sanitized). |


### PR DESCRIPTION
Follow-up to #911/#913. Those documented `ariaLabel` on the four pickers; this asks the same question of every other `aria*` option in the library.

## Method

Every `aria*` key in a component's `Default` object, checked against the Options table of the page that documents that component.

| | |
| --- | --- |
| declared across 19 components | **37** |
| already documented | **28** |
| **working but undocumented** | **11** — this PR |
| on internal primitives, reachable through a shell | 4 of the 11 |

## What was missing

- **Multi Select** `ariaIndicatorLabel`, **Rating** `ariaLabel`, **Range Slider** `ariaLabels`.
- **Time Picker** and **Date and Time Picker** gain the four names of the selects inside the panel. These live on an internal `TimeSelection` primitive and reach both components through the shell's config forwarding — a working path with no trace in the docs.

Verified on the built bundle rather than read off the source: opening a time picker with `ariaSelectHoursLabel` set renders it next to the three defaults.

```
Wybierz godzine | Select minutes | Select seconds | Select AM/PM
```

Range Slider's row carries the reason it matters — handles are indistinguishable to a screen reader, so a slider with more than one wants names — and notes that a shorter array leaves the rest unnamed rather than erroring.

## Two things found on the way, not fixed here

**Password Input has no API tables at all.** Not a missing `aria` row: the page has no Options, Methods or Events section, while the component ships six options (`allowList`, `ariaToggleLabel`, `hideIcon`, `sanitize`, `sanitizeFn`, `showIcon`), a `toggle()` method and its events. That is a whole reference section to write, not a row to add.

**The API tables disagree on their own heading** — 25 pages say `| Name | Type | Default |`, 9 say `| Option | Type | Default |`. Same table, same role, two names; it decides the anchor and what a reader searching the page matches on. Worth one pass, like the `Sass` heading normalisation.

## Verification

`npm run docs-build` — 173 pages, no broken links; rows confirmed in the rendered HTML. Tables re-sorted alphabetically after insertion, so the new keys sit in their slot rather than at the end.
