### PR TITLE
feat(utilities): extend the spacing scale with steps 6-9

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -2,11 +2,11 @@
   "files": [
     {
       "path": "./dist/css/coreui-grid.css",
-      "maxSize": "8.75 kB"
+      "maxSize": "11 kB"
     },
     {
       "path": "./dist/css/coreui-grid.min.css",
-      "maxSize": "7.75 kB"
+      "maxSize": "9.75 kB"
     },
     {
       "path": "./dist/css/coreui-reboot.css",
@@ -18,19 +18,19 @@
     },
     {
       "path": "./dist/css/coreui-utilities.css",
-      "maxSize": "17 kB"
+      "maxSize": "19.5 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",
-      "maxSize": "15.5 kB"
+      "maxSize": "17.75 kB"
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "67 kB"
+      "maxSize": "69.5 kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "62 kB"
+      "maxSize": "64.5 kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/utilities/margin.mdx
+++ b/docs/src/content/docs/utilities/margin.mdx
@@ -7,7 +7,7 @@ utility: "m"
 
 ## Overview
 
-Assign responsive-friendly `margin` values to an element or a subset of its sides with shorthand classes. Includes support for individual properties, all properties, and vertical and horizontal properties. Classes are built from a default Sass map ranging from `.25rem` to `3rem`.
+Assign responsive-friendly `margin` values to an element or a subset of its sides with shorthand classes. Includes support for individual properties, all properties, and vertical and horizontal properties. Classes are built from a default Sass map ranging from `.25rem` to `8rem`.
 
 **Laying out with CSS Grid or flexbox?** Consider using [the gap utility](/utilities/gap/) instead — it spaces the children from the container, so you do not have to strip the margin off the last one.
 
@@ -35,6 +35,10 @@ Where *size* is one of:
 - `3` - (by default) for classes that set the `margin` to `$spacer`
 - `4` - (by default) for classes that set the `margin` to `$spacer * 1.5`
 - `5` - (by default) for classes that set the `margin` to `$spacer * 3`
+- `6` - (by default) for classes that set the `margin` to `$spacer * 4`
+- `7` - (by default) for classes that set the `margin` to `$spacer * 5`
+- `8` - (by default) for classes that set the `margin` to `$spacer * 6`
+- `9` - (by default) for classes that set the `margin` to `$spacer * 8`
 - `auto` - for classes that set the `margin` to auto
 
 (You can add more sizes by adding entries to the `$spacers` Sass map variable.)

--- a/docs/src/content/docs/utilities/padding.mdx
+++ b/docs/src/content/docs/utilities/padding.mdx
@@ -7,7 +7,7 @@ utility: ["p", "pt", "pb", "ps", "pe", "px", "py"]
 
 ## Overview
 
-Assign responsive-friendly `padding` values to an element or a subset of its sides with shorthand classes. Includes support for individual properties, all properties, and vertical and horizontal properties. Classes are built from a default Sass map ranging from `.25rem` to `3rem`.
+Assign responsive-friendly `padding` values to an element or a subset of its sides with shorthand classes. Includes support for individual properties, all properties, and vertical and horizontal properties. Classes are built from a default Sass map ranging from `.25rem` to `8rem`.
 
 Unlike [margin](/utilities/margin/), `padding` takes no negative values and no `auto`, so there is no `.p-n1` and no `.px-auto`.
 
@@ -35,6 +35,10 @@ Where *size* is one of:
 - `3` - (by default) for classes that set the `padding` to `$spacer`
 - `4` - (by default) for classes that set the `padding` to `$spacer * 1.5`
 - `5` - (by default) for classes that set the `padding` to `$spacer * 3`
+- `6` - (by default) for classes that set the `padding` to `$spacer * 4`
+- `7` - (by default) for classes that set the `padding` to `$spacer * 5`
+- `8` - (by default) for classes that set the `padding` to `$spacer * 6`
+- `9` - (by default) for classes that set the `padding` to `$spacer * 8`
 
 (You can add more sizes by adding entries to the `$spacers` Sass map variable.)
 

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -61,6 +61,10 @@ $spacers: (
   3: $spacer,
   4: $spacer * 1.5,
   5: $spacer * 3,
+  6: $spacer * 4,
+  7: $spacer * 5,
+  8: $spacer * 6,
+  9: $spacer * 8,
 ) !default;
 // scss-docs-end spacers-map
 


### PR DESCRIPTION
`$spacers` gains `6: 4rem`, `7: 5rem`, `8: 6rem` and `9: 8rem` — the scale continues upward and **no existing step changes**, so current `m-*`/`p-*` usage renders identically. (Upstream re-graduated their whole scale instead — their 9 equals our 5 — which would be breaking for every spacing class; deliberately not taken.)

Every margin, padding, gap, and gutter utility picks the new steps up across all breakpoints, which is where the cost lives: **+~2.3 kB gzip** on `coreui.css` (budgets raised in a dedicated commit: coreui 67→69.5 / 62→64.5, utilities 17→19.5 / 15.5→17.75, grid 8.75→11 / 7.75→9.75 kB). Candidate for the end-of-v6 size-optimization pass if the upper steps turn out unused.

Docs: margin/padding size enumerations extended; the `spacers-map` capture updates the rest.

Verification: stylelint clean, `npm run css` + layer order intact, classes verified in the compiled bundle (`m-9`, `pt-8`, `gap-6`, `g-7`, `row-gap-9`; negative variants stay off with `$enable-negative-margins`), full pre-push gate passed.