### PR TITLE
chore: bump @coreui/astro-docs to 0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@astrojs/mdx": "^7.0.3",
-        "@coreui/astro-docs": "^0.1.8",
+        "@coreui/astro-docs": "^0.1.9",
         "@eslint/markdown": "^7.5.1",
         "@floating-ui/dom": "^1.8.0",
         "@rollup/plugin-replace": "^6.0.3",
@@ -917,9 +917,9 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.8.tgz",
-      "integrity": "sha512-QrBw3X/j2ikpwy1WopL0zte/3lDbVISbeU5BXy8Ji28LJIawWUhrr7irsy3UxH72y7UJCoaRJWYRcB1tHTBhVQ==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.9.tgz",
+      "integrity": "sha512-gNxj5Lakojwxog6LnLroX0J7so3gKZSilenNv4B7viQ1ERbA+Qkc5at+dfCzdNU8wJQU7yx1FUKChLsel9fNcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "devDependencies": {
     "@astrojs/mdx": "^7.0.3",
-    "@coreui/astro-docs": "^0.1.8",
+    "@coreui/astro-docs": "^0.1.9",
     "@eslint/markdown": "^7.5.1",
     "@floating-ui/dom": "^1.8.0",
     "@rollup/plugin-replace": "^6.0.3",


### PR DESCRIPTION
Closes audit finding **§2.7** (the 100-900 palette grid on `customize/color` rendering unstyled): the engine gained the `docs-scale` classes in [astro-docs#80], which shipped in **0.1.9** — published nine minutes after the commit, so I verified the tarball actually carries it by unpacking it, not by trusting the timestamps.

Our lockfile still resolved **0.1.8**, so every clean install (`npm ci` — CI and the deploy pipeline) built the page without the swatch styles; locally the symlink masked the difference. With the bump, the built site emits **118** `.docs-{color}-{stop}` classes and the page markup matches them.

One line in `package.json` (`^0.1.8` → `^0.1.9`, keeping the caret style) plus the reconciled lock; `npm ci` passes on the result.

The sibling pin in `repos-v6/coreui-react-pro` is bumped separately — that closes the last of the 17 engine pins for 0.1.9.