### PR TITLE
docs: give the v6 styling architecture its own page

### DIFF
--- a/docs/src/content/docs/customize/architecture.mdx
+++ b/docs/src/content/docs/customize/architecture.mdx
@@ -1,0 +1,90 @@
+---
+title: "Architecture"
+description: "How the v6 styling system is put together: cascade layers, design tokens computed in the browser, per-component token surfaces, and theme slots."
+---
+
+<AddedIn version="6.0.0" />
+
+Four mechanisms carry the whole v6 styling system. Each one has a page of its own for the details; this page shows how they fit together, and where your overrides plug in.
+
+## Cascade layers
+
+Every rule the library ships lives in a [cascade layer](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer). The order is declared once, at the top of the bundle:
+
+```css
+@layer colors, config, root, reboot, layout, content, forms, components, custom, helpers, utilities;
+```
+
+Later layers beat earlier ones regardless of selector specificity, which settles by declaration the fights v5 settled with `!important` and specificity hacks:
+
+- **Utilities win over components** because `utilities` comes last — no `!important` involved. That's why [`$enable-important-utilities`](/customize/options/) defaults to `false` in v6.
+- **Your unlayered CSS wins over everything of ours**, because unlayered styles beat every layer. A plain `.card { … }` in your stylesheet overrides the library no matter how simple the selector.
+- **Three layers are empty and reserved for you.** `colors` and `config` sit below everything, for a palette or configuration sheet that the whole library should read but never fight; `custom` slots between `components` and `helpers`, for component overrides that should still lose to utilities. Put your CSS in `@layer custom` when you want `.text-center` on the element to keep working.
+
+One caveat: if your build concatenates our CSS with other stylesheets, make sure the layer declaration emitted at the top of the bundle survives minification — a minifier that predates `@layer` can strip it, and with it the whole ordering.
+
+## Design tokens
+
+Global design decisions — colors, spacing, typography, borders, shadows — are emitted as CSS custom properties on `:root` (in the `root` layer). Components never read Sass variables at run time; they read tokens:
+
+```css
+.alert {
+  padding: var(--cui-alert-padding-y) var(--cui-alert-padding-x);
+}
+```
+
+Two consequences follow:
+
+- **Derived values are computed in the browser, not frozen at build time.** A size that depends on another size is written as `calc(var(--cui-…) * …)`, so overriding the source token at run time propagates to everything derived from it. Sass arithmetic would have baked the result into the file.
+- **A token resolves where it is declared.** Overriding `--cui-body-font-size` on a descendant does not re-resolve `:root`-computed tokens that were derived from it — that is how `var()` substitution works everywhere, not a library rule. Set global tokens globally; set component tokens on the component.
+
+The full token reference lives on [CSS variables](/customize/css-variables/).
+
+## Component tokens
+
+Every component declares its complete styling surface as custom properties on its root class, built from a `$<component>-tokens` Sass map:
+
+<ScssDocs file="scss/mixins/_tokens.scss" capture="mixin-tokens" />
+
+That gives you three override levels, from no build step to full build:
+
+1. **At run time, with CSS** — set the token on the component or any ancestor scope; no compilation involved:
+
+   ```css
+   .my-sidebar .alert { --cui-alert-bg: hotpink; }
+   ```
+
+2. **At build time, per surface** — hand the map your overrides through [Sass modules](/customize/sass/); `null` removes a token entirely:
+
+   ```scss
+   @use "@coreui/coreui-pro/scss/coreui" with (
+     $alert-tokens: (
+       --cui-alert-bg: hotpink,
+       --cui-alert-margin-bottom: null,
+     )
+   );
+   ```
+
+3. **At build time, per variable** — the classic `$alert-padding-y: 2rem` overrides keep working, because the map defaults are built from the same Sass variables. Per-component Sass variables are a transitional layer, kept for migration; the tokens are the API that stays.
+
+## Theme slots
+
+Components do not read colors directly — they read them through `--cui-theme-*` slots with a fallback to their own default:
+
+```css
+.nav-link {
+  color: var(--cui-theme-fg, var(--cui-nav-link-color));
+}
+```
+
+When no theme class is present, the slot is unset and the fallback applies. A theme class — `.alert-danger`, `.theme-primary` — fills the slots for its subtree, and every component inside follows the theme without owning a single state rule:
+
+```css
+.theme-danger {
+  --cui-theme-fg: var(--cui-danger-fg);
+  --cui-theme-bg-subtle: var(--cui-danger-bg-subtle);
+  /* … */
+}
+```
+
+The slot values come from per-color scales generated with `color-mix()` from each color's base token, and the interactive states are derived at run time with relative color syntax — `oklch(from var(--cui-primary) calc(l * .85) c h)` — so overriding `--cui-primary` alone re-colors the subtle backgrounds, borders, emphasis text, hover and active states with it. The color system is documented on [Color](/customize/color/), the scheme switching on [Color modes](/customize/color-modes/).

--- a/docs/src/data/sidebar.yml
+++ b/docs/src/data/sidebar.yml
@@ -38,6 +38,8 @@
   pages:
     - title: Overview
       to: /customize/overview/
+    - title: Architecture
+      to: /customize/architecture/
     - title: Sass
       to: /customize/sass/
     - title: Options


### PR DESCRIPTION
Resolves decision **D4** from `plans/v6-docs-conventions.md`: the styling architecture — cascade layers, the token pipeline, `defaults()`, theme slots — was documented only inside the migration guide, addressed to someone leaving v5. A reader who starts on v6 had no page that explains the system or where an override belongs.

New page: **`customize/architecture`**, second entry in the Customize section, right after Overview.

Named **Architecture**, not Approach: upstream's page of that name is a philosophy essay with the architecture folded in (they link to it for their *layer order*); ours documents the concrete mechanism and links out to the pages that own each subsystem (CSS variables, Sass, Color, Color modes).

Contents, all verified against the build:

- **Cascade layers** — the declared order from `scss/_root.scss:338`, which fights it settles (utilities beat components with no `!important`, unlayered user CSS beats everything, `colors`/`config`/`custom` reserved for the user), and the minifier caveat for concatenated builds.
- **Design tokens** — derived values are `calc()` over tokens computed in the browser, not Sass arithmetic frozen at build time; a token resolves where it is declared.
- **Component tokens** — the `defaults()`/`tokens()` pipeline and the three override levels (run-time CSS custom property → `$<component>-tokens` map via `@use … with()`, `null` removes a token → classic per-variable overrides, described as the transitional layer per D5).
- **Theme slots** — the `var(--cui-theme-*, fallback)` read, how a theme class re-colors a subtree, and the run-time `oklch(from …)` derivation of hover/active (verified working on the Safari 17.5 line earlier today).

Gates: `npm run docs-build` — 174 pages, no broken links; the `mixin-tokens` ScssDocs capture exists in `scss/mixins/_tokens.scss`.