### PR TITLE
fix: stop Safari adding a marker line above nav, pagination and menu items

### DIFF
--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -177,6 +177,10 @@ $menu-tokens: defaults(
     opacity: 1;
   }
 
+  .menu > li {
+    display: flex;
+  }
+
   .menu-item {
     display: flex;
     gap: var(--#{$prefix}menu-item-gap);

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -208,6 +208,10 @@ $tab-pane-tokens: defaults(
     list-style-type: "";
   }
 
+  .nav-item {
+    display: flex;
+  }
+
   .nav-link {
     display: flex;
     gap: var(--#{$prefix}nav-link-gap);

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -136,6 +136,8 @@ $pagination-sizes: defaults(
   }
 
   .page-item {
+    display: flex;
+
     &:not(:first-child) .page-link {
       margin-inline-start: calc(-1 * var(--#{$prefix}pagination-border-width));
     }

--- a/scss/sidebar/_sidebar-nav.scss
+++ b/scss/sidebar/_sidebar-nav.scss
@@ -153,6 +153,10 @@ $sidebar-nav-tree-link-active-icon-bullet-bg:  var(--#{$prefix}border-color) !de
     overflow-y: auto;
     list-style-type: "";
 
+    .nav-item {
+      flex-direction: column;
+    }
+
     .nav-item + .nav-item,
     .nav-item + .nav-group,
     .nav-group + .nav-item,


### PR DESCRIPTION
Safari lays out a list-marker line box for an `<li>` that computes to `display: list-item` under `list-style-type: ""`, whenever that item’s child is a flex container holding an `<svg>`. Because our links are flex and our icons are inline SVG, every item with an icon rendered one line-height taller than its link — 24px at the default font size. Navs, the navbar, the header nav, the sidebar nav, pagination and menus were all too tall and too loose in Safari; Chromium and Firefox lay the same markup out correctly.

The item elements now carry a `display` of their own, so they no longer generate a marker at all: `.nav-item`, `.page-item` and the bare `<li>` children of `.menu` become flex. The sidebar’s `.nav-item` holds a link plus an optional sub-list, so it stacks them with `flex-direction: column` — a plain `display: flex` would put the sub-list beside its toggle.

## Measurements

`li.offsetHeight − link.offsetHeight`, one icon per link, Safari 18 vs Chromium (Playwright), built `dist/css/coreui.css`:

| | Safari before | Safari after | Chromium before/after |
| --- | --- | --- | --- |
| `.nav`, `.nav-pills`, `.nav-underline` | +24 | 0 | 0 |
| `.nav-tabs` | +23 | −1 | −1 |
| `.nav-fill`, `.nav-justified` | +24 | 0 | 0 |
| `.navbar-nav`, `.header-nav` | +24 | 0 | 0 |
| `.pagination` | +24 | 0 | 0 |
| `.menu` | +21 | 0 | 0 |
| navbar dropdown | +24 | 0 | 0 |
| sidebar nav item / closed group | 72 vs 48 | 48 | 48 |

Item widths are unchanged in both engines, and the sidebar’s expanded group still stacks its sub-list under the toggle (checked by comparing bounding rects, not just heights — `display: flex` alone put them side by side).

## Not covered

`.list-unstyled` still shows the same +24 in Safari when the markup puts a flex box with an SVG inside its `<li>`. The list comes from the `list-unstyled` mixin, and the flex child is the consumer’s, so neutralising it means giving every `<li>` under a utility class a display of our choosing. Left alone deliberately — worth its own decision rather than a silent change to a utility.

## Gates

`css-lint` (stylelint + fusv), `js-test-visual` (35 passed), `npm run dist` + bundlewatch (all PASS), pre-push local CI incl. `docs-build` and vnu.