### PR TITLE
docs: name CoreUI where the prose said Bootstrap, and keep cross-references in the build

### DIFF
--- a/docs/src/content/docs/components/card.mdx
+++ b/docs/src/content/docs/components/card.mdx
@@ -14,7 +14,7 @@ A Bootstrap card component is a content container. It incorporates options for i
 
 ## Example
 
-Cards are built with as little markup and styles as possible but still manage to deliver a bunch of control and customization. Built with flexbox, they offer easy alignment and mix well with other Bootstrap components. Cards have no top, left, and right margins by default, so use [spacing utilities](/utilities/margin/) as needed. They have no fixed width to start, so they'll fill the full width of its parent.
+Cards are built with as little markup and styles as possible but still manage to deliver a bunch of control and customization. Built with flexbox, they offer easy alignment and mix well with other CoreUI components. Cards have no top, left, and right margins by default, so use [spacing utilities](/utilities/margin/) as needed. They have no fixed width to start, so they'll fill the full width of its parent.
 
 Below is an example of a basic card with mixed content and a fixed width. Cards have no fixed width to start, so they'll naturally fill the full width of its parent element. This is easily customized with our various [sizing options](#sizing).
 
@@ -496,7 +496,7 @@ Add `.card-translucent` to let the background through the card and blur it. The 
 
 ## Card layout
 
-In addition to styling the content within cards, Bootstrap includes a few options for laying out series of cards. For the time being, **these layout options are not yet responsive**.
+In addition to styling the content within cards, CoreUI includes a few options for laying out series of cards. For the time being, **these layout options are not yet responsive**.
 
 ### Card groups
 

--- a/docs/src/content/docs/components/modal.mdx
+++ b/docs/src/content/docs/components/modal.mdx
@@ -16,7 +16,7 @@ Bootstrap modals are lightweight and multi-purpose popups built on the native `<
 - Focus trapping, background inertness, and the dialog ARIA semantics come from the browser — no `role`, `aria-modal`, `aria-hidden`, or `tabindex` attributes are needed in the markup.
 - The backdrop is the native `::backdrop` pseudo-element. Clicking it closes the modal, and page scroll is blocked while a modal is open.
 - Modals are vertically and horizontally centered by the browser.
-- Due to how HTML5 defines its semantics, [the `autofocus` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autofocus) has no effect in Bootstrap modals. To achieve the same effect, use some custom JavaScript:
+- Due to how HTML5 defines its semantics, [the `autofocus` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autofocus) has no effect in CoreUI modals. To achieve the same effect, use some custom JavaScript:
 
 ```js
 const myModal = document.getElementById('myModal')
@@ -387,7 +387,7 @@ Be sure to add `aria-labelledby="..."`, referencing the modal title, to the `<di
 
 ### Embedding YouTube videos
 
-Embedding YouTube videos in modals requires additional JavaScript not in Bootstrap to automatically stop playback and more. [See this helpful Stack Overflow post](https://stackoverflow.com/questions/18622508/bootstrap-3-and-youtube-in-modal) for more information.
+Embedding YouTube videos in modals requires additional JavaScript not in CoreUI to automatically stop playback and more. [See this helpful Stack Overflow post](https://stackoverflow.com/questions/18622508/bootstrap-3-and-youtube-in-modal) for more information.
 
 ## Optional sizes
 

--- a/docs/src/content/docs/components/nav.mdx
+++ b/docs/src/content/docs/components/nav.mdx
@@ -8,7 +8,7 @@ otherFrameworks:
 
 ## Base nav
 
-Navigation available in Bootstrap share general markup and styles, from the base `.nav` class to the active and disabled states. Swap modifier classes to switch between each style.
+Navigation available in CoreUI share general markup and styles, from the base `.nav` class to the active and disabled states. Swap modifier classes to switch between each style.
 
 The base `.nav` component is built with flexbox and provide a strong foundation for building all types of navigation components. It includes some style overrides (for working with lists), some link padding for larger hit areas, and basic disabled styling.
 

--- a/docs/src/content/docs/components/progress.mdx
+++ b/docs/src/content/docs/components/progress.mdx
@@ -35,7 +35,7 @@ Put that all together, and you have the following examples.
     <div class="progress-bar" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
   </div>`} />
 
