### PR TITLE
feat(avatar): ring the stack, tokenize its overlap, run status off the theme

### DIFF
--- a/docs/src/content/docs/components/avatar.mdx
+++ b/docs/src/content/docs/components/avatar.mdx
@@ -89,7 +89,7 @@ Adjust the size of avatars using the `.avatar-sm`, `.avatar-md`, `.avatar-lg`, a
 
 ## Stacked avatars
 
-Display multiple avatars in a stack to represent a group of users or items, with additional count if there are more avatars than can be displayed.
+Display multiple avatars in a stack to represent a group of users or items, with additional count if there are more avatars than can be displayed. Each avatar in a stack wears a ring in the page background colour, so overlapping photos stay separated in both colour schemes.
 
 <Example code={`<div class="avatars-stack">
     <div class="avatar">
@@ -106,33 +106,47 @@ Display multiple avatars in a stack to represent a group of users or items, with
     </div>
   </div>`} />
 
+Size the whole stack at once with `.avatars-stack-sm` through `.avatars-stack-xl`, and tune the overlap with `--cui-avatar-stack-spacing` — the fraction of the avatar size each one is pulled over its neighbour:
+
+<Example code={`<div class="avatars-stack avatars-stack-lg" style="--cui-avatar-stack-spacing: -.25">
+    <div class="avatar">
+      <img class="avatar-img" src="/assets/img/avatars/1.jpg" alt="user@email.com">
+    </div>
+    <div class="avatar">
+      <img class="avatar-img" src="/assets/img/avatars/2.jpg" alt="user@email.com">
+    </div>
+    <div class="avatar">
+      <img class="avatar-img" src="/assets/img/avatars/3.jpg" alt="user@email.com">
+    </div>
+  </div>`} />
+
 ## Avatars with status
 
-Add `.avatar-status` to show presence. The indicator takes its colour from a background utility, so a state needs no class of its own:
+Add `.avatar-status` to show presence. The indicator takes its colour from a `theme-*` class and defaults to a neutral grey, so "offline" needs no class at all:
 
 <Example code={`<div class="d-flex gap-3">
     <div class="avatar">
       <img class="avatar-img" src="/assets/img/avatars/1.jpg" alt="user@email.com">
-      <span class="avatar-status bg-success" role="img" aria-label="Online"></span>
+      <span class="avatar-status theme-success" role="img" aria-label="Online"></span>
     </div>
     <div class="avatar">
       CUI
-      <span class="avatar-status bg-warning" role="img" aria-label="Away"></span>
+      <span class="avatar-status theme-warning" role="img" aria-label="Away"></span>
     </div>
     <div class="avatar">
       CUI
-      <span class="avatar-status bg-danger" role="img" aria-label="Busy"></span>
+      <span class="avatar-status theme-danger" role="img" aria-label="Busy"></span>
     </div>
     <div class="avatar">
       CUI
-      <span class="avatar-status bg-secondary" role="img" aria-label="Offline"></span>
+      <span class="avatar-status" role="img" aria-label="Offline"></span>
     </div>
   </div>`} />
 
 The indicator is a few pixels of colour and nothing else, so colour is the only thing separating one state from another — not enough on its own, and at this size a different shape would not help either. Where the state means something rather than decorates, name it on the indicator:
 
 ```html
-<span class="avatar-status bg-danger" role="img" aria-label="Busy"></span>
+<span class="avatar-status theme-danger" role="img" aria-label="Busy"></span>
 ```
 
 `role="img"` is what makes the name stick: `aria-label` on a bare `<span>` has no role to attach to, and assistive technology is free to ignore it.
