### PR TITLE
feat(tooltip): keep hover and focus tips open while the pointer is on the tip

### DIFF
--- a/docs/src/content/docs/components/tooltips.mdx
+++ b/docs/src/content/docs/components/tooltips.mdx
@@ -136,7 +136,7 @@ The markup needed for a tooltip consists solely of a `data` attribute and a `tit
 Only add tooltips to HTML elements that are inherently keyboard-focusable and interactive, like links or form controls. While it is possible to make arbitrary HTML elements like `<span>`s focusable by using the `tabindex="0"` attribute, doing so may create confusing tab stops on non-interactive elements for keyboard users. Moreover, most assistive technologies typically do not announce tooltips in these cases. Additionally, avoid depending solely on `hover` to trigger your tooltips, as this approach renders them inaccessible for keyboard users.
 </Callout>
 
-A shown tooltip can be dismissed by pressing the <kbd>Escape</kbd> key, helping satisfy the [WCAG 1.4.13 "Content on Hover or Focus"](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) success criterion.
+A shown tooltip can be dismissed by pressing the <kbd>Escape</kbd> key, and a hover- or focus-triggered tooltip stays open while the pointer or focus is over the trigger or the tip itself — so users can reach interactive content inside it, such as a link. It hides when the pointer leaves both. Together these satisfy the [WCAG 1.4.13 "Content on Hover or Focus"](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) success criterion (dismissable, hoverable, persistent).
 
 ```html
 <!-- HTML to write -->

