### PR TITLE
fix(tooltip)!: drop the dead $tooltip-margin knob and its empty token

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1024,6 +1024,11 @@ adornment in the library — so the button needs no icon markup at all:
   3.5&#8758;1). The surface and arrow keep the same translucent look; the text
   renders at full opacity. The token still works — override it and only the
   background alpha changes.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`$tooltip-margin` and `--cui-tooltip-margin` are removed.** The variable
+  had been `null` and deprecated since v4; the token compiled to an empty
+  value and the `margin` declaration reading it never took effect. Position
+  a tooltip with the JS `offset` option instead.
 
 #### OTP input
 

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -1,6 +1,5 @@
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
-@use "mixins/deprecate" as *;
 @use "mixins/reset-text" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
@@ -15,7 +14,6 @@ $tooltip-border-radius:             var(--#{$prefix}radius-5) !default;
 $tooltip-opacity:                   .9 !default;
 $tooltip-padding-y:                 var(--#{$prefix}spacer-1) !default;
 $tooltip-padding-x:                 var(--#{$prefix}spacer-2) !default;
-$tooltip-margin:                    null !default; // TODO: remove this in v6
 
 $tooltip-arrow-width:               .8rem !default;
 $tooltip-arrow-height:              .4rem !default;
@@ -36,7 +34,6 @@ $tooltip-tokens: defaults(
     --#{$prefix}tooltip-max-width: #{$tooltip-max-width},
     --#{$prefix}tooltip-padding-x: #{$tooltip-padding-x},
     --#{$prefix}tooltip-padding-y: #{$tooltip-padding-y},
-    --#{$prefix}tooltip-margin: #{$tooltip-margin},
     --#{$prefix}tooltip-font-size: #{$tooltip-font-size},
     --#{$prefix}tooltip-color: #{$tooltip-color},
     --#{$prefix}tooltip-bg: #{$tooltip-bg},
@@ -64,8 +61,6 @@ $tooltip-tokens: defaults(
 
     z-index: var(--#{$prefix}tooltip-zindex);
     display: block;
-    margin: var(--#{$prefix}tooltip-margin);
-    @include deprecate("`$tooltip-margin`", "v4", "v4.x", true);
     // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.
     // So reset our font and text properties to avoid inheriting weird values.
     @include reset-text();


### PR DESCRIPTION
- `$tooltip-margin` had been `null` with a v4-era deprecation notice; `--cui-tooltip-margin` compiled to an empty value and the `margin` declaration reading it was invalid at computed-value time — it never did anything.
- Removed: the variable, the token-map entry, the `margin` line, the `deprecate` call and the now-unused mixin import. `fusv` stays clean.
- Positioning stays with the JS `offset` option; the migration guide notes the removal under Tooltip.