### PR TITLE
feat(Callout)!: read the theme slots, keep the colour modifiers as aliases

### DIFF
--- a/docs/src/content/docs/components/callout.mdx
+++ b/docs/src/content/docs/components/callout.mdx
@@ -8,10 +8,19 @@ otherFrameworks:
 
 import { getData } from '@coreui/astro-docs/data'
 
-## Examples
+## Default callout
 
-Callout component is prepared for any length of text, as well as an optional elements like icons, headings, etc. For a styling, use one of the **required** contextual classes (e.g., `.callout-success`).
-<Example code={getData('theme-colors').map((c) => `<div class="callout callout-${c.name}">
+Callouts accommodate text of any length, along with optional elements like icons and headings. `.callout` on its own is a neutral callout — a bordered surface with a thicker leading edge, inheriting the text color of its surroundings.
+
+<Example code={`<div class="callout">
+    New to or unfamiliar with flexbox? Read this CSS Tricks flexbox guide for background, terminology, guidelines, and code snippets.
+  </div>`} />
+
+## Variants
+
+The color comes from a [`.theme-*` class](/customize/components/#theme-variants), which may sit on the callout or on any element above it. It colors the leading edge and tints the border.
+
+<Example code={getData('theme-colors').map((c) => `<div class="callout theme-${c.name}">
     New to or unfamiliar with flexbox? Read this CSS Tricks flexbox guide for background, terminology, guidelines, and code snippets.
   </div>`)} />
 
@@ -20,6 +29,29 @@ Callout component is prepared for any length of text, as well as an optional ele
 
 Relying on color to convey meaning creates a visual cue that assistive technologies, like screen readers, cannot perceive. It's essential that any information represented by color is either apparent from the content itself (e.g., the visible text) or supplemented by alternative methods, such as extra text using the `.visually-hidden` class.
 </Callout>
+
+## Tinted callout
+
+Because the theme class exposes every slot, the background utilities read from it too. Add `.theme-subtle` for a filled callout without naming a color twice.
+
+<Example code={getData('theme-colors').map((c) => `<div class="callout theme-subtle theme-${c.name}">
+    New to or unfamiliar with flexbox? Read this CSS Tricks flexbox guide for background, terminology, guidelines, and code snippets.
+  </div>`)} />
+
+## Deprecated markup
+
+<DeprecatedIn version="6.0.0" />
+
+The v5 spelling — `.callout` with a colour modifier — still works. Each colour class is generated from the same theme map as the class it replaces, so `.callout-primary` *is* `.callout.theme-primary`. They are removed in v7.
+
+<Example code={getData('theme-colors').map((c) => `<div class="callout callout-${c.name}">
+    New to or unfamiliar with flexbox? Read this CSS Tricks flexbox guide for background, terminology, guidelines, and code snippets.
+  </div>`)} />
+
+```diff
+- <div class="callout callout-success">Saved</div>
++ <div class="callout theme-success">Saved</div>
+```
 
 ## Customizing
 
@@ -37,12 +69,10 @@ Sass variables set these defaults at build time and are removed in v7. The CSS v
 
 <ScssDocs file="scss/_callout.scss" capture="callout-variables" />
 
-#### Variants
+### Sass loops
 
-Check out [our Sass maps and loops docs](/customize/sass/#maps-and-loops) for how to customize these loops and extend CoreUI's base-modifier approach to your own code.
+<DeprecatedIn version="6.0.0" />
 
-#### Modifiers
-
-CoreUI's callout component is built with a base-modifier class approach. This means the bulk of the styling is contained to a base class `.callout` while style variations are confined to modifier classes (e.g., `.callout-danger`). These modifier classes are built from the `$callout-variants` map to make customizing the number and name of our modifier classes.
+The loop that creates the modifier classes, pointing each one at the matching theme color. It goes with them in v7.
 
 <ScssDocs file="scss/_callout.scss" capture="callout-modifiers" />

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1941,6 +1941,30 @@ Multi Select's option indicators moved with it — they render as a decorative
   the viewport the same way and, unlike the footer class, is available in both
   editions.
 
+#### Callout
+
+- **The callout takes its colour from a `.theme-*` class**, on the callout or on
+  any element above it, like the alert does. The class colours the leading edge
+  and tints the border, and because it exposes every slot, `.theme-subtle` next
+  to it fills the callout without naming the colour twice.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Deprecated</span>
+  **`.callout-{color}` still works and is removed in v7.** Each modifier is
+  generated from `$theme-colors` through the same `theme-tokens()` mixin as the
+  theme class, so `.callout-primary` *is* `.callout.theme-primary`.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`$callout-variants` is gone.** The modifier classes are generated from
+  `$theme-colors`, so adding a theme colour adds its callout class — there is no
+  separate map to keep in step.
+- **A callout without a colour no longer draws its leading edge in
+  `currentColor`.** `--cui-callout-border-left-color` was read but never
+  declared: only the modifiers set it, so the declaration was invalid on a bare
+  `.callout` and the property fell back to its initial value. It now defaults to
+  the callout's own border colour.
+- **The 1px border of a coloured callout is tinted.** It reads
+  `--cui-theme-border` where it used to stay neutral, so a coloured callout is a
+  coherent block rather than a grey box with a coloured tick. The leading edge
+  is unchanged.
+
 
 ### Helpers
 

--- a/scss/_callout.scss
+++ b/scss/_callout.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/tokens" as *;
@@ -14,8 +15,6 @@ $callout-border-radius:             var(--#{$prefix}radius-5) !default;
 $callout-border-width:              var(--#{$prefix}border-width) !default;
 $callout-border-color:              var(--#{$prefix}border-color) !default;
 $callout-border-left-width:         calc(#{$callout-border-width} * 4) !default;
-
-$callout-variants: theme-color-refs("bg") !default;
 // scss-docs-end callout-variables
 
 $callout-tokens: () !default;
@@ -30,8 +29,9 @@ $callout-tokens: defaults(
     --#{$prefix}callout-margin-x: #{$callout-margin-x},
     --#{$prefix}callout-margin-y: #{$callout-margin-y},
     --#{$prefix}callout-border-width: #{$callout-border-width},
-    --#{$prefix}callout-border-color: #{$callout-border-color},
+    --#{$prefix}callout-border-color: var(--#{$prefix}theme-border, #{$callout-border-color}),
     --#{$prefix}callout-border-left-width: #{$callout-border-left-width},
+    --#{$prefix}callout-border-left-color: var(--#{$prefix}theme-bg, var(--#{$prefix}callout-border-color)),
     --#{$prefix}callout-border-radius: #{$callout-border-radius},
   ),
   $callout-tokens
@@ -52,10 +52,9 @@ $callout-tokens: defaults(
   }
 
   // scss-docs-start callout-modifiers
-  // Generate contextual modifier classes for colorizing the collor.
-  @each $state, $value in $callout-variants {
+  @each $state in map.keys($theme-colors) {
     .callout-#{$state} {
-      --#{$prefix}callout-border-left-color: #{$value};
+      @include theme-tokens($state);
     }
   }
   // scss-docs-end callout-modifiers


### PR DESCRIPTION
## What changes

`.callout` takes its colour from `--cui-theme-*` now, the way `.alert` does. A `.theme-*` class on the callout — or on any element above it, since custom properties inherit — colours the leading edge and tints the border. Because the theme class exposes every slot, `.theme-subtle` next to it fills the callout without naming the colour twice.

`.callout-{color}` is generated from `$theme-colors` through the same `theme-tokens()` mixin, so it keeps working and is exactly `.callout.theme-{color}`. It is marked deprecated and goes in v7.

## Two changes in the output, both measured

Probed in Chromium against a build of the previous source, not reasoned about:

| case | leading edge before | after |
| --- | --- | --- |
| `.callout` | `rgb(33, 38, 49)` — the text colour | `rgb(219, 223, 230)` — the border colour |
| `.callout-info` | `rgb(51, 153, 255)` | unchanged |
| `.callout.theme-info` | `rgb(33, 38, 49)` — theme ignored | `rgb(51, 153, 255)` |

- **A bare callout used to draw its leading edge in `currentColor`.** `--cui-callout-border-left-color` was read by `.callout` but declared only by the modifiers, so on an uncoloured callout the declaration was invalid at computed-value time and the property fell back to its initial value. The docs papered over it by calling the colour class "required". It now defaults to the callout's own border colour.
- **The 1px border of a coloured callout is tinted**, reading `--cui-theme-border` where it used to stay neutral. A coloured callout is a coherent block rather than a grey box with a coloured tick. The leading edge is unchanged, which is what the table above confirms.

## Sass

`$callout-variants` is removed: the modifier classes come from `$theme-colors`, so a new theme colour brings its callout class with it and there is no second map to keep in step.

## Docs

The page follows the alert page — `## Variants` on `.theme-*`, a tinted example, and a `## Deprecated markup` section for the v5 spelling with a `diff` block. The `### Sass loops` section carries `<DeprecatedIn version="6.0.0" />`, since the loop exists only to generate the deprecated classes and goes with them.

## Verification

`npm run css`, `css-lint`, `css-test-class-api`, `docs-build`, `bundlewatch` — all green; the full pre-push gate passed. `coreui.css` is 69.62 kB gzip against a 70.5 kB ceiling, slightly smaller than before despite the extra declarations, because the theme-token blocks are identical to ones already in the file.

## Related

Companion PRs add a `theme` prop to `CCallout` in the React and Vue PRO libraries and deprecate `color`.