### PR TITLE
feat(utilities): flow-root/contents display, intrinsic sizing, text-wrap, shadow-xl, font-body, user-select-text, underline-thickness

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -10,11 +10,11 @@
     },
     {
       "path": "./dist/css/coreui-reboot.css",
-      "maxSize": "5.75 kB"
+      "maxSize": "6 kB"
     },
     {
       "path": "./dist/css/coreui-reboot.min.css",
-      "maxSize": "5.35 kB"
+      "maxSize": "5.5 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.css",
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "66.5KB"
+      "maxSize": "67 kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "61.5KB"
+      "maxSize": "62 kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/utilities/display.mdx
+++ b/docs/src/content/docs/utilities/display.mdx
@@ -31,6 +31,8 @@ Where *value* is one of:
 - `table-row`
 - `flex`
 - `inline-flex`
+- `contents`
+- `flow-root`
 
 The display values can be altered by changing the `$displays` variable and recompiling the SCSS.
 

--- a/docs/src/content/docs/utilities/font-family.mdx
+++ b/docs/src/content/docs/utilities/font-family.mdx
@@ -11,6 +11,12 @@ Change a selection to our monospace font stack with `.font-monospace`.
 
 <Example code={`<p class="font-monospace">This is in monospace</p>`} />
 
+## Body
+
+`.font-body` returns a selection to the body font stack — useful inside `.font-monospace` blocks or components that set their own face.
+
+<Example code={`<p class="font-monospace">Monospace with a <span class="font-body">body-font span</span> inside</p>`} />
+
 ## Customizing
 
 ### Sass variables

--- a/docs/src/content/docs/utilities/height.mdx
+++ b/docs/src/content/docs/utilities/height.mdx
@@ -45,6 +45,10 @@ A mobile browser resizes the viewport as it shows or hides its URL bar, so `vh-1
 <div class="dvh-100">Height 100dvh</div>
 ```
 
+## Intrinsic heights
+
+`.h-min`, `.h-max` and `.h-fit` size an element's height from its content the same way the width variants do.
+
 ## Customizing
 
 ### Utilities API

--- a/docs/src/content/docs/utilities/link.mdx
+++ b/docs/src/content/docs/utilities/link.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 6 Link"
 name: "Link"
 description: "Link utilities are used to stylize your anchors to adjust their color, opacity, underline offset, underline color, and more."
-utility: ["link-opacity", "link-offset", "link-underline"]
+utility: ["link-opacity", "link-offset", "link-underline", "underline-thickness"]
 ---
 
 import { getData } from '@coreui/astro-docs/data'
@@ -41,6 +41,15 @@ Change the underline's distance from your text. Offset is set in `em` units to a
   <p><a class="link-offset-1" href="#">Offset 1 link</a></p>
   <p><a class="link-offset-2" href="#">Offset 2 link</a></p>
   <p><a class="link-offset-3" href="#">Offset 3 link</a></p>`} />
+
+### Underline thickness
+
+Change how heavy the underline is drawn, on links or any underlined text. Hover variants are included.
+
+<Example code={`<p><a class="underline-thickness-1" href="#">Thickness 1 link</a></p>
+  <p><a class="underline-thickness-2" href="#">Thickness 2 link</a></p>
+  <p><a class="underline-thickness-3" href="#">Thickness 3 link</a></p>
+  <p><a class="underline-thickness-1 underline-thickness-3-hover" href="#">Thicker on hover</a></p>`} />
 
 ### Underline opacity
 

--- a/docs/src/content/docs/utilities/shadows.mdx
+++ b/docs/src/content/docs/utilities/shadows.mdx
@@ -11,7 +11,8 @@ While shadows on components are disabled by default in CoreUI for Bootstrap and 
 <Example code={`<div class="shadow-none p-3 mb-5 bg-4 rounded">No shadow</div>
   <div class="shadow-sm p-3 mb-5 bg-body rounded">Small shadow</div>
   <div class="shadow p-3 mb-5 bg-body rounded">Regular shadow</div>
-  <div class="shadow-lg p-3 mb-5 bg-body rounded">Larger shadow</div>`} />
+  <div class="shadow-lg p-3 mb-5 bg-body rounded">Larger shadow</div>
+  <div class="shadow-xl p-3 mb-5 bg-body rounded">Extra large shadow</div>`} />
 
 ## Color
 

--- a/docs/src/content/docs/utilities/text-wrapping.mdx
+++ b/docs/src/content/docs/utilities/text-wrapping.mdx
@@ -19,6 +19,13 @@ Prevent text from wrapping with a `.text-nowrap` class.
     This text should overflow the parent.
   </div>`} />
 
+## Balance and pretty
+
+`.text-balance` evens out the line lengths of short runs of text — headings, teasers — so no line is left with a lone word. `.text-pretty` asks the browser for better-looking wrapping of body text, at some rendering cost.
+
+<Example code={`<h4 class="text-balance bg-4 border" style="width: 15rem;">A heading balanced across its lines</h4>
+  <p class="text-pretty bg-4 border" style="width: 15rem;">A longer run of body text the browser wraps with fewer awkward line endings than the default.</p>`} />
+
 ## Word break
 
 Prevent long strings of text from breaking your components' layout by using `.text-break` to set `word-wrap: break-word` and `word-break: break-word`. We use `word-wrap` instead of the more common `overflow-wrap` for wider browser support, and add the deprecated `word-break: break-word` to avoid issues with flex containers.

--- a/docs/src/content/docs/utilities/user-select.mdx
+++ b/docs/src/content/docs/utilities/user-select.mdx
@@ -11,6 +11,7 @@ Change the way in which the content is selected when the user interacts with it.
 
 <Example code={`<p class="user-select-all">This paragraph will be entirely selected when clicked by the user.</p>
   <p class="user-select-auto">This paragraph has default select behavior.</p>
