### PR TITLE
docs: merge the duplicated Utilities API heading on focus-ring

### DIFF
--- a/docs/src/content/docs/helpers/color-background.mdx
+++ b/docs/src/content/docs/helpers/color-background.mdx
@@ -20,7 +20,7 @@ Color and background helpers combine the power of our [`.text-*` utilities](/uti
 
 ## With components
 
-Use them in place of combined `.text-*` and `.bg-*` classes, like on [badges](/components/badge/#background-colors):
+Use them in place of combined `.text-*` and `.bg-*` classes, like on [badges](/components/badge/):
 
 <Example code={`<span class="badge text-bg-primary">Primary</span>
   <span class="badge text-bg-info">Info</span>`} />

--- a/docs/src/content/docs/helpers/focus-ring.mdx
+++ b/docs/src/content/docs/helpers/focus-ring.mdx
@@ -61,8 +61,6 @@ In addition to `.focus-ring`, we have several `.focus-ring-*` utilities to modif
 
 <Example code={getData('theme-colors').map((c) => `<p><a href="#" class="d-inline-flex focus-ring focus-ring-${c.name} py-1 px-2 text-decoration-none border rounded-2">${c.title} focus</a></p>`)} />
 
-### Utilities API
-
 Focus ring utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <ScssDocs file="scss/_utilities.scss" capture="utils-focus-ring" />


### PR DESCRIPTION
The focus-ring page carried `### Utilities API` twice — once over the `.focus-ring-*` color utilities, once over the API declaration block. Both now sit under a single heading, in the same order.

Also drops a dead `#background-colors` anchor in color-background — the badge page has no such section anymore, so the link points at the page.