### PR TITLE
fix(carousel): captions anchor to their slide; the play/pause control looks like chrome

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "66 kB"
+      "maxSize": "66.5KB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "61 kB"
+      "maxSize": "61.5KB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/components/carousel.mdx
+++ b/docs/src/content/docs/components/carousel.mdx
@@ -255,7 +255,7 @@ Give an autoplaying carousel a visible pause control: a button with `.carousel-c
         <svg class="docs-placeholder-img docs-placeholder-img-lg d-block w-100" width="800" height="400" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Third slide" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Third slide</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Third slide</text></svg>
       </div>
     </div>
-    <button class="carousel-control-play-pause position-absolute top-0 end-0 z-2 m-3" type="button" data-coreui-target="#carouselExampleAutoplay" data-coreui-pause-label="Pause carousel" data-coreui-play-label="Play carousel" aria-label="Pause carousel">
+    <button class="carousel-control-play-pause" type="button" data-coreui-target="#carouselExampleAutoplay" data-coreui-pause-label="Pause carousel" data-coreui-play-label="Play carousel" aria-label="Pause carousel">
       <span class="carousel-control-pause-icon" aria-hidden="true"></span>
       <span class="carousel-control-play-icon" aria-hidden="true"></span>
     </button>

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -2,6 +2,7 @@
 @use "functions/escape-svg" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/color-mode" as *;
+@use "mixins/focus-ring" as *;
 @use "mixins/ltr-rtl" as *;
 @use "mixins/mask-icon" as *;
 @use "mixins/tokens" as *;
@@ -31,6 +32,10 @@ $carousel-caption-padding-y:         1.25rem !default;
 $carousel-caption-spacer:            1.25rem !default;
 
 $carousel-control-icon-width:        2rem !default;
+
+$carousel-play-pause-size:           2.5rem !default;
+$carousel-play-pause-icon-width:     1rem !default;
+$carousel-play-pause-bg:             color-mix(in srgb, var(--#{$prefix}black) 25%, transparent) !default;
 
 $carousel-control-prev-icon-bg:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0'/></svg>") !default;
 $carousel-control-next-icon-bg:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708'/></svg>") !default;
@@ -100,6 +105,10 @@ $carousel-tokens: defaults(
   }
 
   .carousel-item {
+    // The containing block for the slide's own caption; without it every
+    // absolute .carousel-caption resolves against the carousel root and the
+    // captions of all slides stack in one spot.
+    position: relative;
     // `100%` here is `.carousel-inner`'s content box, which `padding-inline`
     // has already inset by the peek on each side, so the peek must NOT be
     // subtracted again — doing so makes every slide `2 * peek` too narrow and
@@ -230,21 +239,55 @@ $carousel-tokens: defaults(
   // Optional play/pause control
   //
   // A discoverable toggle so users can stop an autoplaying carousel, as required
-  // by WCAG 2.2.2 (Pause, Stop, Hide). `.carousel-control-play-pause` is only a
-  // behavior hook — the JS toggles `.paused` on it and its appearance comes from
-  // the wrapping button. The button holds both glyphs and we show whichever
-  // icon matches the current state.
-  .carousel-control-play-pause .carousel-control-play-icon {
-    display: none;
-  }
+  // by WCAG 2.2.2 (Pause, Stop, Hide). Sits in the end corner next to the
+  // indicators row; the JS toggles `.paused` on it and the button holds both
+  // glyphs — we show whichever icon matches the current state.
+  .carousel-control-play-pause {
+    position: absolute;
+    inset-block-end: .625rem;
+    inset-inline-end: .75rem;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: $carousel-play-pause-size;
+    height: $carousel-play-pause-size;
+    padding: 0;
+    color: var(--#{$prefix}carousel-control-color);
+    cursor: pointer;
+    background-color: $carousel-play-pause-bg;
+    border: 0;
+    @include border-radius(50%);
+    opacity: $carousel-control-opacity;
+    @include transition($carousel-control-transition);
 
-  .carousel-control-play-pause.paused {
-    .carousel-control-pause-icon {
-      display: none;
+    &:hover,
+    &:focus-visible {
+      opacity: $carousel-control-hover-opacity;
+    }
+
+    &:focus-visible {
+      @include focus-ring();
+    }
+
+    .carousel-control-pause-icon,
+    .carousel-control-play-icon {
+      width: $carousel-play-pause-icon-width;
+      height: $carousel-play-pause-icon-width;
     }
 
     .carousel-control-play-icon {
-      display: inline-block;
+      display: none;
+    }
+
+    &.paused {
+      .carousel-control-pause-icon {
+        display: none;
+      }
+
+      .carousel-control-play-icon {
+        display: inline-block;
+      }
     }
   }
 


### PR DESCRIPTION
- **Captions:** the scroll engine dropped `.carousel-item`'s `position: relative`, so every absolute caption resolved against the carousel root and all slides' captions stacked in one spot (caught by mrholek on the Dark variant example). The item is its caption's containing block again — probed: caption boxes sit one per slide.
- **Play/pause:** no longer a bare behavior hook — a translucent circle in the end corner next to the indicators (2.5rem, icon 1rem in the control colour, the controls' opacity/hover mechanics, focus ring), with `$carousel-play-pause-size/-icon-width/-bg` knobs. The docs example drops its hand-written positioning utilities.
- Carousel suite green (105 specs); screenshots verified for the default and dark variants. CSS budgets get ~0.4KB headroom — `coreui.css` sat at exactly its ceiling.