### PR TITLE
feat(scss)!: give every theme colour an action-background slot

### DIFF
--- a/docs/src/content/docs/customize/color.mdx
+++ b/docs/src/content/docs/customize/color.mdx
@@ -13,7 +13,7 @@ The palette below covers two different jobs. `secondary` and `tertiary` text and
 
 All of them are declared globally on `:root` and are available through Sass and CSS variables (but not through our color maps or utility classes).
 
-To fade any of these colors, mix it toward `transparent` rather than reaching for a channel triplet — `color-mix(in srgb, var(--cui-secondary-bg) 50%, transparent)`.
+To fade any of these colors, mix it toward `transparent` rather than reaching for a channel triplet — `color-mix(in srgb, var(--cui-bg-4) 50%, transparent)`.
 
 **Heads up!** The surface colors and the theme colors overlap in name without overlapping in purpose: `--cui-secondary-color` is body text at a lighter weight, while `--cui-secondary` is the theme color that `.btn-secondary` and friends are built from. The same split applies to `light` and `dark`.
 
@@ -58,10 +58,10 @@ To fade any of these colors, mix it toward `transparent` rather than reaching fo
     </tr>
     <tr>
       <td>
-        <div class="p-3 rounded-2 border" style="background-color: var(--cui-secondary-bg);">&nbsp;</div>
+        <div class="p-3 rounded-2 border" style="background-color: var(--cui-bg-4);">&nbsp;</div>
       </td>
       <td>
-        `--cui-secondary-bg`
+        `--cui-bg-4`
       </td>
     </tr>
     <tr>

--- a/docs/src/content/docs/customize/theme.mdx
+++ b/docs/src/content/docs/customize/theme.mdx
@@ -35,6 +35,7 @@ Every entry defines the same slots, emitted as `--cui-{color}-{slot}` on `:root`
 | Slot | Emitted token | Description |
 | --- | --- | --- |
 | `base` | `--cui-primary` | The color itself, e.g. a solid button background |
+| — | `--cui-primary-bg` | The action-background slot: what checked, active and filled states read; points at the base |
 | `contrast` | `--cui-primary-contrast` | Text and icons sitting on the solid base |
 | `fg` | `--cui-primary-fg` | The color readable as text, one step lighter than the emphasis |
 | `text-emphasis` | `--cui-primary-text-emphasis` | High-contrast foreground text |

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -237,7 +237,7 @@ finished, not whether the state changed.
   `--cui-accordion-active-bg` and `--cui-accordion-active-color` were fixed to
   `--cui-primary-bg-subtle` / `--cui-primary-text-emphasis`, so every accordion
   turned the brand colour on open whether or not that suited the page. They are
-  `--cui-secondary-bg` and `--cui-body-color` now, and the active tokens resolve
+  `--cui-bg-4` and `--cui-fg-body` now, and the active tokens resolve
   through `--cui-theme-fg` / `-bg-subtle` / `-border` first — so the colour is a
   decision you make per accordion instead of one baked into the component. To
   keep the old look, put `.theme-primary` on the `.accordion`.
@@ -450,7 +450,7 @@ check, radio, carousel and toggler icons already work:
   `.badge` used to be white text with no background of its own, so it was
   invisible until a `.text-bg-*` utility supplied both. It renders neutral on
   its own now — `--cui-badge-color` is `inherit` and `--cui-badge-bg` is
-  `--cui-secondary-bg` — and a `.theme-*` class colours it:
+  `--cui-bg-4` — and a `.theme-*` class colours it:
   `<span class="badge theme-danger">`. The `.badge-*` namespace carries the
   three variants instead: solid (default), `.badge-subtle` and
   `.badge-outline`, each mapping the same theme roles.
@@ -1224,7 +1224,7 @@ adornment in the library — so the button needs no icon markup at all:
   colour of your own gets the whole set for free.
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
   **A bare `.btn` is a neutral button, not an invisible one.** It renders in the
-  surface colours (`--cui-secondary-bg`, one step darker on hover) instead of
+  surface colours (`--cui-bg-4`, one step darker on hover) instead of
   being transparent and unstyled. Buttons that carry a variant or a colour class
   are unaffected. For the old behaviour use `.btn-ghost`, which is transparent
   by design.
@@ -1889,6 +1889,19 @@ as such.
   variables and their tokens are unchanged and keep driving the `rounded-*`
   utilities.
 
