### PR TITLE
fix(button-group): v6 button spelling works in groups; divider; docs on the upstream structure

### DIFF
--- a/docs/src/content/docs/components/button-group.mdx
+++ b/docs/src/content/docs/components/button-group.mdx
@@ -6,9 +6,9 @@ otherFrameworks:
   - button-group
 ---
 
-## Basic example
+## Examples
 
-Wrap a series of buttons with `.btn` in `.btn-group`. Add on optional JavaScript radio and checkbox style behavior with [our buttons plugin](/components/buttons/#button-plugin).
+Wrap a series of buttons in `.btn-group`.
 
 <Example code={`<div class="btn-group" role="group" aria-label="Basic example">
     <button type="button" class="btn-solid theme-primary">Left</button>
@@ -17,12 +17,10 @@ Wrap a series of buttons with `.btn` in `.btn-group`. Add on optional JavaScript
   </div>`} />
 
 <Callout color="info">
-##### Ensure the correct `role` and provide a label
-
-For assistive technologies (ex. screen readers) to communicate that a series of buttons are grouped, a proper `role` attribute has to be provided. For button groups, this should be `role="group"`, while toolbars should have a `role="toolbar"`.
-
-Besides, groups and toolbars should be provided an understandable label, as most assistive technologies will otherwise not declare them, despite the appearance of the specific role attribute. In the following examples provided here, we apply `aria-label`, but options such as `aria-labelledby` can also be used.
+Button groups require an appropriate `role` attribute and explicit label to ensure assistive technologies like screen readers identify buttons as grouped and announce them. Use `role="group"` for button groups or `role="toolbar"` for button toolbars. Then use `aria-label` or `aria-labelledby` to label them.
 </Callout>
+
+### With links
 
 These classes can also be added to groups of links, as an alternative to the [`.nav` navigation components](/components/nav/).
 
@@ -32,7 +30,45 @@ These classes can also be added to groups of links, as an alternative to the [`.
     <a href="#" class="btn-solid theme-primary">Link</a>
   </div>`} />
 
-## Mixed styles
+### Dividers
+
+Add a divider between buttons by adding the `.btn-group-divider` class to the `.btn-group`. Most useful when used with buttons that have the same theme color and a solid fill.
+
+<Example class="d-flex gap-2" code={`<div class="btn-group btn-group-divider" role="group" aria-label="Divided button group">
+    <button type="button" class="btn-solid theme-primary">Left</button>
+    <button type="button" class="btn-solid theme-primary active">Active</button>
+    <button type="button" class="btn-solid theme-primary">Right</button>
+  </div>
+
+  <div class="btn-group btn-group-divider" role="group" aria-label="Divided button group">
+    <button type="button" class="btn-solid theme-secondary">Left</button>
+    <button type="button" class="btn-solid theme-secondary">Right</button>
+  </div>`} />
+
+Works with vertical button groups, too.
+
+<Example class="d-flex align-items-start gap-2" code={`<div class="btn-group-vertical btn-group-divider" role="group" aria-label="Divided vertical button group">
+    <button type="button" class="btn-solid theme-primary">Left</button>
+    <button type="button" class="btn-solid theme-primary active">Active</button>
+    <button type="button" class="btn-solid theme-primary">Right</button>
+  </div>
+
+  <div class="btn-group-vertical btn-group-divider" role="group" aria-label="Divided vertical button group">
+    <button type="button" class="btn-solid theme-secondary">Left</button>
+    <button type="button" class="btn-solid theme-secondary">Right</button>
+  </div>`} />
+
+## Theme variants
+
+Use the `.theme-{color}` classes to apply a theme color to a set of buttons.
+
+<Example code={`<div class="btn-group" role="group" aria-label="Secondary theme example">
+    <button type="button" class="btn-solid theme-secondary">Left</button>
+    <button type="button" class="btn-solid theme-secondary">Middle</button>
+    <button type="button" class="btn-solid theme-secondary">Right</button>
+  </div>`} />
+
+You can mix and match button variants in a button group.
 
 <Example code={`<div class="btn-group" role="group" aria-label="Basic mixed styles example">
     <button type="button" class="btn-solid theme-danger">Left</button>
@@ -40,47 +76,63 @@ These classes can also be added to groups of links, as an alternative to the [`.
     <button type="button" class="btn-solid theme-success">Right</button>
   </div>`} />
 
-## Outlined styles
+## Style variants
 
-<Example code={`<div class="btn-group" role="group" aria-label="Basic outlined example">
+All button styles are supported in button groups. Mix and match with the `.btn-group-divider` class to add dividers between some styles or just use the button borders in others.
+
+<Example code={`<div class="btn-group btn-group-divider" role="group" aria-label="Solid example">
+    <button type="button" class="btn-solid theme-primary">Left</button>
+    <button type="button" class="btn-solid theme-primary">Middle</button>
+    <button type="button" class="btn-solid theme-primary">Right</button>
+  </div>`} />
+
+<Example code={`<div class="btn-group" role="group" aria-label="Outlined example">
     <button type="button" class="btn-outline theme-primary">Left</button>
     <button type="button" class="btn-outline theme-primary">Middle</button>
     <button type="button" class="btn-outline theme-primary">Right</button>
   </div>`} />
 
-## Checkbox and radio button groups
+<Example code={`<div class="btn-group btn-group-divider" role="group" aria-label="Subtle example">
+    <button type="button" class="btn-subtle theme-primary">Left</button>
+    <button type="button" class="btn-subtle theme-primary">Middle</button>
+    <button type="button" class="btn-subtle theme-primary">Right</button>
+  </div>`} />
 
-Combine button-like [checkbox](/forms/checkbox/#toggle-buttons) and [radio](/forms/radio/#toggle-buttons) toggle buttons into a seamless looking button group.
+## Toggle buttons
+
+### Checkbox
+
+Checkbox toggle buttons can be grouped together. Any or all of the buttons can be checked.
 
 <Example code={`<div class="btn-group" role="group" aria-label="Basic checkbox toggle button group">
-    <label class="btn-outline theme-primary btn-check">
+    <label class="btn-check btn-outline theme-primary">
       <input type="checkbox" autocomplete="off">
-      Checkbox 1
+      Check 1
     </label>
-
-    <label class="btn-outline theme-primary btn-check">
+    <label class="btn-check btn-outline theme-primary">
       <input type="checkbox" autocomplete="off">
-      Checkbox 2
+      Check 2
     </label>
-
-    <label class="btn-outline theme-primary btn-check">
+    <label class="btn-check btn-outline theme-primary">
       <input type="checkbox" autocomplete="off">
-      Checkbox 3
+      Check 3
     </label>
   </div>`} />
 
+### Radio
+
+By design, radio toggle button groups can only have one button checked at a time.
+
 <Example code={`<div class="btn-group" role="group" aria-label="Basic radio toggle button group">
-    <label class="btn-outline theme-primary btn-check">
-      <input type="radio" name="btnradio" checked autocomplete="off">
+    <label class="btn-check btn-outline theme-primary">
+      <input type="radio" name="btnradio" autocomplete="off" checked>
       Radio 1
     </label>
-
-    <label class="btn-outline theme-primary btn-check">
+    <label class="btn-check btn-outline theme-primary">
       <input type="radio" name="btnradio" autocomplete="off">
       Radio 2
     </label>
-
-    <label class="btn-outline theme-primary btn-check">
+    <label class="btn-check btn-outline theme-primary">
       <input type="radio" name="btnradio" autocomplete="off">
       Radio 3
     </label>
@@ -88,16 +140,16 @@ Combine button-like [checkbox](/forms/checkbox/#toggle-buttons) and [radio](/for
 
 ## Button toolbar
 
-Join sets of button groups into button toolbars for more complicated components. Use utility classes as needed to space out groups, buttons, and more.
+Combine sets of button groups into button toolbars for more complex components. Use utility classes as needed to space out groups, buttons, and more.
 
 <Example code={`<div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
-    <div class="btn-group me-2" role="group" aria-label="First group">
+    <div class="btn-group" role="group" aria-label="First group">
       <button type="button" class="btn-solid theme-primary">1</button>
       <button type="button" class="btn-solid theme-primary">2</button>
       <button type="button" class="btn-solid theme-primary">3</button>
       <button type="button" class="btn-solid theme-primary">4</button>
     </div>
-    <div class="btn-group me-2" role="group" aria-label="Second group">
+    <div class="btn-group" role="group" aria-label="Second group">
       <button type="button" class="btn-solid theme-secondary">5</button>
       <button type="button" class="btn-solid theme-secondary">6</button>
       <button type="button" class="btn-solid theme-secondary">7</button>
@@ -107,10 +159,10 @@ Join sets of button groups into button toolbars for more complicated components.
     </div>
   </div>`} />
 
-Feel free to combine input groups with button groups in your toolbars. Similar to the example above, you'll likely need some utilities through to space items correctly.
+Feel free to mix input groups with button groups in your toolbars.
 
-<Example code={`<div class="btn-toolbar mb-3" role="toolbar" aria-label="Toolbar with button groups">
-    <div class="btn-group me-2" role="group" aria-label="First group">
+<Example class="d-flex gap-3 flex-column" code={`<div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
+    <div class="btn-group" role="group" aria-label="First group">
       <button type="button" class="btn-outline theme-secondary">1</button>
       <button type="button" class="btn-outline theme-secondary">2</button>
       <button type="button" class="btn-outline theme-secondary">3</button>
@@ -137,26 +189,23 @@ Feel free to combine input groups with button groups in your toolbars. Similar t
 
 ## Sizing
 
-Alternatively, of implementing button sizing classes to each button in a group, add `.btn-group-*` to all `.btn-group`, including each one when nesting multiple groups. The sizes are `.btn-group-xs`, `.btn-group-sm` and `.btn-group-lg` — the same ladder the buttons themselves use.
+Instead of applying button sizing classes to every button in a group, just add `.btn-group-*` to each `.btn-group`, including each one when nesting multiple groups. The sizes are `.btn-group-xs`, `.btn-group-sm` and `.btn-group-lg` — the same ladder the buttons themselves use.
 
-<Example code={`<div class="btn-group btn-group-lg" role="group" aria-label="Large button group">
+<Example class="d-flex gap-3 flex-column align-items-start" code={`<div class="btn-group btn-group-lg" role="group" aria-label="Large button group">
     <button type="button" class="btn-outline theme-primary">Left</button>
     <button type="button" class="btn-outline theme-primary">Middle</button>
     <button type="button" class="btn-outline theme-primary">Right</button>
   </div>
-  <br>
   <div class="btn-group" role="group" aria-label="Default button group">
     <button type="button" class="btn-outline theme-primary">Left</button>
     <button type="button" class="btn-outline theme-primary">Middle</button>
     <button type="button" class="btn-outline theme-primary">Right</button>
   </div>
-  <br>
   <div class="btn-group btn-group-sm" role="group" aria-label="Small button group">
     <button type="button" class="btn-outline theme-primary">Left</button>
     <button type="button" class="btn-outline theme-primary">Middle</button>
     <button type="button" class="btn-outline theme-primary">Right</button>
   </div>
-  <br>
   <div class="btn-group btn-group-xs" role="group" aria-label="Extra small button group">
     <button type="button" class="btn-outline theme-primary">Left</button>
     <button type="button" class="btn-outline theme-primary">Middle</button>
@@ -165,107 +214,86 @@ Alternatively, of implementing button sizing classes to each button in a group, 
 
 ## Nesting
 
-Put a `.btn-group` inside another `.btn-group` when you need dropdown menus combined with a series of buttons.
+Place a `.btn-group` within another `.btn-group` when you want menus mixed with a series of buttons.
 
-<Example code={`<div class="btn-group" role="group" aria-label="Button group with nested dropdown">
+<Example code={`<div class="btn-group" role="group" aria-label="Button group with nested menu">
     <button type="button" class="btn-solid theme-primary">1</button>
     <button type="button" class="btn-solid theme-primary">2</button>
 
     <div class="btn-group" role="group">
-      <button type="button" class="btn-solid theme-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
-        Dropdown
+      <button type="button" class="btn-solid theme-primary" data-coreui-toggle="menu" aria-expanded="false">
+        Menu
       </button>
-      <ul class="dropdown-menu">
-        <li><a class="dropdown-item" href="#">Dropdown link</a></li>
-        <li><a class="dropdown-item" href="#">Dropdown link</a></li>
-      </ul>
+      <div class="menu">
+        <a class="menu-item" href="#">Menu link</a>
+        <a class="menu-item" href="#">Menu link</a>
+      </div>
     </div>
   </div>`} />
 
 ## Vertical variation
 
-Create a set of buttons that appear vertically stacked rather than horizontally. **Split button dropdowns are not supported here.**
+Make a set of buttons appear vertically stacked rather than horizontally. **Split button menus are not supported here.**
 
-<Example code={`<div class="docs-example">
-    <div class="btn-group-vertical" role="group" aria-label="Vertical button group">
-      <button type="button" class="btn-solid theme-primary">Button</button>
-      <button type="button" class="btn-solid theme-primary">Button</button>
-      <button type="button" class="btn-solid theme-primary">Button</button>
-      <button type="button" class="btn-solid theme-primary">Button</button>
-    </div>
+<Example code={`<div class="btn-group-vertical" role="group" aria-label="Vertical button group">
+    <button type="button" class="btn-solid theme-primary">Button</button>
+    <button type="button" class="btn-solid theme-primary">Button</button>
+    <button type="button" class="btn-solid theme-primary">Button</button>
+    <button type="button" class="btn-solid theme-primary">Button</button>
   </div>`} />
 
-<Example code={`<div class="docs-example">
-    <div class="btn-group-vertical" role="group" aria-label="Vertical button group">
-      <div class="btn-group" role="group">
-        <button id="btnGroupVerticalDrop1" type="button" class="btn-solid theme-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
-          Dropdown
-        </button>
-        <ul class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop1">
-          <li><a class="dropdown-item" href="#">Dropdown link</a></li>
-          <li><a class="dropdown-item" href="#">Dropdown link</a></li>
-        </ul>
-      </div>
-      <button type="button" class="btn-solid theme-primary">Button</button>
-      <button type="button" class="btn-solid theme-primary">Button</button>
-      <div class="btn-group dropstart" role="group">
-        <button id="btnGroupVerticalDrop2" type="button" class="btn-solid theme-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
-          Dropdown
-        </button>
-        <ul class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop2">
-          <li><a class="dropdown-item" href="#">Dropdown link</a></li>
-          <li><a class="dropdown-item" href="#">Dropdown link</a></li>
-        </ul>
-      </div>
-      <div class="btn-group dropend" role="group">
-        <button id="btnGroupVerticalDrop3" type="button" class="btn-solid theme-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
-          Dropdown
-        </button>
-        <ul class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop3">
-          <li><a class="dropdown-item" href="#">Dropdown link</a></li>
-          <li><a class="dropdown-item" href="#">Dropdown link</a></li>
-        </ul>
-      </div>
-      <div class="btn-group dropup" role="group">
-        <button id="btnGroupVerticalDrop4" type="button" class="btn-solid theme-primary dropdown-toggle" data-coreui-toggle="dropdown" aria-expanded="false">
-          Dropdown
-        </button>
-        <ul class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop4">
-          <li><a class="dropdown-item" href="#">Dropdown link</a></li>
-          <li><a class="dropdown-item" href="#">Dropdown link</a></li>
-        </ul>
+<Example code={`<div class="btn-group-vertical" role="group" aria-label="Vertical button group">
+    <div class="btn-group" role="group">
+      <button type="button" class="btn-solid theme-primary" data-coreui-toggle="menu" aria-expanded="false">
+        Menu
+      </button>
+      <div class="menu">
+        <a class="menu-item" href="#">Menu link</a>
+        <a class="menu-item" href="#">Menu link</a>
       </div>
     </div>
-  </div>
-
-  <div class="docs-example">
-    <div class="btn-group-vertical" role="group" aria-label="Vertical radio toggle button group">
-      <label class="btn-outline theme-danger btn-check">
-        <input type="radio" name="vbtn-radio" checked autocomplete="off">
-        Radio 1
-      </label>
-      <label class="btn-outline theme-danger btn-check">
-        <input type="radio" name="vbtn-radio" autocomplete="off">
-        Radio 2
-      </label>
-      <label class="btn-outline theme-danger btn-check">
-        <input type="radio" name="vbtn-radio" autocomplete="off">
-        Radio 3
-      </label>
+    <button type="button" class="btn-solid theme-primary">Button</button>
+    <button type="button" class="btn-solid theme-primary">Button</button>
+    <div class="btn-group" role="group">
+      <button type="button" class="btn-solid theme-primary" data-coreui-toggle="menu" data-coreui-placement="left-start" aria-expanded="false">
+        Menu
+      </button>
+      <div class="menu">
+        <a class="menu-item" href="#">Menu link</a>
+        <a class="menu-item" href="#">Menu link</a>
+      </div>
+    </div>
+    <div class="btn-group" role="group">
+      <button type="button" class="btn-solid theme-primary" data-coreui-toggle="menu" data-coreui-placement="right-start" aria-expanded="false">
+        Menu
+      </button>
+      <div class="menu">
+        <a class="menu-item" href="#">Menu link</a>
+        <a class="menu-item" href="#">Menu link</a>
+      </div>
+    </div>
+    <div class="btn-group" role="group">
+      <button type="button" class="btn-solid theme-primary" data-coreui-toggle="menu" data-coreui-placement="top-start" aria-expanded="false">
+        Menu
+      </button>
+      <div class="menu">
+        <a class="menu-item" href="#">Menu link</a>
+        <a class="menu-item" href="#">Menu link</a>
+      </div>
     </div>
   </div>`} />
 
 <Example code={`<div class="btn-group-vertical" role="group" aria-label="Vertical radio toggle button group">
-    <label class="btn-outline theme-danger btn-check">
-      <input type="radio" name="vbtn-radio2" checked autocomplete="off">
+    <label class="btn-check btn-outline theme-danger">
+      <input type="radio" name="vbtn-radio" autocomplete="off" checked>
       Radio 1
     </label>
-    <label class="btn-outline theme-danger btn-check">
-      <input type="radio" name="vbtn-radio2" autocomplete="off">
+    <label class="btn-check btn-outline theme-danger">
+      <input type="radio" name="vbtn-radio" autocomplete="off">
       Radio 2
     </label>
-    <label class="btn-outline theme-danger btn-check">
-      <input type="radio" name="vbtn-radio2" autocomplete="off">
+    <label class="btn-check btn-outline theme-danger">
+      <input type="radio" name="vbtn-radio" autocomplete="off">
       Radio 3
     </label>
   </div>`} />

--- a/scss/buttons/_button-group.scss
+++ b/scss/buttons/_button-group.scss
@@ -3,6 +3,10 @@
 @use "button" as *;
 @use "../config" as *;
 
+// A v6 button may carry only its variant class (`.btn-solid`), so the group
+// plumbing cannot key on `.btn` alone.
+$group-button: ":is(#{$btn-variant-selectors})" !default;
+
 @layer components {
   // Make the div behave like a button
   .btn-group,
@@ -11,21 +15,21 @@
     display: inline-flex;
     vertical-align: middle; // match .btn alignment given font-size hack above
 
-    > .btn {
+    > #{$group-button} {
       position: relative;
       flex: 1 1 auto;
     }
 
     // Bring the hover, focused, and "active" buttons to the front to overlay
     // the borders properly
-    > #{$btn-check-deprecated}:checked + .btn,
-    > #{$btn-check-deprecated}:focus + .btn,
+    > #{$btn-check-deprecated}:checked + #{$group-button},
+    > #{$btn-check-deprecated}:focus + #{$group-button},
     > .btn-check:has(input:checked),
     > .btn-check:has(input:focus),
-    > .btn:hover,
-    > .btn:focus,
-    > .btn:active,
-    > .btn.active {
+    > #{$group-button}:hover,
+    > #{$group-button}:focus,
+    > #{$group-button}:active,
+    > #{$group-button}.active {
       z-index: 1;
     }
   }
@@ -45,7 +49,7 @@
     @include border-radius(var(--#{$prefix}border-radius));
 
     // Prevent double borders when buttons are next to each other
-    > :not(#{$btn-check-deprecated}:first-child) + .btn,
+    > :not(#{$btn-check-deprecated}:first-child) + #{$group-button},
     > .btn-group:not(:first-child) {
       margin-inline-start: calc(-1 * var(--#{$prefix}btn-border-width));
     }
@@ -53,10 +57,10 @@
     // Reset rounded corners
     // A menu trigger carries no class of its own, so it is recognised by the
     // `.menu` that follows it.
-    > .btn:not(:last-child, .dropdown-toggle, :has(+ .menu)),
-    > .btn.dropdown-toggle-split:first-child,
-    > .btn.menu-toggle-split:first-child,
-    > .btn-group:not(:last-child) > .btn {
+    > #{$group-button}:not(:last-child, .dropdown-toggle, :has(+ .menu)),
+    > #{$group-button}.dropdown-toggle-split:first-child,
+    > #{$group-button}.menu-toggle-split:first-child,
+    > .btn-group:not(:last-child) > #{$group-button} {
       @include border-end-radius(0);
     }
 
@@ -65,9 +69,9 @@
     // - the second child and the previous element isn't a deprecated `.btn-check`
     //   input (making it the first child visually)
     // - part of a btn-group which isn't the first child
-    > .btn:nth-child(n + 3),
-    > :not(#{$btn-check-deprecated}) + .btn,
-    > .btn-group:not(:first-child) > .btn {
+    > #{$group-button}:nth-child(n + 3),
+    > :not(#{$btn-check-deprecated}) + #{$group-button},
+    > .btn-group:not(:first-child) > #{$group-button} {
       @include border-start-radius(0);
     }
   }
@@ -99,19 +103,19 @@
     align-items: flex-start;
     justify-content: center;
 
-    > .btn,
+    > #{$group-button},
     > .btn-group {
       width: 100%;
     }
 
-    > .btn:not(:first-child),
+    > #{$group-button}:not(:first-child),
     > .btn-group:not(:first-child) {
       margin-top: calc(-1 * var(--#{$prefix}btn-border-width));
     }
 
     // Reset rounded corners
-    > .btn:not(:last-child, .dropdown-toggle, :has(+ .menu)),
-    > .btn-group:not(:last-child) > .btn {
+    > #{$group-button}:not(:last-child, .dropdown-toggle, :has(+ .menu)),
+    > .btn-group:not(:last-child) > #{$group-button} {
       @include border-bottom-radius(0);
     }
 
@@ -120,9 +124,9 @@
     // - the second child and the previous element isn't a deprecated `.btn-check`
     //   input (making it the first child visually)
     // - part of a btn-group which isn't the first child
-    > .btn:nth-child(n + 3),
-    > :not(#{$btn-check-deprecated}) + .btn,
-    > .btn-group:not(:first-child) > .btn {
+    > #{$group-button}:nth-child(n + 3),
+    > :not(#{$btn-check-deprecated}) + #{$group-button},
+    > .btn-group:not(:first-child) > #{$group-button} {
       @include border-top-radius(0);
     }
   }

--- a/scss/buttons/_button-group.scss
+++ b/scss/buttons/_button-group.scss
@@ -34,6 +34,29 @@ $group-button: ":is(#{$btn-variant-selectors})" !default;
     }
   }
 
+  // Optional: a line between grouped buttons, for styles whose borders
+  // don't separate them (solid, subtle)
+  .btn-group-divider > #{$group-button} + #{$group-button}::before {
+    position: absolute;
+    z-index: 3;
+    content: "";
+    background-color: var(--#{$prefix}btn-color);
+    opacity: .25;
+  }
+
+  .btn-group:where(.btn-group-divider) > #{$group-button} + #{$group-button}::before {
+    inset-inline-start: calc(-1 * var(--#{$prefix}btn-border-width));
+    top: 25%;
+    bottom: 25%;
+    width: var(--#{$prefix}btn-border-width);
+  }
+
+  .btn-group-vertical:where(.btn-group-divider) > #{$group-button} + #{$group-button}::before {
+    inset-inline: var(--#{$prefix}btn-padding-x);
+    top: calc(-1 * var(--#{$prefix}btn-border-width));
+    height: var(--#{$prefix}btn-border-width);
+  }
+
   // Optional: Group multiple button groups together for a toolbar
   .btn-toolbar {
     display: flex;

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -460,8 +460,8 @@ $btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), st
   // scss-docs-start btn-sizes-loop
   @each $size, $_ in $button-sizes {
     .btn-#{$size},
-    .btn-group-#{$size} > .btn,
-    .input-group-#{$size} > .btn {
+    .btn-group-#{$size} > :is(#{$btn-variant-selectors}),
+    .input-group-#{$size} > :is(#{$btn-variant-selectors}) {
       --#{$prefix}btn-gap: var(--#{$prefix}btn-input-#{$size}-gap);
       --#{$prefix}btn-min-height: var(--#{$prefix}btn-input-#{$size}-min-height);
       --#{$prefix}btn-padding-y: var(--#{$prefix}btn-input-#{$size}-padding-y);


### PR DESCRIPTION
- **Selector fix:** buttons written the v6 way (`.btn-solid theme-primary`, no `.btn`) kept all four rounded corners inside a `.btn-group` and their borders never collapsed — every child selector keyed on `.btn`. Group and vertical-group rules (flex sizing, z-index raise, border collapse, corner resets) plus the `.btn-group-*`/`.input-group-*` size loops now match `:is($btn-variant-selectors)`; the deprecated `.btn-check` input stays outside the list, specificity is unchanged. This is also what un-breaks the checkbox/radio toggle groups in the docs.
- **New `.btn-group-divider`:** a 1px line (button text colour at 25% opacity) between adjacent buttons, for styles whose collapsed borders can't separate them (solid, subtle); logical properties, so RTL flips it for free. Documented in the new Dividers section.
- **Docs:** the button-group page mirrors the upstream section structure (Examples → With links → Dividers → Theme variants → Style variants → Toggle buttons → Button toolbar → Sizing → Nesting → Vertical variation). Toggle labels spell `.btn-check` first, toolbar examples drop the hand-written `me-2` margins, sizing stacks via the Example wrapper instead of `<br>`, nesting/vertical examples use the v6 menu API instead of the legacy dropdown, and the duplicated vertical radio example is gone. (The upstream page's `.theme-accent` example substitutes `.theme-secondary` — the accent theme is a separate open decision.)
- Verified with computed-styles probes in Chromium: variant-only groups get outer-corners-only and the −1px collapse (horizontal and vertical), the size loop applies, dividers render 1px at .25 opacity with none on the first button, legacy `.btn` markup is pixel-identical.