### PR TITLE
fix(input-group): grouped buttons in any spelling sit above the input borders

### DIFF
--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -346,7 +346,7 @@ Sass variables set these defaults at build time and are removed in v7. The CSS v
 
 The variables below are the neutral fallbacks — what a variant renders as when no theme colour reaches it.
 
-<ScssDocs file="scss/buttons/_button.scss" capture="btn-variables" />
+<ScssDocs file="scss/buttons/_variables.scss" capture="btn-variables" />
 
 ### Sass maps
 
@@ -356,7 +356,7 @@ The variables below are the neutral fallbacks — what a variant renders as when
 
 `$button-variants` holds every variant. Each entry names, per state, the theme token a button variable reads and the neutral value behind it; `disabled` repeats `base`. Add an entry and both spellings of the new variant are generated — the variant class and the `.btn-{variant}-{color}` class.
 
-<ScssDocs file="scss/buttons/_button.scss" capture="btn-variants" />
+<ScssDocs file="scss/buttons/_variables.scss" capture="btn-variants" />
 
 ### Sass mixins
 

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -11,33 +11,8 @@
 @use "../mixins/transition" as *;
 @use "../theme" as *;
 @use "../config" as *;
-
-// scss-docs-start btn-variables
-$btn-white-space:             nowrap !default; // Set to `normal` to let button text wrap
-
-$btn-color:                   var(--#{$prefix}fg-body) !default;
-$btn-bg:                      var(--#{$prefix}bg-2) !default;
-$btn-hover-bg:                var(--#{$prefix}bg-3) !default;
-$btn-box-shadow:              inset 0 1px 0 color-mix(in srgb, var(--#{$prefix}white) 15%, transparent), 0 1px 1px color-mix(in srgb, var(--#{$prefix}black) 7.5%, transparent) !default;
-$btn-active-box-shadow:       inset 0 3px 5px color-mix(in srgb, var(--#{$prefix}black) 12.5%, transparent) !default;
-
-$btn-link-color:              var(--#{$prefix}link-color) !default;
-$btn-link-hover-color:        var(--#{$prefix}link-hover-color) !default;
-$btn-link-disabled-color:     var(--#{$prefix}fg-3) !default;
-
-$btn-outline-color:           var(--#{$prefix}fg-2) !default;
-$btn-outline-border-color:    var(--#{$prefix}border-color) !default;
-$btn-outline-hover-color:     var(--#{$prefix}fg-body) !default;
-$btn-outline-hover-bg:        var(--#{$prefix}bg-3) !default;
-
-$btn-subtle-color:            var(--#{$prefix}fg-body) !default;
-$btn-subtle-bg:               var(--#{$prefix}bg-2) !default;
-$btn-subtle-hover-bg:         var(--#{$prefix}bg-3) !default;
-
-$btn-ghost-color:             var(--#{$prefix}fg-2) !default;
-$btn-ghost-hover-color:       var(--#{$prefix}fg-body) !default;
-$btn-ghost-hover-bg:          var(--#{$prefix}bg-1) !default;
-// scss-docs-end btn-variables
+@use "variables" as *;
+@forward "variables";
 
 // stylelint-disable custom-property-no-missing-var-function, scss/dollar-variable-default
 
@@ -70,87 +45,6 @@ $button-tokens: defaults(
   $button-tokens
 );
 // scss-docs-end btn-tokens
-
-// scss-docs-start btn-variants
-// Each entry names the theme token a button variable reads and the neutral
-// value behind it, so the variant class alone is a grey button and any theme
-// colour — from `.theme-*`, from a `.btn-*-{color}` class or from an ancestor —
-// colours the whole set. `disabled` repeats `base`.
-$button-variants: () !default;
-$button-variants: defaults(
-  (
-    "solid": (
-      "base": (
-        "color": ("contrast", $btn-color),
-        "bg": ("bg", $btn-bg),
-        "border-color": ("bg", $btn-bg)
-      ),
-      "hover": (
-        "color": ("contrast", $btn-color),
-        "bg": ("hover", $btn-hover-bg),
-        "border-color": ("hover", $btn-hover-bg)
-      ),
-      "active": (
-        "color": ("contrast", $btn-color),
-        "bg": ("active", $btn-hover-bg),
-        "border-color": ("active", $btn-hover-bg)
-      )
-    ),
-    "outline": (
-      "base": (
-        "color": ("fg", $btn-outline-color),
-        "bg": "transparent",
-        "border-color": ("border", $btn-outline-border-color)
-      ),
-      "hover": (
-        "color": ("contrast", $btn-outline-hover-color),
-        "bg": ("hover", $btn-outline-hover-bg),
-        "border-color": ("hover", $btn-outline-border-color)
-      ),
-      "active": (
-        "color": ("contrast", $btn-outline-hover-color),
-        "bg": ("active", $btn-outline-hover-bg),
-        "border-color": ("active", $btn-outline-border-color)
-      )
-    ),
-    "subtle": (
-      "base": (
-        "color": ("fg", $btn-subtle-color),
-        "bg": ("bg-subtle", $btn-subtle-bg),
-        "border-color": "transparent"
-      ),
-      "hover": (
-        "color": ("fg-emphasis", $btn-subtle-color),
-        "bg": ("bg-muted", $btn-subtle-hover-bg),
-        "border-color": "transparent"
-      ),
-      "active": (
-        "color": ("fg-emphasis", $btn-subtle-color),
-        "bg": ("bg-muted", $btn-subtle-hover-bg),
-        "border-color": "transparent"
-      )
-    ),
-    "ghost": (
-      "base": (
-        "color": ("fg", $btn-ghost-color),
-        "bg": "transparent",
-        "border-color": "transparent"
-      ),
-      "hover": (
-        "color": ("contrast", $btn-ghost-hover-color),
-        "bg": ("hover", $btn-ghost-hover-bg),
-        "border-color": ("hover", $btn-ghost-hover-bg)
-      ),
-      "active": (
-        "color": ("contrast", $btn-ghost-hover-color),
-        "bg": ("active", $btn-ghost-hover-bg),
-        "border-color": ("active", $btn-ghost-hover-bg)
-      )
-    )
-  ),
-  $button-variants
-);
-// scss-docs-end btn-variants
 
 $button-link-tokens: () !default;
 
@@ -215,18 +109,6 @@ $button-sizes: defaults(
   }
 }
 // scss-docs-end btn-variant-mixin
-
-// scss-docs-start btn-variant-selectors
-$btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), string.unquote(".btn-icon")) !default;
-@each $variant, $tokens in $button-variants {
-  $btn-variant-selectors: list.append($btn-variant-selectors, string.unquote(".btn-#{$variant}"), comma);
-}
-// scss-docs-end btn-variant-selectors
-
-// The v6 spelling puts `.btn-check` on the `<label>` styled as a button, so the
-// deprecated one — the class on the input — is the `.btn-check` that carries
-// no button spelling at all.
-$btn-check-deprecated: ".btn-check:not(#{$btn-variant-selectors})" !default;
 
 // The solid variant is the one a colour class spells without its variant name:
 // `.btn-primary`, not `.btn-solid-primary`.

--- a/scss/buttons/_variables.scss
+++ b/scss/buttons/_variables.scss
@@ -1,0 +1,131 @@
+@use "sass:list";
+@use "sass:string";
+@use "../functions/defaults" as *;
+@use "../config" as *;
+
+// Emits no CSS, so modules loaded before buttons (the forms) can read the
+// button variables without moving the button rules' emission point.
+
+// scss-docs-start btn-variables
+$btn-white-space:             nowrap !default; // Set to `normal` to let button text wrap
+
+$btn-color:                   var(--#{$prefix}fg-body) !default;
+$btn-bg:                      var(--#{$prefix}bg-2) !default;
+$btn-hover-bg:                var(--#{$prefix}bg-3) !default;
+$btn-box-shadow:              inset 0 1px 0 color-mix(in srgb, var(--#{$prefix}white) 15%, transparent), 0 1px 1px color-mix(in srgb, var(--#{$prefix}black) 7.5%, transparent) !default;
+$btn-active-box-shadow:       inset 0 3px 5px color-mix(in srgb, var(--#{$prefix}black) 12.5%, transparent) !default;
+
+$btn-link-color:              var(--#{$prefix}link-color) !default;
+$btn-link-hover-color:        var(--#{$prefix}link-hover-color) !default;
+$btn-link-disabled-color:     var(--#{$prefix}fg-3) !default;
+
+$btn-outline-color:           var(--#{$prefix}fg-2) !default;
+$btn-outline-border-color:    var(--#{$prefix}border-color) !default;
+$btn-outline-hover-color:     var(--#{$prefix}fg-body) !default;
+$btn-outline-hover-bg:        var(--#{$prefix}bg-3) !default;
+
+$btn-subtle-color:            var(--#{$prefix}fg-body) !default;
+$btn-subtle-bg:               var(--#{$prefix}bg-2) !default;
+$btn-subtle-hover-bg:         var(--#{$prefix}bg-3) !default;
+
+$btn-ghost-color:             var(--#{$prefix}fg-2) !default;
+$btn-ghost-hover-color:       var(--#{$prefix}fg-body) !default;
+$btn-ghost-hover-bg:          var(--#{$prefix}bg-1) !default;
+// scss-docs-end btn-variables
+
+// stylelint-disable scss/dollar-variable-default
+
+// scss-docs-start btn-variants
+// Each entry names the theme token a button variable reads and the neutral
+// value behind it, so the variant class alone is a grey button and any theme
+// colour — from `.theme-*`, from a `.btn-*-{color}` class or from an ancestor —
+// colours the whole set. `disabled` repeats `base`.
+$button-variants: () !default;
+$button-variants: defaults(
+  (
+    "solid": (
+      "base": (
+        "color": ("contrast", $btn-color),
+        "bg": ("bg", $btn-bg),
+        "border-color": ("bg", $btn-bg)
+      ),
+      "hover": (
+        "color": ("contrast", $btn-color),
+        "bg": ("hover", $btn-hover-bg),
+        "border-color": ("hover", $btn-hover-bg)
+      ),
+      "active": (
+        "color": ("contrast", $btn-color),
+        "bg": ("active", $btn-hover-bg),
+        "border-color": ("active", $btn-hover-bg)
+      )
+    ),
+    "outline": (
+      "base": (
+        "color": ("fg", $btn-outline-color),
+        "bg": "transparent",
+        "border-color": ("border", $btn-outline-border-color)
+      ),
+      "hover": (
+        "color": ("contrast", $btn-outline-hover-color),
+        "bg": ("hover", $btn-outline-hover-bg),
+        "border-color": ("hover", $btn-outline-border-color)
+      ),
+      "active": (
+        "color": ("contrast", $btn-outline-hover-color),
+        "bg": ("active", $btn-outline-hover-bg),
+        "border-color": ("active", $btn-outline-border-color)
+      )
+    ),
+    "subtle": (
+      "base": (
+        "color": ("fg", $btn-subtle-color),
+        "bg": ("bg-subtle", $btn-subtle-bg),
+        "border-color": "transparent"
+      ),
+      "hover": (
+        "color": ("fg-emphasis", $btn-subtle-color),
+        "bg": ("bg-muted", $btn-subtle-hover-bg),
+        "border-color": "transparent"
+      ),
+      "active": (
+        "color": ("fg-emphasis", $btn-subtle-color),
+        "bg": ("bg-muted", $btn-subtle-hover-bg),
+        "border-color": "transparent"
+      )
+    ),
+    "ghost": (
+      "base": (
+        "color": ("fg", $btn-ghost-color),
+        "bg": "transparent",
+        "border-color": "transparent"
+      ),
+      "hover": (
+        "color": ("contrast", $btn-ghost-hover-color),
+        "bg": ("hover", $btn-ghost-hover-bg),
+        "border-color": ("hover", $btn-ghost-hover-bg)
+      ),
+      "active": (
+        "color": ("contrast", $btn-ghost-hover-color),
+        "bg": ("active", $btn-ghost-hover-bg),
+        "border-color": ("active", $btn-ghost-hover-bg)
+      )
+    )
+  ),
+  $button-variants
+);
+// scss-docs-end btn-variants
+
+// stylelint-enable scss/dollar-variable-default
+
+// scss-docs-start btn-variant-selectors
+$btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), string.unquote(".btn-icon")) !default;
+@each $variant, $tokens in $button-variants {
+  $btn-variant-selectors: list.append($btn-variant-selectors, string.unquote(".btn-#{$variant}"), comma);
+}
+// scss-docs-end btn-variant-selectors
+
+// The v6 spelling puts `.btn-check` on the `<label>` styled as a button, so the
+// deprecated one — the class on the input — is the `.btn-check` that carries
+// no button spelling at all.
+$btn-check-deprecated: ".btn-check:not(#{$btn-variant-selectors})" !default;

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -1,5 +1,6 @@
 @use "sass:map";
 @use "sass:string";
+@use "../buttons/variables" as *;
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/forms" as *;
@@ -78,7 +79,7 @@ $input-group-tokens: defaults(
     // Ensure buttons are always above inputs for more visually pleasing borders.
     // This isn't needed for `.input-group-text` since it shares the same border-color
     // as our inputs.
-    .btn {
+    :is(#{$btn-variant-selectors}) {
       position: relative;
       z-index: 2;
 


### PR DESCRIPTION
- `.input-group`'s z-index raise keyed on `.btn`, so a button spelled with only a variant class slid under the adjacent input's border on the 1px overlap; it now matches `:is($btn-variant-selectors)`.
- Enabler: the button knobs, `$button-variants`, the selector list and the deprecated `.btn-check` selector move to `buttons/_variables.scss`, a partial that emits no CSS — so a forms module (loaded before buttons) can read them without moving the button rules' emission point (the coreui-pro#776 trap). `_button.scss` forwards it; every existing consumer resolves unchanged.
- Compiled output is byte-identical apart from the two input-group selectors — verified by compiling base and branch side by side; layer order declaration still precedes the first `@layer` block.
- The `btn-variables`/`btn-variants` ScssDocs captures on the buttons page point at the new file.