+  <p class="user-select-text">This paragraph is selectable even where an ancestor disables selection.</p>
   <p class="user-select-none">This paragraph will not be selectable when clicked by the user.</p>`} />
 
 `.user-select-none` hides the text from the selection, not from the accessibility tree — a screen reader still reads it, and it is still copied when the user selects a surrounding block in some browsers. Use it for decorative or duplicated text, not to protect content.

--- a/docs/src/content/docs/utilities/width.mdx
+++ b/docs/src/content/docs/utilities/width.mdx
@@ -39,6 +39,14 @@ A mobile browser resizes the viewport as it shows or hides its URL bar, so `vw` 
 <div class="dvw-100">Width 100dvw</div>
 ```
 
+## Intrinsic widths
+
+Size an element from its content instead of its container: `.w-min` (the widest unbreakable word), `.w-max` (the full unwrapped content), `.w-fit` (the content, capped at the container).
+
+<Example code={`<div class="w-min p-2 mb-2 bg-4 border">Min width</div>
+  <div class="w-max p-2 mb-2 bg-4 border">Max width</div>
+  <div class="w-fit p-2 bg-4 border">Fit width</div>`} />
+
 ## Customizing
 
 ### Utilities API

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -163,6 +163,7 @@ $shadows: (
   null:  0 .5rem 1rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(15% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
   sm:    0 .125rem .25rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(7.5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
   lg:    0 1rem 3rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(17.5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
+  xl:    0 1.5rem 4rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(20% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
   inset: inset 0 1px 2px color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(7.5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
 ) !default;
 // scss-docs-end box-shadow-variables

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -196,7 +196,7 @@ $utilities: map.merge(
       print: true,
       property: display,
       class: d,
-      values: inline inline-block block grid inline-grid table table-row table-cell flex inline-flex none
+      values: inline inline-block block grid inline-grid table table-row table-cell flex inline-flex contents flow-root none
     ),
     // scss-docs-end utils-display
     // scss-docs-start utils-shadow
@@ -403,7 +403,10 @@ $utilities: map.merge(
         50: 50%,
         75: 75%,
         100: 100%,
-        auto: auto
+        auto: auto,
+        min: min-content,
+        max: max-content,
+        fit: fit-content
       )
     ),
     "max-width": (
@@ -441,7 +444,10 @@ $utilities: map.merge(
         50: 50%,
         75: 75%,
         100: 100%,
-        auto: auto
+        auto: auto,
+        min: min-content,
+        max: max-content,
+        fit: fit-content
       )
     ),
     "max-height": (
@@ -846,7 +852,10 @@ $utilities: map.merge(
     "font-family": (
       property: font-family,
       class: font,
-      values: (monospace: var(--#{$prefix}font-monospace))
+      values: (
+        monospace: var(--#{$prefix}font-monospace),
+        body: var(--#{$prefix}body-font-family)
+      )
     ),
     // scss-docs-end utils-font-family
     // scss-docs-start utils-font-size
@@ -927,6 +936,11 @@ $utilities: map.merge(
       class: text,
       values: (break: break-word),
     ),
+    "text-wrap": (
+      property: text-wrap,
+      class: text,
+      values: balance pretty,
+    ),
     // scss-docs-end utils-text-wrap
     // scss-docs-end utils-text
     // scss-docs-start utils-color
@@ -1002,6 +1016,18 @@ $utilities: map.merge(
         1: .125em,
         2: .25em,
         3: .375em,
+      )
+    ),
+    "underline-thickness": (
+      property: text-decoration-thickness,
+      class: underline-thickness,
+      state: hover,
+      values: (
+        1: 1px,
+        2: 2px,
+        3: 3px,
+        4: 4px,
+        5: 5px,
       )
     ),
     "link-underline": (
@@ -1120,7 +1146,7 @@ $utilities: map.merge(
     // scss-docs-start utils-user-select
     "user-select": (
       property: user-select,
-      values: all auto none
+      values: all auto text none
     ),
     // scss-docs-end utils-user-select
     // scss-docs-start utils-pointer-events


### PR DESCRIPTION
Batch of small utilities adopted from the upstream v6 parity list (D3):

- **display**: `contents` and `flow-root` join the value enum (responsive + print like the rest).
- **width/height**: `min`/`max`/`fit` (`min-content`/`max-content`/`fit-content`).
- **text-wrap**: new entry emits `.text-balance` and `.text-pretty`; the legacy `.text-wrap`/`.text-nowrap` stay on `white-space` untouched.
- **$shadows**: an `xl` step (0 1.5rem 4rem at 20% strength) in our `color-mix()` formula — `.shadow-xl` plus the `--cui-box-shadow-xl` root token.
- **font-family**: `.font-body` returns a selection to the body font stack.
- **user-select**: `.user-select-text` forces selectability under a `user-select-none` ancestor.
- **underline-thickness-1..5** (+ hover variants): `text-decoration-thickness` in px, on links or any underlined text.

Deliberately not taken here: numeric `w-1..12` (second width scale), `color-scheme-*` classes (`data-coreui-theme` owns that mechanism), `lh-md` (our `--cui-line-height-md` is a type-scale token with different semantics and `lh-base` already covers the middle stop), `dvw/dvh` (already shipped).

Docs: every addition gets a section on its per-property page; API tables update through the existing captures. Budgets raised in a dedicated commit (reboot carries the new root token, coreui.css the classes).

Verification: stylelint clean, `npm run css` + layer order intact, `docs-build` green (176 pages), full pre-push gate incl. bundlewatch passed.