### PR TITLE
feat(menu,toast): the transition property list lives in a token

### DIFF
--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -43,6 +43,7 @@ $menu-check-color:              currentcolor !default;
 $menu-header-color:             var(--#{$prefix}fg-3) !default;
 $menu-header-padding-x:         .75rem !default;
 $menu-header-padding-y:         .25rem !default;
+$menu-transition-property:      "opacity, transform, display" !default;
 $menu-transition-duration:      .15s !default;
 $menu-transition-timing:        var(--#{$prefix}transition-timing-overlay) !default;
 // scss-docs-end menu-variables
@@ -83,6 +84,7 @@ $menu-tokens: defaults(
     --#{$prefix}menu-header-color: #{$menu-header-color},
     --#{$prefix}menu-header-padding-x: #{$menu-header-padding-x},
     --#{$prefix}menu-header-padding-y: #{$menu-header-padding-y},
+    --#{$prefix}menu-transition-property: #{$menu-transition-property},
     --#{$prefix}menu-transition-duration: #{$menu-transition-duration},
     --#{$prefix}menu-transition-timing: #{$menu-transition-timing},
   ),
@@ -136,10 +138,11 @@ $menu-tokens: defaults(
       transform-origin: top right;
     }
 
-    @include transition(
-      opacity var(--#{$prefix}menu-transition-duration) var(--#{$prefix}menu-transition-timing),
-      transform var(--#{$prefix}menu-transition-duration) var(--#{$prefix}menu-transition-timing),
-      display var(--#{$prefix}menu-transition-duration) allow-discrete
+    @include transition-props(
+      var(--#{$prefix}menu-transition-property),
+      var(--#{$prefix}menu-transition-duration),
+      var(--#{$prefix}menu-transition-timing),
+      allow-discrete
     );
 
     &.show {

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -18,6 +18,7 @@ $toast-border-color:                var(--#{$prefix}border-color-translucent) !d
 $toast-border-radius:               var(--#{$prefix}radius-7) !default;
 $toast-box-shadow:                  var(--#{$prefix}box-shadow) !default;
 $toast-spacing:                     $container-padding-x !default;
+$toast-transition-property:         "opacity, display" !default;
 $toast-transition-duration:         .15s !default;
 $toast-transition-timing:           linear !default;
 
@@ -53,6 +54,7 @@ $toast-tokens: defaults(
     --#{$prefix}toast-header-bg: #{$toast-header-background-color},
     --#{$prefix}toast-header-border-color: #{$toast-header-border-color},
     --#{$prefix}toast-font-size: $toast-font-size,
+    --#{$prefix}toast-transition-property: #{$toast-transition-property},
     --#{$prefix}toast-transition-duration: #{$toast-transition-duration},
     --#{$prefix}toast-transition-timing: #{$toast-transition-timing},
   ),
@@ -82,9 +84,11 @@ $toast-tokens: defaults(
     // `.toast-instant` to skip the animation.
     &:not(.toast-instant) {
       opacity: 0;
-      @include transition(
-        opacity var(--#{$prefix}toast-transition-duration) var(--#{$prefix}toast-transition-timing),
-        display var(--#{$prefix}toast-transition-duration) allow-discrete
+      @include transition-props(
+        var(--#{$prefix}toast-transition-property),
+        var(--#{$prefix}toast-transition-duration),
+        var(--#{$prefix}toast-transition-timing),
+        allow-discrete
       );
     }
 


### PR DESCRIPTION
- `--cui-menu-transition-property` (`opacity, transform, display`) and `--cui-toast-transition-property` (`opacity, display`) join the existing duration/timing tokens; both components animate through `transition-props(…, allow-discrete)` — the shape alert and the buttons already use.
- Computed lists, durations and behavior verified unchanged in Chromium; the only delta is the timing function on `display`, which a discrete property never uses.
- Dialog and drawer keep their hand-written lists deliberately: the `visibility 0s <delay>` choreography can't be expressed in the longhands — replacing it is the display-animation model decision (D3), not a token move.