### PR TITLE
feat(forms)!: labels render medium and full-contrast by default

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -768,6 +768,17 @@ declaration.
   is finally the same height as a sized input; it only shows if you have cut the
   padding below that floor.
 
+#### Form labels carry their own weight
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`.form-label` and `.col-form-label` render medium and full-contrast by
+  default.** `$form-label-font-weight` is `var(--cui-font-weight-medium)`
+  (was `null` — labels inherited the surrounding weight) and
+  `$form-label-color` is `var(--cui-fg-body)` (was `null`), so a label inside
+  a muted or tinted context keeps the page's text colour instead of fading
+  with it. Set the knobs back to `null`, or `--cui-label-font-weight` /
+  `--cui-label-color` to `inherit`, for the old behaviour.
+
 #### Input group: `.has-validation` removed
 
 <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/scss/forms/_labels.scss
+++ b/scss/forms/_labels.scss
@@ -6,8 +6,8 @@
 $form-label-margin-bottom:              .5rem !default;
 $form-label-font-size:                  null !default;
 $form-label-font-style:                 null !default;
-$form-label-font-weight:                null !default;
-$form-label-color:                      null !default;
+$form-label-font-weight:                var(--#{$prefix}font-weight-medium) !default;
+$form-label-color:                      var(--#{$prefix}fg-body) !default;
 // scss-docs-end form-label-variables
 
 $form-label-tokens: () !default;
@@ -50,8 +50,7 @@ $form-label-tokens: defaults(
     --#{$prefix}label-padding-y: calc(var(--#{$prefix}btn-input-padding-y) + var(--#{$prefix}btn-input-border-width));
     --#{$prefix}label-line-height: var(--#{$prefix}btn-input-line-height);
 
-    padding-top: var(--#{$prefix}label-padding-y);
-    padding-bottom: var(--#{$prefix}label-padding-y);
+    padding-block: var(--#{$prefix}label-padding-y);
     margin-bottom: 0; // Override the `<legend>` default
     line-height: var(--#{$prefix}label-line-height);
   }


### PR DESCRIPTION
- `$form-label-font-weight: var(--cui-font-weight-medium)` and `$form-label-color: var(--cui-fg-body)` (both were `null`): labels stop inheriting the surrounding weight/colour — probed 400→500, and inside muted contexts the label keeps the page's text colour.
- Escape hatches stay: the knobs back to `null`, or `--cui-label-font-weight`/`--cui-label-color: inherit`.
- Drive-by per the logical-properties convention: `.col-form-label`'s `padding-top/bottom` pair collapses to `padding-block`.
- Visual suite green (its frames capture bare controls without labels); before/after screenshots of labeled forms eyeballed. Migration entry added.