### PR TITLE
chore: raise the Firefox floor to 130 for exclusive accordions

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -8,6 +8,10 @@
 #
 #   Feature                    Sets the floor for   Used by
 #   -------------------------  -------------------  ------------------------------
+#   <details name="…">         Firefox 130          exclusive accordions: the
+#                                                   grouping is driven off
+#                                                   `details.name`, which reads
+#                                                   back undefined below it
 #   light-dark()               Chrome 123           every theme decision resolves
 #                              Safari/iOS 17.5      through it, with no fallback
 #   @starting-style            Firefox 129          Menu's entry animation
@@ -21,10 +25,12 @@
 #                                                   sidebar indicators, calendar
 #                                                   ranges, rating icons
 #
-# :has() no longer sets the Firefox floor — @property and @starting-style
-# arrived after this file was first written and both sit above it. @property is
-# the one that matters: an unsupported @starting-style only drops an animation,
-# but an ignored `inherits: false` is a live bug.
+# Only the topmost entry per browser binds; the rest are kept because they say
+# what actually breaks below each version. On Firefox that is now
+# `<details name>`: an unsupported @starting-style merely drops an animation and
+# an ignored `inherits: false` leaks a utility into its descendants, but a
+# `details.name` that reads back undefined leaves an exclusive accordion with
+# every panel open at once.
 #
 # Declaring anything lower would be fiction; raising it further is a product
 # choice we have not made. Upstream Bootstrap v6 sits at Chrome 130 / Firefox 132
@@ -39,7 +45,7 @@ unreleased versions
 
 Chrome >= 123
 Edge >= 123
-Firefox >= 129
+Firefox >= 130
 iOS >= 17.5
 Safari >= 17.5
 

--- a/docs/src/content/docs/getting-started/browsers-devices.mdx
+++ b/docs/src/content/docs/getting-started/browsers-devices.mdx
@@ -10,8 +10,8 @@ CoreUI for Bootstrap supports the **latest, stable releases** of all major brows
 Alternative browsers which use the latest version of WebKit, Blink, or Gecko, whether directly or via the platform's web view API, are not explicitly supported. However, CoreUI for Bootstrap should (in most cases) display and function correctly in these browsers as well. More specific support information is provided below.
 
 The floor is set by the platform features v6 depends on, with no fallbacks
-shipped: **Chrome 123, Edge 123, Firefox 129, Safari 17.5 and iOS 17.5**.
-Together with the evergreen lines below, this covers about 86% of global usage
+shipped: **Chrome 123, Edge 123, Firefox 130, Safari 17.5 and iOS 17.5**.
+Together with the evergreen lines below, this covers about 89% of global usage
 as measured with `npx browserslist --coverage`.
 
 Each floor is set by the newest feature v6 already requires, because the floor
@@ -20,16 +20,18 @@ has to hold for the whole 6.x line:
 | Feature | Sets the floor for |
 | --- | --- |
 | `light-dark()` | Chrome and Edge 123, Safari and iOS 17.5 — every theme decision resolves through it, and `color-mix()`, with no fallback |
+| `<details name="…">` | Firefox 130 — exclusive accordions, which group their panels by `details.name` |
 | `@starting-style`, `transition-behavior: allow-discrete` | Firefox 129 — the Menu's entry animation |
 | `@property` | Firefox 128 — `inherits: false` on the colour and opacity utilities' custom properties |
 | `:has()` | Firefox 121 — validation and focus states on Multi Select and Autocomplete, the sidebar navigation indicators, calendar ranges and the rating icons are all selected with it |
 
 A browser below the floor does not merely lose polish. An unsupported `:has()`
 invalidates the whole rule it appears in, and unresolved `light-dark()` leaves
-colors unset. `@property` is the quietest of the three and the one worth
-knowing about: without it the registrations are ignored, custom properties
-inherit again, and a colour or opacity utility on a container tints everything
-nested inside it.
+colors unset. Where `details.name` reads back undefined, an exclusive accordion
+stops closing its siblings and every panel can stand open at once. `@property`
+is the quietest of them and the one worth knowing about: without it the
+registrations are ignored, custom properties inherit again, and a colour or
+opacity utility on a container tints everything nested inside it.
 
 Versions come from MDN's browser compatibility data. Note that caniuse does not
 track `@property`, `@starting-style` or `transition-behavior` at all, so
@@ -44,7 +46,7 @@ unreleased versions
 
 Chrome >= 123
 Edge >= 123
-Firefox >= 129
+Firefox >= 130
 iOS >= 17.5
 Safari >= 17.5
 


### PR DESCRIPTION
Exclusive accordions group their panels off `details.name`. Firefox only exposes that attribute from **130** ([MDN BCD](https://github.com/mdn/browser-compat-data/blob/main/html/elements/details.json): Chrome 120, Firefox 130, Safari 17.2), so on 129 it reads back `undefined`, `_hideSiblings` returns early and every panel in the group can stand open at once. Our declared floor was 129, which put that case one version outside what we claimed to support.

Raising it costs almost nothing: 130 shipped four weeks after 129 (2024-09-03 vs 2024-08-06).

| | before | after |
| --- | --- | --- |
| `browserslist --coverage` | 88.92% | 88.88% |
| Autoprefixer output | — | byte-identical (compared every `-moz-`/`-webkit-` occurrence in `dist/css/coreui.css`) |

## Also in this PR

- The coverage figure on the browsers & devices page still read **86%** and is now 89%.
- The feature table gains the `<details name="…">` row and now says what actually breaks below each version, not just which feature sets it. Only the topmost entry per browser binds; the lower ones are kept because they document the failure mode.

## Not changed

Safari stays at 17.5. Of the features that might have pushed it to 18, none apply to us: `backdrop-filter` is prefixed by Autoprefixer at every one of its 48 occurrences, `content-visibility` is never declared as a property (it appears only inside `transition-property` lists, where an unknown ident is ignored), and `text-wrap: balance` is not shipped at all — `utils-text-wrap` defines only `white-space` and `word-wrap`. `light-dark()` remains what sets the Safari floor.

## Gates

`npm run css` (prefix diff above), `npm run docs-build` — 173 pages, no broken links.