### PR TITLE
fix(Alert): give the neutral alert its own surface

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -334,6 +334,12 @@ finished, not whether the state changed.
 #### Alert
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **An alert without a theme class carries its own surface.** `--cui-alert-bg`
+  falls back to `var(--cui-bg-1)` instead of `transparent`, so a plain
+  `.alert` no longer takes the color of whatever it sits on. Set
+  `--cui-alert-bg: transparent` on the alert to restore the old rendering.
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
   **The alert lays its children out in a row.** It is `display: flex` with
   `align-items: start` and `--cui-alert-gap` between children, so an icon next
   to a label needs no `d-flex` and no spacing utility. Text mixed with inline

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -27,7 +27,7 @@ $alert-tokens: () !default;
 // scss-docs-start alert-css-vars
 $alert-tokens: defaults(
   (
-    --#{$prefix}alert-bg: var(--#{$prefix}theme-bg-subtle, transparent),
+    --#{$prefix}alert-bg: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}bg-1)),
     --#{$prefix}alert-padding-x: #{$alert-padding-x},
     --#{$prefix}alert-padding-y: #{$alert-padding-y},
     --#{$prefix}alert-gap: #{$alert-gap},


### PR DESCRIPTION
An alert without a theme class had a transparent background — it took the color of whatever it sat on, and on any non-page surface (a card, a sidebar) only the border marked it. Writing the new `Default alert` docs section exposed it: the prose describes a surface, the rendering was a hollow frame.

`--cui-alert-bg` now falls back to `var(--cui-bg-1)` instead of `transparent`, so a plain `.alert` reads as its own surface in both color modes. Themed alerts are unchanged — `--cui-theme-bg-subtle` still wins whenever a theme class is present, and `.alert-solid` overrides the background anyway.

Migration guide gets a Breaking entry with the one-line opt-out (`--cui-alert-bg: transparent`).