### PR TITLE
docs: bring the Laravel guide up to the current Laravel skeleton

### DIFF
--- a/docs/src/content/docs/guides/laravel.mdx
+++ b/docs/src/content/docs/guides/laravel.mdx
@@ -3,21 +3,21 @@ title: "CoreUI & Laravel"
 description: "The official guide for how to include and bundle CoreUI’s CSS and JavaScript in your Laravel project."
 ---
 
-## Setup 
+## Setup
 
-1. **Create a new Laravel project.** Start by creating a new Laravel project
+1. **Create a new Laravel project.** Start by creating a new Laravel project:
 
    ```sh
    composer create-project laravel/laravel example-app
    ```
 
-   after installtion go to project
+   After installation, enter the project directory:
 
    ```sh
    cd example-app
    ```
 
-2. **Install CoreUI** Now we can install CoreUI. We’ll also install Floating UI since our dropdowns, popovers, and tooltips depend on it for their positioning. If you don’t plan on using those components, you can omit Floating UI here.
+2. **Install CoreUI.** Now we can install CoreUI. We’ll also install Floating UI since our dropdowns, popovers, and tooltips depend on it for their positioning. If you don’t plan on using those components, you can omit Floating UI here.
 
    ```sh
    npm i --save @coreui/coreui @floating-ui/dom
@@ -29,10 +29,16 @@ description: "The official guide for how to include and bundle CoreUI’s CSS an
    npm i --save @coreui/coreui-pro @floating-ui/dom
    ```
 
-3. **Install additional dependency.** In addition to CoreUI, we need another dependency (Sass) to properly import and bundle CoreUI’s CSS.
+3. **Install Sass.** In addition to CoreUI, we need Sass to properly import and bundle CoreUI’s CSS.
 
    ```sh
    npm i --save-dev sass
+   ```
+
+4. **Remove Tailwind CSS.** A fresh Laravel project ships with Tailwind CSS; CoreUI replaces it.
+
+   ```sh
+   npm remove tailwindcss @tailwindcss/vite
    ```
 
 Now that we have all the necessary dependencies installed and setup, we can get to work creating the project files and importing CoreUI.
@@ -46,7 +52,7 @@ mkdir resources/sass
 touch resources/sass/app.scss
 ```
 
-You can also remove `app.css` file because we don't need it.
+You can also remove the `app.css` file, because we don't need it — it only carried the Tailwind setup we just uninstalled.
 
 ```sh
 rm resources/css/app.css
@@ -88,43 +94,38 @@ example-app/
 
 With dependencies installed and our project folder ready for us to start coding, we can now configure Vite.
 
-1. **Open `vite.config.js` in your editor.** Since it’s not blank, we’ll need to make some changes to work with our `app.scss` file instead of `app.css`.
+1. **Open `vite.config.js` in your editor.** Since it’s not blank, we’ll need to make some changes: point the input at our `app.scss` file instead of `app.css`, and drop the Tailwind plugin we uninstalled.
 
    ```diff
    import { defineConfig } from 'vite';
    import laravel from 'laravel-vite-plugin';
+   -import tailwindcss from '@tailwindcss/vite';
 
    export default defineConfig({
-      plugins: [
-         laravel({
-   -        input: ['resources/css/app.scss', 'resources/js/app.js'],
-   +        input: ['resources/sass/app.scss', 'resources/js/app.js'],
-            refresh: true,
-         }),
-      ],
+       plugins: [
+           laravel({
+   -            input: ['resources/css/app.css', 'resources/js/app.js'],
+   +            input: ['resources/sass/app.scss', 'resources/js/app.js'],
+               refresh: true,
+           }),
+   -        tailwindcss(),
+       ],
+       server: {
+           watch: {
+               ignored: ['**/storage/framework/views/**'],
+           },
+       },
    });
    ```
 
-2. **Next, we modify `resources/views/welcome.blade.php`.** We'll need to add our SCSS and JavaScript files to our blade file.
+2. **Next, we modify `resources/views/welcome.blade.php`.** The welcome view already loads Vite assets in its `<head>` — update the stylesheet path to our SCSS file:
 
    ```diff
-   <!DOCTYPE html>
-   <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
-      <head>
-         <meta charset="utf-8">
-         <meta name="viewport" content="width=device-width, initial-scale=1">
-
-         <title>Laravel</title>
-
-         <!-- Fonts -->
-         <link rel="preconnect" href="https://fonts.bunny.net">
-         <link href="https://fonts.bunny.net/css?family=figtree:400,600&display=swap" rel="stylesheet" />
-   +
-   +     <!-- Scripts -->
-   +     @vite(['resources/sass/app.scss', 'resources/js/app.js'])
-
-         <!-- Styles -->
+   -    @vite(['resources/css/app.css', 'resources/js/app.js'])
+   +    @vite(['resources/sass/app.scss', 'resources/js/app.js'])
    ```
