### PR TITLE
refactor(scss): direction-sensitive declarations use logical properties

### DIFF
--- a/scss/_autocomplete.scss
+++ b/scss/_autocomplete.scss
@@ -20,8 +20,8 @@
   // The ghost completion drawn behind the text.
   .autocomplete-input-hint {
     position: absolute;
-    top: 0;
-    left: 0;
+    inset-block-start: 0;
+    inset-inline-start: 0;
     width: 100%;
     height: 100%;
     pointer-events: none;

--- a/scss/_calendar.scss
+++ b/scss/_calendar.scss
@@ -131,7 +131,7 @@ $calendar-tokens: defaults(
 
     @include media-breakpoint-down(sm) {
       &:not(:first-child) .calendar-nav {
-        border-top: var(--#{$prefix}calendar-nav-border);
+        border-block-start: var(--#{$prefix}calendar-nav-border);
       }
     }
   }
@@ -153,7 +153,7 @@ $calendar-tokens: defaults(
     display: flex;
     align-items: baseline;
     padding: var(--#{$prefix}calendar-nav-padding);
-    border-bottom: var(--#{$prefix}calendar-nav-border);
+    border-block-end: var(--#{$prefix}calendar-nav-border);
   }
 
   .calendar-nav-btn {
@@ -271,8 +271,8 @@ $calendar-tokens: defaults(
         width: 100%;
         height: 100%;
         content: "";
-        border-top: 1px dashed var(--#{$prefix}calendar-cell-selected-bg);
-        border-bottom: 1px dashed var(--#{$prefix}calendar-cell-selected-bg);
+        border-block-start: 1px dashed var(--#{$prefix}calendar-cell-selected-bg);
+        border-block-end: 1px dashed var(--#{$prefix}calendar-cell-selected-bg);
         @include border-radius(0);
       }
     }

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -87,8 +87,8 @@ $card-tokens: defaults(
     }
 
     > .list-group {
-      border-top: inherit;
-      border-bottom: inherit;
+      border-block-start: inherit;
+      border-block-end: inherit;
 
       &:first-child {
         border-top-width: 0;
@@ -105,7 +105,7 @@ $card-tokens: defaults(
     // use a child selector here to prevent double borders.
     > .card-header + .list-group,
     > .list-group + .card-footer {
-      border-top: 0;
+      border-block-start: 0;
     }
   }
 
@@ -147,7 +147,7 @@ $card-tokens: defaults(
     margin-bottom: 0; // Removes the default margin-bottom of <hN>
     color: var(--#{$prefix}theme-contrast, var(--#{$prefix}card-cap-color));
     background-color: var(--#{$prefix}theme-bg, var(--#{$prefix}card-cap-bg));
-    border-bottom: var(--#{$prefix}card-border-width) solid var(--#{$prefix}theme-bg, var(--#{$prefix}card-border-color));
+    border-block-end: var(--#{$prefix}card-border-width) solid var(--#{$prefix}theme-bg, var(--#{$prefix}card-border-color));
 
     &:first-child {
       @include border-radius(var(--#{$prefix}card-inner-border-radius) var(--#{$prefix}card-inner-border-radius) 0 0);
@@ -158,7 +158,7 @@ $card-tokens: defaults(
     padding: var(--#{$prefix}card-cap-padding-y) var(--#{$prefix}card-cap-padding-x);
     color: var(--#{$prefix}theme-contrast, var(--#{$prefix}card-cap-color));
     background-color: var(--#{$prefix}theme-bg, var(--#{$prefix}card-cap-bg));
-    border-top: var(--#{$prefix}card-border-width) solid var(--#{$prefix}theme-bg, var(--#{$prefix}card-border-color));
+    border-block-start: var(--#{$prefix}card-border-width) solid var(--#{$prefix}theme-bg, var(--#{$prefix}card-border-color));
 
     &:last-child {
       @include border-radius(0 0 var(--#{$prefix}card-inner-border-radius) var(--#{$prefix}card-inner-border-radius));
@@ -199,7 +199,7 @@ $card-tokens: defaults(
   .card-header-tabs {
     margin-inline: calc(-.5 * var(--#{$prefix}card-cap-padding-x));
     margin-bottom: calc(-1 * var(--#{$prefix}card-cap-padding-y));
-    border-bottom: 0;
+    border-block-end: 0;
 
     .nav-link.active {
       background-color: var(--#{$prefix}card-bg);
@@ -210,10 +210,7 @@ $card-tokens: defaults(
   // Card image
   .card-img-overlay {
     position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    inset: 0;
     padding: var(--#{$prefix}card-img-overlay-padding);
     @include border-radius(var(--#{$prefix}card-inner-border-radius));
   }

--- a/scss/_combobox.scss
+++ b/scss/_combobox.scss
@@ -127,7 +127,7 @@ $combobox-tokens: defaults(
 
   .combobox-header {
     padding: var(--#{$prefix}combobox-header-padding-y) var(--#{$prefix}combobox-header-padding-x);
-    border-bottom: var(--#{$prefix}combobox-header-border-width) solid var(--#{$prefix}combobox-header-border-color);
+    border-block-end: var(--#{$prefix}combobox-header-border-width) solid var(--#{$prefix}combobox-header-border-color);
   }
 
   .combobox-all {

--- a/scss/_date-picker.scss
+++ b/scss/_date-picker.scss
@@ -96,7 +96,7 @@ $date-picker-tokens: defaults(
     gap: .5rem;
     justify-content: flex-end;
     padding: var(--#{$prefix}date-picker-footer-padding);
-    border-top: var(--#{$prefix}date-picker-footer-border-width) solid var(--#{$prefix}date-picker-footer-border-color);
+    border-block-start: var(--#{$prefix}date-picker-footer-border-width) solid var(--#{$prefix}date-picker-footer-border-color);
   }
 
 }

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -245,7 +245,7 @@ $dialog-tokens: defaults(
     flex-shrink: 0;
     align-items: center;
     padding: var(--#{$prefix}dialog-header-padding);
-    border-bottom: var(--#{$prefix}dialog-header-border-width) solid var(--#{$prefix}dialog-header-border-color);
+    border-block-end: var(--#{$prefix}dialog-header-border-width) solid var(--#{$prefix}dialog-header-border-color);
 
     .btn-close {
       margin-inline-start: auto;
@@ -274,6 +274,6 @@ $dialog-tokens: defaults(
     align-items: center;
     justify-content: flex-end;
     padding: var(--#{$prefix}dialog-footer-padding);
-    border-top: var(--#{$prefix}dialog-footer-border-width) solid var(--#{$prefix}dialog-footer-border-color);
+    border-block-start: var(--#{$prefix}dialog-footer-border-width) solid var(--#{$prefix}dialog-footer-border-color);
   }
 }

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -271,9 +271,8 @@ $drawer-tokens: defaults(
   }
 
   .drawer-sheet {
-    right: 0;
-    bottom: 0;
-    left: 0;
+    inset-block-end: 0;
+    inset-inline: 0;
     width: 100vw;
     margin-inline: auto;
     margin-bottom: calc(-1 * var(--#{$prefix}drawer-border-width));
@@ -327,6 +326,6 @@ $drawer-tokens: defaults(
     align-items: center;
     justify-content: flex-end;
     padding: var(--#{$prefix}drawer-padding-y) var(--#{$prefix}drawer-padding-x);
-    border-top: var(--#{$prefix}drawer-border-width) solid var(--#{$prefix}drawer-border-color);
+    border-block-start: var(--#{$prefix}drawer-border-width) solid var(--#{$prefix}drawer-border-color);
   }
 }

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -272,7 +272,7 @@ $dropdown-dark-tokens: defaults(
     height: 0;
     margin: var(--#{$prefix}dropdown-divider-margin-y) 0;
     overflow: hidden;
-    border-top: 1px solid var(--#{$prefix}dropdown-divider-bg);
+    border-block-start: 1px solid var(--#{$prefix}dropdown-divider-bg);
     opacity: 1; // Revisit in v6 to de-dupe styles that conflict with <hr> element
   }
 

--- a/scss/_footer.scss
+++ b/scss/_footer.scss
@@ -45,7 +45,7 @@ $footer-tokens: defaults(
     padding: var(--#{$prefix}footer-padding-y) var(--#{$prefix}footer-padding-x);
     color: var(--#{$prefix}footer-color);
     background: var(--#{$prefix}footer-bg);
-    border-top: var(--#{$prefix}footer-border);
+    border-block-start: var(--#{$prefix}footer-border);
   }
 
   .footer-sticky {

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -99,7 +99,7 @@ $header-tokens: defaults(
     justify-content: space-between; // space out brand from logo
     padding: var(--#{$prefix}header-padding-y) var(--#{$prefix}header-padding-x);
     background: var(--#{$prefix}header-bg);
-    border-bottom: var(--#{$prefix}header-border);
+    border-block-end: var(--#{$prefix}header-border);
     @include transition(var(--#{$prefix}header-transition));
 
     // Because flex properties aren't inherited, we need to redeclare these first
@@ -134,7 +134,7 @@ $header-tokens: defaults(
     flex-basis: calc(100% + (2 * var(--#{$prefix}header-padding-x)));
     height: 0;
     margin: var(--#{$prefix}header-padding-y) calc(-1 * var(--#{$prefix}header-padding-x));
-    border-top: var(--#{$prefix}header-divider-border);
+    border-block-start: var(--#{$prefix}header-divider-border);
   }
 
   // Header brand

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -208,7 +208,7 @@ $modal-tokens: defaults(
     flex-shrink: 0;
     align-items: center;
     padding: var(--#{$prefix}modal-header-padding);
-    border-bottom: var(--#{$prefix}modal-header-border-width) solid var(--#{$prefix}modal-header-border-color);
+    border-block-end: var(--#{$prefix}modal-header-border-width) solid var(--#{$prefix}modal-header-border-color);
     @include border-top-radius(var(--#{$prefix}modal-inner-border-radius));
 
     .btn-close {
@@ -240,7 +240,7 @@ $modal-tokens: defaults(
     justify-content: flex-end; // Right align buttons with flex property because text-align doesn't work on flex items
     padding: var(--#{$prefix}modal-padding);
     background-color: var(--#{$prefix}modal-footer-bg);
-    border-top: var(--#{$prefix}modal-footer-border-width) solid var(--#{$prefix}modal-footer-border-color);
+    border-block-start: var(--#{$prefix}modal-footer-border-width) solid var(--#{$prefix}modal-footer-border-color);
     @include border-bottom-radius(var(--#{$prefix}modal-inner-border-radius));
   }
 

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -267,7 +267,7 @@ $tab-pane-tokens: defaults(
 
     --#{$prefix}nav-link-border-radius: 0;
 
-    border-bottom: var(--#{$prefix}nav-tabs-border-width) solid var(--#{$prefix}nav-tabs-border-color);
+    border-block-end: var(--#{$prefix}nav-tabs-border-width) solid var(--#{$prefix}nav-tabs-border-color);
 
     .nav-link {
       margin-bottom: calc(-1 * var(--#{$prefix}nav-tabs-border-width));
@@ -331,9 +331,8 @@ $tab-pane-tokens: defaults(
     gap: var(--#{$prefix}nav-underline-gap);
 
     .nav-link {
-      padding-right: 0;
-      padding-left: 0;
-      border-bottom: var(--#{$prefix}nav-underline-border-width) solid transparent;
+      padding-inline: 0;
+      border-block-end: var(--#{$prefix}nav-underline-border-width) solid transparent;
 
       &:hover,
       &:focus {
@@ -362,12 +361,12 @@ $tab-pane-tokens: defaults(
     --#{$prefix}nav-link-disabled-color: var(--#{$prefix}nav-underline-border-link-disabled-color);
 
     gap: var(--#{$prefix}nav-underline-border-gap);
-    border-bottom: var(--#{$prefix}nav-underline-border-border-width) solid var(--#{$prefix}nav-underline-border-border-color);
+    border-block-end: var(--#{$prefix}nav-underline-border-border-width) solid var(--#{$prefix}nav-underline-border-border-color);
 
     .nav-link {
       padding: var(--#{$prefix}nav-underline-border-link-padding-y) var(--#{$prefix}nav-underline-border-link-padding-x);
       margin-bottom: calc(-1 * var(--#{$prefix}nav-underline-border-border-width));
-      border-bottom: var(--#{$prefix}nav-underline-border-border-width) solid transparent;
+      border-block-end: var(--#{$prefix}nav-underline-border-border-width) solid transparent;
 
       &:hover,
       &:focus {

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -349,8 +349,7 @@ $navbar-dark-tokens: defaults(
             }
 
             .nav-link {
-              padding-right: var(--#{$prefix}navbar-nav-link-padding-x);
-              padding-left: var(--#{$prefix}navbar-nav-link-padding-x);
+              padding-inline: var(--#{$prefix}navbar-nav-link-padding-x);
             }
           }
 

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -112,13 +112,13 @@ $offcanvas-tokens: defaults(
         &.offcanvas-top {
           inset: 0 0 auto;
           height: var(--#{$prefix}offcanvas-height);
-          border-bottom: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
+          border-block-end: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
         }
 
         &.offcanvas-bottom {
           inset: auto 0 0;
           height: var(--#{$prefix}offcanvas-height);
-          border-top: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
+          border-block-start: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
         }
 
         &:not(.offcanvas-instant) {

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -204,7 +204,7 @@ $popover-tokens: defaults(
       width: var(--#{$prefix}popover-arrow-width);
       margin-left: calc(-.5 * var(--#{$prefix}popover-arrow-width));
       content: "";
-      border-bottom: var(--#{$prefix}popover-border-width) solid var(--#{$prefix}popover-header-bg);
+      border-block-end: var(--#{$prefix}popover-border-width) solid var(--#{$prefix}popover-header-bg);
     }
   }
 
@@ -253,7 +253,7 @@ $popover-tokens: defaults(
     font-size: var(--#{$prefix}popover-header-font-size);
     color: var(--#{$prefix}popover-header-color);
     background-color: var(--#{$prefix}popover-header-bg);
-    border-bottom: var(--#{$prefix}popover-border-width) solid var(--#{$prefix}popover-border-color);
+    border-block-end: var(--#{$prefix}popover-border-width) solid var(--#{$prefix}popover-border-color);
     @include border-top-radius(var(--#{$prefix}popover-inner-border-radius));
 
     &:empty {

--- a/scss/_rating.scss
+++ b/scss/_rating.scss
@@ -84,7 +84,7 @@ $rating-tokens: defaults(
 
   .rating-item-input {
     position: absolute;
-    left: 0;
+    inset-inline-start: 0;
     z-index: -1;
     width: 100%;
     height: 100%;

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -117,7 +117,7 @@ $time-picker-tokens: defaults(
     display: flex;
     justify-content: flex-end;
     padding: var(--#{$prefix}time-picker-footer-padding);
-    border-top: var(--#{$prefix}time-picker-footer-border-width) solid var(--#{$prefix}time-picker-footer-border-color);
+    border-block-start: var(--#{$prefix}time-picker-footer-border-width) solid var(--#{$prefix}time-picker-footer-border-color);
 
     .btn + .btn {
       margin-inline-start: .5rem;

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -123,7 +123,7 @@ $toast-tokens: defaults(
     color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}toast-header-color));
     background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}toast-header-bg));
     background-clip: padding-box;
-    border-bottom: var(--#{$prefix}toast-border-width) solid var(--#{$prefix}theme-border, var(--#{$prefix}toast-header-border-color));
+    border-block-end: var(--#{$prefix}toast-border-width) solid var(--#{$prefix}theme-border, var(--#{$prefix}toast-header-border-color));
     @include border-top-radius(calc(var(--#{$prefix}toast-border-radius) - var(--#{$prefix}toast-border-width)));
 
     .btn-close {

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -259,8 +259,7 @@ $form-control-select-tokens: defaults(
 
     &.form-control-sm,
     &.form-control-lg {
-      padding-right: 0;
-      padding-left: 0;
+      padding-inline: 0;
     }
   }
 

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -18,9 +18,8 @@ $grid-row-columns:            6 !default;
   display: flex;
   flex-wrap: wrap;
   // TODO: Revisit calc order after https://github.com/react-bootstrap/react-bootstrap/issues/6039 is fixed
+  margin-inline: calc(-.5 * var(--#{$prefix}gutter-x));
   margin-top: calc(-1 * var(--#{$prefix}gutter-y));
-  margin-right: calc(-.5 * var(--#{$prefix}gutter-x));
-  margin-left: calc(-.5 * var(--#{$prefix}gutter-x));
 }
 
 @mixin make-col-ready($include-column-box-sizing: false) {
@@ -33,8 +32,7 @@ $grid-row-columns:            6 !default;
   flex-shrink: 0;
   width: 100%;
   max-width: 100%; // Prevent `.col-auto`, `.col` (& responsive variants) from breaking out the grid
-  padding-right: calc(var(--#{$prefix}gutter-x) * .5);
-  padding-left: calc(var(--#{$prefix}gutter-x) * .5);
+  padding-inline: calc(var(--#{$prefix}gutter-x) * .5);
   margin-top: var(--#{$prefix}gutter-y);
 }
 

--- a/scss/sidebar/_sidebar.scss
+++ b/scss/sidebar/_sidebar.scss
@@ -244,8 +244,8 @@ $sidebar-widths: (
 
     &::before {
       position: absolute;
-      top: 0;
-      left: 0;
+      inset-block-start: 0;
+      inset-inline-start: 0;
       width: 100%;
       height: 100%;
       content: "";


### PR DESCRIPTION
- `border-block-start/end` replaces `border-top/bottom` on headers, footers and dividers across toasts, dialog, drawer, modal, offcanvas, popover header, dropdown divider, cards, calendar, date/time picker, combobox, nav (underline, tabs), header and footer.
- Symmetric pairs collapse: `padding-inline`/`margin-inline` for navbar links, nav-underline links, plaintext controls and the grid gutters; `inset` spellings for full-stretch overlays (card-img-overlay, drawer sheet, rating input, autocomplete hint, sidebar toggler).
- Verified two ways: the compile diff against base contains property renames only (identical values), and the visual suite is green.
- Deliberately physical, recorded in the audit: popover/tooltip arrows (our JS flips placement in RTL, so the placement attribute names a physical side), the popover header notch (`left: 50%` centering — upstream's `margin-inline-start` there looks like their RTL bug), and the carousel (JS-transform-coupled).