### PR TITLE
docs: give the API tables one heading

### DIFF
--- a/docs/src/content/docs/components/chip-set.mdx
+++ b/docs/src/content/docs/components/chip-set.mdx
@@ -100,7 +100,7 @@ Options can be passed using data attributes or JavaScript. To do this, append an
 
 Starting with CoreUI 4.2.6, all components support an **experimental** reserved data attribute named `data-coreui-config`, which can contain simple component configurations as a JSON string. If an element has attributes `data-coreui-config='{"delay":50, "title":689}'` and `data-coreui-title="Custom Title"`, then the final value for `title` will be `Custom Title`, as the standard data attributes will take precedence over values specified in `data-coreui-config`. Moreover, existing data attributes can also hold JSON values like `data-coreui-delay='{"show":50, "hide":250}'`.
 
-| Option | Type | Default | Description |
+| Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `ariaAddedAnnouncement` | string | `'added'` | Wording appended to a chip's value when its addition is announced in the status live region. |
 | `ariaRemoveLabel` | string | `'Remove'` | Accessible label applied to each chip's remove button. |

--- a/docs/src/content/docs/components/chip.mdx
+++ b/docs/src/content/docs/components/chip.mdx
@@ -279,7 +279,7 @@ Options can be passed using data attributes or JavaScript. To do this, append an
 
 Starting with CoreUI 4.2.6, all components support an **experimental** reserved data attribute named `data-coreui-config`, which can contain simple component configurations as a JSON string. If an element has attributes `data-coreui-config='{"delay":50, "title":689}'` and `data-coreui-title="Custom Title"`, then the final value for `title` will be `Custom Title`, as the standard data attributes will take precedence over values specified in `data-coreui-config`. Moreover, existing data attributes can also hold JSON values like `data-coreui-delay='{"show":50, "hide":250}'`.
 
-| Option | Type | Default | Description |
+| Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `ariaRemoveLabel` | string | `'Remove'` | Accessible label for the remove button. |
 | `disabled` | boolean | `false` | Disables interactions and focus. You can also apply the `.disabled` class in markup. |

--- a/docs/src/content/docs/forms/chip-input.mdx
+++ b/docs/src/content/docs/forms/chip-input.mdx
@@ -176,7 +176,7 @@ Options can be passed using data attributes or JavaScript. To do this, append an
 
 Starting with CoreUI 4.2.6, all components support an **experimental** reserved data attribute named `data-coreui-config`, which can contain simple component configurations as a JSON string. If an element has attributes `data-coreui-config='{"delay":50, "title":689}'` and `data-coreui-title="Custom Title"`, then the final value for `title` will be `Custom Title`, as the standard data attributes will take precedence over values specified in `data-coreui-config`. Moreover, existing data attributes can also hold JSON values like `data-coreui-delay='{"show":50, "hide":250}'`.
 
-| Option | Type | Default | Description |
+| Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `chipClassName` | string \| function \| null | `null` | Adds classes to chips. Use a string for all chips or a function `(value) => className` for per-chip styling. |
 | `disabled` | boolean | `false` | Disables the input and marks managed chips as non-interactive. |

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -360,7 +360,7 @@ Options belonging to the inner [calendar](/components/calendar/#options) or
 [date input](/forms/date-input/#options) are forwarded by name, so their data
 attributes work on the picker element too.
 
-| Option | Type | Default | Description |
+| Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `allowList` | object | `SVGAllowlist` | Allowlist used when sanitizing the icon markup. |
 | `ariaCleanerLabel` | string | `'Clear the value'` | Accessible label of the cleaner button. |

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -281,7 +281,7 @@ Options belonging to the inner [calendar](/components/calendar/#options) or
 [date input](/forms/date-input/#options) are forwarded by name, so their data
 attributes work on the picker element too.
 
-| Option | Type | Default | Description |
+| Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `allowList` | object | `SVGAllowlist` | Allowlist used when sanitizing icon markup. |
 | `ariaCleanerLabel` | string | `'Clear the value'` | Accessible label of the cleaner button. |

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -141,7 +141,7 @@ const picker = new coreui.DateTimePicker(element, { locale: 'en-US' })
 Options belonging to the inner [calendar](/components/calendar/#options) or
 [date time input](/forms/date-time-input/#options) are forwarded by name.
 
-| Option | Type | Default | Description |
+| Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `allowList` | object | `SVGAllowlist` | Allowlist used when sanitizing the icon markup. |
 | `ariaCleanerLabel` | string | `'Clear the value'` | Accessible label of the cleaner button. |

--- a/docs/src/content/docs/forms/stepper.mdx
+++ b/docs/src/content/docs/forms/stepper.mdx
@@ -578,7 +578,7 @@ const stepperList = stepperElementList.map(stepperEl => {
 
 ### Options
 
-| Option | Type | Default | Description |
+| Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `linear` | boolean | `true` | Forces steps to be completed in order (sequential navigation). Set `false` for free navigation. |
 | `skipValidation` | boolean | `false` | When set to `true`, disables form validation completely, allowing users to navigate between steps regardless of form state. |

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -194,7 +194,7 @@ const pickerList = pickerElementList.map(pickerEl => {
 Options belonging to the inner [time input](/forms/time-input/#options) are
 forwarded by name, so their data attributes work on the picker element too.
 
-| Option | Type | Default | Description |
+| Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `allowList` | object | `SVGAllowlist` | Allowlist used when sanitizing the icon markup. |
 | `ariaCleanerLabel` | string | `'Clear the value'` | Accessible label of the cleaner button. |


### PR DESCRIPTION
Found while sweeping the `aria*` options in #914.

Twenty-five pages headed the reference table `Name`, eight headed it `Option` — the same table, the same role, two words. `Name` wins, being the form already on three quarters of the pages.

| | before | after |
| --- | --- | --- |
| `\| Name \| Type \| Default \|` | 25 | **33** |
| `\| Option \| Type \| Default \|` | 9 | 1 |

## A correction to how this was first reported

I said the header decided the anchor. It does not: the anchor comes from the `### Options` heading above the table, and the built HTML still carries `id="options"` on every page here. A table header row is not a heading and has no id. What the inconsistency actually costs is smaller — a reader searching the page, and the plain oddity of one library naming the same thing two ways.

## The page left alone

`utilities/api.mdx` keeps `Option`. Its table lists the keys a utility group accepts inside the `$utilities` map rather than a component's options, the prose above it says exactly that, and its third column is `Default value` rather than `Default`. Different table, shared word.

## Verification

`npm run docs-build` — 173 pages, no broken links. Eight files, one line each.
