### PR TITLE
docs: close the bundler guides with the server address, not a missing screenshot

### DIFF
--- a/docs/src/content/docs/guides/parcel.mdx
+++ b/docs/src/content/docs/guides/parcel.mdx
@@ -163,6 +163,4 @@ Importing CoreUI into Parcel takes one line of Sass config and two imports, one 
 
    *[Read our JavaScript docs](/getting-started/javascript/) for more information on how to use CoreUI's plugins.*
 
-4. **And you're done! 🎉** With CoreUI's source Sass and JS fully loaded, your local development server should now look like this.
-
-   Now you can start adding any CoreUI components you want to use.
+4. **And you're done! 🎉** With CoreUI's source Sass and JS fully loaded and running at `http://localhost:1234`, you can start adding any CoreUI components you want to use.

--- a/docs/src/content/docs/guides/vite.mdx
+++ b/docs/src/content/docs/guides/vite.mdx
@@ -168,6 +168,4 @@ In the next and final section to this guide, we’ll import all of CoreUI’s CS
 
    *[Read our JavaScript docs](/getting-started/javascript/) for more information on how to use CoreUI's plugins.*
 
-3. **And you're done! 🎉** With CoreUI's source Sass and JS fully loaded, your local development server should now look like this.
-
-   Now you can start adding any CoreUI components you want to use.
+3. **And you're done! 🎉** With CoreUI's source Sass and JS fully loaded and running at `http://localhost:8080`, you can start adding any CoreUI components you want to use.

--- a/docs/src/content/docs/guides/webpack.mdx
+++ b/docs/src/content/docs/guides/webpack.mdx
@@ -230,9 +230,7 @@ Importing CoreUI into Webpack requires the loaders we installed in the first sec
 
    *[Read our JavaScript docs](/getting-started/javascript/) for more information on how to use CoreUI's plugins.*
 
-4. **And you're done! 🎉** With CoreUI's source Sass and JS fully loaded, your local development server should now look like this.
-
-   Now you can start adding any CoreUI components you want to use.
+4. **And you're done! 🎉** With CoreUI's source Sass and JS fully loaded and running at `http://localhost:8080`, you can start adding any CoreUI components you want to use.
 
 ## Production optimizations
 


### PR DESCRIPTION
The Vite, Webpack and Parcel guides all end on *"your local development server should now look like this."* — with nothing after the sentence; the screenshot it refers to was never there. (Upstream keeps theirs commented out, which is where the sentence came from.)

Each closing now states the address the guide's own config actually serves — `localhost:8080` for Vite and Webpack (both set `port: 8080` explicitly), `localhost:1234` for Parcel (its default, the `start` script sets no port) — and folds the trailing "Now you can start adding…" sentence in.

Laravel got the same fix in #922; this covers the remaining three.

Gates: `npm run docs-build` — 174 pages, no broken links.