### PR TITLE
docs: document the link underline offset token where links are described

### DIFF
--- a/docs/src/content/docs/content/reboot.mdx
+++ b/docs/src/content/docs/content/reboot.mdx
@@ -53,7 +53,7 @@ The `<html>` and `<body>` elements are updated to provide better page-wide defau
 
 ## Links
 
-Links take `--cui-link-color` and switch to `--cui-link-hover-color` on hover. Inside anything that sets a theme, both follow it: the link reads `--cui-theme-fg` and hovers to `--cui-theme-fg-emphasis`, so a link on a colored surface stays part of that surface.
+Links take `--cui-link-color` and switch to `--cui-link-hover-color` on hover. Inside anything that sets a theme, both follow it: the link reads `--cui-theme-fg` and hovers to `--cui-theme-fg-emphasis`, so a link on a colored surface stays part of that surface. The underline sits `.2em` below the text through `--cui-link-underline-offset` (Sass knob: `$link-underline-offset`), clearing descenders; the [`.link-offset-*` utilities](/utilities/link/#underline-offset) adjust it per link, and setting the token to `auto` restores the browser default.
 
 Placeholder links — an `<a>` with neither `href` nor a class — keep the surrounding text color and get no underline, so an anchor waiting for its URL doesn't read as a working link.
 

--- a/docs/src/content/docs/content/typography.mdx
+++ b/docs/src/content/docs/content/typography.mdx
@@ -11,7 +11,7 @@ CoreUI for Bootstrap sets basic global display, typography, and link styles. Whe
 - Use a [native font stack](/content/reboot/#native-font-stack) that selects the best `font-family` for each OS and device.
 - For a more inclusive and accessible type scale, we use the browser's default root `font-size` (typically 16px) so visitors can customize their browser defaults as needed.
 - Use the `$font-family-base`, `$font-size-base`, and `$line-height-base` attributes as our typographic base applied to the `<body>`.
-- Set the global link color via `$link-color`.
+- Set the global link color via `$link-color` and the underline's distance from the text via `$link-underline-offset`.
 - Use `$body-bg` to set a `background-color` on the `<body>` (`#fff` by default).
 
 These styles can be found within `content/_reboot.scss`, and the global variables are defined in `_config.scss`. Make sure to set `$font-size-base` in `rem`.

--- a/docs/src/content/docs/utilities/link.mdx
+++ b/docs/src/content/docs/utilities/link.mdx
@@ -35,7 +35,7 @@ Change the underline's color independent of the link text color.
 
 ### Underline offset
 
-Change the underline's distance from your text. Offset is set in `em` units to automatically scale with the element's current `font-size`.
+Change the underline's distance from your text. Offset is set in `em` units to automatically scale with the element's current `font-size`. Every link already sits on a `.2em` offset from the global `--cui-link-underline-offset` token; these utilities override it per link.
 
 <Example code={`<p><a href="#">Default link</a></p>
   <p><a class="link-offset-1" href="#">Offset 1 link</a></p>


### PR DESCRIPTION
Follow-up to #959 — the token was only in the migration guide:
- `content/reboot` › Links: the `.2em` default, `--cui-link-underline-offset`/`$link-underline-offset`, the `.link-offset-*` cross-link and the `auto` escape hatch.
- `utilities/link` › Underline offset: names the global default the utilities override.
- `content/typography`: the global-knobs list gains `$link-underline-offset`.