### PR TITLE
fix(EventHandler): register scrollend natively and type trigger() by target nullability

### DIFF
--- a/js/src/alert.ts
+++ b/js/src/alert.ts
@@ -40,7 +40,7 @@ class Alert extends BaseComponent {
   async close(): Promise<void> {
     const closeEvent = EventHandler.trigger(this._element, EVENT_CLOSE)
 
-    if (closeEvent!.defaultPrevented) {
+    if (closeEvent.defaultPrevented) {
       return
     }
 

--- a/js/src/carousel.ts
+++ b/js/src/carousel.ts
@@ -264,7 +264,7 @@ class Carousel extends BaseComponent {
       to: targetIndex
     })
 
-    if (slideEvent!.defaultPrevented) {
+    if (slideEvent.defaultPrevented) {
       return
     }
 
@@ -577,7 +577,7 @@ class Carousel extends BaseComponent {
       to: toIndex
     })
 
-    if (slideEvent!.defaultPrevented) {
+    if (slideEvent.defaultPrevented) {
       return
     }
 

--- a/js/src/chip-set.ts
+++ b/js/src/chip-set.ts
@@ -159,7 +159,7 @@ class ChipSet extends BaseComponent {
       relatedTarget: this._input ?? null
     })
 
-    if (addEvent!.defaultPrevented) {
+    if (addEvent.defaultPrevented) {
       return null
     }
 
@@ -202,7 +202,7 @@ class ChipSet extends BaseComponent {
       relatedTarget: this._input ?? null
     })
 
-    if (removeEvent!.defaultPrevented) {
+    if (removeEvent.defaultPrevented) {
       return false
     }
 

--- a/js/src/chip.ts
+++ b/js/src/chip.ts
@@ -128,7 +128,7 @@ class Chip extends BaseComponent {
   remove(): void {
     const removeEvent = EventHandler.trigger(this._element, EVENT_REMOVE)
 
-    if (removeEvent!.defaultPrevented) {
+    if (removeEvent.defaultPrevented) {
       return
     }
 
@@ -158,7 +158,7 @@ class Chip extends BaseComponent {
     }
 
     const selectEvent = EventHandler.trigger(this._element, EVENT_SELECT)
-    if (selectEvent!.defaultPrevented) {
+    if (selectEvent.defaultPrevented) {
       return
     }
 
@@ -178,7 +178,7 @@ class Chip extends BaseComponent {
     }
 
     const deselectEvent = EventHandler.trigger(this._element, EVENT_DESELECT)
-    if (deselectEvent!.defaultPrevented) {
+    if (deselectEvent.defaultPrevented) {
       return
     }
 

--- a/js/src/collapse.ts
+++ b/js/src/collapse.ts
@@ -158,7 +158,7 @@ class Collapse extends BaseComponent {
     }
 
     const startEvent = EventHandler.trigger(this._element, EVENT_SHOW)
-    if (startEvent!.defaultPrevented) {
+    if (startEvent.defaultPrevented) {
       return
     }
 
@@ -206,7 +206,7 @@ class Collapse extends BaseComponent {
     }
 
     const startEvent = EventHandler.trigger(this._element, EVENT_HIDE)
-    if (startEvent!.defaultPrevented) {
+    if (startEvent.defaultPrevented) {
       return
     }
 

--- a/js/src/dialog-base.ts
+++ b/js/src/dialog-base.ts
@@ -69,7 +69,7 @@ class DialogBase extends BaseComponent {
 
     const showEvent = EventHandler.trigger(this._element, this.constructor.eventName('show'), { relatedTarget })
 
-    if (showEvent!.defaultPrevented) {
+    if (showEvent.defaultPrevented) {
       return
     }
 
@@ -92,7 +92,7 @@ class DialogBase extends BaseComponent {
 
     const hideEvent = EventHandler.trigger(this._element, this.constructor.eventName('hide'))
 
-    if (hideEvent!.defaultPrevented) {
+    if (hideEvent.defaultPrevented) {
       return
     }
 
@@ -200,7 +200,7 @@ class DialogBase extends BaseComponent {
   protected _triggerBackdropTransition(): void {
     const hidePreventedEvent = EventHandler.trigger(this._element, this.constructor.eventName('hidePrevented'))
 
-    if (hidePreventedEvent!.defaultPrevented) {
+    if (hidePreventedEvent.defaultPrevented) {
       return
     }
 

--- a/js/src/dialog.ts
+++ b/js/src/dialog.ts
@@ -131,7 +131,7 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
   }
 
   EventHandler.one(target, EVENT_SHOW, showEvent => {
-    if (showEvent!.defaultPrevented) {
+    if (showEvent.defaultPrevented) {
       // only register focus restorer if dialog will actually get shown
       return
     }

--- a/js/src/dom/event-handler.ts
+++ b/js/src/dom/event-handler.ts
@@ -102,6 +102,7 @@ const nativeEvents = new Set([
   'error',
   'abort',
   'scroll',
+  'scrollend',
   'toggle',
   'beforematch'
 ])
@@ -258,6 +259,48 @@ function getTypeEvent(event: string): string {
   return customEvents[event] || event
 }
 
+function trigger(element: EventTarget, event: string, args?: Record<string, unknown>): CoreUIEvent
+function trigger(element: EventTarget | null, event: string, args?: Record<string, unknown>): CoreUIEvent | null
+function trigger(element: EventTarget | null, event: string, args?: Record<string, unknown>): CoreUIEvent | null {
+  if (typeof event !== 'string' || !element) {
+    return null
+  }
+
+  const $ = getjQuery()
+  const typeEvent = getTypeEvent(event)
+  const inNamespace = event !== typeEvent
+
+  let jQueryEvent = null
+  let bubbles = true
+  let nativeDispatch = true
+  let defaultPrevented = false
+
+  if (inNamespace && $) {
+    jQueryEvent = $.Event(event, args)
+
+    $(element).trigger(jQueryEvent)
+    bubbles = !jQueryEvent.isPropagationStopped()
+    nativeDispatch = !jQueryEvent.isImmediatePropagationStopped()
+    defaultPrevented = jQueryEvent.isDefaultPrevented()
+  }
+
+  const evt = hydrateObj(new Event(event, { bubbles, cancelable: true }), args)
+
+  if (defaultPrevented) {
+    evt.preventDefault()
+  }
+
+  if (nativeDispatch) {
+    element.dispatchEvent(evt)
+  }
+
+  if (evt.defaultPrevented && jQueryEvent) {
+    jQueryEvent.preventDefault()
+  }
+
+  return evt
+}
+
 const EventHandler = {
   on(element: EventTarget | null, event: string, handler?: string | EventCallable, delegationFunction?: EventCallable): void {
     addHandler(element as Element, event, handler, delegationFunction, false)
@@ -310,45 +353,8 @@ const EventHandler = {
     }
   },
 
-  trigger(element: EventTarget | null, event: string, args?: Record<string, unknown>): CoreUIEvent | null {
-    if (typeof event !== 'string' || !element) {
-      return null
-    }
-
-    const $ = getjQuery()
-    const typeEvent = getTypeEvent(event)
-    const inNamespace = event !== typeEvent
-
-    let jQueryEvent = null
-    let bubbles = true
-    let nativeDispatch = true
-    let defaultPrevented = false
-
-    if (inNamespace && $) {
-      jQueryEvent = $.Event(event, args)
-
-      $(element).trigger(jQueryEvent)
-      bubbles = !jQueryEvent.isPropagationStopped()
-      nativeDispatch = !jQueryEvent.isImmediatePropagationStopped()
-      defaultPrevented = jQueryEvent.isDefaultPrevented()
-    }
-
-    const evt = hydrateObj(new Event(event, { bubbles, cancelable: true }), args)
-
-    if (defaultPrevented) {
-      evt.preventDefault()
-    }
-
-    if (nativeDispatch) {
-      element.dispatchEvent(evt)
-    }
-
-    if (evt.defaultPrevented && jQueryEvent) {
-      jQueryEvent.preventDefault()
-    }
-
-    return evt
-  }
+  // `isolatedDeclarations` can't infer a shorthand property — the assertion carries the declared type
+  trigger: trigger as typeof trigger
 }
 
 function hydrateObj<T extends object>(obj: T, meta: Record<string, unknown> = {}): T & Record<string, any> {

--- a/js/src/menu.ts
+++ b/js/src/menu.ts
@@ -249,7 +249,7 @@ class Menu extends BaseComponent {
 
     const showEvent = EventHandler.trigger(this._element, this.constructor.eventName('show'), relatedTarget)
 
-    if (showEvent!.defaultPrevented) {
+    if (showEvent.defaultPrevented) {
       return
     }
 
@@ -325,7 +325,7 @@ class Menu extends BaseComponent {
 
   protected _completeHide(relatedTarget: Record<string, unknown>): void {
     const hideEvent = EventHandler.trigger(this._element, this.constructor.eventName('hide'), relatedTarget)
-    if (hideEvent!.defaultPrevented) {
+    if (hideEvent.defaultPrevented) {
       return
     }
 

--- a/js/src/modal.ts
+++ b/js/src/modal.ts
@@ -137,7 +137,7 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
   }
 
   EventHandler.one(target, EVENT_SHOW, showEvent => {
-    if (showEvent!.defaultPrevented) {
+    if (showEvent.defaultPrevented) {
       // only register focus restorer if modal will actually get shown
       return
     }

--- a/js/src/search-button.ts
+++ b/js/src/search-button.ts
@@ -118,7 +118,7 @@ class SearchButton extends BaseComponent {
   }
 
   _handleShortcut(event: any): boolean | null {
-    if (this._isDisabled() || event!.defaultPrevented || event.repeat || this._shouldIgnoreShortcut(event)) {
+    if (this._isDisabled() || event.defaultPrevented || event.repeat || this._shouldIgnoreShortcut(event)) {
       return false
     }
 

--- a/js/src/tab.ts
+++ b/js/src/tab.ts
@@ -99,7 +99,7 @@ class Tab extends BaseComponent {
 
     const showEvent = EventHandler.trigger(innerElem, EVENT_SHOW, { relatedTarget: active })
 
-    if (showEvent!.defaultPrevented || (hideEvent && hideEvent!.defaultPrevented)) {
+    if (showEvent.defaultPrevented || (hideEvent && hideEvent.defaultPrevented)) {
       return
     }
 

--- a/js/src/toast.ts
+++ b/js/src/toast.ts
@@ -88,7 +88,7 @@ class Toast extends BaseComponent {
   async show(): Promise<void> {
     const showEvent = EventHandler.trigger(this._element, EVENT_SHOW)
 
-    if (showEvent!.defaultPrevented) {
+    if (showEvent.defaultPrevented) {
       return
     }
 
@@ -112,7 +112,7 @@ class Toast extends BaseComponent {
 
     const hideEvent = EventHandler.trigger(this._element, EVENT_HIDE)
 
-    if (hideEvent!.defaultPrevented) {
+    if (hideEvent.defaultPrevented) {
       return
     }
 

--- a/js/src/tooltip.ts
+++ b/js/src/tooltip.ts
@@ -263,7 +263,7 @@ class Tooltip extends BaseComponent {
     const shadowRoot = findShadowRoot(this._element)
     const isInTheDom = (shadowRoot || this._element.ownerDocument.documentElement).contains(this._element)
 
-    if (showEvent!.defaultPrevented || !isInTheDom) {
+    if (showEvent.defaultPrevented || !isInTheDom) {
       // Reset the transient hover/active state so a prevented (or not-in-DOM)
       // show doesn't leave `_isHovered` stuck true — otherwise a click-triggered
       // tip would hit the `_enter()` early-return on every later click and never
@@ -326,7 +326,7 @@ class Tooltip extends BaseComponent {
     }
 
     const hideEvent = EventHandler.trigger(this._element, this.constructor.eventName(EVENT_HIDE))
-    if (hideEvent!.defaultPrevented) {
+    if (hideEvent.defaultPrevented) {
       return
     }
 


### PR DESCRIPTION
## What changed

- `scrollend` joins the native-events set. A namespaced listener like `scrollend.coreui.x` previously registered a custom event that never fires; anything scroll-settling (and the planned scrollspy work) needs the native one.
- `trigger()` is now an overloaded standalone function: a non-null `EventTarget` returns the event itself, a nullable one keeps the `| null` return. The jQuery branch is unchanged.
- All 23 non-null assertions components put on trigger results (`showEvent!.defaultPrevented` and friends) are removed — the type system carries the guarantee now. No runtime change outside the `scrollend` entry.

The `trigger: trigger as typeof trigger` spelling in the `EventHandler` object is what `isolatedDeclarations` requires for a shorthand reference to an overloaded function.