### PR TITLE
fix: dispose replaced instances, tab keyboard/ARIA corrections, CoreUI-branded messages

### DIFF
--- a/js/src/base-component.ts
+++ b/js/src/base-component.ts
@@ -39,6 +39,13 @@ class BaseComponent extends Config {
     this._element = element as HTMLElement
     this._config = this._getConfig(config)
 
+    // Dispose any existing instance bound to this element before registering the new one,
+    // so its event listeners and timers are cleaned up instead of leaking
+    const existingInstance = Data.get(this._element, this.constructor.DATA_KEY)
+    if (existingInstance) {
+      existingInstance.dispose()
+    }
+
     Data.set(this._element, this.constructor.DATA_KEY, this)
   }
 

--- a/js/src/dom/data.ts
+++ b/js/src/dom/data.ts
@@ -26,7 +26,7 @@ export default {
     // can be removed later when multiple key/instances are fine to be used
     if (!instanceMap.has(key) && instanceMap.size !== 0) {
       // eslint-disable-next-line no-console
-      console.error(`Bootstrap doesn't allow more than one instance per element. Bound instance: ${Array.from(instanceMap.keys())[0]}.`)
+      console.error(`CoreUI doesn't allow more than one instance per element. Bound instance: ${Array.from(instanceMap.keys())[0]}.`)
       return
     }
 

--- a/js/src/menu.ts
+++ b/js/src/menu.ts
@@ -166,7 +166,7 @@ class Menu extends BaseComponent {
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
     if (typeof computePosition === 'undefined') {
-      throw new TypeError('Bootstrap\'s menus require Floating UI (https://floating-ui.com)')
+      throw new TypeError('CoreUI\'s menus require Floating UI (https://floating-ui.com)')
     }
 
     super(element, config)

--- a/js/src/tab.ts
+++ b/js/src/tab.ts
@@ -12,7 +12,7 @@ import BaseComponent from './base-component.js'
 import EventHandler, { type CoreUIEvent } from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import {
-  defineJQueryPlugin, getNextActiveElement, getTransitionDurationFromElement, isDisabled
+  defineJQueryPlugin, getNextActiveElement, getTransitionDurationFromElement, isDisabled, setAriaAttribute
 } from './util/index.js'
 
 /**
@@ -40,7 +40,6 @@ const END_KEY = 'End'
 
 const CLASS_NAME_ACTIVE = 'active'
 const CLASS_NAME_SHOW = 'show'
-const CLASS_DROPDOWN = 'dropdown'
 
 const SELECTOR_DROPDOWN_TOGGLE = '.dropdown-toggle'
 const SELECTOR_DROPDOWN_MENU = '.dropdown-menu'
@@ -127,7 +126,7 @@ class Tab extends BaseComponent {
 
     const complete = () => {
       element.removeAttribute('tabindex')
-      element.setAttribute('aria-selected', true as unknown as string)
+      setAriaAttribute(element, 'aria-selected', true)
       this._toggleDropDown(element, true)
       EventHandler.trigger(element, EVENT_SHOWN, {
         relatedTarget: relatedElem
@@ -157,7 +156,7 @@ class Tab extends BaseComponent {
     this._deactivate(SelectorEngine.getElementFromSelector(element)) // Search and deactivate the shown section too
 
     const complete = () => {
-      element.setAttribute('aria-selected', false as unknown as string)
+      setAriaAttribute(element, 'aria-selected', false)
       element.setAttribute('tabindex', '-1')
       this._toggleDropDown(element, false)
       EventHandler.trigger(element, EVENT_HIDDEN, { relatedTarget: relatedElem })
@@ -168,6 +167,12 @@ class Tab extends BaseComponent {
 
   _keydown(event: CoreUIEvent): void {
     if (!([ARROW_LEFT_KEY, ARROW_RIGHT_KEY, ARROW_UP_KEY, ARROW_DOWN_KEY, HOME_KEY, END_KEY].includes(event.key))) {
+      return
+    }
+
+    // Don't hijack modifier+arrow shortcuts (e.g. Alt+Left/Right for browser
+    // history navigation); only the bare keys drive tablist navigation.
+    if (event.altKey || event.ctrlKey || event.metaKey) {
       return
     }
 
@@ -210,7 +215,7 @@ class Tab extends BaseComponent {
     child = this._getInnerElement(child)!
     const isActive = this._elemIsActive(child)
     const outerElem = this._getOuterElement(child)
-    child.setAttribute('aria-selected', isActive as unknown as string)
+    setAriaAttribute(child, 'aria-selected', isActive)
 
     if (outerElem !== child) {
       this._setAttributeIfNotExists(outerElem, 'role', 'presentation')
@@ -242,20 +247,19 @@ class Tab extends BaseComponent {
 
   _toggleDropDown(element: HTMLElement, open: boolean): void {
     const outerElem = this._getOuterElement(element)
-    if (!outerElem.classList.contains(CLASS_DROPDOWN)) {
+    const dropdownToggle = SelectorEngine.findOne(SELECTOR_DROPDOWN_TOGGLE, outerElem)
+    if (!dropdownToggle) {
       return
     }
 
-    const toggle = (selector: string, className: string) => {
-      const element = SelectorEngine.findOne(selector, outerElem)
-      if (element) {
-        element.classList.toggle(className, open)
-      }
+    const dropdownMenu = SelectorEngine.findOne(SELECTOR_DROPDOWN_MENU, outerElem)
+
+    dropdownToggle.classList.toggle(CLASS_NAME_ACTIVE, open)
+    if (dropdownMenu) {
+      dropdownMenu.classList.toggle(CLASS_NAME_SHOW, open)
     }
 
-    toggle(SELECTOR_DROPDOWN_TOGGLE, CLASS_NAME_ACTIVE)
-    toggle(SELECTOR_DROPDOWN_MENU, CLASS_NAME_SHOW)
-    outerElem.setAttribute('aria-expanded', open as unknown as string)
+    setAriaAttribute(dropdownToggle, 'aria-expanded', open)
   }
 
   _setAttributeIfNotExists(element: Element, attribute: string, value: string): void {

--- a/js/src/tooltip.ts
+++ b/js/src/tooltip.ts
@@ -170,7 +170,7 @@ class Tooltip extends BaseComponent {
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
     if (typeof computePosition === 'undefined') {
-      throw new TypeError('Bootstrap\'s tooltips require Floating UI (https://floating-ui.com)')
+      throw new TypeError('CoreUI\'s tooltips require Floating UI (https://floating-ui.com)')
     }
 
     super(element, config)
@@ -871,8 +871,8 @@ class Tooltip extends BaseComponent {
       }
     }
 
-    // Coerce number/boolean title and content to strings. `data-bs-title="true"`
-    // / `data-bs-content="false"` are auto-converted to booleans by the data-API,
+    // Coerce number/boolean title and content to strings. `data-coreui-title="true"`
+    // / `data-coreui-content="false"` are auto-converted to booleans by the data-API,
     // which would otherwise fail the (null|string|element|function) type check.
     if (typeof config.title === 'number' || typeof config.title === 'boolean') {
       config.title = config.title.toString()

--- a/js/tests/unit/accordion.spec.js
+++ b/js/tests/unit/accordion.spec.js
@@ -54,9 +54,9 @@ describe('Accordion', () => {
 
       const accordionEl = fixtureEl.querySelector('.accordion')
       const accordionBySelector = new Accordion('.accordion')
-      const accordionByElement = new Accordion(accordionEl)
-
       expect(accordionBySelector._element).toEqual(accordionEl)
+
+      const accordionByElement = new Accordion(accordionEl)
       expect(accordionByElement._element).toEqual(accordionEl)
     })
   })

--- a/js/tests/unit/alert.spec.js
+++ b/js/tests/unit/alert.spec.js
@@ -18,9 +18,9 @@ describe('Alert', () => {
 
     const alertEl = fixtureEl.querySelector('.alert')
     const alertBySelector = new Alert('.alert')
-    const alertByElement = new Alert(alertEl)
-
     expect(alertBySelector._element).toEqual(alertEl)
+
+    const alertByElement = new Alert(alertEl)
     expect(alertByElement._element).toEqual(alertEl)
   })
 

--- a/js/tests/unit/autocomplete.spec.js
+++ b/js/tests/unit/autocomplete.spec.js
@@ -47,9 +47,9 @@ describe('Autocomplete', () => {
 
       const autocompleteEl = fixtureEl.querySelector('[data-coreui-toggle="autocomplete"]')
       const autocompleteBySelector = new Autocomplete('[data-coreui-toggle="autocomplete"]', { options: [] })
-      const autocompleteByElement = new Autocomplete(autocompleteEl, { options: [] })
-
       expect(autocompleteBySelector._element).toEqual(autocompleteEl)
+
+      const autocompleteByElement = new Autocomplete(autocompleteEl, { options: [] })
       expect(autocompleteByElement._element).toEqual(autocompleteEl)
     })
 

--- a/js/tests/unit/base-component.spec.js
+++ b/js/tests/unit/base-component.spec.js
@@ -93,6 +93,19 @@ describe('Base Component', () => {
         expect(elInstance._element).not.toBeDefined()
         expect(selectorInstance._element).not.toBeDefined()
       })
+
+      it('should dispose an existing instance when re-instantiated on the same element', () => {
+        fixtureEl.innerHTML = '<div id="foo"></div>'
+
+        const el = fixtureEl.querySelector('#foo')
+        const firstInstance = new DummyClass(el)
+        const disposeSpy = spyOn(firstInstance, 'dispose').and.callThrough()
+        const secondInstance = new DummyClass(el)
+
+        expect(disposeSpy).toHaveBeenCalled()
+        expect(DummyClass.getInstance(el)).toEqual(secondInstance)
+        expect(DummyClass.getInstance(el)).not.toEqual(firstInstance)
+      })
     })
 
     describe('dispose', () => {

--- a/js/tests/unit/button.spec.js
+++ b/js/tests/unit/button.spec.js
@@ -16,9 +16,9 @@ describe('Button', () => {
     fixtureEl.innerHTML = '<button data-coreui-toggle="button">Placeholder</button>'
     const buttonEl = fixtureEl.querySelector('[data-coreui-toggle="button"]')
     const buttonBySelector = new Button('[data-coreui-toggle="button"]')
-    const buttonByElement = new Button(buttonEl)
-
     expect(buttonBySelector._element).toEqual(buttonEl)
+
+    const buttonByElement = new Button(buttonEl)
     expect(buttonByElement._element).toEqual(buttonEl)
   })
 

--- a/js/tests/unit/chip-input.spec.js
+++ b/js/tests/unit/chip-input.spec.js
@@ -49,9 +49,9 @@ describe('ChipInput', () => {
 
     const el = fixtureEl.querySelector('.chip-input')
     const bySelector = new ChipInput('.chip-input')
-    const byElement = new ChipInput(el)
-
     expect(bySelector._element).toEqual(el)
+
+    const byElement = new ChipInput(el)
     expect(byElement._element).toEqual(el)
   })
 

--- a/js/tests/unit/chip-set.spec.js
+++ b/js/tests/unit/chip-set.spec.js
@@ -26,9 +26,9 @@ describe('ChipSet', () => {
   it('should take care of element either passed as a CSS selector or DOM element', () => {
     const el = setMarkup()
     const bySelector = new ChipSet('.chip-set')
-    const byElement = new ChipSet(el)
-
     expect(bySelector._element).toEqual(el)
+
+    const byElement = new ChipSet(el)
     expect(byElement._element).toEqual(el)
   })
 

--- a/js/tests/unit/chip.spec.js
+++ b/js/tests/unit/chip.spec.js
@@ -17,9 +17,9 @@ describe('Chip', () => {
 
     const chipEl = fixtureEl.querySelector('.chip')
     const chipBySelector = new Chip('.chip')
-    const chipByElement = new Chip(chipEl)
-
     expect(chipBySelector._element).toEqual(chipEl)
+
+    const chipByElement = new Chip(chipEl)
     expect(chipByElement._element).toEqual(chipEl)
   })
 

--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -37,9 +37,9 @@ describe('Collapse', () => {
 
       const collapseEl = fixtureEl.querySelector('div.my-collapse')
       const collapseBySelector = new Collapse('div.my-collapse')
-      const collapseByElement = new Collapse(collapseEl)
-
       expect(collapseBySelector._element).toEqual(collapseEl)
+
+      const collapseByElement = new Collapse(collapseEl)
       expect(collapseByElement._element).toEqual(collapseEl)
     })
 

--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -53,9 +53,9 @@ describe('Dropdown', () => {
 
       const btnDropdown = fixtureEl.querySelector('[data-coreui-toggle="dropdown"]')
       const dropdownBySelector = new Dropdown('[data-coreui-toggle="dropdown"]')
-      const dropdownByElement = new Dropdown(btnDropdown)
-
       expect(dropdownBySelector._element).toEqual(btnDropdown)
+
+      const dropdownByElement = new Dropdown(btnDropdown)
       expect(dropdownByElement._element).toEqual(btnDropdown)
     })
 

--- a/js/tests/unit/navigation.spec.js
+++ b/js/tests/unit/navigation.spec.js
@@ -17,9 +17,9 @@ describe('Navigation', () => {
 
     const navEl = fixtureEl.querySelector('nav')
     const navigationBySelector = new Navigation('nav')
-    const navigationByElement = new Navigation(navEl)
-
     expect(navigationBySelector._element).toEqual(navEl)
+
+    const navigationByElement = new Navigation(navEl)
     expect(navigationByElement._element).toEqual(navEl)
   })
 

--- a/js/tests/unit/scrollspy.spec.js
+++ b/js/tests/unit/scrollspy.spec.js
@@ -100,9 +100,9 @@ describe('ScrollSpy', () => {
 
       const sSpyEl = fixtureEl.querySelector('.content')
       const sSpyBySelector = new ScrollSpy('.content')
-      const sSpyByElement = new ScrollSpy(sSpyEl)
-
       expect(sSpyBySelector._element).toEqual(sSpyEl)
+
+      const sSpyByElement = new ScrollSpy(sSpyEl)
       expect(sSpyByElement._element).toEqual(sSpyEl)
     })
 

--- a/js/tests/unit/search-button.spec.js
+++ b/js/tests/unit/search-button.spec.js
@@ -35,9 +35,9 @@ describe('SearchButton', () => {
 
     const buttonEl = fixtureEl.querySelector('button')
     const buttonBySelector = new SearchButton('[data-coreui-search-button]')
-    const buttonByElement = new SearchButton(buttonEl)
-
     expect(buttonBySelector._element).toEqual(buttonEl)
+
+    const buttonByElement = new SearchButton(buttonEl)
     expect(buttonByElement._element).toEqual(buttonEl)
   })
 

--- a/js/tests/unit/tab.spec.js
+++ b/js/tests/unit/tab.spec.js
@@ -33,9 +33,9 @@ describe('Tab', () => {
 
       const tabEl = fixtureEl.querySelector('[href="#home"]')
       const tabBySelector = new Tab('[href="#home"]')
-      const tabByElement = new Tab(tabEl)
-
       expect(tabBySelector._element).toEqual(tabEl)
+
+      const tabByElement = new Tab(tabEl)
       expect(tabByElement._element).toEqual(tabEl)
     })
 

--- a/js/tests/unit/tab.spec.js
+++ b/js/tests/unit/tab.spec.js
@@ -594,6 +594,35 @@ describe('Tab', () => {
       expect(spyPrevent).toHaveBeenCalledTimes(3)
     })
 
+    it('if keydown event carries a modifier key, do not handle it', () => {
+      fixtureEl.innerHTML = [
+        '<div class="nav">',
+        '  <span id="tab1" class="nav-link" data-coreui-toggle="tab"></span>',
+        '  <span id="tab2" class="nav-link" data-coreui-toggle="tab"></span>',
+        '</div>'
+      ].join('')
+
+      const tabEl1 = fixtureEl.querySelector('#tab1')
+      const tabEl2 = fixtureEl.querySelector('#tab2')
+      const tab1 = new Tab(tabEl1)
+      const tab2 = new Tab(tabEl2)
+      const spyShow1 = spyOn(tab1, 'show').and.callThrough()
+      const spyShow2 = spyOn(tab2, 'show').and.callThrough()
+      const spyPrevent = spyOn(Event.prototype, 'preventDefault').and.callThrough()
+
+      for (const modifier of ['altKey', 'ctrlKey', 'metaKey']) {
+        const keydown = createEvent('keydown')
+        keydown.key = 'ArrowRight'
+        keydown[modifier] = true
+
+        tabEl1.dispatchEvent(keydown)
+      }
+
+      expect(spyShow1).not.toHaveBeenCalled()
+      expect(spyShow2).not.toHaveBeenCalled()
+      expect(spyPrevent).not.toHaveBeenCalled()
+    })
+
     it('if keydown event is left arrow, handle it', () => {
       fixtureEl.innerHTML = [
         '<div class="nav">',
@@ -972,6 +1001,32 @@ describe('Tab', () => {
       expect(firstLiLinkEl).toHaveClass('active')
       expect(fixtureEl.querySelector('li:last-child a')).not.toHaveClass('active')
       expect(fixtureEl.querySelector('li:last-child .dropdown-menu a:first-child')).not.toHaveClass('active')
+    })
+
+    it('should set aria-expanded on the dropdown toggle, not on the nav item', () => {
+      fixtureEl.innerHTML = [
+        '<ul class="nav nav-tabs">',
+        '  <li class="nav-item"><a class="nav-link" href="#home" data-coreui-toggle="tab">Home</a></li>',
+        '  <li class="nav-item dropdown">',
+        '    <a class="nav-link dropdown-toggle" data-coreui-toggle="dropdown" href="#">Dropdown</a>',
+        '    <div class="dropdown-menu">',
+        '      <a class="dropdown-item" href="#dropdown1" id="dropdown1-tab" data-coreui-toggle="tab">@fat</a>',
+        '    </div>',
+        '  </li>',
+        '</ul>'
+      ].join('')
+
+      const dropdownItem = fixtureEl.querySelector('.dropdown-item')
+      const dropdownToggle = fixtureEl.querySelector('.dropdown-toggle')
+      const navItem = fixtureEl.querySelector('li.dropdown')
+
+      dropdownItem.click()
+      expect(dropdownToggle.getAttribute('aria-expanded')).toEqual('true')
+      expect(navItem.hasAttribute('aria-expanded')).toBeFalse()
+
+      fixtureEl.querySelector('li:first-child a').click()
+      expect(dropdownToggle.getAttribute('aria-expanded')).toEqual('false')
+      expect(navItem.hasAttribute('aria-expanded')).toBeFalse()
     })
 
     it('selecting a dropdown tab does not activate another', () => {

--- a/js/tests/unit/toast.spec.js
+++ b/js/tests/unit/toast.spec.js
@@ -32,9 +32,9 @@ describe('Toast', () => {
 
       const toastEl = fixtureEl.querySelector('.toast')
       const toastBySelector = new Toast('.toast')
-      const toastByElement = new Toast(toastEl)
-
       expect(toastBySelector._element).toEqual(toastEl)
+
+      const toastByElement = new Toast(toastEl)
       expect(toastByElement._element).toEqual(toastEl)
     })
 


### PR DESCRIPTION
Three small fixes from the js/src parity audit, one commit each:

## base-component: dispose the previous instance bound to the same element

Constructing a component on an element that already carried an instance left the old instance's listeners and timers alive, while `Data.set` refused the new registration with a `console.error` — the caller held an instance the registry did not. The constructor now disposes the existing instance before registering, so re-instantiating (e.g. an SPA remounting the same DOM) is clean. New spec, plus the fifteen shared `CSS selector or DOM element` specs adapted to assert before the element is reused.

## Tab: keyboard shortcuts and aria-expanded placement

- Arrow keys with Alt/Ctrl/Cmd held (e.g. Alt+Left/Right browser history navigation) were hijacked by tablist navigation while a tab had focus — bare keys only now.
- `aria-expanded` landed on the `.nav-item` wrapper (`role=presentation`, ignored by assistive tech); it now lands on the `.dropdown-toggle` the user activates. No stylesheet selects on `[aria-expanded]`, so no visual impact.
- `aria-selected` writes go through the `setAriaAttribute` helper instead of `as unknown as string` casts.

New specs for both behaviors.

## Runtime messages branded as CoreUI

The multiple-instances `console.error` and the missing-Floating-UI `TypeError`s in Tooltip and Menu still said Bootstrap; a data-API comment in Tooltip still named `data-bs-*` attributes.