+#### Every theme colour gets an action-background slot
+
+`:root` emits `--cui-{color}-bg` for every theme colour, pointing at the
+colour's base token. Active and checked states read the slot instead of the
+base directly — `--cui-list-group-active-bg`, `--cui-menu-item-active-bg`,
+`--cui-pagination-active-bg`, `--cui-nav-pills-link-active-bg`,
+`--cui-progress-bar-bg` and `--cui-range-thumb-bg` are all
+`var(--cui-primary-bg)` now. The resolved values are unchanged; the slot is a
+single place to retune what "filled with the theme colour" means without
+touching the base colour that text and borders derive from. (The `secondary`
+colour's slot takes over the name of the former surface alias — see the
+ladder entry above.)
+
 #### Colour decisions are written, not computed
 
 v6 stops evaluating colours at build time, the way upstream v6 does — Sass
@@ -2505,13 +2518,17 @@ Two consequences for the tokens:
   **The surface tokens move out of the theme-color namespace.**
   `--cui-bg-body`, `--cui-bg-1` … `--cui-bg-4` and `--cui-fg-body`,
   `--cui-fg-1` … `--cui-fg-4` are canonical; `--cui-body-bg`, `--cui-body-color`,
-  `--cui-secondary-bg`, `--cui-secondary-color`, `--cui-tertiary-bg` and
-  `--cui-tertiary-color` remain as aliases with identical values, and go away in
-  v7 — at which point `--cui-secondary-*` belongs to the `secondary` theme color
-  alone. Until then the two systems share the prefix, which is exactly why the
-  ladder moved out: `--cui-secondary-bg` (a page surface) sat next to
-  `--cui-secondary-bg-subtle` (a theme-color slot) with no way to tell which
-  system a token belonged to.
+  `--cui-secondary-color`, `--cui-tertiary-bg` and `--cui-tertiary-color`
+  remain as aliases with identical values, and go away in v7 — at which point
+  the `--cui-secondary-*` prefix belongs to the `secondary` theme color alone.
+  One alias is already gone:
+  <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`--cui-secondary-bg` is the `secondary` theme color's action-background
+  slot now** (see the entry below), not a surface alias. Markup that read it
+  for the surface gets a similar but lighter gray — read `--cui-bg-4`
+  instead. This name is exactly why the ladder moved out of the theme-color
+  namespace: a page surface sat next to `--cui-secondary-bg-subtle` (a
+  theme-color slot) with no way to tell which system a token belonged to.
 - **`.text-body` and `.text-body-emphasis` are unaffected** — they are not
   ordinal, any more than `.text-primary` is.
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -19,7 +19,7 @@ $list-group-item-padding-x:         var(--#{$prefix}spacer-3) !default;
 
 $list-group-hover-bg:               var(--#{$prefix}bg-3) !default;
 $list-group-active-color:           var(--#{$prefix}primary-contrast) !default;
-$list-group-active-bg:              var(--#{$prefix}primary) !default;
+$list-group-active-bg:              var(--#{$prefix}primary-bg) !default;
 $list-group-active-border-color:    $list-group-active-bg !default;
 
 $list-group-disabled-color:         var(--#{$prefix}fg-2) !default;

--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -31,7 +31,7 @@ $menu-item-color:               var(--#{$prefix}menu-color, var(--#{$prefix}fg-b
 $menu-item-hover-color:         var(--#{$prefix}menu-color, var(--#{$prefix}fg-body)) !default;
 $menu-item-hover-bg:            var(--#{$prefix}bg-3) !default;
 $menu-item-active-color:        var(--#{$prefix}primary-contrast) !default;
-$menu-item-active-bg:           var(--#{$prefix}primary) !default;
+$menu-item-active-bg:           var(--#{$prefix}primary-bg) !default;
 $menu-item-disabled-color:      var(--#{$prefix}fg-3) !default;
 $menu-item-gap:                 .5rem !default;
 $menu-item-padding-x:           .75rem !default;

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -38,7 +38,7 @@ $nav-tabs-link-active-border-color: var(--#{$prefix}border-color) var(--#{$prefi
 
 $nav-pills-border-radius:           var(--#{$prefix}radius-9) !default;
 $nav-pills-link-active-color:       var(--#{$prefix}primary-contrast) !default;
-$nav-pills-link-active-bg:          var(--#{$prefix}primary) !default;
+$nav-pills-link-active-bg:          var(--#{$prefix}primary-bg) !default;
 
 $nav-underline-gap:                 1rem !default;
 $nav-underline-border-width:        .125rem !default;

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -28,7 +28,7 @@ $pagination-hover-bg:               var(--#{$prefix}bg-3) !default;
 $pagination-hover-border-color:     var(--#{$prefix}border-color) !default;
 
 $pagination-active-color:           var(--#{$prefix}primary-contrast) !default;
-$pagination-active-bg:              var(--#{$prefix}primary) !default;
+$pagination-active-bg:              var(--#{$prefix}primary-bg) !default;
 $pagination-active-border-color:    $pagination-active-bg !default;
 
 $pagination-disabled-color:         var(--#{$prefix}fg-2) !default;

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -13,7 +13,7 @@ $progress-bg:                          var(--#{$prefix}bg-4) !default;
 $progress-border-radius:               var(--#{$prefix}radius-5) !default;
 $progress-box-shadow:                  var(--#{$prefix}box-shadow-inset) !default;
 $progress-bar-color:                   var(--#{$prefix}primary-contrast) !default;
-$progress-bar-bg:                      var(--#{$prefix}primary) !default;
+$progress-bar-bg:                      var(--#{$prefix}primary-bg) !default;
 $progress-bar-transition:              width .6s ease !default;
 $progress-bar-animation:               progress-bar-stripes 1s linear infinite !default;
 

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -227,7 +227,6 @@ $root-token-defaults: map.merge(
     --#{$prefix}body-color: var(--#{$prefix}fg-body),
     --#{$prefix}body-bg: var(--#{$prefix}bg-body),
     --#{$prefix}secondary-color: var(--#{$prefix}fg-2),
-    --#{$prefix}secondary-bg: var(--#{$prefix}bg-4),
     --#{$prefix}tertiary-color: var(--#{$prefix}fg-3),
     --#{$prefix}tertiary-bg: var(--#{$prefix}bg-3),
     --#{$prefix}emphasis-color: $body-emphasis-color,

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -223,6 +223,12 @@ $theme-state-colors: (
     $tokens: map.set($tokens, --#{$prefix}#{$color}, map.get($slots, "base"));
   }
 
+  // The action-background slot: what checked, active and filled states read.
+  // Points at the base color, so overriding either retunes every action state.
+  @each $color in map.keys($theme-colors) {
+    $tokens: map.set($tokens, --#{$prefix}#{$color}-bg, var(--#{$prefix}#{$color}));
+  }
+
   // A 100-900 scale per theme color, on the same generator the palette uses. The
   // subtle backgrounds, borders and emphasis text below are `light-dark()` pairs
   // of these stops.

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -17,7 +17,7 @@ $form-range-track-box-shadow:              var(--#{$prefix}box-shadow-inset) !de
 
 $form-range-thumb-width:                   1rem !default;
 $form-range-thumb-height:                  var(--#{$prefix}range-thumb-width) !default;
-$form-range-thumb-bg:                      var(--#{$prefix}primary) !default;
+$form-range-thumb-bg:                      var(--#{$prefix}primary-bg) !default;
 $form-range-thumb-border:                  0 !default;
 $form-range-thumb-border-radius:           1rem !default;
 $form-range-thumb-box-shadow:              0 .1rem .25rem color-mix(in srgb, var(--#{$prefix}black) 10%, transparent) !default;


### PR DESCRIPTION
Stage 2 of the scale-alignment program (`workspace/plans/v6-scale-alignment.md`).

`:root` emits `--cui-{color}-bg` for every theme colour, pointing at the colour's base token, and the filled/checked states read the slot instead of the base directly: `list-group-active-bg`, `menu-item-active-bg`, `pagination-active-bg`, `nav-pills-link-active-bg`, `progress-bar-bg` and `range-thumb-bg` all resolve through `var(--cui-primary-bg)` now. Resolved values are unchanged — the slot is one place to retune what "filled with the theme colour" means, separately from the colour that text and borders derive from.

**Breaking:** the slot takes the `--cui-secondary-bg` name from the v5 surface alias, which is removed — exactly the collision the root comment deferred to v7 ("the namespace goes back to the theme colors"), and the same resolution upstream shipped (their `--bs-secondary-bg` is the theme colour). Nothing internal read the bare alias (0 reads in the compiled build — checked; the 14 grep hits were `-bg-subtle`/`-bg-muted` prefix matches). Markup that did read it gets the secondary theme colour, a similar but lighter gray; the surface is `--cui-bg-4`. Migration prose that used the alias as a synonym for the surface (accordion, badge, buttons entries + the customize/color table) now names the ladder token the code actually reads.

Docs: slot row in the customize/theme slots table, migration entries for both the slot and the alias removal. Gates green (pre-push).