### PR TITLE
docs: replace the v5 tail of the browsers page with the v6 platform story

### DIFF
--- a/docs/src/content/docs/getting-started/browsers-devices.mdx
+++ b/docs/src/content/docs/getting-started/browsers-devices.mdx
@@ -58,54 +58,89 @@ not op_mini all
 
 We use [Autoprefixer](https://github.com/postcss/autoprefixer) to handle intended browser support via CSS prefixes, which uses [Browserslist](https://github.com/browserslist/browserslist) to manage these browser versions. Consult their documentation for how to integrate these tools into your projects.
 
-### Mobile devices
+### How to read the query list
 
-Generally speaking, CoreUI for Bootstrap supports the latest versions of each major platform's default browsers. Note that proxy browsers (such as Opera Mini, Opera Mobile's Turbo mode, UC Browser Mini, Amazon Silk) are not supported.
+Two lines of that file do more than they look like they do:
 
-| | Chrome | Firefox | Safari | Android Browser &amp; WebView |
-| --- | --- | --- | --- | --- |
-| **Android** | Supported | Supported | <span class="text-muted">&mdash;</span> | v6.0+ |
-| **iOS** | Supported | Supported | Supported | <span class="text-muted">&mdash;</span> |
+- **`last 2 major versions` carries the mobile coverage.** caniuse tracks Chrome for Android as a single unversioned entry rather than one entry per release, so this line, not the `>=` floors, is what picks it up.
+- **`unreleased versions` is worth several points of coverage and costs nothing.** caniuse gives the newest Safari a null release date while that version already holds most of Safari's usage share, and both range queries and `last N versions` skip unreleased versions. The line cannot pull in anything old, because an unreleased version is newer than every floor.
 
-### Desktop browsers
+The `not …` exclusions drop proxy and niche browsers that cannot run the floor features anyway; keeping them in the query would only grow the compiled CSS with legacy vendor prefixes.
 
-Similarly, the latest versions of most desktop browsers are supported.
+To measure coverage yourself, run `npx browserslist --coverage` in a clone of the repository.
 
