### PR TITLE
feat(Theme): add .theme-reset to drop an inherited theme

### DIFF
--- a/docs/src/content/docs/utilities/theme.mdx
+++ b/docs/src/content/docs/utilities/theme.mdx
@@ -63,6 +63,19 @@ The theme can also come from any element above, so one wrapper themes every pair
     <div class="theme-muted p-3 rounded">Muted</div>
   </div>`} />
 
+## Reset
+
+<AddedIn version="6.0.0" />
+
+`.theme-reset` drops the theme a subtree inherits: it sets every `--cui-theme-*` slot back to `initial`, so components and utilities below it fall back to their defaults.
+
+<Example code={`<div class="theme-primary p-3 rounded">
+    <span class="badge">Primary badge</span>
+    <span class="badge theme-reset">Default badge</span>
+  </div>`} />
+
+<ScssDocs file="scss/_theme.scss" capture="theme-reset" />
+
 ## Customizing
 
 ### Utilities API

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -216,6 +216,16 @@ $theme-state-colors: (
 }
 // scss-docs-end theme-classes
 
+// scss-docs-start theme-reset
+@mixin generate-theme-reset() {
+  .theme-reset {
+    @each $token, $suffix in map.merge($theme-token-refs, ("hover": null, "active": null)) {
+      --#{$prefix}theme-#{$token}: initial;
+    }
+  }
+}
+// scss-docs-end theme-reset
+
 @function theme-color-tokens() {
   $tokens: ();
 

--- a/scss/helpers/_theme-colors.scss
+++ b/scss/helpers/_theme-colors.scss
@@ -2,4 +2,5 @@
 
 @layer helpers {
   @include generate-theme-classes();
+  @include generate-theme-reset();
 }


### PR DESCRIPTION
A subtree inside a themed container had no way back to component defaults — every `--cui-theme-*` slot it inherited stayed in force. `.theme-reset` sets each slot to `initial`, so `var()` reads below it take their fallbacks and components render as if no theme were set.

The slot list loops over the same `$theme-token-refs` map the theme classes are generated from, plus the two interaction tokens, so the reset cannot drift from the classes it undoes. Emitted in the `helpers` layer next to `generate-theme-classes()`.

Docs: a `## Reset` section on utilities/theme with a live example and the `theme-reset` capture. Bundlewatch within budget (pre-push gate green).