### PR TITLE
docs: put variant sections where readers look for them on component pages

### DIFF
--- a/docs/src/content/docs/components/alerts.mdx
+++ b/docs/src/content/docs/components/alerts.mdx
@@ -9,9 +9,17 @@ otherFrameworks:
 import { getData } from '@coreui/astro-docs/data'
 import alertLive from './snippets/alert-live.js?raw'
 
-## Examples
+## Default alert
 
-Bootstrap alerts can accommodate text of any length and feature an optional close button. `.alert` on its own is a neutral alert; the colour comes from a [`.theme-*` class](/customize/components/#theme-variants), which may sit on the alert or on any element above it. For inline dismissal, utilize the [alerts JavaScript plugin](#dismissing).
+Bootstrap alerts can accommodate text of any length and feature an optional close button. `.alert` on its own is a neutral alert — a bordered surface that inherits the text color of its surroundings. For inline dismissal, utilize the [alerts JavaScript plugin](#dismissing).
+
+<Example code={`<div class="alert" role="alert">
+    A simple alert—check it out!
+  </div>`} />
+
+## Variants
+
+The color comes from a [`.theme-*` class](/customize/components/#theme-variants), which may sit on the alert or on any element above it.
 
 <Example code={`<div class="alert theme-primary" role="alert">
     Here's a straightforward example of a primary alert—take a look!
@@ -38,7 +46,18 @@ Bootstrap alerts can accommodate text of any length and feature an optional clos
 Relying on color to convey meaning creates a visual cue that assistive technologies, like screen readers, cannot perceive. It's essential that any information represented by color is either apparent from the content itself (e.g., the visible text) or supplemented by alternative methods, such as extra text using the `.visually-hidden` class.
 </Callout>
 
-### Live example
+## Solid
+
+<AddedIn version="6.0.0" />
+
+Add `.alert-solid` for a high-contrast alert. The background takes the theme color and the text takes the color that reads on it, so a yellow alert gets dark text and a dark one gets light text without you picking either.
+
+<Example code={getData('theme-colors').map((c) => `<div class="alert alert-solid theme-${c.name}" role="alert">
+    Here's a straightforward example of solid ${c.name} alert—take a look!
+  </div>`)} />
+
+
+## Live example
 
 Click the button below to show an alert (initially hidden with inline styles), then dismiss (and destroy) it using the built-in close button.
 
@@ -49,7 +68,7 @@ The JavaScript below initiates our live alert demo:
 
 <Code code={alertLive} lang="js" />
 
-### Link color
+## Link color
 
 Utilize the `.alert-link` utility class to instantly create matching colored links within any alert.
 <Example code={`<div class="alert theme-primary" role="alert">
@@ -71,7 +90,7 @@ Utilize the `.alert-link` utility class to instantly create matching colored lin
     Here's a straightforward example of an info alert with <a href="#" class="alert-link">an example link</a>. Take a look!
   </div>`} />
 
-### Additional content
+## Additional content
 
 Bootstrap alerts can also include additional HTML elements such as headings, paragraphs, and dividers. The alert lays its children out in a row, so wrap them in a [`.vstack`](/helpers/stacks/) to keep them stacked.
 
@@ -84,7 +103,7 @@ Bootstrap alerts can also include additional HTML elements such as headings, par
     </div>
   </div>`} />
 
-### Icons
+## Icons
 
 Put an icon straight into the alert — it lays its children out in a row and spaces them with `--cui-alert-gap`, so no flexbox utilities are needed. Use [CoreUI Icons](https://coreui.io/icons/) or any inline SVG.
 
@@ -141,17 +160,7 @@ Different kinds of alert usually call for different icons. Put the matching SVG 
     </div>
   </div>`} />
 
-### Solid
-
-<AddedIn version="6.0.0" />
-
-Add `.alert-solid` for a high-contrast alert. The background takes the theme color and the text takes the color that reads on it, so a yellow alert gets dark text and a dark one gets light text without you picking either.
-
-<Example code={getData('theme-colors').map((c) => `<div class="alert alert-solid theme-${c.name}" role="alert">
-    Here's a straightforward example of solid ${c.name} alert—take a look!
-  </div>`)} />
-
-### Dismissing
+## Dismissing
 
 Using the JavaScript plugin, you can remove any alert.
 

--- a/docs/src/content/docs/components/badge.mdx
+++ b/docs/src/content/docs/components/badge.mdx
@@ -63,14 +63,6 @@ You can also replace the `.badge` class with a few more utilities without a coun
     </span>
   </button>`} />
 
-### Sizes
-
-Add `.badge-sm` or `.badge-lg` to change the padding and the minimum height.
-
-<Example code={`<span class="badge badge-sm theme-primary">Small</span>
-  <span class="badge theme-primary">Default</span>
-  <span class="badge badge-lg theme-primary">Large</span>`} />
-
 ## Variants
 
 Use the contextual `.theme-{color}` classes to apply a semantic theme color to badges. Combine them with `.badge-subtle` or `.badge-outline` for the other two variants.
@@ -84,6 +76,14 @@ Use the contextual `.theme-{color}` classes to apply a semantic theme color to b
 
 Relying on color to convey meaning creates a visual cue that assistive technologies, like screen readers, cannot perceive. It's essential that any information represented by color is either apparent from the content itself (e.g., the visible text) or supplemented by alternative methods, such as extra text using the `.visually-hidden` class.
 </Callout>
+
+## Sizes
+
+Add `.badge-sm` or `.badge-lg` to change the padding and the minimum height.
+
+<Example code={`<span class="badge badge-sm theme-primary">Small</span>
+  <span class="badge theme-primary">Default</span>
+  <span class="badge badge-lg theme-primary">Large</span>`} />
 
 ## Pill badges
 

--- a/docs/src/content/docs/components/card.mdx
+++ b/docs/src/content/docs/components/card.mdx
@@ -449,6 +449,51 @@ You are able to adjust the borders on the card elements as needed, and even excl
     <div class="card-footer bg-transparent border-success">Footer</div>
   </div>`} />
 
+## Theme variants
+
+A [theme class](/customize/components/#theme-variants) paints the card's frame and caps with the theme color, with contrast text in the header and footer:
+
+<Example class="d-flex flex-wrap gap-3" code={getData('theme-colors').map((c) => `<div class="card theme-${c.name}" style="width: 15rem;">
+    <div class="card-header">Header</div>
+    <div class="card-body">
+      <p class="card-text">Some quick example text to build on the card title.</p>
+    </div>
+    <div class="card-footer">Footer</div>
+  </div>`)} />
+
+Put the theme class on a single section instead and only that section follows it:
+
+<Example code={`<div class="card" style="max-width: 18rem;">
+    <div class="card-header">Header</div>
+    <div class="card-body">
+      <p class="card-text">Some quick example text to build on the card title.</p>
+    </div>
+    <div class="card-footer theme-danger">Something went wrong</div>
+  </div>`} />
+
+Add `.card-subtle` to swap the solid fill for the theme's subtle background and border, with emphasis text in the caps.
+
+<Example class="d-flex flex-wrap gap-3" code={getData('theme-colors').map((c) => `<div class="card card-subtle theme-${c.name}" style="width: 15rem;">
+    <div class="card-header">Header</div>
+    <div class="card-body">
+      <p class="card-text">Some quick example text to build on the card title.</p>
+    </div>
+    <div class="card-footer">Footer</div>
+  </div>`)} />
+
+## Translucent
+
+Add `.card-translucent` to let the background through the card and blur it. The caps thin out with it, so the whole card reads as one surface.
+
+<Example class="bg-black p-4" code={`<div class="card card-translucent" style="width: 18rem;">
+    <div class="card-header">Header</div>
+    <div class="card-body">
+      <h5 class="card-title">Card title</h5>
+      <p class="card-text">Some quick example text to build on the card title.</p>
+    </div>
+    <div class="card-footer">Footer</div>
+  </div>`} />
+
 ## Card layout
 
 In addition to styling the content within cards, Bootstrap includes a few options for laying out series of cards. For the time being, **these layout options are not yet responsive**.
@@ -687,50 +732,6 @@ Just like with card groups, card footers will automatically line up.
     </div>
   </div>`} />
 
-## Theming
-
-A [theme class](/customize/components/#theme-variants) paints the card's frame and caps with the theme color, with contrast text in the header and footer:
-
-<Example class="d-flex flex-wrap gap-3" code={getData('theme-colors').map((c) => `<div class="card theme-${c.name}" style="width: 15rem;">
-    <div class="card-header">Header</div>
-    <div class="card-body">
-      <p class="card-text">Some quick example text to build on the card title.</p>
-    </div>
-    <div class="card-footer">Footer</div>
-  </div>`)} />
-
-Put the theme class on a single section instead and only that section follows it:
-
-<Example code={`<div class="card" style="max-width: 18rem;">
-    <div class="card-header">Header</div>
-    <div class="card-body">
-      <p class="card-text">Some quick example text to build on the card title.</p>
-    </div>
-    <div class="card-footer theme-danger">Something went wrong</div>
-  </div>`} />
-
-Add `.card-subtle` to swap the solid fill for the theme's subtle background and border, with emphasis text in the caps.
-
-<Example class="d-flex flex-wrap gap-3" code={getData('theme-colors').map((c) => `<div class="card card-subtle theme-${c.name}" style="width: 15rem;">
-    <div class="card-header">Header</div>
-    <div class="card-body">
-      <p class="card-text">Some quick example text to build on the card title.</p>
-    </div>
-    <div class="card-footer">Footer</div>
-  </div>`)} />
-
-## Translucent
-
-Add `.card-translucent` to let the background through the card and blur it. The caps thin out with it, so the whole card reads as one surface.
-
-<Example class="bg-black p-4" code={`<div class="card card-translucent" style="width: 18rem;">
-    <div class="card-header">Header</div>
-    <div class="card-body">
-      <h5 class="card-title">Card title</h5>
-      <p class="card-text">Some quick example text to build on the card title.</p>
-    </div>
-    <div class="card-footer">Footer</div>
-  </div>`} />
 
 ## Customizing
 

--- a/docs/src/content/docs/components/nav.mdx
+++ b/docs/src/content/docs/components/nav.mdx
@@ -279,6 +279,34 @@ Similar to the `.nav-fill` example using a `<nav>`-based navigation.
     <a class="nav-link" href="#">Link</a>
     <a class="nav-link disabled" aria-disabled="true">Disabled</a>
   </nav>`} />
+## Variants
+
+A [theme class](/customize/components/#theme-variants) recolors a nav. Every link reads the theme's foreground; what marks the active one follows the variant — a tint on the base nav, a solid fill on pills, the line on either underline.
+
+<Example code={`<ul class="nav theme-success">
+    <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+  </ul>`} />
+
+<Example code={`<ul class="nav nav-pills theme-success">
+    <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+  </ul>`} />
+
+<Example code={`<ul class="nav nav-underline theme-success">
+    <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+  </ul>`} />
+
+<Example code={`<ul class="nav nav-underline-border theme-success">
+    <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+  </ul>`} />
+
 ## Working with flex utilities
 
 If you need responsive nav variations, consider using a series of [flexbox utilities](/utilities/flex/). While more verbose, these utilities offer greater customization across responsive breakpoints. In the example below, our nav will be stacked on the lowest breakpoint, then adapt to a horizontal layout that fills the available width starting from the small breakpoint.
@@ -348,33 +376,6 @@ Add dropdown menus with a little extra HTML and the [dropdowns JavaScript plugin
     </li>
   </ul>`} />
 
-## Theming
-
-A [theme class](/customize/components/#theme-variants) recolors a nav. Every link reads the theme's foreground; what marks the active one follows the variant — a tint on the base nav, a solid fill on pills, the line on either underline.
-
-<Example code={`<ul class="nav theme-success">
-    <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
-    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-  </ul>`} />
-
-<Example code={`<ul class="nav nav-pills theme-success">
-    <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
-    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-  </ul>`} />
-
-<Example code={`<ul class="nav nav-underline theme-success">
-    <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
-    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-  </ul>`} />
-
-<Example code={`<ul class="nav nav-underline-border theme-success">
-    <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Active</a></li>
-    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-    <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-  </ul>`} />
 
 ## Customizing
 

--- a/docs/src/content/docs/components/pagination.mdx
+++ b/docs/src/content/docs/components/pagination.mdx
@@ -84,6 +84,20 @@ You can optionally swap out active or disabled anchors for `<span>`, or omit the
     </ul>
   </nav>`} />
 
+## Variants
+
+A [theme class](/customize/components/#theme-variants) recolors the whole pagination: links read the theme's foreground, the hover state its subtle surface, and the active page its solid color.
+
+<Example code={`<nav aria-label="Themed pagination">
+    <ul class="pagination theme-success">
+      <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+      <li class="page-item"><a class="page-link" href="#">1</a></li>
+      <li class="page-item active" aria-current="page"><a class="page-link" href="#">2</a></li>
+      <li class="page-item"><a class="page-link" href="#">3</a></li>
+      <li class="page-item"><a class="page-link" href="#">Next</a></li>
+    </ul>
+  </nav>`} />
+
 ## Sizing
 
 Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for additional sizes. Each one maps the pagination's tokens onto the shared control scale, so a page link lines up with a button or an input of the same size.
@@ -142,19 +156,6 @@ Or with `.justify-content-end`:
     </ul>
   </nav>`} />
 
-## Theming
-
-A [theme class](/customize/components/#theme-variants) recolors the whole pagination: links read the theme's foreground, the hover state its subtle surface, and the active page its solid color.
-
-<Example code={`<nav aria-label="Themed pagination">
-    <ul class="pagination theme-success">
-      <li class="page-item"><a class="page-link" href="#">Previous</a></li>
-      <li class="page-item"><a class="page-link" href="#">1</a></li>
-      <li class="page-item active" aria-current="page"><a class="page-link" href="#">2</a></li>
-      <li class="page-item"><a class="page-link" href="#">3</a></li>
-      <li class="page-item"><a class="page-link" href="#">Next</a></li>
-    </ul>
-  </nav>`} />
 
 ## Customizing
 

--- a/docs/src/content/docs/components/pagination.mdx
+++ b/docs/src/content/docs/components/pagination.mdx
@@ -6,6 +6,8 @@ otherFrameworks:
   - pagination
 ---
 
+import { getData } from '@coreui/astro-docs/data'
+
 ## Overview
 
 We use a large block of connected links for our pagination, making links hard to miss and easily scalable—all while providing large hit areas. Pagination is built with list HTML elements so screen readers can announce the number of available links. Use a wrapping `<nav>` element to identify it as a navigation section to screen readers and other assistive technologies.
@@ -88,15 +90,15 @@ You can optionally swap out active or disabled anchors for `<span>`, or omit the
 
 A [theme class](/customize/components/#theme-variants) recolors the whole pagination: links read the theme's foreground, the hover state its subtle surface, and the active page its solid color.
 
-<Example code={`<nav aria-label="Themed pagination">
-    <ul class="pagination theme-success">
+<Example code={getData('theme-colors').map((c) => `<nav aria-label="Pagination ${c.title}">
+    <ul class="pagination theme-${c.name}">
       <li class="page-item"><a class="page-link" href="#">Previous</a></li>
       <li class="page-item"><a class="page-link" href="#">1</a></li>
       <li class="page-item active" aria-current="page"><a class="page-link" href="#">2</a></li>
       <li class="page-item"><a class="page-link" href="#">3</a></li>
       <li class="page-item"><a class="page-link" href="#">Next</a></li>
     </ul>
-  </nav>`} />
+  </nav>`)} />
 
 ## Sizing
 

--- a/docs/src/content/docs/components/spinners.mdx
+++ b/docs/src/content/docs/components/spinners.mdx
@@ -26,18 +26,6 @@ Use the border spinners for a lightweight loading indicator.
     <span class="visually-hidden">Loading...</span>
   </div>`} />
 
-### Colors
-
-The border spinner uses `currentColor` for its `border-color`, meaning you can customize the color with [text color utilities][color]. You can use any of our text color utilities on the standard spinner.
-
-<Example code={getData('theme-colors').map((c) => `<div class="spinner-border text-${c.name}" role="status">
-    <span class="visually-hidden">Loading...</span>
-  </div>`)} />
-
-<Callout color="info">
-**Why not use `border-color` utilities?** Each border spinner specifies a `transparent` border for at least one side, so `.border-{color}` utilities would override that.
-</Callout>
-
 ## Growing spinner
 
 If you don't fancy a border spinner, switch to the grow spinner. While it doesn't technically spin, it does repeatedly grow!
@@ -46,11 +34,21 @@ If you don't fancy a border spinner, switch to the grow spinner. While it doesn'
     <span class="visually-hidden">Loading...</span>
   </div>`} />
 
-Once again, this spinner is built with `currentColor`, so you can easily change its appearance with [text color utilities][color]. Here it is in blue, along with the supported variants.
+## Variants
+
+Both spinners use `currentColor` for their appearance, so any [text color utility][color] recolors them.
+
+<Example code={getData('theme-colors').map((c) => `<div class="spinner-border text-${c.name}" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>`)} />
 
 <Example code={getData('theme-colors').map((c) => `<div class="spinner-grow text-${c.name}" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>`)} />
+
+<Callout color="info">
+**Why not use `border-color` utilities?** Each border spinner specifies a `transparent` border for at least one side, so `.border-{color}` utilities would override that.
+</Callout>
 
 ## Alignment
 

--- a/docs/src/content/docs/components/tab.mdx
+++ b/docs/src/content/docs/components/tab.mdx
@@ -13,6 +13,8 @@ Dynamic tabbed interfaces, as described in the [<abbr title="Web Accessibility I
 
 Note that dynamic tabbed interfaces should <em>not</em> contain dropdown menus, as this causes both usability and accessibility issues. From a usability perspective, the fact that the currently displayed tab's trigger element is not immediately visible (as it's inside the closed dropdown menu) can cause confusion. From an accessibility point of view, there is currently no sensible way to map this sort of construct to a standard WAI ARIA pattern, meaning that it cannot be easily made understandable to users of assistive technologies.
 
+## Nav tabs
+
 <Example html={[`<ul class="nav nav-tabs mb-3" id="myTab" role="tablist">`, `  <li class="nav-item" role="presentation">`, `    <button class="nav-link active" id="home-tab" data-coreui-toggle="tab" data-coreui-target="#home-tab-pane" type="button" role="tab" aria-controls="home-tab-pane" aria-selected="true">Home</button>`, `  </li>`, `  <li class="nav-item" role="presentation">`, `    <button class="nav-link" id="profile-tab" data-coreui-toggle="tab" data-coreui-target="#profile-tab-pane" type="button" role="tab" aria-controls="profile-tab-pane" aria-selected="false">Profile</button>`, `  </li>`, `  <li class="nav-item" role="presentation">`, `    <button class="nav-link" id="contact-tab" data-coreui-toggle="tab" data-coreui-target="#contact-tab-pane" type="button" role="tab" aria-controls="contact-tab-pane" aria-selected="false">Contact</button>`, `  </li>`, `  <li class="nav-item" role="presentation">`, `    <button class="nav-link" id="disabled-tab" data-coreui-toggle="tab" data-coreui-target="#disabled-tab-pane" type="button" role="tab" aria-controls="disabled-tab-pane" aria-selected="false" disabled>Disabled</button>`, `  </li>`, `</ul>`, `<div class="tab-content" id="myTabContent">`, `  <div class="tab-pane show active" id="home-tab-pane" role="tabpanel" aria-labelledby="home-tab" tabindex="0">`, `    <p>This is some placeholder content the <strong>Home tab's</strong> associated content. Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling. You can use it with tabs, pills, and any other <code>.nav</code>-powered navigation.</p>`, `</div>`, `  <div class="tab-pane" id="profile-tab-pane" role="tabpanel" aria-labelledby="profile-tab" tabindex="0">`, `    <p>This is some placeholder content the <strong>Profile tab's</strong> associated content. Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling. You can use it with tabs, pills, and any other <code>.nav</code>-powered navigation.</p>`, `  </div>`, `  <div class="tab-pane" id="contact-tab-pane" role="tabpanel" aria-labelledby="contact-tab" tabindex="0">`, `    <p>This is some placeholder content the <strong>Contact tab's</strong> associated content. Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling. You can use it with tabs, pills, and any other <code>.nav</code>-powered navigation.</p>`, `  </div>`, `  <div class="tab-pane" id="disabled-tab-pane" role="tabpanel" aria-labelledby="disabled-tab" tabindex="0">`, `    <p>This is some placeholder content the <strong>Disabled tab's</strong> associated content.</p>`, `  </div>`, `  </div>`]} />
 
 ```html
@@ -38,6 +40,8 @@ Note that dynamic tabbed interfaces should <em>not</em> contain dropdown menus, 
 </div>
 ```
 
+## With arbitrary markup
+
 To help fit your needs, this works with `<ul>`-based markup, as shown above, or with any arbitrary "roll your own" markup. Note that if you're using `<nav>`, you shouldn't add `role="tablist"` directly to it, as this would override the element's native role as a navigation landmark. Instead, switch to an alternative element (in the example below, a simple `<div>`) and wrap the `<nav>` around it.
 
 <Example html={[`<nav>`, `  <div class="nav nav-tabs mb-3" id="nav-tab" role="tablist">`, `    <button class="nav-link active" id="nav-home-tab" data-coreui-toggle="tab" data-coreui-target="#nav-home" type="button" role="tab" aria-controls="nav-home" aria-selected="true">Home</button>`, `    <button class="nav-link" id="nav-profile-tab" data-coreui-toggle="tab" data-coreui-target="#nav-profile" type="button" role="tab" aria-controls="nav-profile" aria-selected="false">Profile</button>`, `    <button class="nav-link" id="nav-contact-tab" data-coreui-toggle="tab" data-coreui-target="#nav-contact" type="button" role="tab" aria-controls="nav-contact" aria-selected="false">Contact</button>`, `    <button class="nav-link" id="nav-disabled-tab" data-coreui-toggle="tab" data-coreui-target="#nav-disabled" type="button" role="tab" aria-controls="nav-disabled" aria-selected="false" disabled>Disabled</button>`, `</div>`, `</nav>`, `<div class="tab-content" id="nav-tabContent">`, `  <div class="tab-pane show active" id="nav-home" role="tabpanel" aria-labelledby="nav-home-tab" tabindex="0">`, `    <p>This is some placeholder content the <strong>Home tab's</strong> associated content. Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling. You can use it with tabs, pills, and any other <code>.nav</code>-powered navigation.</p>`, `  </div>`, `  <div class="tab-pane" id="nav-profile" role="tabpanel" aria-labelledby="nav-profile-tab" tabindex="0">`, `    <p>This is some placeholder content the <strong>Profile tab's</strong> associated content. Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling. You can use it with tabs, pills, and any other <code>.nav</code>-powered navigation.</p>`, `  </div>`, `  <div class="tab-pane" id="nav-contact" role="tabpanel" aria-labelledby="nav-contact-tab" tabindex="0">`, `    <p>This is some placeholder content the <strong>Contact tab's</strong> associated content. Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling. You can use it with tabs, pills, and any other <code>.nav</code>-powered navigation.</p>`, `  </div>`, `  <div class="tab-pane" id="nav-disabled" role="tabpanel" aria-labelledby="nav-disabled-tab" tabindex="0">`, `    <p>This is some placeholder content the <strong>Disabled tab's</strong> associated content.</p>`, `  </div>`, `  </div>`]} />
@@ -58,6 +62,8 @@ To help fit your needs, this works with `<ul>`-based markup, as shown above, or 
   <div class="tab-pane" id="nav-disabled" role="tabpanel" aria-labelledby="nav-disabled-tab" tabindex="0">...</div>
 </div>
 ```
+
+## Pills
 
 The tabs plugin also works with pills.
 
@@ -123,7 +129,9 @@ In general, to facilitate keyboard navigation, it's recommended to make the tab 
 The tab JavaScript plugin **does not** support tabbed interfaces that contain dropdown menus, as these cause both usability and accessibility issues. From a usability perspective, the fact that the currently displayed tab's trigger element is not immediately visible (as it's inside the closed dropdown menu) can cause confusion. From an accessibility point of view, there is currently no sensible way to map this sort of construct to a standard WAI ARIA pattern, meaning that it cannot be easily made understandable to users of assistive technologies.
 </Callout>
 
-## Using data attributes
+## Usage
+
+### Via data attributes
 
 You can activate a tab or pill navigation without writing any JavaScript by simply specifying `data-coreui-toggle="tab"` or `data-coreui-toggle="pill"` on an element. Use these data attributes on `.nav-tabs` or `.nav-pills`.
 
@@ -153,7 +161,7 @@ You can activate a tab or pill navigation without writing any JavaScript by simp
 </div>
 ```
 
-## Via JavaScript
+### Via JavaScript
 
 Enable tabbable tabs via JavaScript (each tab needs to be activated individually):
 
@@ -179,7 +187,7 @@ const triggerFirstTabEl = document.querySelector('#myTab li:first-child button')
 coreui.Tab.getInstance(triggerFirstTabEl).show() // Select first tab
 ```
 
-## Fade effect
+### Fade effect
 
 Every `.tab-pane` fades in as it becomes active — no class to add. The pane you leave goes at once, because two in-flow panes cannot cross-fade without one stacking under the other.
 
@@ -192,7 +200,7 @@ Add `.tab-pane-instant` to a pane to switch its fade off, or retime it with `--c
 </div>
 ```
 
-## Methods
+### Methods
 
 <Callout color="info">
 #### Promises and transitions
@@ -217,7 +225,7 @@ const cuiTab = new coreui.Tab('#myTab')
 | `getOrCreateInstance` | *Static* method which allows you to get the tab instance associated with a DOM element, or create a new one in case it wasn't initialized You can use it like this: `coreui.Tab.getOrCreateInstance(element)`. |
 | `show` | Selects the given tab and shows its associated pane. Any other tab that was previously selected becomes unselected and its associated pane is hidden. **Returns a promise that resolves after the tab pane is shown** (i.e. after the `shown.coreui.tab` event occurs). |
 
-## Events
+### Events
 
 When showing a new tab, the events fire in the following order:
 

--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -111,6 +111,54 @@ Wrap toasts in a toast container to stack them, which adds vertical spacing.
     </div>
   </div>`} />
 
+### Dark toasts
+
+Set `data-coreui-theme="dark"` on a toast to render it dark whatever [color mode](/customize/color-modes/) the page is in:
+
+<Example code={`<div class="toast show" data-coreui-theme="dark" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast-header">
+      <strong class="me-auto">Deployment</strong>
+      <small>11 mins ago</small>
+      <button type="button" class="btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>
+    </div>
+    <div class="toast-body">Build finished and deployed to production.</div>
+  </div>`} />
+
+### Variants
+
+A [theme class](/customize/components/#theme-variants) tints the toast's border and header. Add it to the toast to recolor the whole notification:
+
+<Example class="d-flex flex-column gap-3" code={`<div class="toast theme-success show" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast-header">
+      <strong class="me-auto">Deployment</strong>
+      <small>11 mins ago</small>
+      <button type="button" class="btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>
+    </div>
+    <div class="toast-body">Build finished and deployed to production.</div>
+  </div>
+
+  <div class="toast theme-danger show" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast-header">
+      <strong class="me-auto">Deployment</strong>
+      <small>2 seconds ago</small>
+      <button type="button" class="btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>
+    </div>
+    <div class="toast-body">Build failed on step 4 of 9.</div>
+  </div>`} />
+
+The same classes work on a single part of a toast, so the body can stay neutral while the header carries the theme:
+
+<Example code={`<div class="toast show" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast-header theme-warning">
+      <strong class="me-auto">Certificate</strong>
+      <small>11 mins ago</small>
+      <button type="button" class="btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>
+    </div>
+    <div class="toast-body">The TLS certificate expires in 7 days.</div>
+  </div>`} />
+
+Theme classes also apply from an ancestor, so a themed container passes its colors to every toast inside it.
+
 ### Custom content
 
 Customize your toasts by removing sub-components, adjusting them with [utilities](/utilities/api/), or adding your own markup. In this example, we've made a simpler toast by removing the default `.toast-header`, incorporating a custom hide icon from [CoreUI Icons](https://coreui.io/icons/), and using [flexbox utilities](/utilities/flex/) to modify the layout.
@@ -137,8 +185,6 @@ Alternatively, you can also add additional controls and components to toasts.
   </div>`} />
 
 ### Color schemes
-
-Building on the previous example, you can design various toast color schemes using our color and background utilities. In this case, we've added .text-bg-primary to the .toast. To achieve a clean edge, we remove the default border with .border-0.
 
 Building on the previous example, you can design various toast color schemes using our [color](/utilities/colors/) and [background](/utilities/background/) utilities. We added `.text-bg-primary` to the `.toast`; the close button takes the colour it inherits, so it stays legible on its own. To achieve a clean edge, we remove the default border with `.border-0`.
 
@@ -353,53 +399,6 @@ myToastEl.addEventListener('hidden.coreui.toast', () => {
 })
 ```
 
-## Theming
-
-A [theme class](/customize/components/#theme-variants) tints the toast's border and header. Add it to the toast to recolor the whole notification:
-
-<Example class="d-flex flex-column gap-3" code={`<div class="toast theme-success show" role="alert" aria-live="assertive" aria-atomic="true">
-    <div class="toast-header">
-      <strong class="me-auto">Deployment</strong>
-      <small>11 mins ago</small>
-      <button type="button" class="btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>
-    </div>
-    <div class="toast-body">Build finished and deployed to production.</div>
-  </div>
-
-  <div class="toast theme-danger show" role="alert" aria-live="assertive" aria-atomic="true">
-    <div class="toast-header">
-      <strong class="me-auto">Deployment</strong>
-      <small>2 seconds ago</small>
-      <button type="button" class="btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>
-    </div>
-    <div class="toast-body">Build failed on step 4 of 9.</div>
-  </div>`} />
-
-The same classes work on a single part of a toast, so the body can stay neutral while the header carries the theme:
-
-<Example code={`<div class="toast show" role="alert" aria-live="assertive" aria-atomic="true">
-    <div class="toast-header theme-warning">
-      <strong class="me-auto">Certificate</strong>
-      <small>11 mins ago</small>
-      <button type="button" class="btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>
-    </div>
-    <div class="toast-body">The TLS certificate expires in 7 days.</div>
-  </div>`} />
-
-Theme classes also apply from an ancestor, so a themed container passes its colors to every toast inside it.
-
-### Dark toasts
-
-Set `data-coreui-theme="dark"` on a toast to render it dark whatever [color mode](/customize/color-modes/) the page is in:
-
-<Example code={`<div class="toast show" data-coreui-theme="dark" role="alert" aria-live="assertive" aria-atomic="true">
-    <div class="toast-header">
-      <strong class="me-auto">Deployment</strong>
-      <small>11 mins ago</small>
-      <button type="button" class="btn-close" data-coreui-dismiss="toast" aria-label="Close"></button>
-    </div>
-    <div class="toast-body">Build finished and deployed to production.</div>
-  </div>`} />
 
 ## Customizing
 ### CSS variables


### PR DESCRIPTION
Component pages placed their theme-variant sections inconsistently — some at the very end of the page, under three different names (`Theming`, `Colors`, none at all) — and two pages had structural defects. This PR gives every page the same shape: the base example first, then the variant/modifier sections right after it, then usage/JS, with `Customizing` still closing the page.

- **Alerts** — the page opened with the six-variant loop and never showed a plain `.alert`. Now: `Default alert` (neutral example) → `Variants` (theme loop) → `Solid` → `Live example` → `Link color` → `Additional content` → `Icons` → `Dismissing`, all top-level.
- **Badge** — `Sizes` sat inside `Examples` between `Positioned` and `Variants`; it is its own section after `Variants` now.
- **Spinners** — the color loop was `Border spinner > Colors` although it applies to both spinner types; now a `Variants` section after `Growing spinner` with a loop per type (the second, duplicated loop under `Growing spinner` is merged into it).
- **Pagination** — `Theming` renamed to `Variants` and moved from the tail of the page to after `Disabled and active states`.
- **Card** — `Theming` (now `Theme variants`) and `Translucent` moved from after `Card layout` to before it, next to `Card styles`.
- **Toasts** — the theme examples join `Examples` as `Dark toasts` + `Variants` (after `Stacking`); a duplicated paragraph in `Color schemes` (the unlinked draft copy) is removed.
- **Nav** — `Theming` renamed to `Variants` and moved from before `Customizing` to after `Available styles`.
- **Tabs** — the four demos ran with no headings at all and the JS sections sat flat with `####` directly under `##`. Now: `Nav tabs` / `With arbitrary markup` / `Pills` (the first named to avoid colliding with the demo's `id="nav-tab"` — vnu caught the duplicate ID), and the JS sections nest under `Usage` as `###`.

No inbound links target any renamed anchor (checked `#theming`, `#colors`, `#examples`, tab anchors); `#dismissing`, `#icons`, `#underline`, `#placement`, `#card-groups`, `#background-and-color` are unchanged.

`npm run docs:build` green.
