### PR TITLE
feat(forms): let .input-group-ignore skip the input-group corner logic

### DIFF
--- a/docs/src/content/docs/forms/input-group.mdx
+++ b/docs/src/content/docs/forms/input-group.mdx
@@ -300,6 +300,16 @@ Input groups include support for custom selects and custom file inputs. Browser 
     <button class="btn btn-outline-secondary" type="button" id="inputGroupFileAddon04">Button</button>
   </div>`} />
 
+## Skipping an element
+
+CSS selectors can only account for so much. When a group carries an element that should not take part in the border-radius and negative-margin logic — a hidden input, a tooltip anchor — add `.input-group-ignore` to it and the corners flow to its visible neighbours:
+
+<Example code={`<div class="input-group">
+    <span class="input-group-text" id="visible-addon">@</span>
+    <input type="text" class="form-control input-group-ignore d-none" placeholder="Hidden input" aria-label="Hidden input" aria-describedby="visible-addon">
+    <input type="text" class="form-control" placeholder="Visible input" aria-label="Visible input" aria-describedby="visible-addon">
+  </div>`} />
+
 ## Customizing
 
 ### CSS variables

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -153,16 +153,20 @@ $input-group-tokens: defaults(
       $validation-messages: $validation-messages + ":not(." + string.unquote($state) + "-tooltip)" + ":not(." + string.unquote($state) + "-feedback)";
     }
 
-    > :not(:last-child, .dropdown-toggle, .dropdown-menu, .form-floating),
+    > :not(:last-child, .dropdown-toggle, .dropdown-menu, .input-group-ignore, .form-floating, :has(+ :is(.dropdown-menu, .input-group-ignore):last-child)),
     > .dropdown-toggle:nth-last-child(n + 3),
     > .form-floating:not(:last-child) > .form-control,
     > .form-floating:not(:last-child) > .form-select {
       @include border-end-radius(0);
     }
 
-    > :not(:first-child):not(.dropdown-menu)#{$validation-messages} {
+    > :not(:first-child):not(.dropdown-menu):not(.input-group-ignore)#{$validation-messages} {
       margin-inline-start: calc(-1 * var(--#{$prefix}btn-input-border-width));
       @include border-start-radius(0);
+    }
+
+    > :first-child:is(.input-group-ignore) + :not(.dropdown-menu, .input-group-ignore) {
+      @include border-start-radius(var(--#{$prefix}control-border-radius));
     }
 
     > .form-floating:not(:first-child) > .form-control,


### PR DESCRIPTION
An element marked `.input-group-ignore` no longer takes part in the group's border-radius and negative-margin bookkeeping: its visible neighbours keep their outer corners — including when the ignored element is first or last in the group (`:has()` covers the trailing case, and a first-child ignore hands the start radius to the next visible sibling via `--cui-control-border-radius`, so the sizing variants stay correct).

Use case: hidden inputs, tooltip anchors, or any extra element that has to live inside the group without flattening anyone's corners. Documented with a `## Skipping an element` section on the input-group page.

Verification: stylelint clean, compiled output verified, full pre-push gate incl. the visual suite (which covers the form components) green.