### PR TITLE
fix(close): the close button names its radius stop

### DIFF
--- a/scss/buttons/_close.scss
+++ b/scss/buttons/_close.scss
@@ -59,7 +59,7 @@ $close-tokens: defaults(
     background-color: currentcolor;
     @include mask-icon(var(--#{$prefix}btn-close-icon), var(--#{$prefix}btn-close-icon-size));
     border: 0; // for button elements
-    @include border-radius();
+    @include border-radius(var(--#{$prefix}radius-4));
     opacity: var(--#{$prefix}btn-close-opacity);
 
     // Override <a>'s hover style


### PR DESCRIPTION
- `.btn-close` reads `var(--cui-radius-4)` explicitly instead of the `border-radius()` mixin's semantic default — same `.375rem`, consistent with the components-read-stops model (compiled: `border-radius: var(--cui-radius-4)`).
- The rest of the upstream close-button shape is deliberately NOT adopted (recorded in the audit): their `--btn-close-size: 1.25rem` + `padding: 0` lands a 20px pointer target, below the 24px WCAG 2.2 minimum our `1em` icon + `.25em` padding was engineered for; their icon is a different visual design (filled rounded square with a cut-out X); our focus opacity stays 1.