### PR TITLE
fix(reboot): the table caption reads fg-3, the secondary-text rung

### DIFF
--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -91,7 +91,7 @@ $reboot-kbd-tokens: defaults(
 // from the .table component's variables — that coupling is what kept the table
 // block pinned in _variables.scss.
 $caption-padding-y:    .5rem !default;
-$caption-color:        var(--#{$prefix}fg-2) !default;
+$caption-color:        var(--#{$prefix}fg-3) !default;
 $th-font-weight:       null !default;
 // scss-docs-end reboot-table-variables
 


### PR DESCRIPTION
- `$caption-color` (the fallback behind `--cui-table-caption-color`) moves from `--cui-fg-2` to `--cui-fg-3`, matching `.figure-caption`, toast headers and blockquote footers on the secondary-text rung.
- The migration guide's rung list already described captions this way; the `<caption>` element was the one reader left behind.