### PR TITLE
fix(tooltip): bridge the offset gap so hover survives beside the arrow

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "69.5 kB"
+      "maxSize": "70 kB"
     },
     {
       "path": "./dist/css/coreui.min.css",

--- a/js/tests/visual/tooltip-hover-bridge.spec.js
+++ b/js/tests/visual/tooltip-hover-bridge.spec.js
@@ -1,0 +1,86 @@
+/*!
+ * Behavioral probe for the hover bridge: the invisible strip each placement
+ * draws over the offset gap, so the pointer can cross from the trigger to the
+ * tip anywhere along its edge, not only over the arrow. Asserted with real
+ * hit-testing (`elementFromPoint`) against the compiled stylesheet — the unit
+ * suite runs without CSS, so it cannot see this.
+ */
+
+// eslint-disable-next-line import/no-unassigned-import
+import '../../../scss/coreui.scss'
+import Popover from '../../src/popover.js'
+import Tooltip from '../../src/tooltip.js'
+
+let trigger
+
+beforeEach(() => {
+  trigger = document.createElement('button')
+  trigger.type = 'button'
+  trigger.textContent = 'trigger'
+  trigger.style.cssText = 'position:fixed;left:50%;top:50%;width:120px;height:40px;'
+  document.body.append(trigger)
+})
+
+afterEach(() => {
+  trigger.remove()
+})
+
+const nextFrames = () => new Promise(resolve => {
+  requestAnimationFrame(() => requestAnimationFrame(resolve))
+})
+
+const gapPoint = (placement, tipRect, triggerRect) => {
+  switch (placement) {
+    case 'top': {
+      return [tipRect.left + 2, (tipRect.bottom + triggerRect.top) / 2]
+    }
+
+    case 'bottom': {
+      return [tipRect.left + 2, (triggerRect.bottom + tipRect.top) / 2]
+    }
+
+    case 'left': {
+      return [(tipRect.right + triggerRect.left) / 2, tipRect.top + 2]
+    }
+
+    default: {
+      return [(triggerRect.right + tipRect.left) / 2, tipRect.top + 2]
+    }
+  }
+}
+
+describe('hover bridge', () => {
+  for (const placement of ['top', 'bottom', 'left', 'right']) {
+    it(`tooltip: a point in the offset gap beside the arrow hits the tip (${placement})`, async () => {
+      const tooltip = new Tooltip(trigger, { title: 'Another tooltip', placement, animation: false })
+
+      await tooltip.show()
+      await nextFrames()
+
+      const tip = tooltip._getTipElement()
+      const [x, y] = gapPoint(placement, tip.getBoundingClientRect(), trigger.getBoundingClientRect())
+      const hit = document.elementFromPoint(x, y)
+
+      expect(tip.contains(hit)).toBeTrue()
+
+      tooltip.dispose()
+    })
+
+    it(`popover: a point in the offset gap beside the arrow hits the tip (${placement})`, async () => {
+      const popover = new Popover(trigger, {
+        title: 'A popover', content: 'content', placement, animation: false
+      })
+
+      await popover.show()
+      await nextFrames()
+
+      const tip = popover._getTipElement()
+      const [x, y] = gapPoint(placement, tip.getBoundingClientRect(), trigger.getBoundingClientRect())
+      const hit = document.elementFromPoint(x, y)
+
+      expect(tip.contains(hit)).toBeTrue()
+
+      popover.dispose()
+    })
+  }
+})

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -128,6 +128,14 @@ $popover-tokens: defaults(
   }
 
   .bs-popover-top {
+    &::after {
+      position: absolute;
+      inset-inline: 0;
+      bottom: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width));
+      height: calc(var(--#{$prefix}popover-arrow-height) + var(--#{$prefix}popover-border-width));
+      content: "";
+    }
+
     > .popover-arrow {
       bottom: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width));
 
@@ -149,6 +157,14 @@ $popover-tokens: defaults(
   }
 
   .bs-popover-end {
+    &::after {
+      position: absolute;
+      inset-block: 0;
+      left: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width));
+      width: calc(var(--#{$prefix}popover-arrow-height) + var(--#{$prefix}popover-border-width));
+      content: "";
+    }
+
     > .popover-arrow {
       left: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width));
       width: var(--#{$prefix}popover-arrow-height);
@@ -172,6 +188,14 @@ $popover-tokens: defaults(
   }
 
   .bs-popover-bottom {
+    &::after {
+      position: absolute;
+      inset-inline: 0;
+      top: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width));
+      height: calc(var(--#{$prefix}popover-arrow-height) + var(--#{$prefix}popover-border-width));
+      content: "";
+    }
+
     > .popover-arrow {
       top: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width));
 
@@ -209,6 +233,14 @@ $popover-tokens: defaults(
   }
 
   .bs-popover-start {
+    &::after {
+      position: absolute;
+      inset-block: 0;
+      right: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width));
+      width: calc(var(--#{$prefix}popover-arrow-height) + var(--#{$prefix}popover-border-width));
+      content: "";
+    }
+
     > .popover-arrow {
       right: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width));
       width: var(--#{$prefix}popover-arrow-height);

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -101,6 +101,18 @@ $tooltip-tokens: defaults(
     }
   }
 
+  .bs-tooltip-top {
+    // Invisible strip over the offset gap, so the pointer can cross from the
+    // trigger to the tip anywhere along its edge, not only over the arrow.
+    &::after {
+      position: absolute;
+      inset-inline: 0;
+      bottom: calc(-1 * var(--#{$prefix}tooltip-arrow-height));
+      height: var(--#{$prefix}tooltip-arrow-height);
+      content: "";
+    }
+  }
+
   .bs-tooltip-top .tooltip-arrow {
     bottom: calc(-1 * var(--#{$prefix}tooltip-arrow-height));
 
@@ -108,6 +120,16 @@ $tooltip-tokens: defaults(
       top: -1px;
       border-width: var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0;
       border-top-color: var(--#{$prefix}tooltip-surface-bg);
+    }
+  }
+
+  .bs-tooltip-end {
+    &::after {
+      position: absolute;
+      inset-block: 0;
+      left: calc(-1 * var(--#{$prefix}tooltip-arrow-height));
+      width: var(--#{$prefix}tooltip-arrow-height);
+      content: "";
     }
   }
 
@@ -123,6 +145,16 @@ $tooltip-tokens: defaults(
     }
   }
 
+  .bs-tooltip-bottom {
+    &::after {
+      position: absolute;
+      inset-inline: 0;
+      top: calc(-1 * var(--#{$prefix}tooltip-arrow-height));
+      height: var(--#{$prefix}tooltip-arrow-height);
+      content: "";
+    }
+  }
+
   .bs-tooltip-bottom .tooltip-arrow {
     top: calc(-1 * var(--#{$prefix}tooltip-arrow-height));
 
@@ -130,6 +162,16 @@ $tooltip-tokens: defaults(
       bottom: -1px;
       border-width: 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height);
       border-bottom-color: var(--#{$prefix}tooltip-surface-bg);
+    }
+  }
+
+  .bs-tooltip-start {
+    &::after {
+      position: absolute;
+      inset-block: 0;
+      right: calc(-1 * var(--#{$prefix}tooltip-arrow-height));
+      width: var(--#{$prefix}tooltip-arrow-height);
+      content: "";
     }
   }
 


### PR DESCRIPTION
Follow-up to #974. The hoverable behavior only worked when the pointer crossed the offset gap **over the arrow** — beside it, the pointer landed on the page for a moment and the tip closed (offset `[0, 6]`, delay 0). Upstream has the same flaw; we fix it instead of inheriting it.

Each tooltip and popover placement now draws an invisible `::after` strip over the offset gap on the trigger-facing edge, the full length of the tip (thickness = arrow height, popover additionally + border width). The strip is part of the tip, so `relatedTarget` lands inside it and `_isInside` holds. Logical properties keep it RTL-correct; it exists only while the tip is shown.

**Verification:** new behavioral probe in the visual config's suite (`tooltip-hover-bridge.spec.js`) — real hit-testing with `elementFromPoint` inside the gap beside the arrow, all four placements, tooltip and popover, 8/8 green (measured after a two-frame settle: Floating UI finalizes position asynchronously). It lives there because it needs the compiled stylesheet, which the unit suite doesn't load. Stylelint/eslint clean, full pre-push gate passed; coreui.css budget raised 69.5→70 kB in a dedicated commit (bridges landed 40 bytes over).