### PR TITLE
docs: bridge the color page to the theme layer; name the customization model up front

### DIFF
--- a/docs/src/content/docs/customize/color.mdx
+++ b/docs/src/content/docs/customize/color.mdx
@@ -344,6 +344,18 @@ All these colors are available as a Sass map, `$theme-colors`.
 
 Check out [our Sass maps and loops docs](/customize/sass/#maps-and-loops) for how to modify these colors.
 
+## From colors to theme
+
+The `--cui-{color}-{stop}` tokens are the raw palette. On their own they style nothing — a chosen subset feeds the **theme layer**, where each color picks up semantic roles and every theme-aware component follows. The pipeline, end to end:
+
+1. **`$colors`** (`scss/_colors.scss`) defines the base hues, and each one gets a 100–900 scale of `color-mix()` tokens on `:root` — `--cui-blue-300` and friends, mixed in the browser from the color's own token.
+2. **Theme colors** (`$primary`, `$success`, … in `scss/_theme.scss`) get the same runtime scale from their own tokens — `--cui-primary-300`.
+3. **`$theme-colors`** maps each semantic name to a family of slots (`base`, `contrast`, `fg`, `text-emphasis`, `bg-subtle`, `bg-muted`, `border-subtle`, `focus-ring`), mostly reading that scale through `light-dark()` so every slot adapts to the color mode.
+4. The slots are emitted as **`--cui-{name}-{slot}`** tokens — `--cui-primary-bg-subtle` — the ones the table at the top of this page shows.
+5. **`.theme-{name}`** classes (and component variants like `.alert-danger`) remap them onto generic **`--cui-theme-{slot}`** tokens that components read — so one class restyles any theme-aware component, and overriding `--cui-primary` alone retints the whole family.
+
+The theme layer — the slots, the runtime scale, the classes — is documented in full on [Theme](/customize/theme/), and the mechanics of the slot indirection on [Architecture](/customize/architecture/#theme-slots). The rest of this page stays on the base color layer.
+
 ## All colors
 
 All CoreUI for Bootstrap colors are available as Sass variables and a Sass map in `scss/_colors.scss` file. To avoid increased file sizes, we don't create text or background color classes for each of these variables. Instead, we choose a subset of these colors for a [theme palette](#theme-colors).

--- a/docs/src/content/docs/customize/overview.mdx
+++ b/docs/src/content/docs/customize/overview.mdx
@@ -18,6 +18,8 @@ For those who want to use the distribution files, review the [getting started pa
 
 As you familiarize yourself with Bootstrap, continue exploring this section for more details on how to utilize our global options, making use of and changing our color system, how we build our components, how to use our growing list of CSS custom properties, and how to optimize your code when building with Bootstrap.
 
+In v6, **CSS custom properties are the first-class customization layer**: every design decision the library makes is emitted as a token you can override at run time, and Sass is the configuration language that generates them. Where each kind of override belongs — a token on a selector, a map handed to `@use … with ()`, a classic variable — is laid out on [Architecture](/customize/architecture/).
+
 ## CSPs and embedded SVGs
 
 Several CoreUI for Bootstrap components include embedded SVGs in our CSS to style components consistently and easily across browsers and devices. **For organizations with more strict <abbr title="Content Security Policy">CSP</abbr> configurations**, we've documented all instances of our embedded SVGs (all of which are applied via `background-image`) so you can more thoroughly review your options.


### PR DESCRIPTION
The last two items of the Customize pass.

**`customize/color` — `## From colors to theme`.** The color page documents the palette and the theme page the semantic layer, but nothing said how one becomes the other. The new section walks the pipeline in five steps (base hues → runtime scale → slot families → `--cui-{name}-{slot}` tokens → `.theme-*` classes remapping onto the generic slots components read), adapted to **our** pipeline, not copied — upstream's version describes their token names and steps; ours names the slot families from `$theme-colors` and links [Theme](https://coreui.io/bootstrap/docs/customize/theme/) and [Architecture](https://coreui.io/bootstrap/docs/customize/architecture/#theme-slots) (anchor verified in `_site`).

**`customize/overview`** — one paragraph naming the v6 model up front: CSS custom properties are the first-class customization layer, Sass is the configuration that generates them. The equivalent of upstream's `## Sass vs CSS` section, compressed to a pointer because the full story lives on Architecture.

Also verified while deciding the scope, and worth recording: the rest of the color page is **current** — the swatch contrast ratios the prose promises are really rendered by the engine (`.swatch-*::after`), the hard-coded `#aab3c5` matches `$gray-500` in source, and the engine's `colors.yml` hex labels match our palette. No stale claims to fix; the structural divergence from upstream is deliberate.

Gates: `npm run docs-build` — 175 pages, no broken links.