### PR TITLE
docs: close the layout pages per convention; quote the real make-container

### DIFF
--- a/docs/src/content/docs/customize/components.mdx
+++ b/docs/src/content/docs/customize/components.mdx
@@ -101,7 +101,7 @@ Should you modify your `$grid-breakpoints`, your changes will apply to all the l
 
 <ScssDocs file="scss/_config.scss" capture="grid-breakpoints" />
 
-For more information and examples on how to modify our Sass maps and variables, please refer to [the Sass section of the Grid documentation](/layout/grid/#sass).
+For more information and examples on how to modify our Sass maps and variables, please refer to [the Sass section of the Grid documentation](/layout/grid/#customizing).
 
 ## Creating your own
 

--- a/docs/src/content/docs/layout/breakpoints.mdx
+++ b/docs/src/content/docs/layout/breakpoints.mdx
@@ -31,7 +31,7 @@ These breakpoints are customizable via Sass—you'll find them in a Sass map in 
 
 <ScssDocs file="scss/_config.scss" capture="grid-breakpoints" />
 
-For more information and examples on how to modify our Sass maps and variables, please refer to [the Sass section of the Grid documentation](/layout/grid/#sass).
+For more information and examples on how to modify our Sass maps and variables, please refer to [the Sass section of the Grid documentation](/layout/grid/#customizing).
 
 ## Media queries
 

--- a/docs/src/content/docs/layout/containers.mdx
+++ b/docs/src/content/docs/layout/containers.mdx
@@ -60,26 +60,23 @@ Use `.container-fluid` for a full width container, spanning the entire width of 
 
 ## Customizing
 
+### Sass maps
+
 As shown above, CoreUI for Bootstrap generates a series of predefined container classes to help you build the layouts you desire. You may customize these predefined container classes by modifying the Sass map (found in `_config.scss`) that powers them:
 
 <ScssDocs file="scss/_config.scss" capture="container-max-widths" />
 
-In addition to customizing the Sass, you can also create your own containers with our Sass mixin.
+### Sass mixins
+
+In addition to customizing the Sass, you can also create your own containers with our Sass mixin. The mixin declares the container's own `--cui-gutter-*` properties, so the padding follows a gutter override the same way the built-in containers do:
+
+<ScssDocs file="scss/mixins/_container.scss" capture="make-container" />
 
 ```scss
-// Source mixin
-@mixin make-container($padding-x: $container-padding-x) {
-  width: 100%;
-  padding-right: $padding-x;
-  padding-left: $padding-x;
-  margin-right: auto;
-  margin-left: auto;
-}
-
 // Usage
 .custom-container {
   @include make-container();
 }
 ```
 
-For more information and examples on how to modify our Sass maps and variables, please refer to [the Sass section of the Grid documentation](/layout/grid/#sass).
+For more information and examples on how to modify our Sass maps and variables, please refer to [the Sass section of the Grid documentation](/layout/grid/#customizing).

--- a/docs/src/content/docs/layout/grid.mdx
+++ b/docs/src/content/docs/layout/grid.mdx
@@ -379,11 +379,45 @@ To nest your content with the default grid, add a new `.row` and set of `.col-sm
     </div>
   </div>`} />
 
-## Sass
+## Customizing the grid
+
+Using our built-in grid Sass variables and maps, it's possible to completely customize the predefined grid classes. Change the number of tiers, the media query dimensions, and the container widths—then recompile.
+
+### Columns and gutters
+
+The number of grid columns can be modified via Sass variables. `$grid-columns` is used to generate the widths (in percent) of each individual column while `$grid-gutter-width` sets the width for the column gutters.
+
+```scss
+$grid-columns: 12 !default;
+$grid-gutter-width: 1.5rem !default;
+```
+
+### Grid tiers
+
+Moving beyond the columns themselves, you may also customize the number of grid tiers. If you wanted just four grid tiers, you'd update the `$grid-breakpoints` and `$container-max-widths` to something like this:
+
+```scss
+$grid-breakpoints: (
+  xs: 0,
+  sm: 480px,
+  md: 768px,
+  lg: 1024px
+);
+
+$container-max-widths: (
+  sm: 420px,
+  md: 720px,
+  lg: 960px
+);
+```
+
+When making any changes to the Sass variables or maps, you'll need to save your changes and recompile. Doing so will output a brand new set of predefined grid classes for column widths, offsets, and ordering. Responsive visibility utilities will also be updated to use the custom breakpoints. Make sure to set grid values in `px` (not `rem`, `em`, or `%`).
+
+## Customizing
 
 When using CoreUI for Bootstrap's source Sass files, you have the option of using Sass variables and mixins to create custom, semantic, and responsive page layouts. Our predefined grid classes use these same variables and mixins to provide a whole suite of ready-to-use classes for fast responsive layouts.
 
-### Variables
+### Sass variables
 
 Variables and maps determine the number of columns, the gutter width, and the media query point at which to begin floating columns. We use these to generate the predefined grid classes documented above, as well as for the custom mixins listed below.
 
@@ -396,7 +430,7 @@ $grid-gutter-width: 1.5rem;
 
 <ScssDocs file="scss/_config.scss" capture="container-max-widths" />
 
-### Mixins
+### Sass mixins
 
 Mixins are used in conjunction with the grid variables to generate semantic CSS for individual grid columns.
 
@@ -460,37 +494,3 @@ You can modify the variables to your own custom values, or just use the mixins w
       <div class="example-content-secondary">Secondary content</div>
     </div>
   </div>`} />
-
-## Customizing the grid
-
-Using our built-in grid Sass variables and maps, it's possible to completely customize the predefined grid classes. Change the number of tiers, the media query dimensions, and the container widths—then recompile.
-
-### Columns and gutters
-
-The number of grid columns can be modified via Sass variables. `$grid-columns` is used to generate the widths (in percent) of each individual column while `$grid-gutter-width` sets the width for the column gutters.
-
-```scss
-$grid-columns: 12 !default;
-$grid-gutter-width: 1.5rem !default;
-```
-
-### Grid tiers
-
-Moving beyond the columns themselves, you may also customize the number of grid tiers. If you wanted just four grid tiers, you'd update the `$grid-breakpoints` and `$container-max-widths` to something like this:
-
-```scss
-$grid-breakpoints: (
-  xs: 0,
-  sm: 480px,
-  md: 768px,
-  lg: 1024px
-);
-
-$container-max-widths: (
-  sm: 420px,
-  md: 720px,
-  lg: 960px
-);
-```
-
-When making any changes to the Sass variables or maps, you'll need to save your changes and recompile. Doing so will output a brand new set of predefined grid classes for column widths, offsets, and ordering. Responsive visibility utilities will also be updated to use the custom breakpoints. Make sure to set grid values in `px` (not `rem`, `em`, or `%`).

--- a/scss/mixins/_container.scss
+++ b/scss/mixins/_container.scss
@@ -2,6 +2,7 @@
 
 // Container mixins
 
+// scss-docs-start make-container
 @mixin make-container($gutter: $container-padding-x) {
   --#{$prefix}gutter-x: #{$gutter};
   --#{$prefix}gutter-y: 0;
@@ -9,3 +10,4 @@
   padding-inline: calc(var(--#{$prefix}gutter-x) * .5);
   margin-inline: auto;
 }
+// scss-docs-end make-container


### PR DESCRIPTION
Layout section pass (8 upstream pages ↔ 8 ours, heading-by-heading). The section is in the best shape of any so far — no sidebar orphans, six pairs clean — and two pages needed work:

## `layout/containers` — the docs taught a mixin that no longer exists

`## Customizing` carried a **hand-pasted copy of `make-container`** showing the pre-v6 body: a `$padding-x` parameter and physical `padding-right`/`padding-left`, while the real v6 mixin takes `$gutter`, declares the container's own `--cui-gutter-*` properties, and lays out with `padding-inline`. Anyone following the docs' copy got markup that ignores gutter overrides and breaks in RTL. The mixin gains a `scss-docs` capture (comment-only change — compiled CSS unaffected, layer order checked) and the page quotes the source. The closing section also gains its `### Sass maps` / `### Sass mixins` headings per convention.

## `layout/grid` — the last layout page outside the closing-section convention

The page closed with `## Sass` (flagged in audit §0.1) sitting **before** `## Customizing the grid`. The reference block is now `## Customizing` → `### Sass variables` / `### Sass mixins` / `### Example usage` and moved to the end. **Three pages linked `/layout/grid/#sass`** (breakpoints, containers, customize/components) — all updated to `#customizing`; found by grep, since the link checker does not verify anchors.

## Verified clean, recorded so the next pass doesn't re-litigate

- `breakpoints` — our compressed `## Container queries` covers `set-container()`, `.contains-inline` and the `container-breakpoint-*` mixins, plus we have a dedicated `utilities/container-queries` page upstream lacks; 11 places in the build declare their own `container-type`
- `columns`, `gutters`, `utilities` — heading trees identical 1:1
- `z-index` — content parity; ours additionally links the `.z-*` utilities
- `css-grid` — parity minus their `### Playground`; our `### Sass` under Customizing is how-to prose, left as is

Gates: `npm run css` (layer order intact), `npm run docs-build` — 175 pages, no broken links; `#customizing` and `#sass-mixins` anchors verified in `_site`.