### PR TITLE
docs: indent array-built example markup like the template-literal examples

### DIFF
--- a/docs/src/content/docs/components/chip.mdx
+++ b/docs/src/content/docs/components/chip.mdx
@@ -108,11 +108,11 @@ Add `.chip-img` for an image like an avatar or use our avatar component.
 
 Colour a chip with a [`.theme-*` class](/customize/components/#theme-variants), on the chip itself or on any element above it. Chips are subtle by default as this allows for a clear, themed active state.
 
-<Example code={[`<div class="d-flex flex-wrap gap-1">`, ...getData('theme-colors').map((c) => `<span class="chip theme-${c.name} chip-clickable" tabindex="0">${c.title} chip</span>
-    <span class="chip theme-${c.name} active" tabindex="0">${c.title} chip</span>`), ``, `</div>`]} />
+<Example code={[`<div class="d-flex flex-wrap gap-1">`, ...getData('theme-colors').map((c) => `    <span class="chip theme-${c.name} chip-clickable" tabindex="0">${c.title} chip</span>
+    <span class="chip theme-${c.name} active" tabindex="0">${c.title} chip</span>`), `  </div>`]} />
 
-<Example code={[`<div class="d-flex flex-wrap gap-1">`, ...getData('theme-colors').map((c) => `<span class="chip chip-outline chip-clickable theme-${c.name}" tabindex="0">${c.title} chip</span>
-    <span class="chip chip-outline theme-${c.name} active" tabindex="0">${c.title} chip</span>`), ``, `</div>`]} />
+<Example code={[`<div class="d-flex flex-wrap gap-1">`, ...getData('theme-colors').map((c) => `    <span class="chip chip-outline chip-clickable theme-${c.name}" tabindex="0">${c.title} chip</span>
+    <span class="chip chip-outline theme-${c.name} active" tabindex="0">${c.title} chip</span>`), `  </div>`]} />
 
 ### Active state
 
@@ -358,7 +358,7 @@ The Bootstrap Chip component follows WAI-ARIA patterns for interactive widgets, 
 
 The v5 spelling — `.chip` with a colour modifier — still works and renders identically. Each colour class is generated from the same theme map as the class it replaces, so `.chip-primary` *is* `.chip.theme-primary`. They are removed in v7.
 
-<Example code={[`<div class="d-flex flex-wrap gap-1">`, ...getData('theme-colors').map((c) => `<span class="chip chip-${c.name}">${c.title} chip</span>`), ``, `</div>`]} />
+<Example code={[`<div class="d-flex flex-wrap gap-1">`, ...getData('theme-colors').map((c) => `    <span class="chip chip-${c.name}">${c.title} chip</span>`), `  </div>`]} />
 
 ```diff
 - <span class="chip chip-success">Done</span>

--- a/docs/src/content/docs/components/list-group.mdx
+++ b/docs/src/content/docs/components/list-group.mdx
@@ -140,11 +140,11 @@ The responsive variants measure the nearest [query container](/utilities/contain
 
 Colour a list item with a [`.theme-*` class](/customize/components/#theme-variants). It works on the item, on the `.list-group` above it, or on both — an item's own theme wins over the one it inherits.
 
-<Example code={[`<ul class="list-group">`, `<li class="list-group-item">A simple default list group item</li>`, ...getData('theme-colors').map((c) => `<li class="list-group-item theme-${c.name}">A simple ${c.name} list group item</li>`), ``, `</ul>`]} />
+<Example code={[`<ul class="list-group">`, `    <li class="list-group-item">A simple default list group item</li>`, ...getData('theme-colors').map((c) => `    <li class="list-group-item theme-${c.name}">A simple ${c.name} list group item</li>`), `  </ul>`]} />
 
 Theme classes also work with `.list-group-item-action`. Note the addition of the hover styles here not present in the previous example. Also supported is the `.active` state; apply it to indicate an active selection on a themed list group item.
 
-<Example code={[`<div class="list-group">`, `<a href="#" class="list-group-item list-group-item-action">A simple default list group item</a>`, ...getData('theme-colors').map((c) => `<a href="#" class="list-group-item list-group-item-action theme-${c.name}">A simple ${c.name} list group item</a>`), ``, `</div>`]} />
+<Example code={[`<div class="list-group">`, `    <a href="#" class="list-group-item list-group-item-action">A simple default list group item</a>`, ...getData('theme-colors').map((c) => `    <a href="#" class="list-group-item list-group-item-action theme-${c.name}">A simple ${c.name} list group item</a>`), `  </div>`]} />
 
 <Callout color="info">
 ##### Conveying meaning to assistive technologies
@@ -405,7 +405,7 @@ tabElms.forEach(tabElm => {
 
 The v5 spelling — `.list-group-item` with a colour modifier — still works and renders identically. Each colour class is generated from the same theme map as the class it replaces, so `.list-group-item-primary` *is* `.list-group-item.theme-primary`. They are removed in v7.
 
-<Example code={[`<ul class="list-group">`, ...getData('theme-colors').map((c) => `<li class="list-group-item list-group-item-${c.name}">A simple ${c.name} list group item</li>`), ``, `</ul>`]} />
+<Example code={[`<ul class="list-group">`, ...getData('theme-colors').map((c) => `    <li class="list-group-item list-group-item-${c.name}">A simple ${c.name} list group item</li>`), `  </ul>`]} />
 
 ```diff
 - <li class="list-group-item list-group-item-success">Done</li>


### PR DESCRIPTION
Six examples assembled from arrays (list-group Variants ×2 + Deprecated markup, chip Variants ×2 + deprecated colors) rendered their children flush with the wrapper element and left a blank line before the closing tag. Child lines now carry the same indentation as every template-literal example, and the stray empty entry is gone.