-| | Chrome | Firefox | Microsoft Edge | Opera | Safari |
-| --- | --- | --- | --- | --- | --- |
-| **Mac** | Supported | Supported | Supported | Supported | Supported |
-| **Windows** | Supported | Supported | Supported | Supported | <span class="text-muted">&mdash;</span> |
+## Modern platform features
+
+The floor table above names what *sets* each floor; this is the fuller inventory of platform features v6 leans on:
+
+| Feature | Used by |
+| --- | --- |
+| `light-dark()`, `color-mix()`, `oklch()` | every color in the library — theme tokens, color modes, translucent variants |
+| Cascade layers (`@layer`) | the whole stylesheet ships in a fixed layer order, so your own unlayered CSS always wins |
+| `:has()` | validation and focus states on field components, button groups, sidebar indicators, calendar ranges, rating |
+| `@property` | `inherits: false` registrations that keep the color and opacity utilities from leaking into descendants |
+| `@starting-style` + `transition-behavior: allow-discrete` | entry and exit animations on Menu, Dialog, Drawer, Modal, Offcanvas, Popover, Tooltip, Toasts and Alerts |
+| Native `<dialog>` | Dialog and Drawer — the top layer, `::backdrop` and focus containment come from the browser |
+| `<details name="…">` | exclusive accordions |
+| Container queries (`@container`) | stacked tables, horizontal list groups, card groups and stacks respond to their container, not the viewport |
+| Logical properties | spacing, borders and RTL support throughout — there is no separate RTL stylesheet |
+| Range syntax in media queries | every breakpoint compiles to `@media (width >= …)` |
+
+### Also safe to use
+
+The floors clear more of the platform than the library currently uses. Everything below needs no fallback, no vendor prefix, and no polyfill anywhere in the supported range, so reach for it freely when you build on top of CoreUI:
+
+- Native CSS nesting (Chrome 120, Firefox 117, Safari 17.2)
+- `text-wrap: balance` (Chrome 114, Firefox 121, Safari 17.5)
+- `:focus-visible` for keyboard-only focus styling
+- Container query units and `subgrid`
+- Dynamic viewport units (`dvh`, `dvw`) — the library itself sizes scrollable menus with `dvh`
+- The `popover` attribute (Chrome 114, Firefox 125, Safari 17)
+
+Versions come from MDN's browser compatibility data, same as the floor table.
+
+### Not available yet
+
+These sit above at least one of our floors, so v6 cannot rely on them without a fallback — and neither should you if you target the same range. Note that with the Safari floor at 17.5, **Safari is the blocker as often as Firefox**:
+
+| Feature | First fully supported in |
+| --- | --- |
+| Unprefixed `backdrop-filter` | Safari 18 — keep the `-webkit-` prefix; our build emits both |
+| `content-visibility` | Chrome 85, Firefox 125, Safari 18 |
+| Relative color syntax, `rgb(from …)` | Chrome 122, Firefox 128, Safari 18 |
+| `interpolate-size` / `calc-size()` | Chrome 129, no Firefox or Safari yet |
+| View transitions | Chrome 111, Firefox 144, Safari 18 |
+| Anchor positioning | Chrome 125, Firefox 147, Safari 26 |
+| Style container queries | Chrome 111, Firefox 151, Safari 18 |
+| `@scope` | Chrome 118, Firefox 146, Safari 26.4 |
+| Invoker Commands API (`command` / `commandfor`) | Chrome 135, Firefox 144, Safari 26.2 |
+| Scrollbar styling (`scrollbar-color`) | Chrome 121, Firefox 64, Safari 26.2 |
+| `text-box-trim` | Chrome 133, Firefox 154, Safari 18.2 |
+
+Two of these the library already touches, carefully: `interpolate-size` sits behind `@supports`, so accordions and collapses animate to their intrinsic height where it exists and jump without it; `backdrop-filter` is emitted with both spellings by the build. Anchor positioning is the one most worth waiting for — it would let Menu, Tooltip, Popover and Combobox drop their [Floating UI](https://floating-ui.com/) dependency. Re-check these before you assume one has landed.
+
+## JavaScript
+
+Every browser meeting the CSS floor above fully supports ES modules and the DOM APIs our plugins use — no transpilation or polyfills are required or provided. Both builds work across the whole range: the UMD bundles (`coreui.js`, exposing the `coreui` global) and the ES modules (`coreui.esm.js`). See [JavaScript](/getting-started/javascript/) for loading patterns.
+
+## Mobile devices
+
+Generally speaking, CoreUI for Bootstrap supports the latest versions of each major platform's default browsers. Proxy browsers (such as Opera Mini, Opera Mobile's Turbo mode, UC Browser Mini, Amazon Silk) are not supported.
+
+| Platform | Supported browsers |
+| --- | --- |
+| Android | Chrome (last two major versions) |
+| iOS and iPadOS | Safari 17.5+, Chrome (uses WebKit on iOS) |
+| Windows, macOS, Linux | Chrome 123+, Edge 123+, Firefox 130+; Safari 17.5+ on macOS |
 
 For Firefox, in addition to the latest normal stable release, we also support the latest [Extended Support Release (ESR)](https://www.mozilla.org/en-US/firefox/enterprise/) version of Firefox.
 
-Unofficially, CoreUI for Bootstrap should look and behave well enough in Chromium and Chrome for Linux, and Firefox for Linux, though they are not officially supported.
+As always, make sure you include the responsive viewport meta tag in your `<head>` for proper rendering on mobile devices:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1">
+```
 
 ## Internet Explorer
 
 Internet Explorer is not supported. **If you require Internet Explorer support, please use CoreUI v3.** If you need the previous browser floors (Chrome 60+, Safari 12+), stay on CoreUI v5.
-
-## Modals and dropdowns on mobile
-
-### Overflow and scrolling
-
-Support for `overflow: hidden;` on the `<body>` element is quite limited in iOS and Android. To that end, when you scroll past the top or bottom of a modal in either of those devices' browsers, the `<body>` content will begin to scroll. See [Chrome bug #175502](https://bugs.chromium.org/p/chromium/issues/detail?id=175502) (fixed in Chrome v40) and [WebKit bug #153852](https://bugs.webkit.org/show_bug.cgi?id=153852).
-
-### iOS text fields and scrolling
-
-As of iOS 9.2, while a modal is open, if the initial touch of a scroll gesture is within the boundary of a textual `<input />` or a `<textarea>`, the `<body>` content underneath the modal will be scrolled instead of the modal itself. See [WebKit bug #153856](https://bugs.webkit.org/show_bug.cgi?id=153856).
-
-### Navbar Dropdowns
-
-The `.dropdown-backdrop` element isn't used on iOS in the nav because of the complexity of z-indexing. Thus, to close dropdowns in navbars, you must directly click the dropdown element (or [any other element which will fire a click event in iOS](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event#Safari_Mobile)).
-
-## Browser zooming
-
-Page zooming inevitably presents rendering artifacts in some components, both in CoreUI for Bootstrap and the rest of the web. Depending on the issue, we may be able to fix it (search first and then open an issue if need be). However, we tend to ignore these as they often have no direct solution other than hacky workarounds.
-
-## Validators
-
-In order to provide the best possible experience to old and buggy browsers, CoreUI for Bootstrap uses [CSS browser hacks](http://browserhacks.com/) in several places to target special CSS to certain browser versions in order to work around bugs in the browsers themselves. These hacks understandably cause CSS validators to complain that they are invalid. In a couple places, we also use bleeding-edge CSS features that aren't yet fully standardized, but these are used purely for progressive enhancement.
-
-These validation warnings don't matter in practice since the non-hacky portion of our CSS does fully validate and the hacky portions don't interfere with the proper functioning of the non-hacky portion, hence why we deliberately ignore these particular warnings.
-
-Our HTML docs likewise have some trivial and inconsequential HTML validation warnings due to our inclusion of a workaround for [a certain Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=654072).

--- a/docs/src/content/docs/getting-started/browsers-devices.mdx
+++ b/docs/src/content/docs/getting-started/browsers-devices.mdx
@@ -83,6 +83,7 @@ The floor table above names what *sets* each floor; this is the fuller inventory
 | Native `<dialog>` | Dialog and Drawer — the top layer, `::backdrop` and focus containment come from the browser |
 | `<details name="…">` | exclusive accordions |
 | Container queries (`@container`) | stacked tables, horizontal list groups, card groups and stacks respond to their container, not the viewport |
+| Relative color syntax (`oklch(from …)`) | theme hover and active states derive from the base color at runtime |
 | Logical properties | spacing, borders and RTL support throughout — there is no separate RTL stylesheet |
 | Range syntax in media queries | every breakpoint compiles to `@media (width >= …)` |
 
@@ -107,7 +108,7 @@ These sit above at least one of our floors, so v6 cannot rely on them without a 
 | --- | --- |
 | Unprefixed `backdrop-filter` | Safari 18 — keep the `-webkit-` prefix; our build emits both |
 | `content-visibility` | Chrome 85, Firefox 125, Safari 18 |
-| Relative color syntax, `rgb(from …)` | Chrome 122, Firefox 128, Safari 18 |
+| Relative color syntax with number channel values | Chrome 122, Firefox 128, Safari 18 — the slice v6 uses, `calc()` on channel keywords, works on Safari 17.5; passing plain numbers as replacement channels is what Safari below 18 gets wrong |
 | `interpolate-size` / `calc-size()` | Chrome 129, no Firefox or Safari yet |
 | View transitions | Chrome 111, Firefox 144, Safari 18 |
 | Anchor positioning | Chrome 125, Firefox 147, Safari 26 |


### PR DESCRIPTION
The back half of `getting-started/browsers-devices` still described v5. Removed:

- **`## Modals and dropdowns on mobile`** — documents `.dropdown-backdrop`, a class with **zero occurrences** in the v6 build, plus iOS 9.2 modal-scrolling bugs with a "fixed in Chrome v40" link.
- **`## Validators`** — apologises for [CSS browser hacks](http://browserhacks.com/) the v6 stylesheet no longer contains.
- **`## Browser zooming`** — generic prose with no v6 content.
- The two **"Supported"-matrix tables** that carried no version information at all.

Added, mirroring the upstream page structure but computed against **our** floors (Chrome/Edge 123, Firefox 130, Safari/iOS 17.5):

- **`### How to read the query list`** — which browserslist lines carry mobile coverage and why `unreleased versions` matters.
- **`## Modern platform features`** — the full inventory of what v6 leans on, verified against the build (we *do* use `@container` — stacked tables, horizontal list groups, card groups, stacks — and range media syntax; we do *not* use scroll snap, unlike upstream's carousel).
- **`### Also safe to use`** / **`### Not available yet`** — every version from MDN browser-compat-data queried today, **not** copied from upstream: their floors differ, so their split does not transfer. `text-wrap: balance` (Safari 17.5) is *inside* our range; `content-visibility` (Safari 18) is *not* — the reverse of both statements on their page. With Safari at 17.5, **Safari blocks as often as Firefox** (relative color syntax, `content-visibility`, unprefixed `backdrop-filter`, scrollbar styling).
- **`## JavaScript`** — every floor browser runs both the UMD and ESM builds, no polyfills. (Upstream's section says "ES modules only, no global" — that is their architecture, not ours.)
- **`## Mobile devices`** — one table with actual versions, replacing the two matrices; the ESR sentence survives because current ESR lines (140/153) sit above the new Firefox floor.

Notes: `interpolate-size` and `backdrop-filter` are listed as *not yet* with a note on how the library already uses each behind a guard (`@supports` / dual spelling from Autoprefixer).

Gates: `npm run docs-build` — 173 pages, no broken links.