### PR TITLE
feat(scss)!: interaction surfaces sit two rungs lighter on the ladder

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1889,6 +1889,19 @@ as such.
   variables and their tokens are unchanged and keep driving the `rounded-*`
   utilities.
 
+#### Interaction surfaces sit two rungs lighter on the ladder
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **Hover, active and disabled surfaces read lighter ladder rungs.** Hover
+  states read `--cui-bg-1` (was `--cui-bg-3`), active and disabled states
+  `--cui-bg-2` (was `--cui-bg-4`), across list groups, menus, navs,
+  pagination, breadcrumb links, the accordion's open header, the file-input
+  button and disabled controls; the badge's neutral fill, the popover
+  header, the progress track, the avatar fallback and input-group addons
+  step down the same way. Interaction feedback is a tint rather than a
+  block of gray — the same relationships, two rungs closer to the page.
+  Set the component's own token to keep a darker surface.
+
 #### Every theme colour gets an action-background slot
 
 `:root` emits `--cui-{color}-bg` for every theme colour, pointing at the

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -24,7 +24,7 @@ $accordion-button-bg:                     var(--#{$prefix}accordion-bg) !default
 $accordion-transition-property:           #{var(--#{$prefix}btn-input-action-transition-property), border-radius} !default;
 $accordion-transition-duration:           var(--#{$prefix}btn-input-transition-duration) !default;
 $accordion-transition-timing:             var(--#{$prefix}btn-input-transition-timing) !default;
-$accordion-button-active-bg:              var(--#{$prefix}bg-4) !default;
+$accordion-button-active-bg:              var(--#{$prefix}bg-2) !default;
 $accordion-button-active-color:           var(--#{$prefix}fg-body) !default;
 $accordion-active-border-color:           $accordion-border-color !default;
 

--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -13,7 +13,7 @@ $avatar-size:                  2rem !default;
 // The label scales with the frame, so a size only has to be given once.
 $avatar-font-size-ratio:       .4 !default;
 $avatar-color:                 inherit !default;
-$avatar-bg:                    var(--#{$prefix}bg-4) !default;
+$avatar-bg:                    var(--#{$prefix}bg-2) !default;
 $avatar-border-radius:         50em !default;
 $avatar-status-size:           .5rem !default;
 $avatar-status-border-radius:  50em !default;

--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -13,7 +13,7 @@ $badge-font-size:                   .75em !default;
 $badge-font-size-floor:             12px !default;
 $badge-font-weight:                 var(--#{$prefix}font-weight-semibold) !default;
 $badge-color:                       inherit !default;
-$badge-bg:                          var(--#{$prefix}bg-4) !default;
+$badge-bg:                          var(--#{$prefix}bg-2) !default;
 $badge-border-width:                var(--#{$prefix}border-width) !default;
 $badge-border-color:                transparent !default;
 $badge-border-radius:               var(--#{$prefix}radius-7) !default;

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -19,7 +19,7 @@ $breadcrumb-link-padding-y:         .25rem !default;
 $breadcrumb-link-padding-x:         .5rem !default;
 $breadcrumb-link-color:             var(--#{$prefix}fg-2) !default;
 $breadcrumb-link-hover-color:       var(--#{$prefix}fg-body) !default;
-$breadcrumb-link-hover-bg:          var(--#{$prefix}bg-3) !default;
+$breadcrumb-link-hover-bg:          var(--#{$prefix}bg-1) !default;
 $breadcrumb-link-border-radius:     var(--#{$prefix}radius-7) !default;
 $breadcrumb-divider:                string.quote("/") !default;
 $breadcrumb-divider-flipped:        $breadcrumb-divider !default;

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -17,7 +17,7 @@ $list-group-border-radius:          var(--#{$prefix}radius-5) !default;
 $list-group-item-padding-y:         var(--#{$prefix}spacer-2) !default;
 $list-group-item-padding-x:         var(--#{$prefix}spacer-3) !default;
 
-$list-group-hover-bg:               var(--#{$prefix}bg-3) !default;
+$list-group-hover-bg:               var(--#{$prefix}bg-1) !default;
 $list-group-active-color:           var(--#{$prefix}primary-contrast) !default;
 $list-group-active-bg:              var(--#{$prefix}primary-bg) !default;
 $list-group-active-border-color:    $list-group-active-bg !default;
@@ -29,7 +29,7 @@ $list-group-action-color:           var(--#{$prefix}fg-2) !default;
 $list-group-action-hover-color:     var(--#{$prefix}emphasis-color) !default;
 
 $list-group-action-active-color:    var(--#{$prefix}fg-body) !default;
-$list-group-action-active-bg:       var(--#{$prefix}bg-4) !default;
+$list-group-action-active-bg:       var(--#{$prefix}bg-2) !default;
 // scss-docs-end list-group-variables
 
 $list-group-tokens: () !default;

--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -29,7 +29,7 @@ $menu-divider-margin-y:         .125rem !default;
 $menu-divider-margin-x:         .25rem !default;
 $menu-item-color:               var(--#{$prefix}menu-color, var(--#{$prefix}fg-body)) !default;
 $menu-item-hover-color:         var(--#{$prefix}menu-color, var(--#{$prefix}fg-body)) !default;
-$menu-item-hover-bg:            var(--#{$prefix}bg-3) !default;
+$menu-item-hover-bg:            var(--#{$prefix}bg-1) !default;
 $menu-item-active-color:        var(--#{$prefix}primary-contrast) !default;
 $menu-item-active-bg:           var(--#{$prefix}primary-bg) !default;
 $menu-item-disabled-color:      var(--#{$prefix}fg-3) !default;
@@ -162,7 +162,7 @@ $menu-tokens: defaults(
   }
 
   .menu-translucent {
-    --#{$prefix}menu-item-hover-bg: color-mix(in oklch, var(--#{$prefix}bg-3) 85%, transparent);
+    --#{$prefix}menu-item-hover-bg: color-mix(in oklch, var(--#{$prefix}bg-1) 85%, transparent);
     --#{$prefix}menu-item-active-bg: color-mix(in oklch, var(--#{$prefix}primary) 75%, transparent);
 
     background-color: color-mix(in oklch, var(--#{$prefix}menu-bg) 80%, transparent);

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -20,7 +20,7 @@ $nav-link-border-radius:            var(--#{$prefix}border-radius) !default;
 $nav-link-font-weight:              null !default;
 $nav-link-color:                    var(--#{$prefix}link-color) !default;
 $nav-link-hover-color:              var(--#{$prefix}link-hover-color) !default;
-$nav-link-hover-bg:                 var(--#{$prefix}bg-3) !default;
+$nav-link-hover-bg:                 var(--#{$prefix}bg-1) !default;
 $nav-link-active-color:             var(--#{$prefix}emphasis-color) !default;
 $nav-link-active-bg:                var(--#{$prefix}bg-4) !default;
 $nav-link-transition-property:      color, background-color, border-color !default;

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -24,7 +24,7 @@ $pagination-focus-color:            var(--#{$prefix}link-hover-color) !default;
 $pagination-focus-bg:               var(--#{$prefix}bg-4) !default;
 
 $pagination-hover-color:            var(--#{$prefix}link-hover-color) !default;
-$pagination-hover-bg:               var(--#{$prefix}bg-3) !default;
+$pagination-hover-bg:               var(--#{$prefix}bg-1) !default;
 $pagination-hover-border-color:     var(--#{$prefix}border-color) !default;
 
 $pagination-active-color:           var(--#{$prefix}primary-contrast) !default;
@@ -32,7 +32,7 @@ $pagination-active-bg:              var(--#{$prefix}primary-bg) !default;
 $pagination-active-border-color:    $pagination-active-bg !default;
 
 $pagination-disabled-color:         var(--#{$prefix}fg-2) !default;
-$pagination-disabled-bg:            var(--#{$prefix}bg-4) !default;
+$pagination-disabled-bg:            var(--#{$prefix}bg-2) !default;
 $pagination-disabled-border-color:  var(--#{$prefix}border-color) !default;
 
 $pagination-transition:             color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -17,7 +17,7 @@ $popover-inner-border-radius:       calc(#{$popover-border-radius} - #{$popover-
 $popover-box-shadow:                var(--#{$prefix}box-shadow) !default;
 
 $popover-header-font-size:          var(--#{$prefix}body-font-size) !default;
-$popover-header-bg:                 var(--#{$prefix}bg-4) !default;
+$popover-header-bg:                 var(--#{$prefix}bg-1) !default;
 $popover-header-color:              var(--#{$prefix}heading-color) !default;
 $popover-header-padding-y:          .5rem !default;
 $popover-header-padding-x:          var(--#{$prefix}spacer-3) !default;

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -9,7 +9,7 @@
 // scss-docs-start progress-variables
 $progress-height:                      1rem !default;
 $progress-font-size:                   var(--#{$prefix}font-size-sm) !default;
-$progress-bg:                          var(--#{$prefix}bg-4) !default;
+$progress-bg:                          var(--#{$prefix}bg-2) !default;
 $progress-border-radius:               var(--#{$prefix}radius-5) !default;
 $progress-box-shadow:                  var(--#{$prefix}box-shadow-inset) !default;
 $progress-bar-color:                   var(--#{$prefix}primary-contrast) !default;

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -19,7 +19,7 @@ $form-floating-label-disabled-color:    var(--#{$prefix}gray-600) !default;
 // The label is a sibling of the control, so it cannot inherit the control's own
 // background — the textarea mask has to be told the same colour a second time.
 $form-floating-label-bg:                var(--#{$prefix}btn-input-bg) !default;
-$form-floating-label-disabled-bg:       var(--#{$prefix}bg-4) !default;
+$form-floating-label-disabled-bg:       var(--#{$prefix}bg-2) !default;
 $form-floating-label-border-radius:     var(--#{$prefix}btn-input-border-radius) !default;
 $form-floating-transition-property:     "opacity, transform" !default;
 $form-floating-transition-duration:     .1s !default;

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -19,8 +19,8 @@ $form-color-width:                3rem !default;
 
 // scss-docs-start form-file-variables
 $form-file-button-color:          var(--#{$prefix}btn-input-color) !default;
-$form-file-button-bg:             var(--#{$prefix}bg-3) !default;
-$form-file-button-hover-bg:       var(--#{$prefix}bg-4) !default;
+$form-file-button-bg:             var(--#{$prefix}bg-1) !default;
+$form-file-button-hover-bg:       var(--#{$prefix}bg-2) !default;
 // scss-docs-end form-file-variables
 
 // stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
@@ -60,7 +60,7 @@ $form-control-tokens: defaults(
     --#{$prefix}control-focus-border-color: var(--#{$prefix}btn-input-focus-border-color),
     --#{$prefix}control-focus-ring: var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring-color)),
     --#{$prefix}control-disabled-color: var(--#{$prefix}fg-body),
-    --#{$prefix}control-disabled-bg: var(--#{$prefix}bg-4),
+    --#{$prefix}control-disabled-bg: var(--#{$prefix}bg-2),
     --#{$prefix}control-disabled-border-color: var(--#{$prefix}border-color),
     --#{$prefix}control-action-color: #{$form-file-button-color},
     --#{$prefix}control-action-bg: #{$form-file-button-bg},

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -11,7 +11,7 @@
 $form-range-track-width:                   100% !default;
 $form-range-track-height:                  .5rem !default;
 $form-range-track-cursor:                  pointer !default;
-$form-range-track-bg:                      var(--#{$prefix}bg-4) !default;
+$form-range-track-bg:                      var(--#{$prefix}bg-3) !default;
 $form-range-track-border-radius:           1rem !default;
 $form-range-track-box-shadow:              var(--#{$prefix}box-shadow-inset) !default;
 

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -11,7 +11,7 @@ $input-group-addon-padding-y:           var(--#{$prefix}btn-input-padding-y) !de
 $input-group-addon-padding-x:           var(--#{$prefix}btn-input-padding-x) !default;
 $input-group-addon-font-weight:         var(--#{$prefix}btn-input-font-weight) !default;
 $input-group-addon-color:               var(--#{$prefix}btn-input-color) !default;
-$input-group-addon-bg:                  var(--#{$prefix}bg-3) !default;
+$input-group-addon-bg:                  var(--#{$prefix}bg-2) !default;
 $input-group-addon-border-color:        var(--#{$prefix}btn-input-border-color) !default;
 // scss-docs-end input-group-variables
 


### PR DESCRIPTION
Stage 3 of the scale-alignment program (`workspace/plans/v6-scale-alignment.md`).

Hover, active and disabled states read the darker half of the surface ladder, so interaction feedback rendered as a block of gray. Hover reads `--cui-bg-1` (was `bg-3`) and active/disabled `--cui-bg-2` (was `bg-4`) across list groups, menus, navs, pagination, breadcrumb links, the accordion's open header, the file-input button and disabled controls; the badge's neutral fill, the popover header, the progress track, the avatar fallback and input-group addons step down the same way, and the range track moves to `bg-3`. 17 tokens in 14 files; state relationships unchanged — everything sits two rungs closer to the page, and the migration entry names the opt-out (set the component's own token).

Deliberately NOT in scope, each recorded in the plan: the dark-side ladder recipe (sub-decision 2a — their pure `gray-950/975` stops vs our `color-mix` rungs), `nav-link-active-bg: transparent` (their nav redesign, not a ladder step), theme-wrapped reads (avatar, pagination active), and every fg-ladder delta (stage 3, blocked on the recipe decision).

Gates green (pre-push, incl. the visual suite).