### PR TITLE
feat(forms): floating labels over the field components

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "70 kB"
+      "maxSize": "70.5 kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "64.5 kB"
+      "maxSize": "65 kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "./dist/js/coreui.bundle.js",
-      "maxSize": "124.25KB"
+      "maxSize": "125KB"
     },
     {
       "path": "./dist/js/coreui.bundle.min.js",
@@ -42,15 +42,15 @@
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "113.25KB"
+      "maxSize": "114KB"
     },
     {
       "path": "./dist/js/coreui.esm.min.js",
-      "maxSize": "81.25KB"
+      "maxSize": "81.75KB"
     },
     {
       "path": "./dist/js/coreui.js",
-      "maxSize": "114.25KB"
+      "maxSize": "115KB"
     },
     {
       "path": "./dist/js/coreui.min.js",

--- a/docs/src/content/docs/forms/autocomplete.mdx
+++ b/docs/src/content/docs/forms/autocomplete.mdx
@@ -220,6 +220,20 @@ The frame carries the size. Add `.form-control-sm` or `.form-control-lg` to the 
     data-coreui-toggle="autocomplete"
   ></div>`} />
 
+## Floating labels
+
+Autocomplete supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). Wrap the component in `.form-floating` and put a `<label>` beside it. The component's own `placeholder` is hidden while the label rests inside the field, so the two never overlap.
+
+<Example pro code={`<div class="form-floating">
+    <div
+      data-coreui-toggle="autocomplete"
+      data-coreui-id="floatingAutocomplete"
+      data-coreui-options="Angular, Bootstrap, React.js, Vue.js"
+      data-coreui-placeholder="Search frameworks..."
+    ></div>
+    <label for="floatingAutocomplete">Framework</label>
+  </div>`} />
+
 ## Cleaner functionality
 
 Enable a cleaner button to quickly clear input element:

--- a/docs/src/content/docs/forms/autocomplete.mdx
+++ b/docs/src/content/docs/forms/autocomplete.mdx
@@ -225,13 +225,13 @@ The frame carries the size. Add `.form-control-sm` or `.form-control-lg` to the 
 Autocomplete supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). Wrap the component in `.form-floating` and put a `<label>` beside it. The component's own `placeholder` is hidden while the label rests inside the field, so the two never overlap.
 
 <Example pro code={`<div class="form-floating">
+    <label for="floatingAutocomplete">Framework</label>
     <div
       data-coreui-toggle="autocomplete"
       data-coreui-id="floatingAutocomplete"
       data-coreui-options="Angular, Bootstrap, React.js, Vue.js"
       data-coreui-placeholder="Search frameworks..."
     ></div>
-    <label for="floatingAutocomplete">Framework</label>
   </div>`} />
 
 ## Cleaner functionality

--- a/docs/src/content/docs/forms/date-input.mdx
+++ b/docs/src/content/docs/forms/date-input.mdx
@@ -227,8 +227,8 @@ form.addEventListener('submit', event => {
 The date input supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). When the field is empty and not focused, the mask placeholders are hidden so the label can rest inside the field; focusing the field floats the label and reveals the mask.
 
 <Example pro code={`<div class="form-floating">
-    <div class="form-control form-date-time" data-coreui-date-input data-coreui-format="dd.MM.yyyy" id="floatingDateInput"></div>
     <label for="floatingDateInput">Delivery date</label>
+    <div class="form-control form-date-time" data-coreui-date-input data-coreui-format="dd.MM.yyyy" id="floatingDateInput"></div>
   </div>`} />
 
 ## Sizing

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -160,12 +160,9 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
 
 ## Floating labels
 
-The date picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): wrap the component in `.form-floating` and put a `<label>` beside it. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
+The date picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): set `floatingLabel` and the component renders the label itself — no wrapper markup needed — and the text also becomes the field's accessible name. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
 
-<Example pro code={`<div class="form-floating">
-    <div id="floatingExample" data-coreui-locale="en-US" data-coreui-toggle="date-picker"></div>
-    <label for="floatingExample">Label</label>
-  </div>`} />
+<Example pro code={`<div data-coreui-locale="en-US" data-coreui-floating-label="Delivery date" data-coreui-toggle="date-picker"></div>`} />
 
 ## Sizing
 

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -158,6 +158,15 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
     <div class="form-text">We deliver on working days only.</div>
   </div>`} />
 
+## Floating labels
+
+The date picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): wrap the component in `.form-floating` and put a `<label>` beside it. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
+
+<Example pro code={`<div class="form-floating">
+    <div id="floatingExample" data-coreui-locale="en-US" data-coreui-toggle="date-picker"></div>
+    <label for="floatingExample">Label</label>
+  </div>`} />
+
 ## Sizing
 
 Set heights using the `data-coreui-size` attribute like `data-coreui-size="lg"`

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -122,9 +122,9 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
 
 ## Floating labels
 
-Each field carries its own [floating label](https://coreui.io/bootstrap/docs/forms/floating-labels/): set `startLabel` and `endLabel` and the picker renders a label over each date, floating independently — fill in the check-in date and only its label rises. The label text also becomes the field's accessible name, so the visible and spoken labels stay one thing. No wrapper markup is needed.
+Each field carries its own [floating label](https://coreui.io/bootstrap/docs/forms/floating-labels/): set `floatingLabels` and the picker renders a label over each date, floating independently — fill in the check-in date and only its label rises. The label text also becomes the field's accessible name, so the visible and spoken labels stay one thing. No wrapper markup is needed.
 
-<Example pro code={`<div data-coreui-locale="en-US" data-coreui-start-label="Check-in" data-coreui-end-label="Check-out" data-coreui-toggle="date-range-picker"></div>`} />
+<Example pro code={`<div data-coreui-locale="en-US" data-coreui-floating-labels='["Check-in", "Check-out"]' data-coreui-toggle="date-range-picker"></div>`} />
 
 ## Sizing
 
@@ -300,8 +300,8 @@ attributes work on the picker element too.
 | `container` | string, element, false | `false` | Teleport target for the dropdown. |
 | `disabled` | boolean | `false` | Disables the fields and the popup. |
 | `endDate` | date, string, null | `null` | Initial end of the range. |
-| `endLabel` | string, null | `null` | Renders a floating label over the end field, and becomes its accessible name. |
 | `endName` | string, null | `null` | Name of the end hidden input. |
+| `floatingLabels` | array, null | `null` | Renders a floating label over each field — `['Check-in', 'Check-out']` — which also becomes that field's accessible name. |
 | `indicatorIcon` | string | calendar SVG | Inline SVG rendered by the component (sanitized). |
 | `inputOptions` | object | `{}` | Programmatic escape hatch for date input options. |
 | `locale` | string | browser locale | Drives section order, separators, and calendar labels. |
@@ -313,7 +313,6 @@ attributes work on the picker element too.
 | `separatorIconRtl` | string | mirrored arrow SVG | Inline SVG used when the picker renders in an RTL context. |
 | `size` | string, null | `null` | `'sm'` or `'lg'`. |
 | `startDate` | date, string, null | `null` | Initial start of the range. |
-| `startLabel` | string, null | `null` | Renders a floating label over the start field, and becomes its accessible name. |
 | `startName` | string, null | `null` | Name of the start hidden input. |
 
 ### Methods

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -122,7 +122,7 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
 
 ## Floating labels
 
-The date range picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): wrap the component in `.form-floating` and put a `<label>` beside it. One label covers the pair — it floats as soon as either date is set or any part of the field has focus. Each field reveals its own mask: with only the start date set, the empty end keeps its mask hidden and the arrow is what says a second date belongs there.
+The date range picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): wrap the component in `.form-floating` and put a `<label>` beside it. One label covers the pair — it floats as soon as either date is set or any part of the field has focus. Each field reveals its own mask, and the arrow shows only while you are in the field or once both dates are set — so a half-filled range at rest reads as just the start date.
 
 <Example pro code={`<div class="form-floating">
     <div id="floatingExample" data-coreui-locale="en-US" data-coreui-toggle="date-range-picker"></div>

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -122,12 +122,9 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
 
 ## Floating labels
 
-The date range picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): wrap the component in `.form-floating` and put a `<label>` beside it. One label covers the pair — it floats as soon as either date is set or any part of the field has focus. Each field reveals its own mask, and the arrow shows only while you are in the field or once both dates are set — so a half-filled range at rest reads as just the start date.
+Each field carries its own [floating label](https://coreui.io/bootstrap/docs/forms/floating-labels/): set `startLabel` and `endLabel` and the picker renders a label over each date, floating independently — fill in the check-in date and only its label rises. The label text also becomes the field's accessible name, so the visible and spoken labels stay one thing. No wrapper markup is needed.
 
-<Example pro code={`<div class="form-floating">
-    <div id="floatingExample" data-coreui-locale="en-US" data-coreui-toggle="date-range-picker"></div>
-    <label for="floatingExample">Stay dates</label>
-  </div>`} />
+<Example pro code={`<div data-coreui-locale="en-US" data-coreui-start-label="Check-in" data-coreui-end-label="Check-out" data-coreui-toggle="date-range-picker"></div>`} />
 
 ## Sizing
 
@@ -303,6 +300,7 @@ attributes work on the picker element too.
 | `container` | string, element, false | `false` | Teleport target for the dropdown. |
 | `disabled` | boolean | `false` | Disables the fields and the popup. |
 | `endDate` | date, string, null | `null` | Initial end of the range. |
+| `endLabel` | string, null | `null` | Renders a floating label over the end field, and becomes its accessible name. |
 | `endName` | string, null | `null` | Name of the end hidden input. |
 | `indicatorIcon` | string | calendar SVG | Inline SVG rendered by the component (sanitized). |
 | `inputOptions` | object | `{}` | Programmatic escape hatch for date input options. |
@@ -315,6 +313,7 @@ attributes work on the picker element too.
 | `separatorIconRtl` | string | mirrored arrow SVG | Inline SVG used when the picker renders in an RTL context. |
 | `size` | string, null | `null` | `'sm'` or `'lg'`. |
 | `startDate` | date, string, null | `null` | Initial start of the range. |
+| `startLabel` | string, null | `null` | Renders a floating label over the start field, and becomes its accessible name. |
 | `startName` | string, null | `null` | Name of the start hidden input. |
 
 ### Methods

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -122,7 +122,7 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
 
 ## Floating labels
 
-The date range picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): wrap the component in `.form-floating` and put a `<label>` beside it. One label covers the pair — it floats as soon as either date is set or any part of the field has focus, and at rest the masks and the arrow between the fields hide so the label has the field to itself.
+The date range picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): wrap the component in `.form-floating` and put a `<label>` beside it. One label covers the pair — it floats as soon as either date is set or any part of the field has focus. Each field reveals its own mask: with only the start date set, the empty end keeps its mask hidden and the arrow is what says a second date belongs there.
 
 <Example pro code={`<div class="form-floating">
     <div id="floatingExample" data-coreui-locale="en-US" data-coreui-toggle="date-range-picker"></div>

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -120,6 +120,15 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
     <div class="form-text">Both dates are included in the report.</div>
   </div>`} />
 
+## Floating labels
+
+The date range picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): wrap the component in `.form-floating` and put a `<label>` beside it. One label covers the pair — it floats as soon as either date is set or any part of the field has focus, and at rest the masks and the arrow between the fields hide so the label has the field to itself.
+
+<Example pro code={`<div class="form-floating">
+    <div id="floatingExample" data-coreui-locale="en-US" data-coreui-toggle="date-range-picker"></div>
+    <label for="floatingExample">Stay dates</label>
+  </div>`} />
+
 ## Sizing
 
 <Example pro code={`<div class="row mb-3">

--- a/docs/src/content/docs/forms/date-time-input.mdx
+++ b/docs/src/content/docs/forms/date-time-input.mdx
@@ -121,8 +121,8 @@ The field participates in the standard form validation styling, [the same way as
 The date-time input supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). When the field is empty and not focused, the mask placeholders are hidden so the label can rest inside the field; focusing the field floats the label and reveals the mask.
 
 <Example pro code={`<div class="form-floating">
-    <div class="form-control form-date-time" data-coreui-date-time-input data-coreui-format="dd.MM.yyyy HH:mm" id="floatingDateTimeInput"></div>
     <label for="floatingDateTimeInput">Appointment</label>
+    <div class="form-control form-date-time" data-coreui-date-time-input data-coreui-format="dd.MM.yyyy HH:mm" id="floatingDateTimeInput"></div>
   </div>`} />
 
 ## Sizing

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -70,12 +70,9 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
 
 ## Floating labels
 
-The date time picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): wrap the component in `.form-floating` and put a `<label>` beside it. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
+The date time picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): set `floatingLabel` and the component renders the label itself — no wrapper markup needed — and the text also becomes the field's accessible name. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
 
