### PR TITLE
fix(autocomplete): the hint overlay restates the frame padding

### DIFF
--- a/scss/_autocomplete.scss
+++ b/scss/_autocomplete.scss
@@ -24,6 +24,9 @@
     inset-inline-start: 0;
     width: 100%;
     height: 100%;
+    // The group carries the frame padding and zeroes it on inner controls, so
+    // the overlay has to restate it or the ghost text starts at the frame edge.
+    padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
     pointer-events: none;
     opacity: .5;
   }


### PR DESCRIPTION
Reported by mrholek: the hint's ghost input had wrong paddings.

Root cause, probed in Chromium against the compiled CSS: the v6 `form-control-group` architecture puts the frame padding on the **group** and zeroes it on inner controls — and the hint is an absolutely positioned overlay spanning the whole frame, so its ghost text started at the frame edge, offset from the real input's text by the full control padding (measured 12px inline, 6px block). The overlay now restates `--cui-control-padding-y/-x`, which also tracks the `sm`/`lg` size classes; re-probed after the fix, the ghost's text origin lands exactly on the real input's (45, 39 vs 45, 39).

v5 is not affected — its hint is a normally padded `.form-control` outside any padding-zeroing group, so no backport entry. React consumes this CSS through the package; its markup already matches vanilla's.

Verification: before/after Chromium geometry probe, stylelint clean, full pre-push gate incl. the visual suite (autocomplete is covered by `field-components.spec`) green.