-Bootstrap provides a handful of [utilities for setting width](/utilities/width/). Depending on your needs, these may help with quickly configuring progress.
+CoreUI provides a handful of [utilities for setting width](/utilities/width/). Depending on your needs, these may help with quickly configuring progress.
 
 <Example code={`<div class="progress">
     <div class="progress-bar w-75" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>

--- a/docs/src/content/docs/components/spinners.mdx
+++ b/docs/src/content/docs/components/spinners.mdx
@@ -52,7 +52,7 @@ Both spinners use `currentColor` for their appearance, so any [text color utilit
 
 ## Alignment
 
-Spinners in Bootstrap are built with `em`s, `currentColor`, and `display: inline-flex`. This means they can easily be resized, recolored, and quickly aligned.
+Spinners in CoreUI are built with `em`s, `currentColor`, and `display: inline-flex`. This means they can easily be resized, recolored, and quickly aligned.
 
 ### Margin
 

--- a/docs/src/content/docs/content/tables.mdx
+++ b/docs/src/content/docs/content/tables.mdx
@@ -44,7 +44,7 @@ export const snippet = (classes) => `<table class="${classes}">\n  ...\n</table>
 
 Due to the widespread use of `<table>` elements across third-party widgets like calendars and date pickers, CoreUI for Bootstrap's tables are **opt-in**. Add the base class `.table` to any `<table>`, then extend with our optional modifier classes or custom styles. All table styles are not inherited in Bootstrap, meaning any nested tables can be styled independent from the parent.
 
-Using the most basic table markup, here's how `.table`-based tables look in Bootstrap.
+Using the most basic table markup, here's how `.table`-based tables look in CoreUI.
 
 <Example code={demo('table')} />
 

--- a/docs/src/content/docs/customize/css-variables.mdx
+++ b/docs/src/content/docs/customize/css-variables.mdx
@@ -21,7 +21,7 @@ Because `light-dark()` resolves both modes above, only one value still needs a d
 
 ## Component variables
 
-CoreUI is increasingly making use of custom properties as local variables for various components. This way we reduce our compiled CSS, ensure styles aren't inherited in places like nested tables, and allow some basic restyling and extending of Bootstrap components after Sass compilation.
+CoreUI is increasingly making use of custom properties as local variables for various components. This way we reduce our compiled CSS, ensure styles aren't inherited in places like nested tables, and allow some basic restyling and extending of CoreUI components after Sass compilation.
 
 Have a look at our table documentation for some [insight into how we're using CSS variables](/content/tables/#how-do-the-variants-and-accented-tables-work). Our [navbars also use CSS variables](/components/navbar/#css) as of v4.2.6. We're also using CSS variables across our grids—primarily for gutters the [new opt-in CSS grid](/layout/css-grid/)—with more component usage coming in the future.
 
@@ -52,7 +52,7 @@ a {
 
 <AddedIn version="4.3.0" />
 
-Bootstrap provides custom `:focus` styles using a combination of Sass and CSS variables that can be optionally added to specific components and elements. We do not yet globally override all `:focus` styles.
+CoreUI provides custom `:focus` styles using a combination of Sass and CSS variables that can be optionally added to specific components and elements. We do not yet globally override all `:focus` styles.
 
 In our Sass, we set default values that can be customized before compiling.
 

--- a/docs/src/content/docs/forms/autocomplete.mdx
+++ b/docs/src/content/docs/forms/autocomplete.mdx
@@ -222,7 +222,7 @@ The frame carries the size. Add `.form-control-sm` or `.form-control-lg` to the 
 
 ## Floating labels
 
-Autocomplete supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). Wrap the component in `.form-floating` and put a `<label>` beside it. The component's own `placeholder` is hidden while the label rests inside the field, so the two never overlap.
+Autocomplete supports [floating labels](/forms/floating-labels/). Wrap the component in `.form-floating` and put a `<label>` beside it. The component's own `placeholder` is hidden while the label rests inside the field, so the two never overlap.
 
 <Example pro code={`<div class="form-floating">
     <label for="floatingAutocomplete">Framework</label>

--- a/docs/src/content/docs/forms/date-input.mdx
+++ b/docs/src/content/docs/forms/date-input.mdx
@@ -224,7 +224,7 @@ form.addEventListener('submit', event => {
 
 ## Floating labels
 
-The date input supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). When the field is empty and not focused, the mask placeholders are hidden so the label can rest inside the field; focusing the field floats the label and reveals the mask.
+The date input supports [floating labels](/forms/floating-labels/). When the field is empty and not focused, the mask placeholders are hidden so the label can rest inside the field; focusing the field floats the label and reveals the mask.
 
 <Example pro code={`<div class="form-floating">
     <label for="floatingDateInput">Delivery date</label>

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -160,7 +160,7 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
 
 ## Floating labels
 
-The date picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): set `floatingLabel` and the component renders the label itself — no wrapper markup needed — and the text also becomes the field's accessible name. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
+The date picker supports [floating labels](/forms/floating-labels/): set `floatingLabel` and the component renders the label itself — no wrapper markup needed — and the text also becomes the field's accessible name. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
 
 <Example pro code={`<div data-coreui-locale="en-US" data-coreui-floating-label="Delivery date" data-coreui-toggle="date-picker"></div>`} />
 

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -122,7 +122,7 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
 
 ## Floating labels
 
-Each field carries its own [floating label](https://coreui.io/bootstrap/docs/forms/floating-labels/): set `floatingLabels` and the picker renders a label over each date, floating independently — fill in the check-in date and only its label rises. The label text also becomes the field's accessible name, so the visible and spoken labels stay one thing. No wrapper markup is needed.
+Each field carries its own [floating label](/forms/floating-labels/): set `floatingLabels` and the picker renders a label over each date, floating independently — fill in the check-in date and only its label rises. The label text also becomes the field's accessible name, so the visible and spoken labels stay one thing. No wrapper markup is needed.
 
 <Example pro code={`<div data-coreui-locale="en-US" data-coreui-floating-labels='["Check-in", "Check-out"]' data-coreui-toggle="date-range-picker"></div>`} />
 

--- a/docs/src/content/docs/forms/date-time-input.mdx
+++ b/docs/src/content/docs/forms/date-time-input.mdx
@@ -118,7 +118,7 @@ The field participates in the standard form validation styling, [the same way as
 
 ## Floating labels
 
-The date-time input supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). When the field is empty and not focused, the mask placeholders are hidden so the label can rest inside the field; focusing the field floats the label and reveals the mask.
+The date-time input supports [floating labels](/forms/floating-labels/). When the field is empty and not focused, the mask placeholders are hidden so the label can rest inside the field; focusing the field floats the label and reveals the mask.
 
 <Example pro code={`<div class="form-floating">
     <label for="floatingDateTimeInput">Appointment</label>

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -70,7 +70,7 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
 
 ## Floating labels
 
-The date time picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): set `floatingLabel` and the component renders the label itself — no wrapper markup needed — and the text also becomes the field's accessible name. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
+The date time picker supports [floating labels](/forms/floating-labels/): set `floatingLabel` and the component renders the label itself — no wrapper markup needed — and the text also becomes the field's accessible name. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
 
 <Example pro code={`<div data-coreui-locale="en-US" data-coreui-floating-label="Appointment" data-coreui-toggle="date-time-picker"></div>`} />
 

--- a/docs/src/content/docs/forms/multi-select.mdx
+++ b/docs/src/content/docs/forms/multi-select.mdx
@@ -398,7 +398,7 @@ We use the following JavaScript to set up our multi-select:
 
 ## Floating labels
 
-Multi Select supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). Wrap the component in `.form-floating` and put a `<label>` beside it. It has no input to report emptiness, so the label floats on focus and on the first selection, and the component's `placeholder` is hidden while the label rests inside the field.
+Multi Select supports [floating labels](/forms/floating-labels/). Wrap the component in `.form-floating` and put a `<label>` beside it. It has no input to report emptiness, so the label floats on focus and on the first selection, and the component's `placeholder` is hidden while the label rests inside the field.
 
 <Example pro code={`<div class="form-floating">
     <label for="floatingMultiSelect">Frameworks</label>

--- a/docs/src/content/docs/forms/number-input.mdx
+++ b/docs/src/content/docs/forms/number-input.mdx
@@ -79,7 +79,7 @@ a number field can share a frame with anything else the group holds:
 
 ## Floating labels
 
-The number input supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). Wrap the control in `.form-floating` and put a `<label>` beside it — the stepper buttons ride along with the field.
+The number input supports [floating labels](/forms/floating-labels/). Wrap the control in `.form-floating` and put a `<label>` beside it — the stepper buttons ride along with the field.
 
 <Example pro code={`<div class="form-floating">
     <label for="floatingNumberInput">Quantity</label>

--- a/docs/src/content/docs/forms/password-input.mdx
+++ b/docs/src/content/docs/forms/password-input.mdx
@@ -53,7 +53,7 @@ Use the `readonly` attribute to make the input non-editable but still selectable
 
 ## Floating labels
 
-The password input supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). Wrap the control in `.form-floating` and put a `<label>` beside it — the toggle button rides along with the field, and the placeholder stays hidden until the label floats.
+The password input supports [floating labels](/forms/floating-labels/). Wrap the control in `.form-floating` and put a `<label>` beside it — the toggle button rides along with the field, and the placeholder stays hidden until the label floats.
 
 <Example pro code={`<div class="form-floating">
     <label for="floatingPasswordInput">Password</label>

--- a/docs/src/content/docs/forms/time-input.mdx
+++ b/docs/src/content/docs/forms/time-input.mdx
@@ -117,7 +117,7 @@ The field participates in the standard form validation styling, [the same way as
 
 ## Floating labels
 
-The time input supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/). When the field is empty and not focused, the mask placeholders are hidden so the label can rest inside the field; focusing the field floats the label and reveals the mask.
+The time input supports [floating labels](/forms/floating-labels/). When the field is empty and not focused, the mask placeholders are hidden so the label can rest inside the field; focusing the field floats the label and reveals the mask.
 
 <Example pro code={`<div class="form-floating">
     <label for="floatingTimeInput">Meeting time</label>

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -68,7 +68,7 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
 
 ## Floating labels
 
-The time picker supports [floating labels](https://coreui.io/bootstrap/docs/forms/floating-labels/): set `floatingLabel` and the component renders the label itself — no wrapper markup needed — and the text also becomes the field's accessible name. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
+The time picker supports [floating labels](/forms/floating-labels/): set `floatingLabel` and the component renders the label itself — no wrapper markup needed — and the text also becomes the field's accessible name. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
 
 <Example pro code={`<div data-coreui-locale="en-US" data-coreui-floating-label="Meeting time" data-coreui-toggle="time-picker"></div>`} />
 

--- a/docs/src/content/docs/getting-started/accessibility.mdx
+++ b/docs/src/content/docs/getting-started/accessibility.mdx
@@ -21,7 +21,7 @@ Because CoreUI for Bootstrap components are purposely designed to be fairly gene
 
 ### Color contrast
 
-Some combinations of colors that currently make up Bootstrap's default palette—used throughout the framework for things such as button variations, alert variations, form validation indicators—may lead to *insufficient* color contrast (below the recommended [WCAG 2.2 text color contrast ratio of 4.5:1](https://www.w3.org/TR/WCAG/#contrast-minimum) and the [WCAG 2.2 non-text color contrast ratio of 3:1](https://www.w3.org/TR/WCAG/#non-text-contrast)), particularly when used against a light background. Authors are encouraged to test their specific uses of color and, where necessary, manually modify/extend these default colors to ensure adequate color contrast ratios.
+Some combinations of colors that currently make up CoreUI's default palette—used throughout the framework for things such as button variations, alert variations, form validation indicators—may lead to *insufficient* color contrast (below the recommended [WCAG 2.2 text color contrast ratio of 4.5:1](https://www.w3.org/TR/WCAG/#contrast-minimum) and the [WCAG 2.2 non-text color contrast ratio of 3:1](https://www.w3.org/TR/WCAG/#non-text-contrast)), particularly when used against a light background. Authors are encouraged to test their specific uses of color and, where necessary, manually modify/extend these default colors to ensure adequate color contrast ratios.
 
 ### Visually hidden content
 

--- a/docs/src/content/docs/getting-started/browsers-devices.mdx
+++ b/docs/src/content/docs/getting-started/browsers-devices.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Browsers and devices"
-description: "Learn about the browsers and devices, from modern to old, that are supported by Bootstrap, including known quirks and bugs for each."
+description: "Learn about the browsers and devices, from modern to old, that are supported by CoreUI, including known quirks and bugs for each."
 ---
 
 ## Supported browsers

--- a/docs/src/content/docs/getting-started/rtl.mdx
+++ b/docs/src/content/docs/getting-started/rtl.mdx
@@ -9,7 +9,7 @@ We recommend getting familiar with CoreUI for Bootstrap first by reading through
 
 ## Required HTML
 
-There are two strict requirements for enabling RTL in Bootstrap-powered pages.
+There are two strict requirements for enabling RTL in CoreUI-powered pages.
 
 1. Set `dir="rtl"` on the `<html>` element.
 2. Add an appropriate `lang` attribute, like `lang="ar"`, on the `<html>` element.

--- a/docs/src/content/docs/guides/build-tools.mdx
+++ b/docs/src/content/docs/guides/build-tools.mdx
@@ -28,7 +28,7 @@ Our [package.json](https://github.com/coreui/coreui/blob/v[[config:current_versi
 
 ## Sass
 
-Bootstrap uses [Dart Sass](https://sass-lang.com/dart-sass) for compiling our Sass source files into CSS files (included in our build process), and we recommend you do the same if you're compiling Sass using your own asset pipeline. We previously used Node Sass for Bootstrap v4, but LibSass and packages built on top of it, including Node Sass, are now [deprecated](https://sass-lang.com/blog/libsass-is-deprecated).
+CoreUI uses [Dart Sass](https://sass-lang.com/dart-sass) for compiling our Sass source files into CSS files (included in our build process), and we recommend you do the same if you're compiling Sass using your own asset pipeline. We previously used Node Sass for CoreUI v4, but LibSass and packages built on top of it, including Node Sass, are now [deprecated](https://sass-lang.com/blog/libsass-is-deprecated).
 
 Dart Sass uses a rounding precision of 10 and for efficiency reasons does not allow adjustment of this value. We don't lower this precision during further processing of our generated CSS, such as during minification, but if you chose to do so we recommend maintaining a precision of at least 6 to prevent issues with browser rounding.
 

--- a/docs/src/content/docs/helpers/focus-ring.mdx
+++ b/docs/src/content/docs/helpers/focus-ring.mdx
@@ -51,7 +51,7 @@ Push it away from the element with `--cui-focus-ring-offset`, which defaults to
 
 ### Sass variables
 
-Customize the focus ring Sass variables to modify all usage of the focus ring styles across your Bootstrap-powered project.
+Customize the focus ring Sass variables to modify all usage of the focus ring styles across your CoreUI-powered project.
 
 <ScssDocs file="scss/_root.scss" capture="focus-ring-variables" />
 

--- a/docs/src/content/docs/helpers/stacks.mdx
+++ b/docs/src/content/docs/helpers/stacks.mdx
@@ -4,7 +4,7 @@ name: "Stacks"
 description: "Shorthand helpers that build on top of our flexbox utilities to make component layout faster and easier than ever."
 ---
 
-Stacks offer a shortcut for applying a number of flexbox properties to quickly and easily create layouts in Bootstrap. All credit for the concept and implementation goes to the open source [Pylon project](https://almonk.github.io/pylon/).
+Stacks offer a shortcut for applying a number of flexbox properties to quickly and easily create layouts in CoreUI. All credit for the concept and implementation goes to the open source [Pylon project](https://almonk.github.io/pylon/).
 
 ## Vertical
 

--- a/docs/src/content/docs/helpers/stretched-link.mdx
+++ b/docs/src/content/docs/helpers/stretched-link.mdx
@@ -6,7 +6,7 @@ description: "Make any HTML element or CoreUI for Bootstrap component clickable 
 
 Add `.stretched-link` to a link to make its [containing block](https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block) clickable via a `::after` pseudo element. In most cases, this means that an element with `position: relative;` that contains a link with the `.stretched-link` class is clickable. Please note given [how CSS `position` works](https://www.w3.org/TR/CSS21/visuren.html#propdef-position), `.stretched-link` cannot be mixed with most table elements.
 
-Cards have `position: relative` by default in Bootstrap, so in this case you can safely add the `.stretched-link` class to a link in the card without any other HTML changes.
+Cards have `position: relative` by default in CoreUI, so in this case you can safely add the `.stretched-link` class to a link in the card without any other HTML changes.
 
 Multiple links and tap targets are not recommended with stretched links. However, some `position` and `z-index` styles can help should this be required.
 

--- a/docs/src/content/docs/layout/breakpoints.mdx
+++ b/docs/src/content/docs/layout/breakpoints.mdx
@@ -68,7 +68,7 @@ These Sass mixins translate in our compiled CSS using the values declared in our
 
 ```scss
 // X-Small devices (portrait phones, less than 576px)
-// No media query for `xs` since this is the default in Bootstrap
+// No media query for `xs` since this is the default in CoreUI
 
 // Small devices (landscape phones, 576px and up)
 @media (width >= 576px) { ... }

--- a/docs/src/content/docs/layout/css-grid.mdx
+++ b/docs/src/content/docs/layout/css-grid.mdx
@@ -27,7 +27,7 @@ With CoreUI, we've added the option to enable a separate grid system that's buil
 
 - **Responsive classes use container queries.** Each `.grid` is a query container (`container-type: inline-size`), so responsive `.g-col-*` and `.g-start-*` classes respond to the width of the `.grid` itself rather than the viewport.
 
-In the future, Bootstrap will likely shift to a hybrid solution as the `gap` property has achieved nearly full browser support for flexbox.
+In the future, CoreUI will likely shift to a hybrid solution as the `gap` property has achieved nearly full browser support for flexbox.
 
 ## Key differences
 

--- a/docs/src/content/docs/layout/grid.mdx
+++ b/docs/src/content/docs/layout/grid.mdx
@@ -42,7 +42,7 @@ Breaking it down, here's how the grid system comes together:
 
 - **Gutters are also responsive and customizable.** [Gutter classes are available](/layout/gutters/) across all breakpoints, with all the same sizes as our [margin and padding spacing](/utilities/margin/). Change horizontal gutters with `.gx-*` classes, vertical gutters with `.gy-*`, or all gutters with `.g-*` classes. `.g-0` is also available to remove gutters.
 
-- **Sass variables, maps, and mixins power the grid.** If you don't want to use the predefined grid classes in Bootstrap, you can use our [grid's source Sass](#sass) to create your own with more semantic markup. We also include some CSS custom properties to consume these Sass variables for even greater flexibility for you.
+- **Sass variables, maps, and mixins power the grid.** If you don't want to use the predefined grid classes in CoreUI, you can use our [grid's source Sass](#sass) to create your own with more semantic markup. We also include some CSS custom properties to consume these Sass variables for even greater flexibility for you.
 
 Be aware of the limitations and [bugs around flexbox](https://github.com/philipwalton/flexbugs), like the [inability to use some HTML elements as flex containers](https://github.com/philipwalton/flexbugs#flexbug-9).
 

--- a/docs/src/content/docs/migration/v4.mdx
+++ b/docs/src/content/docs/migration/v4.mdx
@@ -22,10 +22,10 @@ description: "Track and review changes to the CoreUI for Bootstrap source files,
 ## Documentation changes
 
 - Redesigned homepage, docs layout, and footer.
-- Added [new Parcel guide](https://coreui.io/bootstrap/docs/getting-started/parcel/).
-- Added [new Customize section](https://coreui.io/bootstrap/docs/customize/overview/).
-- Reorganized all form documentation into [new Forms section](https://coreui.io/bootstrap/docs/forms/overview/), breaking apart the content into more focused pages.
-- Similarly, updated [the Layout section](https://coreui.io/bootstrap/docs/layout/breakpoints/), to flesh out grid content more clearly.
+- Added [new Parcel guide](/guides/parcel/).
+- Added [new Customize section](/customize/overview/).
+- Reorganized all form documentation into [new Forms section](/forms/overview/), breaking apart the content into more focused pages.
+- Similarly, updated [the Layout section](/layout/breakpoints/), to flesh out grid content more clearly.
 - Renamed "Navs" component page to "Navs & Tabs".
 - Renamed "Checks" page to "Checks & radios".
 - Redesigned the navbar and added a new subnav to make it easier to get around our sites and docs versions.
@@ -80,7 +80,7 @@ description: "Track and review changes to the CoreUI for Bootstrap source files,
 - **New breakpoint!** Added new `xxl` breakpoint for `1400px` and up. No changes to all other breakpoints.
 
 - **Improved gutters.** Gutters are now set in rems, and are narrower than v4 (`1.5rem`, or about `24px`, down from `30px`). This aligns our grid system's gutters with our spacing utilities.
-  - Added new [gutter class](https://coreui.io/bootstrap/docs/layout/gutters/) (`.g-*`, `.gx-*`, and `.gy-*`) to control horizontal/vertical gutters, horizontal gutters, and vertical gutters.
+  - Added new [gutter class](/layout/gutters/) (`.g-*`, `.gx-*`, and `.gy-*`) to control horizontal/vertical gutters, horizontal gutters, and vertical gutters.
   - <span class="badge bg-danger">Breaking</span> Renamed `.no-gutters` to `.g-0` to match new gutter utilities.
 
 - Columns no longer have `position: relative` applied, so you may have to add `.position-relative` to some elements to restore that behavior.
@@ -191,9 +191,9 @@ description: "Track and review changes to the CoreUI for Bootstrap source files,
 
 ### Buttons
 
-- <span class="badge bg-danger">Breaking</span> **[Toggle buttons](https://coreui.io/bootstrap/docs/forms/checks-radios/#toggle-buttons), with checkboxes or radios, no longer require JavaScript and have new markup.** We no long require a wrapping element, add `.btn-check` to the `<input />`, and pair it with any `.btn` classes on the `<label>`. _The docs for this has moved from our Buttons page to the new Forms section._
+- <span class="badge bg-danger">Breaking</span> **[Toggle buttons](/forms/checkbox/#toggle-buttons), with checkboxes or radios, no longer require JavaScript and have new markup.** We no long require a wrapping element, add `.btn-check` to the `<input />`, and pair it with any `.btn` classes on the `<label>`. _The docs for this has moved from our Buttons page to the new Forms section._
 
-- <span class="badge bg-danger">Breaking</span> **Dropped `.btn-block` for utilities.** Instead of using `.btn-block` on the `.btn`, wrap your buttons with `.d-grid` and a `.gap-*` utility to space them as needed. Switch to responsive classes for even more control over them. [Read the docs for some examples.](https://coreui.io/bootstrap/docs/components/buttons/#block-buttons)
+- <span class="badge bg-danger">Breaking</span> **Dropped `.btn-block` for utilities.** Instead of using `.btn-block` on the `.btn`, wrap your buttons with `.d-grid` and a `.gap-*` utility to space them as needed. Switch to responsive classes for even more control over them. [Read the docs for some examples.](/components/buttons/#block-buttons)
 
 - Updated our `button-variant()` and `button-outline-variant()` mixins to support additional parameters.
 

--- a/docs/src/content/docs/utilities/z-index.mdx
+++ b/docs/src/content/docs/utilities/z-index.mdx
@@ -19,7 +19,7 @@ We call these "low-level" `z-index` utilities because of their default values of
 
 ## Overlays
 
-Bootstrap overlay components—dropdown, modal, offcanvas, popover, toast, and tooltip—all have their own `z-index` values to ensure a usable experience with competing "layers" of an interface.
+CoreUI overlay components—dropdown, modal, offcanvas, popover, toast, and tooltip—all have their own `z-index` values to ensure a usable experience with competing "layers" of an interface.
 
 <AddedIn version="6.0.0" />
 


### PR DESCRIPTION
Two passes over the vanilla v6 docs, both about a reader landing somewhere that does not look like our documentation.

## The prose called the framework Bootstrap

Twenty-two sentences across components, layout, utilities, helpers, customize and getting-started described this library as "Bootstrap" — `Bootstrap overlay components`, `your Bootstrap-powered project`, `Cards have position: relative by default in Bootstrap`, `supported by Bootstrap`. Nothing told the reader whether they were being told about us or about upstream. They name CoreUI now.

Left alone on purpose:

- the SEO titles and descriptions (`Bootstrap 6 Calendar`, `password input fields in Bootstrap`, `Bootstrap Password Input`) — that wording is the page's product positioning, not a mis-attribution;
- the two references that really are about upstream: the component comparison in the introduction, and the ported utility keys in the v6 migration guide.

`CoreUI for Bootstrap` is untouched — it is this edition's own name.

## Eighteen links walked out of the build

They pointed at coreui.io/bootstrap/docs for a page in this very site — eleven of them the floating-labels page, referenced from every form control that supports one. On the v6 docs they send the reader to the live v5 site instead of to the page next door. All relative now.

Two also had a stale path, so they were wrong even as absolute links: the Parcel guide moved to `/guides/parcel/`, and the v6 split of `forms/checks-radios` put toggle buttons on `/forms/checkbox/#toggle-buttons`.

Companion PRs: coreui/coreui-react-pro#189 and coreui/coreui-vue-pro#130.