-<Example pro code={`<div class="form-floating">
-    <div id="floatingExample" data-coreui-locale="en-US" data-coreui-toggle="date-time-picker"></div>
-    <label for="floatingExample">Label</label>
-  </div>`} />
+<Example pro code={`<div data-coreui-locale="en-US" data-coreui-floating-label="Appointment" data-coreui-toggle="date-time-picker"></div>`} />
 
 ## Sizing
 

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -68,6 +68,15 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
     <div class="form-text">Local time, in your own time zone.</div>
   </div>`} />
 
+## Floating labels
+
+The date time picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): wrap the component in `.form-floating` and put a `<label>` beside it. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
+
+<Example pro code={`<div class="form-floating">
+    <div id="floatingExample" data-coreui-locale="en-US" data-coreui-toggle="date-time-picker"></div>
+    <label for="floatingExample">Label</label>
+  </div>`} />
+
 ## Sizing
 
 <Example pro code={`<div class="row mb-3">

--- a/docs/src/content/docs/forms/multi-select.mdx
+++ b/docs/src/content/docs/forms/multi-select.mdx
@@ -396,6 +396,20 @@ We use the following JavaScript to set up our multi-select:
 
 <Code code={multiSelectIndeterminate} lang="js" />
 
+## Floating labels
+
+Multi Select supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). Wrap the component in `.form-floating` and put a `<label>` beside it. It has no input to report emptiness, so the label floats on focus and on the first selection, and the component's `placeholder` is hidden while the label rests inside the field.
+
+<Example pro code={`<div class="form-floating">
+    <select id="floatingMultiSelect" data-coreui-multi-select multiple>
+      <option value="0">Angular</option>
+      <option value="1">Bootstrap</option>
+      <option value="2">React.js</option>
+      <option value="3">Vue.js</option>
+    </select>
+    <label for="floatingMultiSelect">Frameworks</label>
+  </div>`} />
+
 ## Sizing
 
 The frame carries the size. Add `.form-control-sm` or `.form-control-lg` to the `<select>` — the component copies the element's classes onto the `.form-control-group` it builds, so the field matches our similarly sized text inputs.

--- a/docs/src/content/docs/forms/multi-select.mdx
+++ b/docs/src/content/docs/forms/multi-select.mdx
@@ -401,13 +401,13 @@ We use the following JavaScript to set up our multi-select:
 Multi Select supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). Wrap the component in `.form-floating` and put a `<label>` beside it. It has no input to report emptiness, so the label floats on focus and on the first selection, and the component's `placeholder` is hidden while the label rests inside the field.
 
 <Example pro code={`<div class="form-floating">
+    <label for="floatingMultiSelect">Frameworks</label>
     <select id="floatingMultiSelect" data-coreui-multi-select multiple>
       <option value="0">Angular</option>
       <option value="1">Bootstrap</option>
       <option value="2">React.js</option>
       <option value="3">Vue.js</option>
     </select>
-    <label for="floatingMultiSelect">Frameworks</label>
   </div>`} />
 
 ## Sizing

--- a/docs/src/content/docs/forms/number-input.mdx
+++ b/docs/src/content/docs/forms/number-input.mdx
@@ -77,6 +77,15 @@ a number field can share a frame with anything else the group holds:
     <input type="number" class="form-control" value="3" aria-label="Quantity" data-coreui-toggle="number-input">
   </div>`} />
 
+## Floating labels
+
+The number input supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). Wrap the control in `.form-floating` and put a `<label>` beside it — the stepper buttons ride along with the field.
+
+<Example pro code={`<div class="form-floating">
+    <input class="form-control" type="number" placeholder=" " id="floatingNumberInput" value="42" data-coreui-toggle="number-input">
+    <label for="floatingNumberInput">Quantity</label>
+  </div>`} />
+
 ## Accessibility
 
 The buttons carry labels (`Increase` / `Decrease` by default, both

--- a/docs/src/content/docs/forms/number-input.mdx
+++ b/docs/src/content/docs/forms/number-input.mdx
@@ -82,8 +82,8 @@ a number field can share a frame with anything else the group holds:
 The number input supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). Wrap the control in `.form-floating` and put a `<label>` beside it — the stepper buttons ride along with the field.
 
 <Example pro code={`<div class="form-floating">
-    <input class="form-control" type="number" placeholder=" " id="floatingNumberInput" value="42" data-coreui-toggle="number-input">
     <label for="floatingNumberInput">Quantity</label>
+    <input class="form-control" type="number" placeholder=" " id="floatingNumberInput" value="42" data-coreui-toggle="number-input">
   </div>`} />
 
 ## Accessibility

--- a/docs/src/content/docs/forms/password-input.mdx
+++ b/docs/src/content/docs/forms/password-input.mdx
@@ -56,8 +56,8 @@ Use the `readonly` attribute to make the input non-editable but still selectable
 The password input supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). Wrap the control in `.form-floating` and put a `<label>` beside it — the toggle button rides along with the field, and the placeholder stays hidden until the label floats.
 
 <Example pro code={`<div class="form-floating">
-    <input class="form-control" type="password" placeholder=" " id="floatingPasswordInput" data-coreui-toggle="password-input">
     <label for="floatingPasswordInput">Password</label>
+    <input class="form-control" type="password" placeholder=" " id="floatingPasswordInput" data-coreui-toggle="password-input">
   </div>`} />
 
 ## Usage

--- a/docs/src/content/docs/forms/password-input.mdx
+++ b/docs/src/content/docs/forms/password-input.mdx
@@ -51,6 +51,15 @@ Use the `readonly` attribute to make the input non-editable but still selectable
 
 <Example pro code={`<input type="password" class="form-control" placeholder="Readonly password input" value="Readonly input here..." readonly data-coreui-toggle="password-input">`} />
 
+## Floating labels
+
+The password input supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). Wrap the control in `.form-floating` and put a `<label>` beside it — the toggle button rides along with the field, and the placeholder stays hidden until the label floats.
+
+<Example pro code={`<div class="form-floating">
+    <input class="form-control" type="password" placeholder=" " id="floatingPasswordInput" data-coreui-toggle="password-input">
+    <label for="floatingPasswordInput">Password</label>
+  </div>`} />
+
 ## Usage
 
 Add `data-coreui-toggle="password-input"` to the field. The plugin initializes

--- a/docs/src/content/docs/forms/time-input.mdx
+++ b/docs/src/content/docs/forms/time-input.mdx
@@ -120,8 +120,8 @@ The field participates in the standard form validation styling, [the same way as
 The time input supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). When the field is empty and not focused, the mask placeholders are hidden so the label can rest inside the field; focusing the field floats the label and reveals the mask.
 
 <Example pro code={`<div class="form-floating">
-    <div class="form-control form-date-time" data-coreui-time-input data-coreui-format="HH:mm" id="floatingTimeInput"></div>
     <label for="floatingTimeInput">Meeting time</label>
+    <div class="form-control form-date-time" data-coreui-time-input data-coreui-format="HH:mm" id="floatingTimeInput"></div>
   </div>`} />
 
 ## Sizing

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -68,12 +68,9 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
 
 ## Floating labels
 
-The time picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): wrap the component in `.form-floating` and put a `<label>` beside it. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
+The time picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): set `floatingLabel` and the component renders the label itself — no wrapper markup needed — and the text also becomes the field's accessible name. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
 
-<Example pro code={`<div class="form-floating">
-    <div id="floatingExample" data-coreui-locale="en-US" data-coreui-toggle="time-picker"></div>
-    <label for="floatingExample">Label</label>
-  </div>`} />
+<Example pro code={`<div data-coreui-locale="en-US" data-coreui-floating-label="Meeting time" data-coreui-toggle="time-picker"></div>`} />
 
 ## Sizing
 

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -66,6 +66,15 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
     <div class="form-text">Local time, in your own time zone.</div>
   </div>`} />
 
