### PR TITLE
feat(nav)!: tabs draw their line with an inset box-shadow

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1014,6 +1014,17 @@ adornment in the library — so the button needs no icon markup at all:
   and the two underline variants take neither fill, hover or active: they mark
   their state with a line, and a radius curves that line's ends while a fill says
   the same thing twice.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`.nav-tabs` draws its line with an inset `box-shadow`, not a border.** The
+  links no longer pull themselves over the container's border with a negative
+  `margin-bottom`; each link carries its own bottom border (the line colour at
+  rest, the panel colour when active) and the container paints the line as
+  `box-shadow: inset 0 calc(-1 * var(--cui-nav-tabs-border-width)) 0
+  var(--cui-nav-tabs-border-color)`. The rendered result is pixel-identical,
+  but custom CSS targeting `.nav-tabs`' `border-bottom` or the links' negative
+  margin needs a second look; recolour the line through
+  `--cui-nav-tabs-border-color`. `.card-header-tabs` compensates with a deeper
+  negative margin instead of zeroing the border.
 - **`--cui-nav-gap` is new**, declared on `.nav` and defaulting to `0`, so the
   base nav renders exactly as it did. It gives the token a home on the component
   whose name it carries: `.navbar-nav` already overrode it, and `.nav-underline`

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -198,12 +198,11 @@ $card-tokens: defaults(
 
   .card-header-tabs {
     margin-inline: calc(-.5 * var(--#{$prefix}card-cap-padding-x));
-    margin-bottom: calc(-1 * var(--#{$prefix}card-cap-padding-y));
-    border-block-end: 0;
+    margin-bottom: calc(-1 * var(--#{$prefix}card-cap-padding-y) - var(--#{$prefix}nav-tabs-border-width));
 
     .nav-link.active {
       background-color: var(--#{$prefix}card-bg);
-      border-bottom-color: var(--#{$prefix}card-bg);
+      border-block-end-color: var(--#{$prefix}card-bg);
     }
   }
 

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -267,11 +267,11 @@ $tab-pane-tokens: defaults(
 
     --#{$prefix}nav-link-border-radius: 0;
 
-    border-block-end: var(--#{$prefix}nav-tabs-border-width) solid var(--#{$prefix}nav-tabs-border-color);
+    box-shadow: inset 0 calc(-1 * var(--#{$prefix}nav-tabs-border-width)) 0 var(--#{$prefix}nav-tabs-border-color);
 
     .nav-link {
-      margin-bottom: calc(-1 * var(--#{$prefix}nav-tabs-border-width));
       border: var(--#{$prefix}nav-tabs-border-width) solid transparent;
+      border-block-end-color: var(--#{$prefix}nav-tabs-border-color);
       @include border-top-radius(var(--#{$prefix}nav-tabs-border-radius));
 
       &:hover,
@@ -337,7 +337,7 @@ $tab-pane-tokens: defaults(
       &:hover,
       &:focus {
         background-color: var(--#{$prefix}nav-link-hover-bg);
-        border-bottom-color: currentcolor;
+        border-block-end-color: currentcolor;
       }
     }
 
@@ -346,7 +346,7 @@ $tab-pane-tokens: defaults(
       font-weight: var(--#{$prefix}font-weight-bold);
       color: var(--#{$prefix}theme-fg, var(--#{$prefix}nav-underline-link-active-color));
       background-color: var(--#{$prefix}nav-link-active-bg);
-      border-bottom-color: currentcolor;
+      border-block-end-color: currentcolor;
     }
   }
 
@@ -371,7 +371,7 @@ $tab-pane-tokens: defaults(
       &:hover,
       &:focus {
         background-color: var(--#{$prefix}nav-link-hover-bg);
-        border-bottom-color: currentcolor;
+        border-block-end-color: currentcolor;
       }
     }
 
@@ -380,7 +380,7 @@ $tab-pane-tokens: defaults(
       font-weight: var(--#{$prefix}font-weight-bold);
       color: var(--#{$prefix}theme-fg, var(--#{$prefix}nav-underline-border-link-active-color));
       background-color: var(--#{$prefix}nav-link-active-bg);
-      border-bottom-color: currentcolor;
+      border-block-end-color: currentcolor;
     }
   }
 


### PR DESCRIPTION
- `.nav-tabs` paints its line as `box-shadow: inset 0 calc(-1 * width) 0 color` instead of `border-block-end`; the links drop the `margin-bottom: -1px` trick and carry their own bottom border (line colour at rest, panel colour when active — our three-value hover/active border tokens already had the bottom slot).
- `.card-header-tabs` compensates with a deeper negative margin (`- cap-padding-y - border-width`) instead of zeroing a border that no longer exists; its active link recolours `border-block-end-color`.
- Verified: base vs branch screenshots (plain tabs with active/hover/disabled + card-header tabs) are byte-identical, geometry probes equal.
- Migration entry under Nav; drive-by: the underline variants' `border-bottom-color` spellings go logical per the B2 convention.