### PR TITLE
fix(scss)!: the last components leave the semantic radius for scale stops

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1890,9 +1890,11 @@ as such.
   emits `--cui-radius-0` through `--cui-radius-9` (multiples of `$radius`,
   `.5rem` by default) plus `--cui-radius-pill`, and component tokens read
   stops instead of the one global `--cui-border-radius`: buttons, inputs,
-  alerts, list groups, tabs, progress, tooltips and thumbnails sit on
-  `--cui-radius-5` (`.5rem`), badges, cards, popovers, dialogs, drawers and
-  menus on `--cui-radius-7` (`.75rem`), pills on `--cui-radius-9` (`1.5rem`).
+  alerts, list groups, tabs, nav links, progress, tooltips, thumbnails,
+  callouts, combobox options and the range slider's tooltip sit on
+  `--cui-radius-5` (`.5rem`), badges, cards, popovers, dialogs, drawers,
+  menus, accordions, toasts, dropdowns and popups on `--cui-radius-7`
+  (`.75rem`), pills on `--cui-radius-9` (`1.5rem`).
   Everything that used the `.375rem` default is visibly rounder. To keep a
   component on its old radius, set its own token
   (`--cui-card-border-radius: .375rem`); to retune the whole page, override

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -17,7 +17,7 @@ $accordion-color:                         var(--#{$prefix}fg-body) !default;
 $accordion-bg:                            var(--#{$prefix}bg-body) !default;
 $accordion-border-width:                  var(--#{$prefix}border-width) !default;
 $accordion-border-color:                  var(--#{$prefix}border-color) !default;
-$accordion-border-radius:                 var(--#{$prefix}border-radius) !default;
+$accordion-border-radius:                 var(--#{$prefix}radius-7) !default;
 
 $accordion-button-color:                  var(--#{$prefix}fg-2) !default;
 $accordion-button-bg:                     var(--#{$prefix}accordion-bg) !default;

--- a/scss/_callout.scss
+++ b/scss/_callout.scss
@@ -10,7 +10,7 @@ $callout-padding-y:                 var(--#{$prefix}spacer-3) !default;
 $callout-padding-x:                 var(--#{$prefix}spacer-3) !default;
 $callout-margin-y:                  var(--#{$prefix}spacer-3) !default;
 $callout-margin-x:                  0 !default;
-$callout-border-radius:             var(--#{$prefix}border-radius) !default;
+$callout-border-radius:             var(--#{$prefix}radius-5) !default;
 $callout-border-width:              var(--#{$prefix}border-width) !default;
 $callout-border-color:              var(--#{$prefix}border-color) !default;
 $callout-border-left-width:         calc(#{$callout-border-width} * 4) !default;

--- a/scss/_combobox.scss
+++ b/scss/_combobox.scss
@@ -30,7 +30,7 @@ $combobox-select-all-hover-color:     var(--#{$prefix}fg-body) !default;
 $combobox-select-all-hover-bg:        var(--#{$prefix}bg-3) !default;
 $combobox-select-all-border-width:    0 !default;
 $combobox-select-all-border-color:    transparent !default;
-$combobox-select-all-border-radius:   var(--#{$prefix}border-radius) !default;
+$combobox-select-all-border-radius:   var(--#{$prefix}radius-5) !default;
 
 $combobox-options-gap:                .125rem !default;
 $combobox-options-padding-y:          .375rem !default;
@@ -41,7 +41,7 @@ $combobox-options-color:              var(--#{$prefix}fg-body) !default;
 
 $combobox-optgroup-label-padding-y:      .5rem !default;
 $combobox-optgroup-label-padding-x:      .625rem !default;
-$combobox-optgroup-label-border-radius:  var(--#{$prefix}border-radius) !default;
+$combobox-optgroup-label-border-radius:  var(--#{$prefix}radius-5) !default;
 $combobox-optgroup-label-font-size:      80% !default;
 $combobox-optgroup-label-font-weight:    var(--#{$prefix}font-weight-bold) !default;
 $combobox-optgroup-label-color:          var(--#{$prefix}fg-3) !default;
@@ -53,7 +53,7 @@ $combobox-option-margin-y:            0 !default;
 $combobox-option-margin-x:            0 !default;
 $combobox-option-border-width:        var(--#{$prefix}btn-input-border-width) !default;
 $combobox-option-border-color:        transparent !default;
-$combobox-option-border-radius:       var(--#{$prefix}border-radius) !default;
+$combobox-option-border-radius:       var(--#{$prefix}radius-5) !default;
 $combobox-option-hover-color:         var(--#{$prefix}fg-body) !default;
 $combobox-option-hover-bg:            var(--#{$prefix}bg-3) !default;
 $combobox-option-disabled-color:      var(--#{$prefix}fg-2) !default;

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -17,7 +17,7 @@ $dropdown-font-size:                var(--#{$prefix}body-font-size) !default;
 $dropdown-color:                    var(--#{$prefix}fg-body) !default;
 $dropdown-bg:                       var(--#{$prefix}bg-body) !default;
 $dropdown-border-color:             var(--#{$prefix}border-color-translucent) !default;
-$dropdown-border-radius:            var(--#{$prefix}border-radius) !default;
+$dropdown-border-radius:            var(--#{$prefix}radius-7) !default;
 $dropdown-border-width:             var(--#{$prefix}border-width) !default;
 $dropdown-inner-border-radius:      calc(#{$dropdown-border-radius} - #{$dropdown-border-width}) !default;
 $dropdown-divider-bg:               $dropdown-border-color !default;

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -16,7 +16,7 @@ $nav-link-font-size:                null !default;
 $nav-link-gap:                      .5rem !default;
 $nav-link-align:                    center !default;
 $nav-link-justify:                  center !default;
-$nav-link-border-radius:            var(--#{$prefix}border-radius) !default;
+$nav-link-border-radius:            var(--#{$prefix}radius-5) !default;
 $nav-link-font-weight:              null !default;
 $nav-link-color:                    var(--#{$prefix}fg-2) !default;
 $nav-link-hover-color:              var(--#{$prefix}fg-1) !default;

--- a/scss/_popup.scss
+++ b/scss/_popup.scss
@@ -10,7 +10,7 @@ $popup-zindex:          1000 !default;
 $popup-bg:              var(--#{$prefix}bg-body) !default;
 $popup-border-width:    var(--#{$prefix}border-width) !default;
 $popup-border-color:    var(--#{$prefix}border-color) !default;
-$popup-border-radius:   var(--#{$prefix}border-radius) !default;
+$popup-border-radius:   var(--#{$prefix}radius-7) !default;
 $popup-box-shadow:      var(--#{$prefix}box-shadow) !default;
 $popup-transition-duration: .15s !default;
 $popup-transition-timing:   var(--#{$prefix}transition-timing-overlay) !default;

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -47,7 +47,7 @@ $range-slider-tooltip-margin-bottom:       .25rem !default;
 $range-slider-tooltip-font-size:           var(--#{$prefix}font-size-sm) !default;
 $range-slider-tooltip-color:               var(--#{$prefix}fg-body) !default;
 $range-slider-tooltip-bg:                  var(--#{$prefix}bg-4) !default;
-$range-slider-tooltip-border-radius:       var(--#{$prefix}border-radius) !default;
+$range-slider-tooltip-border-radius:       var(--#{$prefix}radius-5) !default;
 $range-slider-tooltip-box-shadow:          var(--#{$prefix}box-shadow) !default;
 $range-slider-tooltip-transition:          visibility .15s, opacity .15s ease !default;
 

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -15,7 +15,7 @@ $toast-color:                       var(--#{$prefix}fg-body) !default;
 $toast-background-color:            var(--#{$prefix}bg-body) !default;
 $toast-border-width:                var(--#{$prefix}border-width) !default;
 $toast-border-color:                var(--#{$prefix}border-color-translucent) !default;
-$toast-border-radius:               var(--#{$prefix}border-radius) !default;
+$toast-border-radius:               var(--#{$prefix}radius-7) !default;
 $toast-box-shadow:                  var(--#{$prefix}box-shadow) !default;
 $toast-spacing:                     $container-padding-x !default;
 $toast-transition-duration:         .15s !default;


### PR DESCRIPTION
- `--cui-radius-7` (.75rem): accordion, toast, dropdown panel, popup — the panel stop the other panels already sit on.
- `--cui-radius-5` (.5rem): nav links, combobox items (option, optgroup label, select-all), callout, range slider's tooltip — the control stop.
- The `rounded-*` utilities stay on the semantic `--cui-border-radius` tokens, as decided in the radius-scale pass.
- Migration guide's per-stop lists now carry the full component set. Visual suite green (its frames capture closed fields; item radii only show when a panel is open).