### PR TITLE
fix(accordion): pull the header's focus ring inside the item

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -194,6 +194,9 @@ finished, not whether the state changed.
 - **A `<summary>` is not a heading.** Where the accordion divides a page into
   sections, wrap the label in an `<h2>`–`<h6>` inside the summary; the heading
   inherits the summary's typography.
+- **The header's focus ring draws 1px inside the item**
+  (`--cui-focus-ring-offset: -1px` on `.accordion-header:focus-visible`), so it
+  no longer overlaps the borders of adjacent items.
 - **The panel animation is CSS-driven** through `interpolate-size:
   allow-keywords`, which only Chromium implements today. `accordion.js` supplies
   the same animation in Firefox and Safari; that part of it goes away, without a

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -249,6 +249,8 @@ $accordion-tokens: defaults(
     }
 
     &:focus-visible {
+      --#{$prefix}focus-ring-offset: -1px;
+
       position: relative;
       z-index: 3;
       @include focus-ring(true);


### PR DESCRIPTION
- `.accordion-header:focus-visible` sets `--cui-focus-ring-offset: -1px` (the token the `focus-ring` mixin already reads), so the ring draws inside the item instead of overlapping adjacent items' borders.
- Verified with a keyboard-focus probe in Chromium: computed `outline-offset: -1px` with `:focus-visible` matching.
- One-line note under the accordion's migration section.