### PR TITLE
docs: name the list-group theme section Variants

### DIFF
--- a/docs/src/content/docs/components/list-group.mdx
+++ b/docs/src/content/docs/components/list-group.mdx
@@ -136,13 +136,13 @@ The responsive variants measure the nearest [query container](/utilities/contain
     <li class="list-group-item">A third item</li>
   </ul>`)} />
 
-## Contextual classes
+## Variants
 
 Colour a list item with a [`.theme-*` class](/customize/components/#theme-variants). It works on the item, on the `.list-group` above it, or on both — an item's own theme wins over the one it inherits.
 
 <Example code={[`<ul class="list-group">`, `<li class="list-group-item">A simple default list group item</li>`, ...getData('theme-colors').map((c) => `<li class="list-group-item theme-${c.name}">A simple ${c.name} list group item</li>`), ``, `</ul>`]} />
 
-Contextual classes also work with `.list-group-item-action`. Note the addition of the hover styles here not present in the previous example. Also supported is the `.active` state; apply it to indicate an active selection on a contextual list group item.
+Theme classes also work with `.list-group-item-action`. Note the addition of the hover styles here not present in the previous example. Also supported is the `.active` state; apply it to indicate an active selection on a themed list group item.
 
 <Example code={[`<div class="list-group">`, `<a href="#" class="list-group-item list-group-item-action">A simple default list group item</a>`, ...getData('theme-colors').map((c) => `<a href="#" class="list-group-item list-group-item-action theme-${c.name}">A simple ${c.name} list group item</a>`), ``, `</div>`]} />
 


### PR DESCRIPTION
The section already demonstrated theme classes — the v5 name `Contextual classes` survived the rewrite, and `.list-group-item-{color}` already lives under `Deprecated markup` as the v5 spelling removed in v7. This renames the section to `Variants` and clears the two remaining "contextual" mentions in prose. No inbound links target `#contextual-classes`.