### PR TITLE
feat(accordion): small variant

### DIFF
--- a/docs/src/content/docs/components/accordion.mdx
+++ b/docs/src/content/docs/components/accordion.mdx
@@ -93,6 +93,23 @@ Put a whole `.accordion` inside an `.accordion-body` to nest one. Give each leve
     </details>
   </div>`} />
 
+## Small
+
+Add `.accordion-sm` for a compact accordion — tighter padding, a smaller radius and the small font size, all through the component's own tokens:
+
+<ScssDocs file="scss/_accordion.scss" capture="accordion-sm-css-vars" />
+
+<Example code={`<div class="accordion accordion-sm">
+    <details class="accordion-item" name="accordion-sm-example" open>
+      <summary class="accordion-header">Accordion Item #1</summary>
+      <div class="accordion-body">A compact accordion body for denser layouts.</div>
+    </details>
+    <details class="accordion-item" name="accordion-sm-example">
+      <summary class="accordion-header">Accordion Item #2</summary>
+      <div class="accordion-body">The same markup, just the small variant's tokens.</div>
+    </details>
+  </div>`} />
+
 ## Flush
 
 Add `.accordion-flush` to remove the default `background-color`, some borders, and some rounded corners to render accordions edge-to-edge with their parent container.

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -45,6 +45,7 @@ $accordion-button-active-icon:            var(--#{$prefix}accordion-btn-icon) !d
 $accordion-tokens: () !default;
 
 // stylelint-disable scss/dollar-variable-default
+// stylelint-disable custom-property-no-missing-var-function
 
 // scss-docs-start accordion-css-vars
 $accordion-tokens: defaults(
@@ -80,6 +81,7 @@ $accordion-tokens: defaults(
 // scss-docs-end accordion-css-vars
 
 // stylelint-enable scss/dollar-variable-default
+// stylelint-enable custom-property-no-missing-var-function
 
 @layer components {
   .accordion {
@@ -262,6 +264,15 @@ $accordion-tokens: defaults(
     font-size: var(--#{$prefix}accordion-font-size);
   }
 
+
+  .accordion-sm {
+    // scss-docs-start accordion-sm-css-vars
+    --#{$prefix}accordion-padding-x: .875rem;
+    --#{$prefix}accordion-padding-y: .625rem;
+    --#{$prefix}accordion-border-radius: var(--#{$prefix}radius-5);
+    --#{$prefix}accordion-font-size: var(--#{$prefix}font-size-sm);
+    // scss-docs-end accordion-sm-css-vars
+  }
 
   .accordion-flush {
     > .accordion-item {


### PR DESCRIPTION
`.accordion-sm` tightens the accordion through its own tokens — padding `.625/.875rem`, radius `var(--cui-radius-5)`, font size `var(--cui-font-size-sm)`. Pure token overrides, no new rules on the items; documented with a `## Small` section and the `accordion-sm-css-vars` capture on the accordion page.

The tokens map gains the same `custom-property-no-missing-var-function` guard the other component maps carry — the variant now redeclares four of its keys in a rule, which trips the known stylelint false positive.

Verification: stylelint clean, compiled output verified, `docs-build` via the pre-push gate green.