### PR TITLE
fix(Tooltip): keep the tip's hover/focus listeners on delegated tooltips

### DIFF
--- a/js/src/tooltip.ts
+++ b/js/src/tooltip.ts
@@ -103,6 +103,10 @@ type TooltipConfig = {
   trigger: string
 }
 
+// Delegated tooltips are created on the fly with their `trigger` forced to
+// `manual`, so the real trigger is stored here for later reference.
+type TooltipInternalConfig = TooltipConfig & { _trigger: string }
+
 const Default: TooltipConfig = {
   allowList: DefaultAllowlist,
   animation: true,
@@ -659,12 +663,7 @@ class Tooltip extends BaseComponent {
           context.toggle()
         })
       } else if (trigger !== TRIGGER_MANUAL) {
-        const eventIn = trigger === TRIGGER_HOVER ?
-          this.constructor.eventName(EVENT_MOUSEENTER) :
-          this.constructor.eventName(EVENT_FOCUSIN)
-        const eventOut = trigger === TRIGGER_HOVER ?
-          this.constructor.eventName(EVENT_MOUSELEAVE) :
-          this.constructor.eventName(EVENT_FOCUSOUT)
+        const [eventIn, eventOut] = this._getTriggerEvents(trigger)
 
         EventHandler.on(this._element, eventIn, this._config.selector as string, event => {
           const context = this._initializeOnDelegatedTarget(event)
@@ -694,9 +693,9 @@ class Tooltip extends BaseComponent {
   // itself, so users can reach interactive content inside it (WCAG 1.4.13).
   // Hover/focus tips get matching leave listeners on the tip element.
   protected _setTipListeners(tip: HTMLElement): void {
-    const { trigger } = this._config
+    const trigger = this._getTrigger()
 
-    if (trigger === TRIGGER_MANUAL || trigger.includes('click')) {
+    if (trigger === TRIGGER_MANUAL || trigger.includes(TRIGGER_CLICK)) {
       return
     }
 
@@ -707,9 +706,7 @@ class Tooltip extends BaseComponent {
 
     for (const name of trigger.split(' ')) {
       if (name === TRIGGER_HOVER || name === TRIGGER_FOCUS) {
-        const eventOut = name === TRIGGER_HOVER ?
-          this.constructor.eventName(EVENT_MOUSELEAVE) :
-          this.constructor.eventName(EVENT_FOCUSOUT)
+        const [, eventOut] = this._getTriggerEvents(name)
         EventHandler.on(tip, eventOut, this._tipEventOut)
       }
     }
@@ -720,13 +717,11 @@ class Tooltip extends BaseComponent {
       return
     }
 
-    const { trigger } = this._config
+    const trigger = this._getTrigger()
 
     for (const name of trigger.split(' ')) {
       if (name === TRIGGER_HOVER || name === TRIGGER_FOCUS) {
-        const eventOut = name === TRIGGER_HOVER ?
-          this.constructor.eventName(EVENT_MOUSELEAVE) :
-          this.constructor.eventName(EVENT_FOCUSOUT)
+        const [, eventOut] = this._getTriggerEvents(name)
         EventHandler.off(tip, eventOut, this._tipEventOut)
       }
     }
@@ -736,6 +731,25 @@ class Tooltip extends BaseComponent {
 
   protected _isInside(element: Node | null): boolean {
     return this._element.contains(element) || Boolean(this.tip?.contains(element))
+  }
+
+  protected _getTrigger(): string {
+    return (this._config as TooltipInternalConfig)._trigger
+  }
+
+  protected _getTriggerEvents(trigger: string): [string, string] {
+    const events: Record<string, [string, string]> = {
+      [TRIGGER_HOVER]: [
+        this.constructor.eventName(EVENT_MOUSEENTER),
+        this.constructor.eventName(EVENT_MOUSELEAVE)
+      ],
+      [TRIGGER_FOCUS]: [
+        this.constructor.eventName(EVENT_FOCUSIN),
+        this.constructor.eventName(EVENT_FOCUSOUT)
+      ]
+    }
+
+    return events[trigger]
   }
 
   protected _setEscapeListener(): void {
@@ -863,6 +877,11 @@ class Tooltip extends BaseComponent {
 
   override _configAfterMerge(config: ComponentConfig): ComponentConfig {
     config.container = config.container === false ? document.body : getElement(config.container)
+
+    // Delegated tooltips are created on the fly with `trigger` set to `manual`,
+    // which makes the real trigger hard to check later. Preserve it here so the
+    // tip listeners know whether the tooltip is hover- or focus-driven.
+    config._trigger = config._trigger || config.trigger
 
     if (typeof config.delay === 'number') {
       config.delay = {

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -908,6 +908,37 @@ describe('Tooltip', () => {
       })
     })
 
+    it('should hide a delegated tooltip when the cursor leaves the tip element', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div><a href="#" rel="tooltip" title="Another tooltip">trigger</a></div>'
+
+        const containerEl = fixtureEl.querySelector('div')
+        const tooltipContainer = new Tooltip(containerEl, {
+          selector: 'a[rel="tooltip"]',
+          trigger: 'hover'
+        })
+
+        const tooltipEl = containerEl.querySelector('a')
+
+        tooltipEl.addEventListener('shown.coreui.tooltip', () => {
+          const delegated = Tooltip.getInstance(tooltipEl)
+          const leaveTipEvent = createEvent('mouseout')
+          Object.defineProperty(leaveTipEvent, 'relatedTarget', {
+            value: document.body
+          })
+
+          delegated._getTipElement().dispatchEvent(leaveTipEvent)
+        })
+
+        tooltipEl.addEventListener('hidden.coreui.tooltip', () => {
+          tooltipContainer.dispose()
+          resolve()
+        })
+
+        tooltipEl.dispatchEvent(createEvent('mouseover', { bubbles: true }))
+      })
+    })
+
     it('should hide a tooltip when the cursor leaves the tip element', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip">trigger</a>'


### PR DESCRIPTION
## What changed

A tooltip created through the `selector` option gets its `trigger` forced to `manual` on the delegated instance, so `_setTipListeners` bailed out and never attached the tip's `mouseleave`/`focusout` listeners. Two visible consequences:

- moving the pointer from the trigger onto the tip closed it, so interactive tip content was unreachable (WCAG 1.4.13 — the hoverable-tip behavior from #974 silently did not apply to delegated tooltips),
- leaving the tip never hid it once it was kept open another way.

The original trigger is now preserved as `config._trigger` during `_configAfterMerge` and the tip listeners read it via `_getTrigger()`. The repeated in/out event ternaries collapsed into one `_getTriggerEvents()` lookup.

## Tests

New spec: `should hide a delegated tooltip when the cursor leaves the tip element` — fails on the previous code (no listener on the tip, `hidden` never fires).