### PR TITLE
docs: document TypeScript support and the JS component list

### DIFF
--- a/docs/src/content/docs/getting-started/introduction.mdx
+++ b/docs/src/content/docs/getting-started/introduction.mdx
@@ -70,29 +70,11 @@ If you decide to go with the separate scripts solution, Floating UI must come fi
 
 #### Modules
 
-If you use `<script type="module">`, please refer to our [using CoreUI for Bootstrap as a module](/getting-started/javascript/#using-coreui-as-a-module) section.
+If you use `<script type="module">`, please refer to our [using CoreUI for Bootstrap as a module](/getting-started/javascript/#using-coreui-for-bootstrap-as-a-module) section.
 
 #### Components
 
-Curious which components explicitly require our JavaScript and Floating UI? Click the show components link below. If you're at all unsure about the general page structure, keep reading for an example page template.
-
-<details>
-<summary class="text-primary mb-3">Show components requiring JavaScript</summary>
-
-- Accordions for extending our Collapse plugin
-- Alerts for dismissing
-- Buttons for toggling states and checkbox/radio functionality
-- Carousel for all slide behaviors, controls, and indicators
-- Collapse for toggling visibility of content
-- Dropdowns for displaying and positioning (also requires [Floating UI](https://floating-ui.com/))
-- Modals for displaying, positioning, and scroll behavior
-- Navbar for extending our Collapse plugin to implement responsive behavior
-- Offcanvases for displaying, positioning, and scroll behavior
-- Toasts for displaying and dismissing
-- Tooltips and popovers for displaying and positioning (also requires [Floating UI](https://floating-ui.com/))
-- Scrollspy for scroll behavior and navigation updates
-
-</details>
+Curious which components explicitly require our JavaScript and Floating UI? See the [JS components list](/getting-started/javascript/#js-components) on the JavaScript page. If you're at all unsure about the general page structure, keep reading for an example page template.
 
 ## Bootstrap Replacement
 

--- a/docs/src/content/docs/getting-started/javascript.mdx
+++ b/docs/src/content/docs/getting-started/javascript.mdx
@@ -3,11 +3,48 @@ title: "JavaScript"
 description: "Bring CoreUI for Bootstrap to life with our optional JavaScript plugins. Learn about each plugin, our data and programmatic API options, and more."
 ---
 
+## JS components
+
+Curious which components explicitly require our JavaScript and [Floating UI](https://floating-ui.com/)?
+
+- Accordion for animating panels and closing the rest of an exclusive group
+- Alerts for dismissing
+- Autocomplete, Combobox and Multi Select for the whole selection behavior (Combobox also requires [Floating UI](https://floating-ui.com/))
+- Buttons for toggling states and checkbox/radio functionality; Loading Button for its busy state
+- Calendar, Date Picker, Date Range Picker and Time Picker for date and time selection — the calendar is our own, with no third-party dependency
+- Carousel for all slide behaviors, controls, and indicators
+- Chips for dismissing, and Chip Input for typing chips into a field
+- Collapse for toggling visibility of content
+- Dialog and Drawer for displaying, positioning, and scroll behavior
+- Menu and Dropdown for displaying and positioning (also requires [Floating UI](https://floating-ui.com/))
+- Modal and Offcanvas for displaying, positioning, and focus behavior
+- Number Input, OTP Input, Password Input, Password Strength, Range Slider, Rating and Stepper for their form behaviors
+- Scrollspy for scroll behavior and navigation updates
+- Sidebar and Navigation for the app shell's responsive behaviors
+- Tab for toggling tab panes
+- Toasts for displaying and dismissing
+- Tooltips and popovers for displaying and positioning (also requires [Floating UI](https://floating-ui.com/))
+
+[Floating UI](https://floating-ui.com/) is a `peerDependency` and the only third-party runtime we rely on — install it only if you use the components listed with it.
+
 ## Individual or compiled
 
 Plugins can be included individually (using CoreUI's individual `js/dist/*.js`), or all at once using `coreui.js` or the minified `coreui.min.js` (don't include both).
 
 If you use a bundler (Webpack, Rollup...), you can use `/js/dist/*.js` files which are UMD ready.
+
+## TypeScript
+
+Our plugins are authored in TypeScript and ship with type declarations — no `@types/…` package is needed. The main entry point and every individual plugin under `js/dist/*.js` come with their own `.d.ts`:
+
+```ts
+import { Tooltip } from '@coreui/coreui-pro'
+
+const tooltip = Tooltip.getOrCreateInstance('#example')
+tooltip.show()
+```
+
+Some plugin modules also export their configuration object type (for example `TooltipConfig`) if you need to type your own wrappers.
 
 ## Usage with JavaScript frameworks
 


### PR DESCRIPTION
Two gaps on `getting-started/javascript`, both found comparing the page against upstream's v6 sidebar:

- **`## JS components`** — the page never answered which components need the JavaScript at all. The new list covers every behavior the plugins add and marks the three places that require [Floating UI](https://floating-ui.com/): Menu (and Dropdown built on it), Tooltip (and Popover/Rating built on it), and Combobox — verified against the imports in `js/src`, not copied from upstream (their list names Vanilla Calendar Pro; our calendar is our own). It also states that Floating UI is the **only** third-party runtime and a `peerDependency`.
- **`## TypeScript`** — v6 is authored in TypeScript and ships a `.d.ts` next to every plugin under `js/dist/`, but the page never said so, leaving TS users to look for a `@types/…` package that does not exist. The section shows a typed `getOrCreateInstance` call and says *some* plugins export their configuration type — today 10 of 44 do (`TooltipConfig`, `MenuConfig`, …), which is its own inconsistency, recorded in the workspace TODO rather than papered over here.

Section placement mirrors the upstream page order (`JS components` opens, `TypeScript` follows `Individual or compiled`), which our page already tracked.

Gates: `npm run docs-build` — 173 pages, no broken links.