@@ -146,6 +160,10 @@ The ring around the indicator follows the page background through `--cui-avatar-
 Avatars use local CSS variables on `.avatar` for enhanced real-time customization.
 
 <ScssDocs file="scss/_avatar.scss" capture="avatar-css-vars" />
+
+Stacks carry their own variables on `.avatars-stack`:
+
+<ScssDocs file="scss/_avatar.scss" capture="avatar-stack-css-vars" />
 
 ### Sass variables
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -333,6 +333,18 @@ finished, not whether the state changed.
   hover changed `margin-inline-end`, which moved every avatar after it; it now
   uses `transform`, so nothing else shifts. `$avatar-transition` changes from
   `margin .15s` to `transform .15s ease-in-out` accordingly.
+- **Stacked avatars wear a ring and stop pulling what follows them.** Each
+  avatar in a stack gets a border in the page background colour
+  (`--cui-avatar-stack-ring-width` / `-color`), so overlapping photos stay
+  separated; the last avatar drops its negative margin, which used to drag
+  the content after the stack underneath it. The overlap is a token now —
+  `--cui-avatar-stack-spacing`, the fraction of the avatar size — and
+  `.avatars-stack-sm` through `-xl` size every avatar in a stack at once.
+- **The status indicator follows `.theme-{color}` and is never invisible.**
+  `.avatar-status` reads the theme slot and falls back to the new
+  `--cui-avatar-status-bg` (a neutral grey), so a bare indicator reads as
+  "offline" instead of rendering as an empty ring. Background utilities keep
+  working on it.
 
 #### Alert
 

--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -16,9 +16,13 @@ $avatar-color:                 inherit !default;
 $avatar-bg:                    var(--#{$prefix}bg-2) !default;
 $avatar-border-radius:         50em !default;
 $avatar-status-size:           .5rem !default;
+$avatar-status-bg:             var(--#{$prefix}secondary) !default;
 $avatar-status-border-radius:  50em !default;
 $avatar-status-border-width:   1px !default;
 $avatar-status-border-color:   var(--#{$prefix}bg-body) !default;
+$avatar-stack-spacing:         -.4 !default;
+$avatar-stack-ring-width:      2px !default;
+$avatar-stack-ring-color:      var(--#{$prefix}bg-body) !default;
 $avatar-stack-hover-transform: translateY(-2px) !default;
 $avatar-transition:            transform .15s ease-in-out !default;
 
@@ -52,6 +56,7 @@ $avatar-tokens: defaults(
     --#{$prefix}avatar-bg: var(--#{$prefix}theme-bg, #{$avatar-bg}),
     --#{$prefix}avatar-border-radius: #{$avatar-border-radius},
     --#{$prefix}avatar-status-size: #{$avatar-status-size},
+    --#{$prefix}avatar-status-bg: #{$avatar-status-bg},
     --#{$prefix}avatar-status-border-radius: #{$avatar-status-border-radius},
     --#{$prefix}avatar-status-border-width: #{$avatar-status-border-width},
     --#{$prefix}avatar-status-border-color: #{$avatar-status-border-color},
@@ -59,6 +64,19 @@ $avatar-tokens: defaults(
   $avatar-tokens
 );
 // scss-docs-end avatar-css-vars
+
+$avatar-stack-tokens: () !default;
+
+// scss-docs-start avatar-stack-css-vars
+$avatar-stack-tokens: defaults(
+  (
+    --#{$prefix}avatar-stack-spacing: #{$avatar-stack-spacing},
+    --#{$prefix}avatar-stack-ring-width: #{$avatar-stack-ring-width},
+    --#{$prefix}avatar-stack-ring-color: #{$avatar-stack-ring-color},
+  ),
+  $avatar-stack-tokens
+);
+// scss-docs-end avatar-stack-css-vars
 
 // stylelint-enable scss/dollar-variable-default
 
@@ -127,12 +145,14 @@ $avatar-variants: defaults(
     display: block;
     width: var(--#{$prefix}avatar-status-size);
     height: var(--#{$prefix}avatar-status-size);
+    background-color: var(--#{$prefix}theme-bg, var(--#{$prefix}avatar-status-bg));
     border: var(--#{$prefix}avatar-status-border-width) solid var(--#{$prefix}avatar-status-border-color);
     @include border-radius(var(--#{$prefix}avatar-status-border-radius));
   }
 
   @each $size, $map in $avatar-sizes {
-    .avatar-#{$size} {
+    .avatar-#{$size},
+    .avatars-stack-#{$size} .avatar {
       --#{$prefix}avatar-size: #{map.get($map, "size")};
 
       @if map.has-key($map, "status-size") {
@@ -142,10 +162,17 @@ $avatar-variants: defaults(
   }
 
   .avatars-stack {
+    @include tokens($avatar-stack-tokens);
+
     display: flex;
 
     .avatar {
-      margin-inline-end: calc(-.4 * var(--#{$prefix}avatar-size));
+      margin-inline-end: calc(var(--#{$prefix}avatar-stack-spacing) * var(--#{$prefix}avatar-size));
+      border: var(--#{$prefix}avatar-stack-ring-width) solid var(--#{$prefix}avatar-stack-ring-color);
+
+      &:last-child {
+        margin-inline-end: 0;
+      }
 
       // Lifted rather than pulled apart: changing the margin here moves every
       // avatar after this one.


### PR DESCRIPTION
### Stacked avatars

- Each avatar in a stack wears a border in the page background colour (`--cui-avatar-stack-ring-width`/`-color`), so overlapping photos stay separated in both colour schemes.
- The last avatar drops its negative margin — it used to pull the content after the stack underneath it (same defect exists in v5, added to the backport list).
- The overlap fraction moves from a value baked into `calc()` to the runtime token `--cui-avatar-stack-spacing`, in line with the v6 browser-side-styling rule.
- New `.avatars-stack-sm`…`-xl` size every avatar in a stack at once.

### Status indicator

`.avatar-status` reads the theme slot and falls back to the new `--cui-avatar-status-bg` (neutral grey): `theme-*` classes colour it, and a bare indicator reads as offline instead of rendering as an empty ring. Background utilities still win over it (utilities layer).

Docs: stack ring/sizing/spacing documented on the avatar page, statuses example switched to `theme-*`, new `avatar-stack-css-vars` capture in Customizing, migration guide entries added.

Verification: stylelint clean, `npm run css` with the `@layer` declaration still ahead of the first layer block, `docs-build` green (176 pages), pre-push gate (lint → build → bundlewatch → tests → visual → docs) passed.