### PR TITLE
fix(card): the header tabs' negative margin survives the cascade

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -196,7 +196,9 @@ $card-tokens: defaults(
   // Header navs
   //
 
-  .card-header-tabs {
+  // Combined selector: `.nav` alone matches the base class's `margin-bottom: 0`
+  // at equal specificity, and _nav.scss is emitted after this file.
+  .nav.card-header-tabs {
     margin-inline: calc(-.5 * var(--#{$prefix}card-cap-padding-x));
     margin-bottom: calc(-1 * var(--#{$prefix}card-cap-padding-y) - var(--#{$prefix}nav-tabs-border-width));
 


### PR DESCRIPTION
- `.card-header-tabs`'s negative `margin-bottom` was overridden by the base `.nav { margin-bottom: 0 }` — equal specificity, and `_nav.scss` is emitted after `_card.scss` — so a strip of header padding always showed between the tabs' line and the card body (the bug predates the box-shadow mechanism; the byte-identical check in #955 faithfully preserved it).
- The selector is `.nav.card-header-tabs` now (the same combined-selector shape upstream uses for the same reason), with a comment naming the trap.
- Measured in Chromium: computed margin `-9px`, active tab flush with the body (gap 0, was 9px); screenshot matches the upstream example.