### PR TITLE
feat(dialog,drawer): one tokenized transition covers both directions

### DIFF
--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -19,6 +19,7 @@ $dialog-border-color:               var(--#{$prefix}border-color-translucent) !d
 $dialog-border-width:               var(--#{$prefix}border-width) !default;
 $dialog-border-radius:              var(--#{$prefix}radius-7) !default;
 $dialog-box-shadow:                 var(--#{$prefix}box-shadow-lg) !default;
+$dialog-transition-property:        "opacity, transform, visibility" !default;
 $dialog-transition-duration:        .3s !default;
 $dialog-transition-timing:          var(--#{$prefix}transition-timing-overlay) !default;
 $dialog-slide-distance:             3rem !default;
@@ -68,6 +69,7 @@ $dialog-tokens: defaults(
     --#{$prefix}dialog-border-width: #{$dialog-border-width},
     --#{$prefix}dialog-border-radius: #{$dialog-border-radius},
     --#{$prefix}dialog-box-shadow: #{$dialog-box-shadow},
+    --#{$prefix}dialog-transition-property: #{$dialog-transition-property},
     --#{$prefix}dialog-transition-duration: #{$dialog-transition-duration},
     --#{$prefix}dialog-transition-timing: #{$dialog-transition-timing},
     --#{$prefix}dialog-backdrop-bg: #{$dialog-backdrop-bg},
@@ -112,10 +114,15 @@ $dialog-tokens: defaults(
 
     &:not(.dialog-instant) {
       opacity: 0;
-      @include transition(
-        opacity var(--#{$prefix}dialog-transition-duration) var(--#{$prefix}dialog-transition-timing),
-        transform var(--#{$prefix}dialog-transition-duration) var(--#{$prefix}dialog-transition-timing),
-        visibility 0s var(--#{$prefix}dialog-transition-duration)
+      // One transition covers both directions. `visibility` animates with the
+      // rest because it interpolates as a step that stays `visible` while
+      // either end is visible: it flips visible at once on entry, and only
+      // after the animation on exit. Keep it in the property list when you
+      // override the token, or the exit becomes invisible.
+      @include transition-props(
+        var(--#{$prefix}dialog-transition-property),
+        var(--#{$prefix}dialog-transition-duration),
+        var(--#{$prefix}dialog-transition-timing)
       );
 
       &.dialog-slide-down {
@@ -129,11 +136,6 @@ $dialog-tokens: defaults(
       &[open]:not(.hiding) {
         visibility: visible;
         opacity: 1;
-        @include transition(
-          opacity var(--#{$prefix}dialog-transition-duration) var(--#{$prefix}dialog-transition-timing),
-          transform var(--#{$prefix}dialog-transition-duration) var(--#{$prefix}dialog-transition-timing),
-          visibility 0s
-        );
         transform: none;
       }
 

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -22,6 +22,7 @@ $drawer-border-color:               var(--#{$prefix}border-color-translucent) !d
 $drawer-border-width:               var(--#{$prefix}border-width) !default;
 $drawer-border-radius:              var(--#{$prefix}radius-7) !default;
 $drawer-box-shadow:                 var(--#{$prefix}box-shadow-lg) !default;
+$drawer-transition-property:        "transform, visibility" !default;
 $drawer-transition-duration:        .3s !default;
 $drawer-transition-timing:          var(--#{$prefix}transition-timing-overlay) !default;
 $drawer-scale-transform:            scale(1.02) !default;
@@ -50,6 +51,7 @@ $drawer-tokens: defaults(
     --#{$prefix}drawer-border-color: #{$drawer-border-color},
     --#{$prefix}drawer-border-radius: #{$drawer-border-radius},
     --#{$prefix}drawer-box-shadow: #{$drawer-box-shadow},
+    --#{$prefix}drawer-transition-property: #{$drawer-transition-property},
     --#{$prefix}drawer-transition-duration: #{$drawer-transition-duration},
     --#{$prefix}drawer-transition-timing: #{$drawer-transition-timing},
     --#{$prefix}drawer-title-line-height: #{$drawer-title-line-height},
@@ -133,9 +135,12 @@ $drawer-tokens: defaults(
         }
 
         &:not(.drawer-instant) {
-          @include transition(
-            transform var(--#{$prefix}drawer-transition-duration) var(--#{$prefix}drawer-transition-timing),
-            visibility 0s var(--#{$prefix}drawer-transition-duration)
+          // One transition covers both directions — see the note in _dialog.scss
+          // on `visibility` in the property list.
+          @include transition-props(
+            var(--#{$prefix}drawer-transition-property),
+            var(--#{$prefix}drawer-transition-duration),
+            var(--#{$prefix}drawer-transition-timing)
           );
 
           &:where(.drawer-start) {
@@ -168,10 +173,6 @@ $drawer-tokens: defaults(
 
           &[open]:not(.hiding) {
             visibility: visible;
-            @include transition(
-              transform var(--#{$prefix}drawer-transition-duration) var(--#{$prefix}drawer-transition-timing),
-              visibility 0s
-            );
             transform: none;
           }
 


### PR DESCRIPTION
- `--cui-dialog-transition-property` (`opacity, transform, visibility`) and `--cui-drawer-transition-property` (`transform, visibility`) join the duration/timing tokens; both components animate through `transition-props`.
- The `visibility 0s <delay>` trick and the second transition list in the `[open]` state are gone: `visibility` transitioned at full duration interpolates as a step that stays visible while either end is visible — immediate on entry, end-of-animation on exit — so one list covers both directions. A comment warns to keep `visibility` in the list when overriding the token.
- Dialog and drawer unit suites pass (122 specs, including the exit choreography); backdrop transitions are untouched.