+
+   The `@vite` directive sits inside an `@if` that falls back to inline styles until the first build — after `npm run build` (or with the dev server running) your bundled CSS and JS take over. The default welcome page is styled with Tailwind classes, so it will render unstyled once CoreUI replaces it; that's expected — it's the canvas for your own markup.
 
 ## Import CoreUI
 
@@ -144,7 +145,7 @@ With dependencies installed and our project folder ready for us to start coding,
 
    *You can also import our stylesheets individually if you want. [Read our Sass import docs](/customize/sass/#importing) for details.*
 
-2. **Next we import CoreUI’s JavaScript**. Add the following to resources/js/bootstrap.js to import all of CoreUI’s JS. Floating UI will be imported automatically through CoreUI.
+2. **Next we import CoreUI’s JavaScript**. Add the following to `resources/js/bootstrap.js` to import all of CoreUI’s JS. Floating UI will be imported automatically through CoreUI.
 
    ```js
    // Import all of CoreUI's JS
@@ -172,7 +173,7 @@ With dependencies installed and our project folder ready for us to start coding,
 
 ## Build and Run Laravel App
 
-1. **Now we need to build CSS and JS files.** From the `example-app` folder in your terminal, run that 
+1. **Build the CSS and JS files.** From the `example-app` folder in your terminal, run:
 
    ```sh
    npm run build
@@ -181,9 +182,9 @@ With dependencies installed and our project folder ready for us to start coding,
 2. **And finally, we can start our Laravel App.** From the `example-app` folder in your terminal, run:
 
    ```sh
-   php artisan serve	
+   php artisan serve
    ```
 
-3. **And you’re done!** 🎉 With CoreUI’s source Sass and JS fully loaded, your local development server should now look like this.
+   During development, run `composer run dev` instead — it starts the PHP server and the Vite dev server together, so changes to your Sass and JS rebuild on save.
 
-   Now you can start adding any CoreUI components you want to use.
+3. **And you’re done!** 🎉 Your app is running at `http://localhost:8000` with CoreUI’s source Sass and JS fully loaded. Now you can start adding any CoreUI components you want to use.


### PR DESCRIPTION
The guide was written against the Laravel 9/10 skeleton. Verified against today's `laravel/laravel` master (13.x line) and three instructions no longer match a fresh project:

| guide said | fresh project has |
| --- | --- |
| `vite.config.js` diff with only the `laravel()` plugin, and a `-` line removing `input: ['resources/css/app.scss', …]` — a line that never existed (the file says `app.css`) | `@tailwindcss/vite` import, a `tailwindcss()` plugin entry and a `server.watch` block — Laravel ships **Tailwind CSS 4 by default** now |
| "remove `app.css` because we don't need it" | `app.css` is the **Tailwind entry point**; removing the file alone leaves the packages and the broken plugin import behind |
| "add `@vite([…])` to `welcome.blade.php`" with a fonts-context diff (`figtree`) | the welcome view **already loads Vite assets** inside an `@if` fallback (fonts are `instrument-sans` now) — following the guide produced a second directive; the real edit is changing the stylesheet path in the existing one |

What still holds, verified rather than assumed: `resources/js/bootstrap.js` **does** still exist in the current skeleton (axios setup), so the JS import step stays; `composer create-project` remains a supported install path; the Sass and JS import steps were correct.

Also: the setup now removes Tailwind explicitly (`npm remove tailwindcss @tailwindcss/vite`), notes that the Tailwind-styled welcome page renders unstyled by design once CoreUI takes over, points development at `composer run dev` (the skeleton's concurrent server+Vite script), and fixes the prose — "after installtion", a dangling "should now look like this" with no screenshot, trailing whitespace in the `php artisan serve` command.

Gates: `npm run docs-build` — 173 pages, no broken links; `/customize/sass/#importing` anchor confirmed present.