### PR TITLE
refactor(carousel): the transform engine lives behind the .slide gate

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -37,6 +37,9 @@ $carousel-transition:                transform $carousel-transition-duration eas
 // scss-docs-end carousel-variables
 
 @layer components {
+  // The legacy transform engine, deprecated in v6. Gated behind the `.slide`
+  // class the v5 markup always carried, so existing markup keeps this engine
+  // while a bare `.carousel` belongs to the scroll engine.
   // Notes on the classes:
   //
   // 1. .carousel.pointer-event should ideally be pan-y (to allow for users to scroll vertically)
@@ -49,189 +52,191 @@ $carousel-transition:                transform $carousel-transition-duration eas
   //    slide in its in-transition state. Only one of these occurs at a time.
   // 5. .carousel-item-next.carousel-item-start and .carousel-item-prev.carousel-item-end
   //    is the upcoming slide in transition.
-
-  .carousel {
+  .carousel.slide {
     position: relative;
-  }
 
-  .carousel.pointer-event {
-    touch-action: pan-y;
-  }
+    &.pointer-event {
+      touch-action: pan-y;
+    }
 
-  .carousel-inner {
-    position: relative;
-    width: 100%;
-    overflow: hidden;
-    @include clearfix();
-  }
+    .carousel-inner {
+      position: relative;
+      width: 100%;
+      overflow: hidden;
+      @include clearfix();
+    }
 
-  .carousel-item {
-    position: relative;
-    display: none;
-    float: left;
-    width: 100%;
-    margin-right: -100%;
-    backface-visibility: hidden;
-    @include transition($carousel-transition);
-  }
-
-  .carousel-item.active,
-  .carousel-item-next,
-  .carousel-item-prev {
-    display: block;
-  }
-
-  .carousel-item-next:not(.carousel-item-start),
-  .active.carousel-item-end {
-    transform: translateX(100%);
-  }
-
-  .carousel-item-prev:not(.carousel-item-end),
-  .active.carousel-item-start {
-    transform: translateX(-100%);
-  }
-
-  //
-  // Alternate transitions
-  //
-
-  .carousel-fade {
     .carousel-item {
-      opacity: 0;
-      transition-property: opacity;
-      transform: none;
+      position: relative;
+      display: none;
+      float: left;
+      width: 100%;
+      margin-right: -100%;
+      backface-visibility: hidden;
+      @include transition($carousel-transition);
     }
 
     .carousel-item.active,
-    .carousel-item-next.carousel-item-start,
-    .carousel-item-prev.carousel-item-end {
-      z-index: 1;
-      opacity: 1;
+    .carousel-item-next,
+    .carousel-item-prev {
+      display: block;
     }
 
-    .active.carousel-item-start,
+    .carousel-item-next:not(.carousel-item-start),
     .active.carousel-item-end {
-      z-index: 0;
-      opacity: 0;
-      @include transition(opacity 0s $carousel-transition-duration);
+      transform: translateX(100%);
     }
-  }
 
-  .carousel-control-prev,
-  .carousel-control-next {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    z-index: 1;
-    // Use flex for alignment (1-3)
-    display: flex; // 1. allow flex styles
-    align-items: center; // 2. vertically center contents
-    justify-content: center; // 3. horizontally center contents
-    width: $carousel-control-width;
-    padding: 0;
-    color: var(--#{$prefix}carousel-control-color);
-    text-align: center;
-    background: none;
-    border: 0;
-    opacity: $carousel-control-opacity;
-    @include transition($carousel-control-transition);
-
-    // Hover/focus state
-    &:hover,
-    &:focus {
-      color: var(--#{$prefix}carousel-control-color);
-      text-decoration: none;
-      opacity: $carousel-control-hover-opacity;
+    .carousel-item-prev:not(.carousel-item-end),
+    .active.carousel-item-start {
+      transform: translateX(-100%);
     }
-  }
-  .carousel-control-prev {
-    left: 0;
-    // stylelint-disable-next-line scss/at-function-named-arguments
-    background-image: if(sass($enable-gradients): linear-gradient(90deg, color-mix(in srgb, var(--#{$prefix}black) 25%, transparent), color-mix(in srgb, var(--#{$prefix}black) .1%, transparent)));
-  }
-  .carousel-control-next {
-    right: 0;
-    // stylelint-disable-next-line scss/at-function-named-arguments
-    background-image: if(sass($enable-gradients): linear-gradient(270deg, color-mix(in srgb, var(--#{$prefix}black) 25%, transparent), color-mix(in srgb, var(--#{$prefix}black) .1%, transparent)));
-  }
 
-  // Icons for within
-  .carousel-control-prev-icon,
-  .carousel-control-next-icon {
-    display: inline-block;
-    width: $carousel-control-icon-width;
-    height: $carousel-control-icon-width;
-    // Painted through the mask, so the arrow follows the control's colour
-    // instead of carrying it inside the SVG and being inverted by a filter.
-    background-color: var(--#{$prefix}carousel-control-color);
-    @include mask-icon($size: 100% 100%, $position: 50%);
-  }
+    //
+    // Alternate transitions
+    // The `.slide` scope pushes these one class over the budget; the compiled
+    // specificity has to stay as it was, so the budget yields, not the selector.
+    // stylelint-disable selector-max-class
+    &.carousel-fade {
+      .carousel-item {
+        opacity: 0;
+        transition-property: opacity;
+        transform: none;
+      }
 
-  .carousel-control-prev-icon {
-    @include ltr-rtl-value-only("mask-image", escape-svg($carousel-control-prev-icon-bg), escape-svg($carousel-control-next-icon-bg));
-  }
-  .carousel-control-next-icon {
-    @include ltr-rtl-value-only("mask-image", escape-svg($carousel-control-next-icon-bg), escape-svg($carousel-control-prev-icon-bg));
-  }
+      .carousel-item.active,
+      .carousel-item-next.carousel-item-start,
+      .carousel-item-prev.carousel-item-end {
+        z-index: 1;
+        opacity: 1;
+      }
 
-  // Optional indicator pips/controls
-  //
-  // Add a container (such as a list) with the following class and add an item (ideally a focusable control,
-  // like a button) with data#{$data-infix}target for each slide your carousel holds.
+      .active.carousel-item-start,
+      .active.carousel-item-end {
+        z-index: 0;
+        opacity: 0;
+        @include transition(opacity 0s $carousel-transition-duration);
+      }
+    }
+    // stylelint-enable selector-max-class
 
-  .carousel-indicators {
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 2;
-    display: flex;
-    justify-content: center;
-    padding: 0;
-    // Use the .carousel-control's width as margin so we don't overlay those
-    margin-right: $carousel-control-width;
-    margin-bottom: 1rem;
-    margin-left: $carousel-control-width;
-
-    [data#{$data-infix}target] {
-      box-sizing: content-box;
-      flex: 0 1 auto;
-      width: $carousel-indicator-width;
-      height: $carousel-indicator-height;
+    .carousel-control-prev,
+    .carousel-control-next {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      z-index: 1;
+      // Use flex for alignment (1-3)
+      display: flex; // 1. allow flex styles
+      align-items: center; // 2. vertically center contents
+      justify-content: center; // 3. horizontally center contents
+      width: $carousel-control-width;
       padding: 0;
-      margin-right: $carousel-indicator-spacer;
-      margin-left: $carousel-indicator-spacer;
-      text-indent: -999px;
-      cursor: pointer;
-      background-color: $carousel-indicator-active-bg;
-      background-clip: padding-box;
+      color: var(--#{$prefix}carousel-control-color);
+      text-align: center;
+      background: none;
       border: 0;
-      // Use transparent borders to increase the hit area by 10px on top and bottom.
-      border-top: $carousel-indicator-hit-area-height solid transparent;
-      border-bottom: $carousel-indicator-hit-area-height solid transparent;
-      opacity: $carousel-indicator-opacity;
-      @include transition($carousel-indicator-transition);
+      opacity: $carousel-control-opacity;
+      @include transition($carousel-control-transition);
+
+      // Hover/focus state
+      &:hover,
+      &:focus {
+        color: var(--#{$prefix}carousel-control-color);
+        text-decoration: none;
+        opacity: $carousel-control-hover-opacity;
+      }
+    }
+    .carousel-control-prev {
+      left: 0;
+      // stylelint-disable-next-line scss/at-function-named-arguments
+      background-image: if(sass($enable-gradients): linear-gradient(90deg, color-mix(in srgb, var(--#{$prefix}black) 25%, transparent), color-mix(in srgb, var(--#{$prefix}black) .1%, transparent)));
+    }
+    .carousel-control-next {
+      right: 0;
+      // stylelint-disable-next-line scss/at-function-named-arguments
+      background-image: if(sass($enable-gradients): linear-gradient(270deg, color-mix(in srgb, var(--#{$prefix}black) 25%, transparent), color-mix(in srgb, var(--#{$prefix}black) .1%, transparent)));
     }
 
-    .active {
-      opacity: $carousel-indicator-active-opacity;
+    // Icons for within
+    .carousel-control-prev-icon,
+    .carousel-control-next-icon {
+      display: inline-block;
+      width: $carousel-control-icon-width;
+      height: $carousel-control-icon-width;
+      // Painted through the mask, so the arrow follows the control's colour
+      // instead of carrying it inside the SVG and being inverted by a filter.
+      background-color: var(--#{$prefix}carousel-control-color);
+      @include mask-icon($size: 100% 100%, $position: 50%);
+    }
+
+    .carousel-control-prev-icon {
+      @include ltr-rtl-value-only("mask-image", escape-svg($carousel-control-prev-icon-bg), escape-svg($carousel-control-next-icon-bg));
+    }
+    .carousel-control-next-icon {
+      @include ltr-rtl-value-only("mask-image", escape-svg($carousel-control-next-icon-bg), escape-svg($carousel-control-prev-icon-bg));
+    }
+
+    // Optional indicator pips/controls
+    //
+    // Add a container (such as a list) with the following class and add an item (ideally a focusable control,
+    // like a button) with data#{$data-infix}target for each slide your carousel holds.
+
+    .carousel-indicators {
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: 2;
+      display: flex;
+      justify-content: center;
+      padding: 0;
+      // Use the .carousel-control's width as margin so we don't overlay those
+      margin-right: $carousel-control-width;
+      margin-bottom: 1rem;
+      margin-left: $carousel-control-width;
+
+      [data#{$data-infix}target] {
+        box-sizing: content-box;
+        flex: 0 1 auto;
+        width: $carousel-indicator-width;
+        height: $carousel-indicator-height;
+        padding: 0;
+        margin-right: $carousel-indicator-spacer;
+        margin-left: $carousel-indicator-spacer;
+        text-indent: -999px;
+        cursor: pointer;
+        background-color: $carousel-indicator-active-bg;
+        background-clip: padding-box;
+        border: 0;
+        // Use transparent borders to increase the hit area by 10px on top and bottom.
+        border-top: $carousel-indicator-hit-area-height solid transparent;
+        border-bottom: $carousel-indicator-hit-area-height solid transparent;
+        opacity: $carousel-indicator-opacity;
+        @include transition($carousel-indicator-transition);
+      }
+
+      .active {
+        opacity: $carousel-indicator-active-opacity;
+      }
+    }
+
+    // Optional captions
+    //
+    //
+
+    .carousel-caption {
+      position: absolute;
+      right: (100% - $carousel-caption-width) * .5;
+      bottom: $carousel-caption-spacer;
+      left: (100% - $carousel-caption-width) * .5;
+      padding-top: $carousel-caption-padding-y;
+      padding-bottom: $carousel-caption-padding-y;
+      color: var(--#{$prefix}carousel-caption-color);
+      text-align: center;
     }
   }
 
-  // Optional captions
-  //
-  //
-
-  .carousel-caption {
-    position: absolute;
-    right: (100% - $carousel-caption-width) * .5;
-    bottom: $carousel-caption-spacer;
-    left: (100% - $carousel-caption-width) * .5;
-    padding-top: $carousel-caption-padding-y;
-    padding-bottom: $carousel-caption-padding-y;
-    color: var(--#{$prefix}carousel-caption-color);
-    text-align: center;
-  }
 }
 
 // Dark mode carousel


### PR DESCRIPTION
Stage 1 of the carousel-scroll plan: every legacy rule scoped under `.carousel.slide` (the class the v5 markup always required), freeing a bare `.carousel` for the scroll engine.

- Full-specificity `.slide`, not `:where()` — inside legacy markup these rules must outrank the scroll engine's on the shared class names.
- Proof: compiled diff against base is selector-only; computed styles equal at rest and mid-transition (fade state classes); screenshots byte-identical; a bare `.carousel` carries no legacy styles.
- The fade block runs one class over `selector-max-class` — silenced with a comment saying why the budget yields.
- `carousel-dark` and the `:root` tokens stay unscoped (shared between engines).