### PR TITLE
feat(scss): the type scale grows 5xl and 6xl display stops

### DIFF
--- a/docs/src/content/docs/content/typography.mdx
+++ b/docs/src/content/docs/content/typography.mdx
@@ -243,7 +243,7 @@ Align terms and descriptions horizontally by using our grid system's predefined 
 
 Headings scale with the viewport: the larger sizes are written as `clamp()`, so they grow with the screen up to the size given as the ceiling and stop there.
 
-The same sizes are on `:root` as `--cui-font-size-*` tokens, one per stop of the `$font-sizes` scale, and reachable as [font size utilities](/utilities/font-size/) — `.fs-xs` through `.fs-4xl`, or `.text-*` for the size plus the leading that belongs to it. Use them to give a non-heading element a heading's size without also giving it a heading's weight.
+The same sizes are on `:root` as `--cui-font-size-*` tokens, one per stop of the `$font-sizes` scale, and reachable as [font size utilities](/utilities/font-size/) — `.fs-xs` through `.fs-6xl`, or `.text-*` for the size plus the leading that belongs to it. Use them to give a non-heading element a heading's size without also giving it a heading's weight.
 
 ## Customizing
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -3194,8 +3194,10 @@ $font-sizes: (
 ```
 
 - **`$font-sizes` changed shape** — it was `(1: $h1-font-size, … 6: $h6-font-size)`
-  and is now keyed `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, with a nested
-  map per stop.
+  and is now keyed `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`,
+  with a nested map per stop. The two top stops sit above the headings — display
+  sizes (`$font-size-5xl`/`-6xl`, up to `3rem` and `3.5rem`) continuing the same
+  fluid progression, numerically level with `.display-5` and `.display-4`.
   <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
   If you overrode `$font-sizes`, move your values into the new shape. The numeric
   keys live on in `$font-sizes-legacy`, which is derived from the named scale.

--- a/docs/src/content/docs/utilities/font-size.mdx
+++ b/docs/src/content/docs/utilities/font-size.mdx
@@ -19,13 +19,15 @@ Quickly change the `font-size` of text. While our heading classes (e.g., `.h1`�
 The same sizes are also available under named stops, which read better than a
 number once a scale has more than a handful of steps:
 
-<Example code={`<p class="fs-4xl">.fs-4xl text</p>
+<Example code={`<p class="fs-6xl">.fs-6xl text</p>
+  <p class="fs-4xl">.fs-4xl text</p>
   <p class="fs-2xl">.fs-2xl text</p>
   <p class="fs-lg">.fs-lg text</p>
   <p class="fs-xs">.fs-xs text</p>`} />
 
 `.fs-1` … `.fs-6` and the named stops are the same sizes: `.fs-1` is `.fs-4xl`,
-`.fs-2` is `.fs-3xl`, and so on down to `.fs-6`, which is `.fs-md`.
+`.fs-2` is `.fs-3xl`, and so on down to `.fs-6`, which is `.fs-md`. The `5xl`
+and `6xl` stops sit above the headings — display sizes with no numeric alias.
 
 ## With line height
 

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -209,6 +209,8 @@ $h3-font-size:                clamp(1.3rem, 1.3rem + .6vw, 1.75rem) !default;
 $h4-font-size:                clamp(1.275rem, 1.275rem + .3vw, 1.5rem) !default;
 $h5-font-size:                $font-size-lg !default;
 $h6-font-size:                var(--#{$prefix}body-font-size) !default;
+$font-size-5xl:               clamp(1.425rem, 1.425rem + 2.1vw, 3rem) !default;
+$font-size-6xl:               clamp(1.475rem, 1.475rem + 2.7vw, 3.5rem) !default;
 // scss-docs-end font-variables
 
 // scss-docs-start headings-variables
@@ -235,7 +237,9 @@ $font-sizes: (
   "xl":  ("font-size": $h4-font-size,         "line-height": $headings-line-height),
   "2xl": ("font-size": $h3-font-size,         "line-height": $headings-line-height),
   "3xl": ("font-size": $h2-font-size,         "line-height": $headings-line-height),
-  "4xl": ("font-size": $h1-font-size,         "line-height": $headings-line-height)
+  "4xl": ("font-size": $h1-font-size,         "line-height": $headings-line-height),
+  "5xl": ("font-size": $font-size-5xl,        "line-height": $headings-line-height),
+  "6xl": ("font-size": $font-size-6xl,        "line-height": $headings-line-height)
 ) !default;
 // scss-docs-end font-sizes
 


### PR DESCRIPTION
- `$font-size-5xl` (fluid to `3rem`) and `$font-size-6xl` (fluid to `3.5rem`) continue the scale's own progression (min +.05rem, slope +.6vw, max +.5rem per stop) — numerically level with `.display-5`/`.display-4`, so the display classes and the scale agree.
- The `$font-sizes` entries produce the `:root` token pairs and the `.fs-5xl`/`.fs-6xl`/`.text-*` utilities with no further wiring; headings keep their stops (probed: `h1` 40px unchanged, `.fs-5xl` = `.display-5`, `.fs-6xl` = `.display-4` at 1600px).
- This settles the type-scale comparison with upstream: we keep our recipe (body-derived small stops, our fluid clamps) and match their scale's reach with the two display stops; heading assignments stay — our `h1` and theirs share the same 2.5rem maximum.
- Docs: font-size utilities page and typography updated; migration's scale entry lists the full key set.