+## Floating labels
+
+The time picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): wrap the component in `.form-floating` and put a `<label>` beside it. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
+
+<Example pro code={`<div class="form-floating">
+    <div id="floatingExample" data-coreui-locale="en-US" data-coreui-toggle="time-picker"></div>
+    <label for="floatingExample">Label</label>
+  </div>`} />
+
 ## Sizing
 
 <Example pro code={`<div class="row mb-3">

--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -18,7 +18,7 @@ import SelectorEngine from './dom/selector-engine.js'
 import Popup from './util/popup.js'
 import type { ComponentConfig } from './util/config.js'
 import { getWeekSectionsFromLocale } from './util/date-sections.js'
-import { createControlGroupAction } from './util/form-control-group.js'
+import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
 import { CLEANER_ICON } from './util/icons.js'
 import { defineJQueryPlugin } from './util/index.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
@@ -73,6 +73,7 @@ type DatePickerConfig = {
   calendarOptions: Record<string, any>
   container: Element | boolean | string
   disabled: boolean
+  floatingLabel: string | null
   indicatorIcon: string
   inputOptions: Record<string, any>
   locale: string
@@ -95,6 +96,7 @@ const Default: DatePickerConfig = {
   container: false,
   date: null,
   disabled: false,
+  floatingLabel: null,
   indicatorIcon: DEFAULT_INDICATOR_ICON,
   inputOptions: {},
   locale: navigator.language,
@@ -116,6 +118,7 @@ const DefaultType: Record<string, string> = {
   container: '(string|element|boolean)',
   date: '(date|string|null)',
   disabled: 'boolean',
+  floatingLabel: '(string|null)',
   indicatorIcon: 'string',
   inputOptions: 'object',
   locale: 'string',
@@ -292,7 +295,7 @@ class DatePicker extends BaseComponent {
     }
 
     const inputEl = document.createElement('div')
-    inputGroup.append(inputEl)
+    appendControlGroupField(inputGroup, inputEl, this._config.floatingLabel, `${this.constructor.NAME}-`)
 
     const action = (className: string, icon: string, label: string) => createControlGroupAction({
       className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => this._sanitizeIcon(value)
@@ -313,7 +316,7 @@ class DatePicker extends BaseComponent {
       locale: this._config.locale,
       name: this._config.name,
       ...(this._resolveFormat() ? { format: this._resolveFormat() } : {})
-    }, this._config.inputOptions))
+    }, { ...(this._config.floatingLabel ? { ariaLabel: this._config.floatingLabel } : {}), ...this._config.inputOptions }))
 
     // Selection flows panel → field; this is the only bridge back, so a date
     // typed into the field reaches the calendar too. The guard stops the echo

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -15,11 +15,11 @@ import DateInput from './date-input.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import Popup from './util/popup.js'
+import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
 import type { ComponentConfig } from './util/config.js'
 import { getWeekSectionsFromLocale } from './util/date-sections.js'
-import { createControlGroupAction } from './util/form-control-group.js'
 import { CLEANER_ICON } from './util/icons.js'
-import { defineJQueryPlugin, getUID } from './util/index.js'
+import { defineJQueryPlugin } from './util/index.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 
 /**
@@ -55,7 +55,6 @@ const CLASS_NAME_INPUT_GROUP = 'form-control-group'
 const CLASS_NAME_PICKER = 'picker'
 const CLASS_NAME_POPUP = 'popup'
 const CLASS_NAME_RANGES = 'date-picker-ranges'
-const CLASS_NAME_FORM_FLOATING = 'form-floating'
 const CLASS_NAME_SEPARATOR = 'form-control-icon'
 const CLASS_NAME_SHOW = 'show'
 
@@ -89,12 +88,11 @@ type DateRangePickerConfig = {
   size: string | null
   calendars: number
   endDate: Date | string | null
-  endLabel: string | null
   endName: string | null
+  floatingLabels: string[] | null
   separatorIcon: string
   separatorIconRtl: string
   startDate: Date | string | null
-  startLabel: string | null
   startName: string | null
 }
 
@@ -110,8 +108,8 @@ const Default: DateRangePickerConfig = {
   container: false,
   disabled: false,
   endDate: null,
-  endLabel: null,
   endName: null,
+  floatingLabels: null,
   indicatorIcon: DEFAULT_INDICATOR_ICON,
   inputOptions: {},
   locale: navigator.language,
@@ -123,7 +121,6 @@ const Default: DateRangePickerConfig = {
   separatorIconRtl: DEFAULT_SEPARATOR_ICON_RTL,
   size: null,
   startDate: null,
-  startLabel: null,
   startName: null
 }
 
@@ -139,8 +136,8 @@ const DefaultType: Record<string, string> = {
   container: '(string|element|boolean)',
   disabled: 'boolean',
   endDate: '(date|string|null)',
-  endLabel: '(string|null)',
   endName: '(string|null)',
+  floatingLabels: '(array|null)',
   indicatorIcon: 'string',
   inputOptions: 'object',
   locale: 'string',
@@ -152,7 +149,6 @@ const DefaultType: Record<string, string> = {
   separatorIconRtl: 'string',
   size: '(string|null)',
   startDate: '(date|string|null)',
-  startLabel: '(string|null)',
   startName: '(string|null)'
 }
 
@@ -338,6 +334,11 @@ class DateRangePicker extends BaseComponent {
 
   // Both halves are the same primitive, so without a name of its own each would
   // announce identically and give no clue which end of the range it is.
+  _floatingLabel(index: number): string | null {
+    const labels = this._config.floatingLabels
+    return (Array.isArray(labels) && labels[index]) || null
+  }
+
   _ariaLabel(index: number): string {
     const labels = this._config.ariaLabels
     return (Array.isArray(labels) && labels[index]) || (Default.ariaLabels as string[])[index]
@@ -372,29 +373,13 @@ class DateRangePicker extends BaseComponent {
       inputGroup.classList.add(`${CLASS_NAME_FORM_CONTROL}-${this._config.size}`)
     }
 
-    // With a label the field gets its own `.form-floating` inside the group, so
-    // the two labels float independently — the label text also becomes the
+    // With floating labels each field gets its own `.form-floating` inside the
+    // group, so the two labels float independently — the label text is also the
     // field's accessible name, keeping the visible and spoken labels one thing.
-    const appendField = (inputEl: HTMLElement, labelText: string | null) => {
-      if (!labelText) {
-        inputGroup.append(inputEl)
-        return
-      }
-
-      const wrapper = document.createElement('div')
-      wrapper.classList.add(CLASS_NAME_FORM_FLOATING)
-      inputEl.id ||= getUID(`${this.constructor.NAME}-`)
-      const label = document.createElement('label')
-      label.htmlFor = inputEl.id
-      label.textContent = labelText
-      wrapper.append(inputEl, label)
-      inputGroup.append(wrapper)
-    }
-
-    const start = this._createInput(this._config.startDate, this._config.startName, this._config.startLabel ?? this._ariaLabel(0))
+    const start = this._createInput(this._config.startDate, this._config.startName, this._floatingLabel(0) ?? this._ariaLabel(0))
     this._startInput = start.input
     this._startInputElement = start.inputEl
-    appendField(start.inputEl, this._config.startLabel)
+    appendControlGroupField(inputGroup, start.inputEl, this._floatingLabel(0), `${this.constructor.NAME}-`)
 
     const separator = document.createElement('span')
     separator.classList.add(CLASS_NAME_SEPARATOR)
@@ -402,10 +387,10 @@ class DateRangePicker extends BaseComponent {
     separator.innerHTML = this._sanitizeIcon(this._resolveSeparatorIcon())
     inputGroup.append(separator)
 
-    const end = this._createInput(this._config.endDate, this._config.endName, this._config.endLabel ?? this._ariaLabel(1))
+    const end = this._createInput(this._config.endDate, this._config.endName, this._floatingLabel(1) ?? this._ariaLabel(1))
     this._endInput = end.input
     this._endInputElement = end.inputEl
-    appendField(end.inputEl, this._config.endLabel)
+    appendControlGroupField(inputGroup, end.inputEl, this._floatingLabel(1), `${this.constructor.NAME}-`)
 
     // See DatePicker — the bridge from typed values back to the calendar
     EventHandler.on(start.inputEl, DateInput.eventName(DateInput.CHANGE_EVENT_NAME), (event: any) => {

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -19,7 +19,7 @@ import type { ComponentConfig } from './util/config.js'
 import { getWeekSectionsFromLocale } from './util/date-sections.js'
 import { createControlGroupAction } from './util/form-control-group.js'
 import { CLEANER_ICON } from './util/icons.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, getUID } from './util/index.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 
 /**
@@ -55,6 +55,7 @@ const CLASS_NAME_INPUT_GROUP = 'form-control-group'
 const CLASS_NAME_PICKER = 'picker'
 const CLASS_NAME_POPUP = 'popup'
 const CLASS_NAME_RANGES = 'date-picker-ranges'
+const CLASS_NAME_FORM_FLOATING = 'form-floating'
 const CLASS_NAME_SEPARATOR = 'form-control-icon'
 const CLASS_NAME_SHOW = 'show'
 
@@ -88,10 +89,12 @@ type DateRangePickerConfig = {
   size: string | null
   calendars: number
   endDate: Date | string | null
+  endLabel: string | null
   endName: string | null
   separatorIcon: string
   separatorIconRtl: string
   startDate: Date | string | null
+  startLabel: string | null
   startName: string | null
 }
 
@@ -107,6 +110,7 @@ const Default: DateRangePickerConfig = {
   container: false,
   disabled: false,
   endDate: null,
+  endLabel: null,
   endName: null,
   indicatorIcon: DEFAULT_INDICATOR_ICON,
   inputOptions: {},
@@ -119,6 +123,7 @@ const Default: DateRangePickerConfig = {
   separatorIconRtl: DEFAULT_SEPARATOR_ICON_RTL,
   size: null,
   startDate: null,
+  startLabel: null,
   startName: null
 }
 
@@ -134,6 +139,7 @@ const DefaultType: Record<string, string> = {
   container: '(string|element|boolean)',
   disabled: 'boolean',
   endDate: '(date|string|null)',
+  endLabel: '(string|null)',
   endName: '(string|null)',
   indicatorIcon: 'string',
   inputOptions: 'object',
@@ -146,6 +152,7 @@ const DefaultType: Record<string, string> = {
   separatorIconRtl: 'string',
   size: '(string|null)',
   startDate: '(date|string|null)',
+  startLabel: '(string|null)',
   startName: '(string|null)'
 }
 
@@ -365,10 +372,29 @@ class DateRangePicker extends BaseComponent {
       inputGroup.classList.add(`${CLASS_NAME_FORM_CONTROL}-${this._config.size}`)
     }
 
-    const start = this._createInput(this._config.startDate, this._config.startName, this._ariaLabel(0))
+    // With a label the field gets its own `.form-floating` inside the group, so
+    // the two labels float independently — the label text also becomes the
+    // field's accessible name, keeping the visible and spoken labels one thing.
+    const appendField = (inputEl: HTMLElement, labelText: string | null) => {
+      if (!labelText) {
+        inputGroup.append(inputEl)
+        return
+      }
+
+      const wrapper = document.createElement('div')
+      wrapper.classList.add(CLASS_NAME_FORM_FLOATING)
+      inputEl.id ||= getUID(`${this.constructor.NAME}-`)
+      const label = document.createElement('label')
+      label.htmlFor = inputEl.id
+      label.textContent = labelText
+      wrapper.append(inputEl, label)
+      inputGroup.append(wrapper)
+    }
+
+    const start = this._createInput(this._config.startDate, this._config.startName, this._config.startLabel ?? this._ariaLabel(0))
     this._startInput = start.input
     this._startInputElement = start.inputEl
-    inputGroup.append(start.inputEl)
+    appendField(start.inputEl, this._config.startLabel)
 
     const separator = document.createElement('span')
     separator.classList.add(CLASS_NAME_SEPARATOR)
@@ -376,10 +402,10 @@ class DateRangePicker extends BaseComponent {
     separator.innerHTML = this._sanitizeIcon(this._resolveSeparatorIcon())
     inputGroup.append(separator)
 
-    const end = this._createInput(this._config.endDate, this._config.endName, this._ariaLabel(1))
+    const end = this._createInput(this._config.endDate, this._config.endName, this._config.endLabel ?? this._ariaLabel(1))
     this._endInput = end.input
     this._endInputElement = end.inputEl
-    inputGroup.append(end.inputEl)
+    appendField(end.inputEl, this._config.endLabel)
 
     // See DatePicker — the bridge from typed values back to the calendar
     EventHandler.on(start.inputEl, DateInput.eventName(DateInput.CHANGE_EVENT_NAME), (event: any) => {

--- a/js/src/date-time-picker.ts
+++ b/js/src/date-time-picker.ts
@@ -18,7 +18,7 @@ import Popup from './util/popup.js'
 import TimeSelection from './util/time-selection.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 import type { ComponentConfig } from './util/config.js'
-import { createControlGroupAction } from './util/form-control-group.js'
+import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
 import { CLEANER_ICON } from './util/icons.js'
 import { defineJQueryPlugin } from './util/index.js'
 
@@ -73,6 +73,7 @@ type DateTimePickerConfig = {
   calendarOptions: Record<string, any>
   container: Element | boolean | string
   disabled: boolean
+  floatingLabel: string | null
   indicatorIcon: string
   inputOptions: Record<string, any>
   locale: string
@@ -97,6 +98,7 @@ const Default: DateTimePickerConfig = {
   container: false,
   date: null,
   disabled: false,
+  floatingLabel: null,
   indicatorIcon: DEFAULT_INDICATOR_ICON,
   inputOptions: {},
   locale: navigator.language,
@@ -120,6 +122,7 @@ const DefaultType: Record<string, string> = {
   container: '(string|element|boolean)',
   date: '(date|string|null)',
   disabled: 'boolean',
+  floatingLabel: '(string|null)',
   indicatorIcon: 'string',
   inputOptions: 'object',
   locale: 'string',
@@ -284,7 +287,7 @@ class DateTimePicker extends BaseComponent {
     }
 
     const inputEl = document.createElement('div')
-    inputGroup.append(inputEl)
+    appendControlGroupField(inputGroup, inputEl, this._config.floatingLabel, `${this.constructor.NAME}-`)
 
     const action = (className: string, icon: string, label: string) => createControlGroupAction({
       className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => this._sanitizeIcon(value)
@@ -304,7 +307,7 @@ class DateTimePicker extends BaseComponent {
       disabled: this._config.disabled,
       locale: this._config.locale,
       name: this._config.name
-    }, this._config.inputOptions))
+    }, { ...(this._config.floatingLabel ? { ariaLabel: this._config.floatingLabel } : {}), ...this._config.inputOptions }))
 
     // See DatePicker — the bridge from a typed value back to both panel halves
     EventHandler.on(inputEl, DateTimeInput.eventName(DateTimeInput.CHANGE_EVENT_NAME), (event: any) => {

--- a/js/src/multi-select.ts
+++ b/js/src/multi-select.ts
@@ -72,6 +72,7 @@ const CLASS_NAME_DISABLED = 'disabled'
 const CLASS_NAME_HEADER = 'combobox-header'
 const CLASS_NAME_INPUT_GROUP = 'form-control-group'
 const CLASS_NAME_SELECT = 'form-multi-select'
+const CLASS_NAME_SELECT_FILLED = 'form-multi-select-filled'
 const CLASS_NAME_SELECT_ALL = 'combobox-all'
 const CLASS_NAME_SELECT_ALL_WITH_CHECKBOX = 'combobox-all-with-checkbox'
 const CLASS_NAME_OPTGROUP_LABEL_WITH_CHECKBOX = 'combobox-optgroup-label-with-checkbox'
@@ -1191,6 +1192,12 @@ class MultiSelect extends Combobox {
   _updateSelection(): void {
     const selection = SelectorEngine.findOne(SELECTOR_SELECTION, this._wrapperElement)!
     const search = SelectorEngine.findOne(SELECTOR_SEARCH, this._wrapperElement)
+
+    // The DOM does not otherwise encode "something is selected" once search is
+    // on — a single selection lives in the search input's placeholder attribute
+    // — and the floating label needs the state, the way the date-time field
+    // carries `.form-date-time-filled`.
+    this._wrapperElement.classList.toggle(CLASS_NAME_SELECT_FILLED, this._selected.length > 0)
 
     if (this._selected.length === 0 && !this._config.search) {
       this._renderEmptySelection(selection)

--- a/js/src/time-picker.ts
+++ b/js/src/time-picker.ts
@@ -16,7 +16,7 @@ import Popup from './util/popup.js'
 import TimeSelection from './util/time-selection.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 import type { ComponentConfig } from './util/config.js'
-import { createControlGroupAction } from './util/form-control-group.js'
+import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
 import { CLEANER_ICON } from './util/icons.js'
 import { defineJQueryPlugin } from './util/index.js'
 
@@ -65,6 +65,7 @@ type TimePickerConfig = {
   cleanerIcon: string
   container: Element | boolean | string
   disabled: boolean
+  floatingLabel: string | null
   indicatorIcon: string
   inputOptions: Record<string, any>
   locale: string
@@ -85,6 +86,7 @@ const Default: TimePickerConfig = {
   cleanerIcon: CLEANER_ICON,
   container: false,
   disabled: false,
+  floatingLabel: null,
   indicatorIcon: DEFAULT_INDICATOR_ICON,
   inputOptions: {},
   locale: navigator.language,
@@ -105,6 +107,7 @@ const DefaultType: Record<string, string> = {
   cleanerIcon: 'string',
   container: '(string|element|boolean)',
   disabled: 'boolean',
+  floatingLabel: '(string|null)',
   indicatorIcon: 'string',
   inputOptions: 'object',
   locale: 'string',
@@ -262,7 +265,7 @@ class TimePicker extends BaseComponent {
     }
 
     const inputEl = document.createElement('div')
-    inputGroup.append(inputEl)
+    appendControlGroupField(inputGroup, inputEl, this._config.floatingLabel, `${this.constructor.NAME}-`)
 
     const action = (className: string, icon: string, label: string) => createControlGroupAction({
       className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => this._sanitizeIcon(value)
@@ -282,7 +285,7 @@ class TimePicker extends BaseComponent {
       disabled: this._config.disabled,
       locale: this._config.locale,
       name: this._config.name
-    }, this._config.inputOptions))
+    }, { ...(this._config.floatingLabel ? { ariaLabel: this._config.floatingLabel } : {}), ...this._config.inputOptions }))
 
     // See DatePicker — the bridge from a typed value back to the panel
     EventHandler.on(inputEl, TimeInput.eventName(TimeInput.CHANGE_EVENT_NAME), (event: any) => {

--- a/js/src/util/form-control-group.ts
+++ b/js/src/util/form-control-group.ts
@@ -9,6 +9,9 @@
  * --------------------------------------------------------------------------
  */
 
+import { getUID } from './index.js'
+
+const CLASS_NAME_FORM_FLOATING = 'form-floating'
 const CLASS_NAME_GROUP = 'form-control-group'
 const CLASS_NAME_FORM_CONTROL = 'form-control'
 
@@ -80,6 +83,34 @@ type ActionOptions = {
  * @param {object} options The button's class, icon, accessible label, disabled state and the icon sanitizer.
  * @returns {HTMLButtonElement} The button.
  */
+/**
+ * Appends a field to the group — wrapped in its own `.form-floating` with a
+ * rendered `<label>` when `floatingLabel` is set, so a generated frame can
+ * carry a floating label without any wrapper markup from the author. The
+ * label text is the visible half; passing it on as the field's accessible
+ * name is the caller's job, so the two stay one thing.
+ * @param {HTMLElement} group The `.form-control-group` frame.
+ * @param {HTMLElement} field The control to append.
+ * @param {string | null} floatingLabel The label text, or null to append bare.
+ * @param {string} uidPrefix Prefix for the generated id the label points at.
+ */
+export const appendControlGroupField = (group: HTMLElement, field: HTMLElement, floatingLabel: string | null, uidPrefix: string): void => {
+  if (!floatingLabel) {
+    group.append(field)
+    return
+  }
+
+  const wrapper = document.createElement('div')
+  wrapper.classList.add(CLASS_NAME_FORM_FLOATING)
+  field.id ||= getUID(uidPrefix)
+  const label = document.createElement('label')
+  label.htmlFor = field.id
+  label.textContent = floatingLabel
+  // Label first — a screen reader announces it before the field's value.
+  wrapper.append(label, field)
+  group.append(wrapper)
+}
+
 export const createControlGroupAction = (options: ActionOptions): HTMLButtonElement => {
   const button = document.createElement('button')
   button.classList.add(options.className)

--- a/js/tests/visual/floating-labels.spec.js
+++ b/js/tests/visual/floating-labels.spec.js
@@ -132,14 +132,19 @@ describe('floating labels', () => {
     expect(getComputedStyle(rest.querySelector('.form-control-icon')).color).toBe('rgba(0, 0, 0, 0)')
   })
 
-  // With only the start set, the empty end would stand bare under no label if
-  // its mask showed — each control reveals its own, the arrow says "a second
-  // date belongs here".
-  it('keeps the empty end mask hidden while only the start date is set', () => {
+  // With only the start set and no focus, the empty half shows nothing at all:
+  // the end would stand bare under no label if its mask showed, and the arrow —
+  // mid-field, since the pair flexes 50/50 — would hang over nothing.
+  it('shows only the start date while the rest of the range is empty and blurred', () => {
     const root = build(HOST_DIV, DateRangePicker, { locale: 'en-US', startDate: DATE })
     const [start, end] = root.querySelectorAll('.form-date-time')
     expect(getComputedStyle(start.querySelector('.form-date-time-section')).color).not.toBe('rgba(0, 0, 0, 0)')
     expect(getComputedStyle(end.querySelector('.form-date-time-section')).color).toBe('rgba(0, 0, 0, 0)')
+    expect(getComputedStyle(root.querySelector('.form-control-icon')).color).toBe('rgba(0, 0, 0, 0)')
+  })
+
+  it('shows the arrow once the end date is set', () => {
+    const root = build(HOST_DIV, DateRangePicker, { locale: 'en-US', startDate: DATE, endDate: new Date(2026, 6, 20) })
     expect(getComputedStyle(root.querySelector('.form-control-icon')).color).not.toBe('rgba(0, 0, 0, 0)')
   })
 

--- a/js/tests/visual/floating-labels.spec.js
+++ b/js/tests/visual/floating-labels.spec.js
@@ -132,6 +132,17 @@ describe('floating labels', () => {
     expect(getComputedStyle(rest.querySelector('.form-control-icon')).color).toBe('rgba(0, 0, 0, 0)')
   })
 
+  // With only the start set, the empty end would stand bare under no label if
+  // its mask showed — each control reveals its own, the arrow says "a second
+  // date belongs here".
+  it('keeps the empty end mask hidden while only the start date is set', () => {
+    const root = build(HOST_DIV, DateRangePicker, { locale: 'en-US', startDate: DATE })
+    const [start, end] = root.querySelectorAll('.form-date-time')
+    expect(getComputedStyle(start.querySelector('.form-date-time-section')).color).not.toBe('rgba(0, 0, 0, 0)')
+    expect(getComputedStyle(end.querySelector('.form-date-time-section')).color).toBe('rgba(0, 0, 0, 0)')
+    expect(getComputedStyle(root.querySelector('.form-control-icon')).color).not.toBe('rgba(0, 0, 0, 0)')
+  })
+
   it('floats the range label once only the start date is set', () => {
     const root = build(HOST_DIV, DateRangePicker, { locale: 'en-US', startDate: DATE })
     expect(labelFloats(root)).toBeTrue()

--- a/js/tests/visual/floating-labels.spec.js
+++ b/js/tests/visual/floating-labels.spec.js
@@ -132,6 +132,55 @@ describe('floating labels', () => {
     expect(getComputedStyle(rest.querySelector('.form-control-icon')).color).toBe('rgba(0, 0, 0, 0)')
   })
 
+  // The per-field mode: startLabel / endLabel render a label inside the group
+  // over each date, no wrapper markup. Each floats on its own field's state.
+  const buildTwoLabel = config => {
+    container = document.createElement('div')
+    container.style.cssText = 'padding: 1rem; width: 640px;'
+    container.innerHTML = '<div id="host"></div>'
+    document.body.append(container)
+
+    new DateRangePicker(container.querySelector('#host'), {
+      locale: 'en-US', startLabel: 'Check-in', endLabel: 'Check-out', ...config
+    })
+    return container.querySelector('.form-control-group')
+  }
+
+  const floatsByText = (group, text) =>
+    getComputedStyle([...group.querySelectorAll('label')].find(l => l.textContent === text)).transform !== 'none'
+
+  it('renders a label per range field and floats only the filled one', () => {
+    const group = buildTwoLabel({ startDate: DATE })
+    expect(floatsByText(group, 'Check-in')).toBeTrue()
+    expect(floatsByText(group, 'Check-out')).toBeFalse()
+  })
+
+  it('rests both range labels while the range is empty', () => {
+    const group = buildTwoLabel({})
+    expect(floatsByText(group, 'Check-in')).toBeFalse()
+    expect(floatsByText(group, 'Check-out')).toBeFalse()
+  })
+
+  it('floats both range labels once both dates are set', () => {
+    const group = buildTwoLabel({ startDate: DATE, endDate: new Date(2026, 6, 20) })
+    expect(floatsByText(group, 'Check-in')).toBeTrue()
+    expect(floatsByText(group, 'Check-out')).toBeTrue()
+  })
+
+  it('keeps the per-field-labelled group at a plain control height', () => {
+    const group = buildTwoLabel({ startDate: DATE })
+    expect(Math.round(group.getBoundingClientRect().height)).toBe(plainHeight)
+  })
+
+  // The field keeps its own inline padding, so the group's start padding would
+  // stack under it and indent label and value twice.
+  it('starts the range value at a plain control text offset', () => {
+    const group = buildTwoLabel({ startDate: DATE })
+    const section = group.querySelector('.form-date-time-section')
+    const inset = Math.round(section.getBoundingClientRect().left - group.getBoundingClientRect().left)
+    expect(inset).toBeLessThanOrEqual(14)
+  })
+
   // With only the start set and no focus, the empty half shows nothing at all:
   // the end would stand bare under no label if its mask showed, and the arrow —
   // mid-field, since the pair flexes 50/50 — would hang over nothing.

--- a/js/tests/visual/floating-labels.spec.js
+++ b/js/tests/visual/floating-labels.spec.js
@@ -1,0 +1,126 @@
+/*!
+ * Floating labels over the field components. Every one of them wraps its control
+ * in `.form-control-group`, which the `.form-floating > .form-control` rules do
+ * not reach — so the label silently stayed put and the field kept a plain height.
+ * Asserting computed style rather than pixels: the question is whether the state
+ * selectors match at all, and a screenshot would answer it far less directly.
+ * Copyright 2026 The Bootstrap Authors
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ */
+
+// eslint-disable-next-line import/no-unassigned-import
+import '../../../scss/coreui.scss'
+import Autocomplete from '../../src/autocomplete.js'
+import DateInput from '../../src/date-input.js'
+import MultiSelect from '../../src/multi-select.js'
+import NumberInput from '../../src/number-input.js'
+import PasswordInput from '../../src/password-input.js'
+
+const OPTIONS = [{ value: 1, label: 'Angular' }, { value: 2, label: 'Bootstrap' }]
+const DATE = new Date(2026, 6, 14)
+
+let container
+
+const mount = html => {
+  container = document.createElement('div')
+  container.style.cssText = 'padding: 1rem; width: 420px;'
+  container.innerHTML = `<div class="form-floating">${html}<label for="host">Label</label></div>`
+  document.body.append(container)
+  return container.querySelector('.form-floating')
+}
+
+const labelFloats = root => getComputedStyle(root.querySelector('label')).transform !== 'none'
+const wrapperHeight = root => Math.round(root.firstElementChild.getBoundingClientRect().height)
+
+// A plain `.form-control` is the reference: whatever height it gets under
+// `.form-floating`, every field component has to match, or the row it sits in
+// stops lining up.
+let plainHeight
+
+afterEach(() => container?.remove())
+
+describe('floating labels', () => {
+  beforeAll(() => {
+    const root = mount('<input type="text" class="form-control" id="host" placeholder=" ">')
+    plainHeight = wrapperHeight(root)
+    container.remove()
+  })
+
+  it('leaves the label in place while a plain control is empty', () => {
+    expect(labelFloats(mount('<input type="text" class="form-control" id="host" placeholder=" ">'))).toBeFalse()
+  })
+
+  it('floats the label once a plain control has a value', () => {
+    expect(labelFloats(mount('<input type="text" class="form-control" id="host" placeholder=" " value="x">'))).toBeTrue()
+  })
+
+  // Mount, initialise, hand back the wrapper — one expression per case, so the
+  // table below reads as a matrix rather than a pile of statements.
+  const build = (html, Component, config) => {
+    const root = mount(html)
+
+    new Component(root.querySelector('#host'), config)
+    return root
+  }
+
+  const HOST_DIV = '<div id="host"></div>'
+  const HOST_INPUT = '<input type="text" class="form-control" id="host" placeholder=" ">'
+  const HOST_INPUT_VALUE = '<input type="text" class="form-control" id="host" placeholder=" " value="42">'
+  // stepUp() throws on anything but the numeric types, so the number input gets
+  // a real type="number" host rather than sharing the text one.
+  const HOST_NUMBER = '<input type="number" class="form-control" id="host" placeholder=" ">'
+  const HOST_NUMBER_VALUE = '<input type="number" class="form-control" id="host" placeholder=" " value="42">'
+  const HOST_SELECT = '<select id="host" multiple><option value="1">Angular</option></select>'
+  const HOST_SELECT_SELECTED = '<select id="host" multiple><option value="1" selected>Angular</option></select>'
+  const SELECTED = [{ ...OPTIONS[0], selected: true }, OPTIONS[1]]
+
+  const cases = [
+    ['Date Input',
+      () => build(HOST_DIV, DateInput, {}),
+      () => build(HOST_DIV, DateInput, { date: DATE })],
+    ['Password Input',
+      () => build(HOST_INPUT, PasswordInput, {}),
+      () => build(HOST_INPUT_VALUE, PasswordInput, {})],
+    ['Number Input',
+      () => build(HOST_NUMBER, NumberInput, {}),
+      () => build(HOST_NUMBER_VALUE, NumberInput, { value: 42 })],
+    ['Autocomplete',
+      () => build(HOST_DIV, Autocomplete, { options: OPTIONS }),
+      () => build(HOST_DIV, Autocomplete, { options: OPTIONS, value: 1 })],
+    ['Multi Select',
+      () => build(HOST_DIV, MultiSelect, { options: OPTIONS }),
+      () => build(HOST_DIV, MultiSelect, { options: SELECTED })],
+    // The docs example builds it from a `<select>`, a different init path that
+    // has to reach the same structure.
+    ['Multi Select over a select',
+      () => build(HOST_SELECT, MultiSelect, {}),
+      () => build(HOST_SELECT_SELECTED, MultiSelect, {})]
+  ]
+
+  // The toggle is created by the component, so a wrong data attribute in an
+  // example kills it silently while the label keeps floating via the plain-input
+  // rules — which is exactly how it slipped past the first review pass.
+  it('keeps the password toggle visible and centred under .form-floating', () => {
+    const root = build('<input type="password" class="form-control" id="host" placeholder=" " value="secret">', PasswordInput, {})
+    const group = root.querySelector('.form-control-group')
+    const button = group.querySelector('.form-control-action')
+    const g = group.getBoundingClientRect()
+    const b = button.getBoundingClientRect()
+    expect(b.height).toBeGreaterThan(0)
+    expect(Math.abs((b.top + (b.height / 2)) - (g.top + (g.height / 2)))).toBeLessThanOrEqual(1)
+  })
+
+  for (const [name, empty, filled] of cases) {
+    it(`leaves the label in place while ${name} is empty`, () => {
+      expect(labelFloats(empty())).toBeFalse()
+    })
+
+    it(`floats the label once ${name} has a value`, () => {
+      expect(labelFloats(filled())).toBeTrue()
+    })
+
+    it(`gives ${name} the same height as a plain control`, () => {
+      expect(wrapperHeight(empty())).toBe(plainHeight)
+    })
+  }
+})

--- a/js/tests/visual/floating-labels.spec.js
+++ b/js/tests/visual/floating-labels.spec.js
@@ -135,6 +135,22 @@ describe('floating labels', () => {
     expect(getComputedStyle(rest.querySelector('.form-control-icon')).color).toBe('rgba(0, 0, 0, 0)')
   })
 
+  // Search mode renders no placeholder element — a single selection lives in
+  // the search input's placeholder attribute — so the states must come from the
+  // JS-managed filled class, and the resting label must also silence the search
+  // input's own placeholder text.
+  it('rests the label over an empty searchable Multi Select and hides its placeholder', () => {
+    const root = build(HOST_DIV, MultiSelect, { options: OPTIONS, search: 'global' })
+    expect(labelFloats(root)).toBeFalse()
+    const search = root.querySelector('.form-multi-select-search')
+    expect(getComputedStyle(search, '::placeholder').color).toBe('rgba(0, 0, 0, 0)')
+  })
+
+  it('floats the label once a searchable single Multi Select has a selection', () => {
+    const root = build(HOST_DIV, MultiSelect, { multiple: false, options: SELECTED, search: 'global' })
+    expect(labelFloats(root)).toBeTrue()
+  })
+
   // The per-field mode: startLabel / endLabel render a label inside the group
   // over each date, no wrapper markup. Each floats on its own field's state.
   const buildTwoLabel = config => {

--- a/js/tests/visual/floating-labels.spec.js
+++ b/js/tests/visual/floating-labels.spec.js
@@ -12,9 +12,13 @@
 import '../../../scss/coreui.scss'
 import Autocomplete from '../../src/autocomplete.js'
 import DateInput from '../../src/date-input.js'
+import DatePicker from '../../src/date-picker.js'
+import DateRangePicker from '../../src/date-range-picker.js'
+import DateTimePicker from '../../src/date-time-picker.js'
 import MultiSelect from '../../src/multi-select.js'
 import NumberInput from '../../src/number-input.js'
 import PasswordInput from '../../src/password-input.js'
+import TimePicker from '../../src/time-picker.js'
 
 const OPTIONS = [{ value: 1, label: 'Angular' }, { value: 2, label: 'Bootstrap' }]
 const DATE = new Date(2026, 6, 14)
@@ -94,8 +98,44 @@ describe('floating labels', () => {
     // has to reach the same structure.
     ['Multi Select over a select',
       () => build(HOST_SELECT, MultiSelect, {}),
-      () => build(HOST_SELECT_SELECTED, MultiSelect, {})]
+      () => build(HOST_SELECT_SELECTED, MultiSelect, {})],
+    // The pickers wrap one date-time control (two for the range) in the same
+    // group; their empty state is the JS-managed class, not :placeholder-shown.
+    ['Date Picker',
+      () => build(HOST_DIV, DatePicker, { locale: 'en-US' }),
+      () => build(HOST_DIV, DatePicker, { locale: 'en-US', date: DATE })],
+    ['Time Picker',
+      () => build(HOST_DIV, TimePicker, { locale: 'en-US' }),
+      () => build(HOST_DIV, TimePicker, { locale: 'en-US', time: new Date(2026, 0, 1, 14, 30) })],
+    ['Date Time Picker',
+      () => build(HOST_DIV, DateTimePicker, { locale: 'en-US' }),
+      () => build(HOST_DIV, DateTimePicker, { locale: 'en-US', date: DATE })],
+    ['Date Range Picker',
+      () => build(HOST_DIV, DateRangePicker, { locale: 'en-US' }),
+      () => build(HOST_DIV, DateRangePicker, { locale: 'en-US', startDate: DATE, endDate: new Date(2026, 6, 20) })]
   ]
+
+  // The masks (and the range picker's arrow) hide at rest so the label has the
+  // field to itself, and come back once it floats.
+  it('hides the picker mask while at rest and reveals it when filled', () => {
+    const rest = build(HOST_DIV, DatePicker, { locale: 'en-US' })
+    const restSection = rest.querySelector('.form-date-time-section')
+    expect(getComputedStyle(restSection).color).toBe('rgba(0, 0, 0, 0)')
+
+    const filled = build(HOST_DIV, DatePicker, { locale: 'en-US', date: DATE })
+    const filledSection = filled.querySelector('.form-date-time-section')
+    expect(getComputedStyle(filledSection).color).not.toBe('rgba(0, 0, 0, 0)')
+  })
+
+  it('hides the range arrow while at rest', () => {
+    const rest = build(HOST_DIV, DateRangePicker, { locale: 'en-US' })
+    expect(getComputedStyle(rest.querySelector('.form-control-icon')).color).toBe('rgba(0, 0, 0, 0)')
+  })
+
+  it('floats the range label once only the start date is set', () => {
+    const root = build(HOST_DIV, DateRangePicker, { locale: 'en-US', startDate: DATE })
+    expect(labelFloats(root)).toBeTrue()
+  })
 
   // The toggle is created by the component, so a wrong data attribute in an
   // example kills it silently while the label keeps floating via the plain-input

--- a/js/tests/visual/floating-labels.spec.js
+++ b/js/tests/visual/floating-labels.spec.js
@@ -25,16 +25,19 @@ const DATE = new Date(2026, 6, 14)
 
 let container
 
+let labelFirst = false
+
 const mount = html => {
   container = document.createElement('div')
   container.style.cssText = 'padding: 1rem; width: 420px;'
-  container.innerHTML = `<div class="form-floating">${html}<label for="host">Label</label></div>`
+  const label = '<label for="host">Label</label>'
+  container.innerHTML = `<div class="form-floating">${labelFirst ? label + html : html + label}</div>`
   document.body.append(container)
   return container.querySelector('.form-floating')
 }
 
 const labelFloats = root => getComputedStyle(root.querySelector('label')).transform !== 'none'
-const wrapperHeight = root => Math.round(root.firstElementChild.getBoundingClientRect().height)
+const wrapperHeight = root => Math.round((root.querySelector(':scope > :not(label)')).getBoundingClientRect().height)
 
 // A plain `.form-control` is the reference: whatever height it gets under
 // `.form-floating`, every field component has to match, or the row it sits in
@@ -141,7 +144,7 @@ describe('floating labels', () => {
     document.body.append(container)
 
     new DateRangePicker(container.querySelector('#host'), {
-      locale: 'en-US', startLabel: 'Check-in', endLabel: 'Check-out', ...config
+      locale: 'en-US', floatingLabels: ['Check-in', 'Check-out'], ...config
     })
     return container.querySelector('.form-control-group')
   }
@@ -181,6 +184,22 @@ describe('floating labels', () => {
     expect(inset).toBeLessThanOrEqual(14)
   })
 
+  // The single pickers take the same shape through `floatingLabel` — the
+  // component renders wrapper and label itself, no markup needed.
+  it('renders and floats the single picker label from the floatingLabel option', () => {
+    container = document.createElement('div')
+    container.style.cssText = 'padding: 1rem; width: 420px;'
+    container.innerHTML = '<div id="host"></div>'
+    document.body.append(container)
+
+    new DatePicker(container.querySelector('#host'), { locale: 'en-US', floatingLabel: 'Delivery date', date: DATE })
+    const group = container.querySelector('.form-control-group')
+    const label = group.querySelector('label')
+    expect(label.textContent).toBe('Delivery date')
+    expect(getComputedStyle(label).transform).not.toBe('none')
+    expect(Math.round(group.getBoundingClientRect().height)).toBe(plainHeight)
+  })
+
   // With only the start set and no focus, the empty half shows nothing at all:
   // the end would stand bare under no label if its mask showed, and the arrow —
   // mid-field, since the pair flexes 50/50 — would hang over nothing.
@@ -215,17 +234,31 @@ describe('floating labels', () => {
     expect(Math.abs((b.top + (b.height / 2)) - (g.top + (g.height / 2)))).toBeLessThanOrEqual(1)
   })
 
-  for (const [name, empty, filled] of cases) {
-    it(`leaves the label in place while ${name} is empty`, () => {
-      expect(labelFloats(empty())).toBeFalse()
-    })
+  // The label may sit either side of the control — the docs write it first, the
+  // v5 order still works — so every case runs in both directions.
+  for (const order of ['label after', 'label first']) {
+    describe(order, () => {
+      beforeEach(() => {
+        labelFirst = order === 'label first'
+      })
 
-    it(`floats the label once ${name} has a value`, () => {
-      expect(labelFloats(filled())).toBeTrue()
-    })
+      afterEach(() => {
+        labelFirst = false
+      })
 
-    it(`gives ${name} the same height as a plain control`, () => {
-      expect(wrapperHeight(empty())).toBe(plainHeight)
+      for (const [name, empty, filled] of cases) {
+        it(`leaves the label in place while ${name} is empty`, () => {
+          expect(labelFloats(empty())).toBeFalse()
+        })
+
+        it(`floats the label once ${name} has a value`, () => {
+          expect(labelFloats(filled())).toBeTrue()
+        })
+
+        it(`gives ${name} the same height as a plain control`, () => {
+          expect(wrapperHeight(empty())).toBe(plainHeight)
+        })
+      }
     })
   }
 })

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -169,16 +169,19 @@ $form-floating-tokens: defaults(
       }
 
       &:focus-within > .form-control,
-      > .form-control:not(:placeholder-shown) {
+      > .form-control:not(.form-date-time, :placeholder-shown) {
         padding-top: var(--#{$prefix}form-floating-input-padding-t);
         padding-bottom: var(--#{$prefix}form-floating-input-padding-b);
       }
     }
 
+    // `:not(:placeholder-shown)` is vacuously true on the div-based
+    // `.form-date-time`, so it is excluded here; its filled state lives in
+    // forms/_form-date-time.scss, keyed to the JS-managed class instead.
     > label:has(~ .form-control-group:focus-within),
-    > label:has(~ .form-control-group > .form-control:not(:placeholder-shown)),
+    > label:has(~ .form-control-group > .form-control:not(.form-date-time, :placeholder-shown)),
     > .form-control-group:focus-within ~ label,
-    > .form-control-group:has(> .form-control:not(:placeholder-shown)) ~ label {
+    > .form-control-group:has(> .form-control:not(.form-date-time, :placeholder-shown)) ~ label {
       transform: var(--#{$prefix}form-floating-label-transform);
     }
 

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -131,11 +131,11 @@ $form-floating-tokens: defaults(
     }
 
     > label:has(~ .form-control:focus),
-    > label:has(~ .form-control:not(:placeholder-shown)),
+    > label:has(~ .form-control:not(.form-date-time, :placeholder-shown)),
     > label:has(~ .form-control-plaintext),
     > label:has(~ .form-select),
     > .form-control:focus ~ label,
-    > .form-control:not(:placeholder-shown) ~ label,
+    > .form-control:not(.form-date-time, :placeholder-shown) ~ label,
     > .form-control-plaintext ~ label,
     > .form-select ~ label {
       transform: var(--#{$prefix}form-floating-label-transform);

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -146,6 +146,42 @@ $form-floating-tokens: defaults(
       transform: var(--#{$prefix}form-floating-label-transform);
     }
 
+    // The field components — Password Input, Number Input, Autocomplete, Multi
+    // Select — wrap their control in `.form-control-group`, so every `> .form-control`
+    // rule above misses it and the label never moves. The group takes the height,
+    // and the control inside it takes the padding shift.
+    > .form-control-group {
+      height: var(--#{$prefix}form-floating-height);
+      min-height: var(--#{$prefix}form-floating-height);
+      line-height: var(--#{$prefix}form-floating-line-height);
+
+      // Only the block axis: the group's frame already carries the inline
+      // padding, and restating it on the control indents the text twice.
+      > .form-control {
+        padding-top: var(--#{$prefix}form-floating-padding-y);
+        padding-bottom: var(--#{$prefix}form-floating-padding-y);
+
+        // Hidden until the label is out of the way, exactly as the direct-child
+        // rule above does it — otherwise the two overlap while the field is empty.
+        &::placeholder {
+          color: transparent;
+        }
+      }
+
+      &:focus-within > .form-control,
+      > .form-control:not(:placeholder-shown) {
+        padding-top: var(--#{$prefix}form-floating-input-padding-t);
+        padding-bottom: var(--#{$prefix}form-floating-input-padding-b);
+      }
+    }
+
+    > label:has(~ .form-control-group:focus-within),
+    > label:has(~ .form-control-group > .form-control:not(:placeholder-shown)),
+    > .form-control-group:focus-within ~ label,
+    > .form-control-group:has(> .form-control:not(:placeholder-shown)) ~ label {
+      transform: var(--#{$prefix}form-floating-label-transform);
+    }
+
     > label:has(~ textarea:focus)::after,
     > label:has(~ textarea:not(:placeholder-shown))::after,
     > textarea:focus ~ label::after,

--- a/scss/forms/_form-date-time.scss
+++ b/scss/forms/_form-date-time.scss
@@ -158,17 +158,16 @@ $form-date-time-tokens: defaults(
       }
     }
 
-    // The arrow follows the group: at rest it would sit alone under the label,
-    // active it separates the pair — "12/31/2026 →" is what says a second date
-    // belongs here while the end keeps its mask hidden.
-    &:not(:focus-within, :has(.form-date-time-filled)) {
-      > .form-control-icon {
-        color: transparent;
-      }
+    // The arrow shows only when there is something on both of its sides: while
+    // the group has focus, or once the end date is set. Blurred with only the
+    // start filled, the fields flex 50/50 and the arrow would hang mid-field
+    // over nothing — an orphan, not a hint.
+    &:not(:focus-within) > .form-control-icon:has(+ .form-date-time:not(.form-date-time-filled)) {
+      color: transparent;
+    }
 
-      ~ label {
-        transform: none;
-      }
+    &:not(:focus-within, :has(.form-date-time-filled)) ~ label {
+      transform: none;
     }
 
     &:focus-within ~ label,

--- a/scss/forms/_form-date-time.scss
+++ b/scss/forms/_form-date-time.scss
@@ -133,6 +133,14 @@ $form-date-time-tokens: defaults(
     }
   }
 
+  // The label may sit either side of the control (see forms/_floating-labels.scss)
+  // — the block above catches the label written after it, this one the label
+  // written first, the order the docs use.
+  .form-floating > label:has(~ .form-date-time:focus-within),
+  .form-floating > label:has(~ .form-date-time.form-date-time-filled) {
+    transform: var(--#{$prefix}form-floating-label-transform);
+  }
+
   // Per-field labels: with `startLabel` / `endLabel` set, the range picker
   // wraps each of its controls in its own `.form-floating` inside the group,
   // and the direct-child block above runs the states per field. What is left
@@ -200,5 +208,12 @@ $form-date-time-tokens: defaults(
     &:has(.form-date-time-filled) ~ label {
       transform: var(--#{$prefix}form-floating-label-transform);
     }
+  }
+
+  // Label-first over a picker group. Focus-forward comes from the shared block;
+  // what is missing there is "a following group holds a filled control" — as a
+  // descendant match, because `:has()` cannot nest inside `:has()`.
+  .form-floating > label:has(~ .form-control-group .form-date-time-filled) {
+    transform: var(--#{$prefix}form-floating-label-transform);
   }
 }

--- a/scss/forms/_form-date-time.scss
+++ b/scss/forms/_form-date-time.scss
@@ -133,6 +133,32 @@ $form-date-time-tokens: defaults(
     }
   }
 
+  // Per-field labels: with `startLabel` / `endLabel` set, the range picker
+  // wraps each of its controls in its own `.form-floating` inside the group,
+  // and the direct-child block above runs the states per field. What is left
+  // is geometry: the wrapper takes over the control's flex share, and the
+  // group gives up its block padding so the floating height fits inside the
+  // frame instead of stacking on top of it.
+  .form-control-group:has(> .form-floating) {
+    padding-block: 0;
+    // The inline start too: the field keeps its own inline padding, so the
+    // group's would stack under it and indent label and value twice. The end
+    // stays — that is the cleaner and toggle buttons' cushion.
+    padding-inline-start: 0;
+
+    > .form-floating {
+      display: flex;
+      flex: 1 1 auto;
+      min-width: 0;
+
+      > .form-date-time {
+        width: 100%;
+        height: calc(var(--#{$prefix}form-floating-height) - var(--#{$prefix}btn-input-border-width) * 2);
+        min-height: calc(var(--#{$prefix}form-floating-height) - var(--#{$prefix}btn-input-border-width) * 2);
+      }
+    }
+  }
+
   // The pickers wrap this control in `.form-control-group` — one of them for
   // Date/Time/DateTime Picker, two side by side for the range picker — so the
   // direct-child block above never matches there. The group's shared rules in

--- a/scss/forms/_form-date-time.scss
+++ b/scss/forms/_form-date-time.scss
@@ -132,4 +132,38 @@ $form-date-time-tokens: defaults(
       transform: var(--#{$prefix}form-floating-label-transform);
     }
   }
+
+  // The pickers wrap this control in `.form-control-group` — one of them for
+  // Date/Time/DateTime Picker, two side by side for the range picker — so the
+  // direct-child block above never matches there. The group's shared rules in
+  // forms/_floating-labels.scss give it the height; this block re-binds the
+  // states the same way: focus is `:focus-within` on the group, so opening the
+  // calendar from the action button floats the label too, and filled is "any
+  // control inside carries the JS-managed class". At rest the range arrow
+  // (`.form-control-icon`) hides with the masks — without that it would sit
+  // alone under the label.
+  .form-floating > .form-control-group:has(> .form-date-time) {
+    &:focus-within > .form-date-time,
+    &:has(.form-date-time-filled) > .form-date-time {
+      padding-top: var(--#{$prefix}form-floating-input-padding-t);
+      padding-bottom: var(--#{$prefix}form-floating-input-padding-b);
+    }
+
+    &:not(:focus-within, :has(.form-date-time-filled)) {
+      .form-date-time-section,
+      .form-date-time-separator,
+      > .form-control-icon {
+        color: transparent;
+      }
+
+      ~ label {
+        transform: none;
+      }
+    }
+
+    &:focus-within ~ label,
+    &:has(.form-date-time-filled) ~ label {
+      transform: var(--#{$prefix}form-floating-label-transform);
+    }
+  }
 }

--- a/scss/forms/_form-date-time.scss
+++ b/scss/forms/_form-date-time.scss
@@ -139,9 +139,7 @@ $form-date-time-tokens: defaults(
   // forms/_floating-labels.scss give it the height; this block re-binds the
   // states the same way: focus is `:focus-within` on the group, so opening the
   // calendar from the action button floats the label too, and filled is "any
-  // control inside carries the JS-managed class". At rest the range arrow
-  // (`.form-control-icon`) hides with the masks — without that it would sit
-  // alone under the label.
+  // control inside carries the JS-managed class".
   .form-floating > .form-control-group:has(> .form-date-time) {
     &:focus-within > .form-date-time,
     &:has(.form-date-time-filled) > .form-date-time {
@@ -149,9 +147,21 @@ $form-date-time-tokens: defaults(
       padding-bottom: var(--#{$prefix}form-floating-input-padding-b);
     }
 
-    &:not(:focus-within, :has(.form-date-time-filled)) {
+    // Each control reveals its own mask — a control neither focused nor filled
+    // keeps it hidden even while its sibling floats the label. With one control
+    // that is exactly the old group-at-rest state; with two, the range's empty
+    // end no longer stands bare under no label once the start is set.
+    > .form-date-time:not(:focus-within, .form-date-time-filled) {
       .form-date-time-section,
-      .form-date-time-separator,
+      .form-date-time-separator {
+        color: transparent;
+      }
+    }
+
+    // The arrow follows the group: at rest it would sit alone under the label,
+    // active it separates the pair — "12/31/2026 →" is what says a second date
+    // belongs here while the end keeps its mask hidden.
+    &:not(:focus-within, :has(.form-date-time-filled)) {
       > .form-control-icon {
         color: transparent;
       }

--- a/scss/forms/_form-multi-select.scss
+++ b/scss/forms/_form-multi-select.scss
@@ -109,4 +109,34 @@ $form-multi-select-tokens: defaults(
     }
   }
 
+  // Multi Select has no input to ask, so the float is re-bound to the placeholder
+  // element the component renders only while nothing is selected — the same shape
+  // the date input uses with `.form-date-time-filled`. The shared
+  // `.form-control-group` rules in forms/_floating-labels.scss cover the height;
+  // what is left is the empty state, which they read from `:placeholder-shown`.
+  .form-floating > .form-multi-select {
+    &:not(:focus-within, :has(.form-multi-select-placeholder)),
+    &:focus-within {
+      .form-multi-select-selection {
+        padding-top: var(--#{$prefix}form-floating-input-padding-t);
+        padding-bottom: var(--#{$prefix}form-floating-input-padding-b);
+      }
+    }
+
+    &:not(:focus-within):has(.form-multi-select-placeholder) {
+      .form-multi-select-placeholder {
+        color: transparent;
+      }
+
+      ~ label {
+        transform: none;
+      }
+    }
+
+    &:focus-within ~ label,
+    &:not(:has(.form-multi-select-placeholder)) ~ label {
+      transform: var(--#{$prefix}form-floating-label-transform);
+    }
+  }
+
 }

--- a/scss/forms/_form-multi-select.scss
+++ b/scss/forms/_form-multi-select.scss
@@ -139,4 +139,20 @@ $form-multi-select-tokens: defaults(
     }
   }
 
+  // Label-first. "Has a selection" cannot be asked from the label's side in one
+  // selector — `:has()` does not nest — so the cascade does the logic: float by
+  // default, rest while the placeholder element is present, float again on
+  // focus regardless.
+  .form-floating > label:has(~ .form-multi-select) {
+    transform: var(--#{$prefix}form-floating-label-transform);
+  }
+
+  .form-floating > label:has(~ .form-multi-select .form-multi-select-placeholder) {
+    transform: none;
+  }
+
+  .form-floating > label:has(~ .form-multi-select:focus-within) {
+    transform: var(--#{$prefix}form-floating-label-transform);
+  }
+
 }

--- a/scss/forms/_form-multi-select.scss
+++ b/scss/forms/_form-multi-select.scss
@@ -109,22 +109,27 @@ $form-multi-select-tokens: defaults(
     }
   }
 
-  // Multi Select has no input to ask, so the float is re-bound to the placeholder
-  // element the component renders only while nothing is selected — the same shape
-  // the date input uses with `.form-date-time-filled`. The shared
-  // `.form-control-group` rules in forms/_floating-labels.scss cover the height;
-  // what is left is the empty state, which they read from `:placeholder-shown`.
+  // Multi Select has no input to ask, so the float is re-bound to the JS-managed
+  // `.form-multi-select-filled` on the component itself — the same shape the
+  // date input uses with `.form-date-time-filled`, and the only signal that
+  // covers search mode, where a single selection lives in the search input's
+  // placeholder attribute and the placeholder element never renders. The shared
+  // `.form-control-group` rules in forms/_floating-labels.scss cover the height.
   .form-floating > .form-multi-select {
-    &:not(:focus-within, :has(.form-multi-select-placeholder)),
-    &:focus-within {
+    &:focus-within,
+    &.form-multi-select-filled {
       .form-multi-select-selection {
         padding-top: var(--#{$prefix}form-floating-input-padding-t);
         padding-bottom: var(--#{$prefix}form-floating-input-padding-b);
       }
     }
 
-    &:not(:focus-within):has(.form-multi-select-placeholder) {
+    &:not(:focus-within, .form-multi-select-filled) {
       .form-multi-select-placeholder {
+        color: transparent;
+      }
+
+      .form-multi-select-search::placeholder {
         color: transparent;
       }
 
@@ -134,24 +139,15 @@ $form-multi-select-tokens: defaults(
     }
 
     &:focus-within ~ label,
-    &:not(:has(.form-multi-select-placeholder)) ~ label {
+    &.form-multi-select-filled ~ label {
       transform: var(--#{$prefix}form-floating-label-transform);
     }
   }
 
-  // Label-first. "Has a selection" cannot be asked from the label's side in one
-  // selector — `:has()` does not nest — so the cascade does the logic: float by
-  // default, rest while the placeholder element is present, float again on
-  // focus regardless.
-  .form-floating > label:has(~ .form-multi-select) {
-    transform: var(--#{$prefix}form-floating-label-transform);
-  }
-
-  .form-floating > label:has(~ .form-multi-select .form-multi-select-placeholder) {
-    transform: none;
-  }
-
-  .form-floating > label:has(~ .form-multi-select:focus-within) {
+  // Label-first — the filled state is a class on the element itself, so both
+  // directions read it plainly.
+  .form-floating > label:has(~ .form-multi-select:focus-within),
+  .form-floating > label:has(~ .form-multi-select.form-multi-select-filled) {
     transform: var(--#{$prefix}form-floating-label-transform);
   }
 


### PR DESCRIPTION
Requested as "can the date input get something placeholder-like so floating labels can work" — and it turned out the date input already has exactly that (`.form-date-time-filled` + hidden mask, `forms/_form-date-time.scss`). What was actually missing is the rest of the family: **Password Input, Number Input, Autocomplete and Multi Select all ignored `.form-floating` entirely.**

## Why it never worked

`.form-floating` targets `> .form-control` — a **direct child**. Every field component wraps its control in `.form-control-group`, so the control is a grandchild and no rule matched: no height, no padding shift, no label movement.

Probed the rendered DOM in Chromium before writing any CSS: all four wrappers carry `.form-control-group` (`.password-input`, `.number-input`, `.autocomplete`, `.form-multi-select` are siblings on the same element). That makes it **one shared block**, not four.

## The shape

- **Shared** (`forms/_floating-labels.scss`): `.form-floating > .form-control-group` takes the floating height; the `.form-control` inside takes the padding shift; its placeholder is hidden until the label floats — same as the direct-child rule does. Empty state read from `:placeholder-shown`, which the probe confirmed works for Password, Number and Autocomplete (their input is real).
- **Multi Select** (`forms/_form-multi-select.scss`): no input to ask, so the float re-binds to `:has(.form-multi-select-placeholder)` — the element the component renders only while nothing is selected. Same pattern the date input already uses with `.form-date-time-filled`. Zero JS changes: the signal existed, the stylesheet just didn't read it.

## Verification

New spec `js/tests/visual/floating-labels.spec.js` — 20 assertions: label floats on value / stays put when empty for all five components, **both Multi Select init paths** (options config and `<select>`, which reach the component differently), and a height guard pinning every wrapper to a plain control's height under `.form-floating` (58px, so rows line up).

Asserts computed style rather than screenshots: the question is whether the state selectors match at all.

## Docs

A *Floating labels* section on each of the four pages, in each page's section order, with runnable examples matching each component's init idiom (`data-coreui-toggle` for password/number, declarative autocomplete, `<select>` for Multi Select).

## Gates

`css-compile` · `css-lint` · `css-test` (62) · `css-test-class-api` · `js-lint` (0 errors) · `js-test-visual` (63, incl. the 20 new) · `docs-build` (176 pages) · `bundlewatch` — `coreui.css` 69.7 kB against 70 kB.

## Note for review

`coreui.css` is 0.3 kB under its ceiling after this. Not raising it here — per the v6 rule I'll bump it when a feature actually crosses, but the next PR on this file probably will.

React/Vue ports: the classes ship in the shared CSS, so the framework editions gain the behaviour with the package bump; their docs mirrors will follow as separate PRs after this lands.