--- a/js/src/tooltip.ts
+++ b/js/src/tooltip.ts
@@ -160,6 +160,7 @@ class Tooltip extends BaseComponent {
   protected declare _activeTrigger: Record<string, boolean>
   protected declare _floatingCleanup: (() => void) | null
   protected declare _keydownHandler: ((event: KeyboardEvent) => void) | null
+  protected declare _tipEventOut: ((event: CoreUIEvent) => void) | null
   protected declare _templateFactory: TemplateFactory | null
   protected declare _newContent: Record<string, TemplateContentEntry> | null
   protected declare _mediaQueryListeners: BreakpointListener[]
@@ -182,6 +183,7 @@ class Tooltip extends BaseComponent {
     this._activeTrigger = {}
     this._floatingCleanup = null
     this._keydownHandler = null
+    this._tipEventOut = null
     this._templateFactory = null
     this._newContent = null
     this._mediaQueryListeners = []
@@ -285,6 +287,7 @@ class Tooltip extends BaseComponent {
     if (!this._element.ownerDocument.documentElement.contains(this.tip)) {
       container.append(tip)
       EventHandler.trigger(this._element, this.constructor.eventName(EVENT_INSERTED))
+      this._setTipListeners(tip)
     }
 
     await this._createFloating(tip)
@@ -671,7 +674,7 @@ class Tooltip extends BaseComponent {
         EventHandler.on(this._element, eventOut, this._config.selector as string, event => {
           const context = this._initializeOnDelegatedTarget(event)
           context._activeTrigger[event.type === 'focusout' ? TRIGGER_FOCUS : TRIGGER_HOVER] =
-            context._element.contains(event.relatedTarget)
+            context._isInside(event.relatedTarget)
 
           context._leave()
         })
@@ -685,6 +688,54 @@ class Tooltip extends BaseComponent {
     }
 
     EventHandler.on(this._element.closest(SELECTOR_MODAL), EVENT_MODAL_HIDE, this._hideModalHandler)
+  }
+
+  // Keep the tooltip open while the pointer or focus moves onto the tip
+  // itself, so users can reach interactive content inside it (WCAG 1.4.13).
+  // Hover/focus tips get matching leave listeners on the tip element.
+  protected _setTipListeners(tip: HTMLElement): void {
+    const { trigger } = this._config
+
+    if (trigger === TRIGGER_MANUAL || trigger.includes('click')) {
+      return
+    }
+
+    this._tipEventOut = event => {
+      this._activeTrigger[event.type === 'focusout' ? TRIGGER_FOCUS : TRIGGER_HOVER] = this._isInside(event.relatedTarget as Node | null)
+      this._leave()
+    }
+
+    for (const name of trigger.split(' ')) {
+      if (name === TRIGGER_HOVER || name === TRIGGER_FOCUS) {
+        const eventOut = name === TRIGGER_HOVER ?
+          this.constructor.eventName(EVENT_MOUSELEAVE) :
+          this.constructor.eventName(EVENT_FOCUSOUT)
+        EventHandler.on(tip, eventOut, this._tipEventOut)
+      }
+    }
+  }
+
+  protected _removeTipListeners(tip: HTMLElement): void {
+    if (!this._tipEventOut) {
+      return
+    }
+
+    const { trigger } = this._config
+
+    for (const name of trigger.split(' ')) {
+      if (name === TRIGGER_HOVER || name === TRIGGER_FOCUS) {
+        const eventOut = name === TRIGGER_HOVER ?
+          this.constructor.eventName(EVENT_MOUSELEAVE) :
+          this.constructor.eventName(EVENT_FOCUSOUT)
+        EventHandler.off(tip, eventOut, this._tipEventOut)
+      }
+    }
+
+    this._tipEventOut = null
+  }
+
+  protected _isInside(element: Node | null): boolean {
+    return this._element.contains(element) || Boolean(this.tip?.contains(element))
   }
 
   protected _setEscapeListener(): void {
@@ -859,6 +910,7 @@ class Tooltip extends BaseComponent {
     }
 
     if (this.tip) {
+      this._removeTipListeners(this.tip)
       this.tip.remove()
       this.tip = null
     }

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -881,6 +881,60 @@ describe('Tooltip', () => {
       })
     })
 
+    it('should not hide a tooltip if the cursor moves from the trigger onto the tip', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip">trigger</a>'
+
+        const tooltipEl = fixtureEl.querySelector('a')
+        const tooltip = new Tooltip(tooltipEl)
+
+        const spy = spyOn(tooltip, 'hide').and.callThrough()
+
+        tooltipEl.addEventListener('mouseover', () => {
+          const moveMouseToTipEvent = createEvent('mouseout')
+          Object.defineProperty(moveMouseToTipEvent, 'relatedTarget', {
+            value: tooltip._getTipElement()
+          })
+
+          tooltipEl.dispatchEvent(moveMouseToTipEvent)
+        })
+
+        tooltipEl.addEventListener('mouseout', () => {
+          expect(spy).not.toHaveBeenCalled()
+          resolve()
+        })
+
+        tooltipEl.dispatchEvent(createEvent('mouseover'))
+      })
+    })
+
+    it('should hide a tooltip when the cursor leaves the tip element', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip">trigger</a>'
+
+        const tooltipEl = fixtureEl.querySelector('a')
+        const tooltip = new Tooltip(tooltipEl)
+
+        const spy = spyOn(tooltip, 'hide').and.callThrough()
+
+        tooltipEl.addEventListener('shown.coreui.tooltip', () => {
+          const leaveTipEvent = createEvent('mouseout')
+          Object.defineProperty(leaveTipEvent, 'relatedTarget', {
+            value: document.body
+          })
+
+          tooltip._getTipElement().dispatchEvent(leaveTipEvent)
+        })
+
+        tooltipEl.addEventListener('hidden.coreui.tooltip', () => {
+          expect(spy).toHaveBeenCalled()
+          resolve()
+        })
+
+        tooltipEl.dispatchEvent(createEvent('mouseover'))
+      })
+    })
+
     it('should properly maintain tooltip state if leave event occurs and enter event occurs during hide transition', () => {
       return new Promise(resolve => {
         // Style this tooltip to give it plenty of room for Floating UI to do what it wants


### PR DESCRIPTION
Leaving the trigger toward the tip no longer counts as leaving: the active-trigger bookkeeping asks whether the pointer or focus landed inside the trigger **or the tip** (`_isInside`), and the tip itself carries matching `mouseleave`/`focusout` listeners, removed together with the tip in `_disposeFloating`. Users can reach interactive content inside a tooltip — a link, a button — which together with the existing Escape dismissal completes [WCAG 1.4.13](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) (dismissable, hoverable, persistent).

Click- and manual-trigger tips are unchanged (the tip listeners are skipped for them), and Popover inherits the behavior through the class hierarchy.

Docs: the WCAG paragraph on the tooltip page now describes all three criteria.

Verification: two new specs (pointer moves from trigger onto the tip → stays open; pointer leaves the tip → hides), tooltip suite 100/100 green in Chromium, typecheck and eslint clean, full pre-push gate passed.