### PR TITLE
feat(button-group): the toolbar spaces its groups with a built-in gap

### DIFF
--- a/docs/src/content/docs/components/button-group.mdx
+++ b/docs/src/content/docs/components/button-group.mdx
@@ -88,16 +88,16 @@ Combine button-like [checkbox](/forms/checkbox/#toggle-buttons) and [radio](/for
 
 ## Button toolbar
 
-Join sets of button groups into button toolbars for more complicated components. The toolbar spaces its groups with a `.5rem` gap; use utility classes for a different rhythm.
+Join sets of button groups into button toolbars for more complicated components. Use utility classes as needed to space out groups, buttons, and more.
 
 <Example code={`<div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
-    <div class="btn-group" role="group" aria-label="First group">
+    <div class="btn-group me-2" role="group" aria-label="First group">
       <button type="button" class="btn-solid theme-primary">1</button>
       <button type="button" class="btn-solid theme-primary">2</button>
       <button type="button" class="btn-solid theme-primary">3</button>
       <button type="button" class="btn-solid theme-primary">4</button>
     </div>
-    <div class="btn-group" role="group" aria-label="Second group">
+    <div class="btn-group me-2" role="group" aria-label="Second group">
       <button type="button" class="btn-solid theme-secondary">5</button>
       <button type="button" class="btn-solid theme-secondary">6</button>
       <button type="button" class="btn-solid theme-secondary">7</button>
@@ -107,10 +107,10 @@ Join sets of button groups into button toolbars for more complicated components.
     </div>
   </div>`} />
 
-Feel free to combine input groups with button groups in your toolbars.
+Feel free to combine input groups with button groups in your toolbars. Similar to the example above, you'll likely need some utilities through to space items correctly.
 
 <Example code={`<div class="btn-toolbar mb-3" role="toolbar" aria-label="Toolbar with button groups">
-    <div class="btn-group" role="group" aria-label="First group">
+    <div class="btn-group me-2" role="group" aria-label="First group">
       <button type="button" class="btn-outline theme-secondary">1</button>
       <button type="button" class="btn-outline theme-secondary">2</button>
       <button type="button" class="btn-outline theme-secondary">3</button>

--- a/docs/src/content/docs/components/button-group.mdx
+++ b/docs/src/content/docs/components/button-group.mdx
@@ -88,16 +88,16 @@ Combine button-like [checkbox](/forms/checkbox/#toggle-buttons) and [radio](/for
 
 ## Button toolbar
 
-Join sets of button groups into button toolbars for more complicated components. Use utility classes as needed to space out groups, buttons, and more.
+Join sets of button groups into button toolbars for more complicated components. The toolbar spaces its groups with a `.5rem` gap; use utility classes for a different rhythm.
 
 <Example code={`<div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
-    <div class="btn-group me-2" role="group" aria-label="First group">
+    <div class="btn-group" role="group" aria-label="First group">
       <button type="button" class="btn-solid theme-primary">1</button>
       <button type="button" class="btn-solid theme-primary">2</button>
       <button type="button" class="btn-solid theme-primary">3</button>
       <button type="button" class="btn-solid theme-primary">4</button>
     </div>
-    <div class="btn-group me-2" role="group" aria-label="Second group">
+    <div class="btn-group" role="group" aria-label="Second group">
       <button type="button" class="btn-solid theme-secondary">5</button>
       <button type="button" class="btn-solid theme-secondary">6</button>
       <button type="button" class="btn-solid theme-secondary">7</button>
@@ -107,10 +107,10 @@ Join sets of button groups into button toolbars for more complicated components.
     </div>
   </div>`} />
 
-Feel free to combine input groups with button groups in your toolbars. Similar to the example above, you'll likely need some utilities through to space items correctly.
+Feel free to combine input groups with button groups in your toolbars.
 
 <Example code={`<div class="btn-toolbar mb-3" role="toolbar" aria-label="Toolbar with button groups">
-    <div class="btn-group me-2" role="group" aria-label="First group">
+    <div class="btn-group" role="group" aria-label="First group">
       <button type="button" class="btn-outline theme-secondary">1</button>
       <button type="button" class="btn-outline theme-secondary">2</button>
       <button type="button" class="btn-outline theme-secondary">3</button>

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1190,6 +1190,9 @@ adornment in the library — so the button needs no icon markup at all:
   it — while the variable's own comment told you to set `nowrap`, which is to say
   the default was the one nobody wanted. A long label now keeps the button one
   line tall and makes it wider instead.
+- **`.btn-toolbar` spaces its groups on its own** with a `.5rem` `gap`
+  (`--cui-spacer-2`). Drop the `me-*` utilities that carried the spacing in
+  v5, or they now add to the gap.
 
   It is still a token, so the old behaviour is one declaration away — on a single
   button, on a theme, or globally:

--- a/scss/buttons/_button-group.scss
+++ b/scss/buttons/_button-group.scss
@@ -34,6 +34,7 @@
   .btn-toolbar {
     display: flex;
     flex-wrap: wrap;
+    gap: var(--#{$prefix}spacer-2);
     justify-content: flex-start;
 
     .input-group {


### PR DESCRIPTION
- `.btn-toolbar` sets `gap: var(--cui-spacer-2)` (.5rem), so groups no longer touch by default.
- The toolbar examples on the button-group page drop their `me-2` utilities and the prose no longer tells the reader to space groups by hand.
- Migration guide: leftover `me-*` margins now add to the gap.