### PR TITLE
docs: put the Theme page in the sidebar

### DIFF
--- a/docs/src/data/sidebar.yml
+++ b/docs/src/data/sidebar.yml
@@ -50,6 +50,8 @@
       to: /customize/options/
     - title: Color
       to: /customize/color/
+    - title: Theme
+      to: /customize/theme/
     - title: Color modes
       to: /customize/color-modes/
     - title: Components


### PR DESCRIPTION
`customize/theme` documents the center of the v6 color system — slot families, the runtime scale, theme classes, adding a color — and **five pages link to it** (`customize/color` twice, `customize/color-modes`, `utilities/link`, `utilities/colors`, `helpers/focus-ring`). It was never listed in the sidebar, so a reader browsing Customize could not discover the page the others lean on. Found comparing the section against upstream, whose sidebar carries Theme.

One line: the entry slots between Color and Color modes, matching how the three pages hand off to each other (palette → semantic layer → scheme switching) and upstream's placement.

Gates: `npm run docs-build` — 175 pages, no broken links.