### PR TITLE
fix(buttons)!: neutral button on the surface ladder and the control radius stop

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1901,6 +1901,17 @@ as such.
   step down the same way. Interaction feedback is a tint rather than a
   block of gray — the same relationships, two rungs closer to the page.
   Set the component's own token to keep a darker surface.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The neutral button steps down the ladder with everything else.** A `.btn`
+  without a theme colour rests on `--cui-bg-2` (was `--cui-bg-4`) and hovers
+  on `--cui-bg-3` (was a hard-coded `gray-300`/`gray-700` pair outside the
+  ladder); the neutral subtle variant rests on `--cui-bg-2` and the ghost
+  variant's hover wash is `--cui-bg-1`. The default button is visibly
+  lighter. Its corners also now read `--cui-btn-input-border-radius`
+  (`--cui-radius-5`, `.5rem`) instead of the global `--cui-border-radius`,
+  so buttons match the fields they sit next to in input groups; `.btn-group`
+  clips to the same stop. Set `$btn-bg`/`$btn-hover-bg` or the `--cui-btn-*`
+  tokens to keep the old look.
 
 #### Every theme colour gets an action-background slot
 

--- a/scss/buttons/_button-group.scss
+++ b/scss/buttons/_button-group.scss
@@ -42,7 +42,7 @@
   }
 
   .btn-group {
-    @include border-radius(var(--#{$prefix}border-radius));
+    @include border-radius(var(--#{$prefix}btn-input-border-radius));
 
     // Prevent double borders when buttons are next to each other
     > :not(#{$btn-check-deprecated}:first-child) + .btn,

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -16,8 +16,8 @@
 $btn-white-space:             nowrap !default; // Set to `normal` to let button text wrap
 
 $btn-color:                   var(--#{$prefix}fg-body) !default;
-$btn-bg:                      var(--#{$prefix}bg-4) !default;
-$btn-hover-bg:                light-dark(var(--#{$prefix}gray-300), var(--#{$prefix}gray-700)) !default;
+$btn-bg:                      var(--#{$prefix}bg-2) !default;
+$btn-hover-bg:                var(--#{$prefix}bg-3) !default;
 $btn-box-shadow:              inset 0 1px 0 color-mix(in srgb, var(--#{$prefix}white) 15%, transparent), 0 1px 1px color-mix(in srgb, var(--#{$prefix}black) 7.5%, transparent) !default;
 $btn-active-box-shadow:       inset 0 3px 5px color-mix(in srgb, var(--#{$prefix}black) 12.5%, transparent) !default;
 
@@ -31,12 +31,12 @@ $btn-outline-hover-color:     var(--#{$prefix}fg-body) !default;
 $btn-outline-hover-bg:        var(--#{$prefix}bg-3) !default;
 
 $btn-subtle-color:            var(--#{$prefix}fg-body) !default;
-$btn-subtle-bg:               var(--#{$prefix}bg-4) !default;
+$btn-subtle-bg:               var(--#{$prefix}bg-2) !default;
 $btn-subtle-hover-bg:         var(--#{$prefix}bg-3) !default;
 
 $btn-ghost-color:             var(--#{$prefix}fg-2) !default;
 $btn-ghost-hover-color:       var(--#{$prefix}fg-body) !default;
-$btn-ghost-hover-bg:          var(--#{$prefix}bg-3) !default;
+$btn-ghost-hover-bg:          var(--#{$prefix}bg-1) !default;
 // scss-docs-end btn-variables
 
 // The v6 spelling puts `.btn-check` on the `<label>` next to `.btn`, so the
@@ -62,7 +62,7 @@ $button-tokens: defaults(
     --#{$prefix}btn-color: #{$btn-color},
     --#{$prefix}btn-border-width: var(--#{$prefix}btn-input-border-width),
     --#{$prefix}btn-border-color: transparent,
-    --#{$prefix}btn-border-radius: var(--#{$prefix}border-radius),
+    --#{$prefix}btn-border-radius: var(--#{$prefix}btn-input-border-radius),
     --#{$prefix}btn-hover-border-color: transparent,
     --#{$prefix}btn-box-shadow: #{$btn-box-shadow},
     --#{$prefix}btn-active-shadow: #{$btn-active-box-shadow},


### PR DESCRIPTION
- The neutral `.btn` rests on `--cui-bg-2` (was `--cui-bg-4`), hovers on `--cui-bg-3` (was a hard-coded `light-dark(gray-300, gray-700)` pair outside the ladder), disabled repeats the base. Neutral subtle rests on `bg-2`; the ghost hover wash is `bg-1`, the flat-hover rung.
- Buttons read `--cui-btn-input-border-radius` (`radius-5`, .5rem) instead of the global `--cui-border-radius` (.375rem), so they match adjacent fields in input groups; `.btn-group` clips to the same stop. The migration guide already described buttons as sitting on `radius-5` — this makes that true.
- Themed buttons are untouched (theme slots resolve before the neutral fallbacks) — verified with a computed-styles probe in Chromium, light and dark.
- Migration guide: neutral-button entry added under the interaction-surfaces section.