### PR TITLE
feat(reboot): links keep their underline .2em below the text

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1472,6 +1472,11 @@ Multi Select's option indicators moved with it — they render as a decorative
   read by navs and pagination, but a plain `<a>` only ever changed its underline.
   It now switches color as well, and inside a themed surface it hovers to
   `--cui-theme-fg-emphasis`.
+- **The underline sits `.2em` below the text.** `<a>` reads the new
+  `--cui-link-underline-offset` token (knob: `$link-underline-offset`), so
+  underlines clear descenders instead of cutting through them. The
+  `.link-offset-*` utilities and `.icon-link` still override it per element;
+  set the token to `auto` for the old browser default.
 - **`accent-color: var(--cui-primary)` on `:root`.** Native controls we don't
   restyle — a bare checkbox, radio, range or `<progress>` — follow the brand
   color instead of the browser's blue.

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -71,6 +71,7 @@ $spacers: (
 // Style anchor elements.
 
 $link-decoration:                         underline !default;
+$link-underline-offset:                   .2em !default;
 $link-hover-decoration:                   null !default;
 
 // Define the minimum dimensions at which your layout will change,

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -236,6 +236,7 @@ $root-token-defaults: map.merge(
     --#{$prefix}heading-color: $headings-color,
     --#{$prefix}link-color: $link-color,
     --#{$prefix}link-decoration: $link-decoration,
+    --#{$prefix}link-underline-offset: $link-underline-offset,
     --#{$prefix}link-hover-color: $link-hover-color,
     --#{$prefix}link-hover-decoration: $link-hover-decoration,
     --#{$prefix}code-color: $code-color,

--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -360,6 +360,7 @@ $th-font-weight:       null !default;
   a {
     color: color-mix(in srgb, var(--#{$prefix}theme-fg, var(--#{$prefix}link-color)) calc(var(--#{$prefix}link-opacity, 1) * 100%), transparent);
     text-decoration: $link-decoration;
+    text-underline-offset: var(--#{$prefix}link-underline-offset);
 
     &:hover {
       color: color-mix(in srgb, var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}link-hover-color)) calc(var(--#{$prefix}link-opacity, 1) * 100%), transparent);


### PR DESCRIPTION
- `<a>` reads the new `--cui-link-underline-offset` token (knob `$link-underline-offset`, `.2em` — declared on `:root` with the other link tokens), so underlines clear descenders.
- Probed in Chromium: plain link 3.2px, `.link-offset-2` (4px) and `.icon-link`'s own token still win their cascade.
- Our `--cui-link-opacity` color model is untouched; migration note under Reboot.