### PR TITLE
docs: point the dead in-page links at sections that exist

### DIFF
--- a/docs/src/content/docs/components/header.mdx
+++ b/docs/src/content/docs/components/header.mdx
@@ -28,7 +28,7 @@ Headers come with built-in support for a handful of sub-components. Choose from 
 
 - `.header-brand` for your company, product, or project name.
 - `.header-nav` for a full-height and lightweight navigation (including support for dropdowns).
-- `.header-toggler` for use with our collapse plugin and other [navigation toggling](#responsive-behaviors) behaviors.
+- `.header-toggler` for use with our collapse plugin and other [navigation toggling](/components/collapse/) behaviors.
 - `.header-text` for adding vertically centered strings of text.
 
 Here's an example of all the sub-components included in a responsive header.
@@ -218,7 +218,7 @@ Headers may contain bits of text with the help of `.header-text`. This class adj
 
 ## Containers
 
-Although it's not required, you can wrap a header in a `.container` to center it on a page or add one within to only center the contents of a [fixed or static top header](#placement).
+Although it's not required, you can wrap a header in a `.container` to center it on a page or add one within to only center the contents of a fixed or static top header.
 
 <Example code={`<div class="container">
     <header class="header">

--- a/docs/src/content/docs/components/menu.mdx
+++ b/docs/src/content/docs/components/menu.mdx
@@ -21,7 +21,7 @@ Toggle menus with buttons whenever possible. Here’s an example using a CoreUI 
 
 Menus are toggleable, contextual overlays for displaying lists of links and more. They’re made interactive with the included CoreUI menu JavaScript plugin. They’re toggled by clicking, not by hovering; this is [an intentional design decision](https://markdotto.com/blog/bootstrap-explained-dropdowns/).
 
-Menus are built on a third party library, [Floating UI](https://floating-ui.com/), which provides dynamic positioning and viewport detection. Use `coreui.bundle.min.js` / `coreui.bundle.js` which includes Floating UI, or include Floating UI separately via an [import map](/getting-started/javascript/#using-bootstrap-as-a-module). Floating UI isn’t used to position menus in navbars though as dynamic positioning isn’t required.
+Menus are built on a third party library, [Floating UI](https://floating-ui.com/), which provides dynamic positioning and viewport detection. Use `coreui.bundle.min.js` / `coreui.bundle.js` which includes Floating UI, or include Floating UI separately via an [import map](/getting-started/javascript/#using-coreui-for-bootstrap-as-a-module). Floating UI isn’t used to position menus in navbars though as dynamic positioning isn’t required.
 
 ## Examples
 

--- a/docs/src/content/docs/components/nav.mdx
+++ b/docs/src/content/docs/components/nav.mdx
@@ -48,7 +48,7 @@ Change the style of `.nav`s component with modifiers and utilities. Mix and matc
 
 ### Horizontal alignment
 
-Change the horizontal alignment of your nav with [flexbox utilities](/utilities/flex/#horizontal-alignment). By default, navs are left-aligned, but you can easily change them to center or right aligned.
+Change the horizontal alignment of your nav with [flexbox utilities](/utilities/justify-content/). By default, navs are left-aligned, but you can easily change them to center or right aligned.
 
 Centered with `.justify-content-center`:
 

--- a/docs/src/content/docs/components/popovers.mdx
+++ b/docs/src/content/docs/components/popovers.mdx
@@ -93,7 +93,7 @@ const popover = new coreui.Popover(document.querySelector('.example-popover'), {
 
 <AddedIn version="4.2.6" />
 
-You can customize the appearance of popovers using [CSS variables](#variables). We set a custom class with `data-coreui-custom-class="custom-popover"` to scope our custom appearance and use it to override some of the local CSS variables.
+You can customize the appearance of popovers using [CSS variables](#css-variables). We set a custom class with `data-coreui-custom-class="custom-popover"` to scope our custom appearance and use it to override some of the local CSS variables.
 <ScssDocs file="@docs/_component-examples.scss" capture="custom-popovers" />
 <Example code={`<button type="button" class="btn-solid theme-secondary"
           data-coreui-toggle="popover" data-coreui-placement="right"

--- a/docs/src/content/docs/components/tooltips.mdx
+++ b/docs/src/content/docs/components/tooltips.mdx
@@ -56,7 +56,7 @@ You can choose to use either `title` or `data-coreui-title` in your HTML. If you
 
 <AddedIn version="4.2.0" />
 
-Feel free to personalize the look of your tooltips with [CSS variables](#variables)! By setting a custom class using `data-coreui-custom-class="custom-tooltip"`, you can easily define your custom style and use it to adjust a local CSS variable.
+Feel free to personalize the look of your tooltips with [CSS variables](#css-variables)! By setting a custom class using `data-coreui-custom-class="custom-tooltip"`, you can easily define your custom style and use it to adjust a local CSS variable.
 
 <ScssDocs file="@docs/_component-examples.scss" capture="custom-tooltip" />
 

--- a/docs/src/content/docs/customize/css-variables.mdx
+++ b/docs/src/content/docs/customize/css-variables.mdx
@@ -23,7 +23,7 @@ Because `light-dark()` resolves both modes above, only one value still needs a d
 
 CoreUI is increasingly making use of custom properties as local variables for various components. This way we reduce our compiled CSS, ensure styles aren't inherited in places like nested tables, and allow some basic restyling and extending of CoreUI components after Sass compilation.
 
-Have a look at our table documentation for some [insight into how we're using CSS variables](/content/tables/#how-do-the-variants-and-accented-tables-work). Our [navbars also use CSS variables](/components/navbar/#css) as of v4.2.6. We're also using CSS variables across our grids—primarily for gutters the [new opt-in CSS grid](/layout/css-grid/)—with more component usage coming in the future.
+Have a look at our table documentation for some [insight into how we're using CSS variables](/content/tables/#how-do-the-variants-and-accented-tables-work). Our [navbars also use CSS variables](/components/navbar/#css-variables) as of v4.2.6. We're also using CSS variables across our grids—primarily for gutters the [new opt-in CSS grid](/layout/css-grid/)—with more component usage coming in the future.
 
 Whenever possible, we'll assign CSS variables at the base component level (e.g., `.navbar` for navbar and its sub-components). This reduces guessing on where and how to customize, and allows for easy modifications by our team in future updates.
 

--- a/docs/src/content/docs/forms/switch.mdx
+++ b/docs/src/content/docs/forms/switch.mdx
@@ -37,7 +37,7 @@ Add `role="switch"` to convey the nature of the control to assistive technologie
   </div>`} />
 
 ## Sizing
-`.switch-sm`, `.switch-lg` and `.switch-xl` size the whole row — the track, its thumb, and the label beside it — the way [`.check-sm`](/forms/checkbox/#sizes) and [`.radio-lg`](/forms/radio/#sizes) do.
+`.switch-sm`, `.switch-lg` and `.switch-xl` size the whole row — the track, its thumb, and the label beside it — the way [`.check-sm`](/forms/checkbox/#sizing) and [`.radio-lg`](/forms/radio/#sizing) do.
 
 Each sets **one** custom property. The track's width follows its height through the aspect ratio, the thumb follows the height minus the padding, and the alignment margin is computed from the line — so nothing needs re-tuning per size.
 

--- a/docs/src/content/docs/layout/grid.mdx
+++ b/docs/src/content/docs/layout/grid.mdx
@@ -42,7 +42,7 @@ Breaking it down, here's how the grid system comes together:
 
 - **Gutters are also responsive and customizable.** [Gutter classes are available](/layout/gutters/) across all breakpoints, with all the same sizes as our [margin and padding spacing](/utilities/margin/). Change horizontal gutters with `.gx-*` classes, vertical gutters with `.gy-*`, or all gutters with `.g-*` classes. `.g-0` is also available to remove gutters.
 
-- **Sass variables, maps, and mixins power the grid.** If you don't want to use the predefined grid classes in CoreUI, you can use our [grid's source Sass](#sass) to create your own with more semantic markup. We also include some CSS custom properties to consume these Sass variables for even greater flexibility for you.
+- **Sass variables, maps, and mixins power the grid.** If you don't want to use the predefined grid classes in CoreUI, you can use our [grid's source Sass](#sass-variables) to create your own with more semantic markup. We also include some CSS custom properties to consume these Sass variables for even greater flexibility for you.
 
 Be aware of the limitations and [bugs around flexbox](https://github.com/philipwalton/flexbugs), like the [inability to use some HTML elements as flex containers](https://github.com/philipwalton/flexbugs#flexbug-9).
 

--- a/docs/src/content/docs/migration/v5.mdx
+++ b/docs/src/content/docs/migration/v5.mdx
@@ -81,7 +81,7 @@ Learn more by reading the new [color modes documentation](/customize/color-modes
 
 #### Close button
 
-- <span class="badge text-warning-emphasis bg-warning-subtle">Deprecated</span> The `.btn-close-white` class has been deprecated and replaced with `data-coreui-theme="dark"` on the close button or any parent element. [See the docs for an example.](/components/close-button/#dark-variant)
+- <span class="badge text-warning-emphasis bg-warning-subtle">Deprecated</span> The `.btn-close-white` class has been deprecated and replaced with `data-coreui-theme="dark"` on the close button or any parent element. [See the docs for an example.](/components/close-button/#on-a-dark-surface)
 
 #### Date Picker
 
@@ -179,7 +179,7 @@ Subheader component has been removed.
 
 - Added new focus ring helper for removing the default `outline` and setting a custom `box-shadow` focus ring.
 
-- [Colored links](/helpers/colored-links/) once again have `!important` so they work better with our newly added link utilities.
+- [Colored links](/utilities/link/#coloring-links) once again have `!important` so they work better with our newly added link utilities.
 
 ### Utilities
 
@@ -197,7 +197,7 @@ Subheader component has been removed.
 
 - Renamed Sass and CSS variables `${color}-text` to `${color}-text-emphasis` to match their associated utilities.
 
-- Added new `.link-body-emphasis` helper alongside our [colored links](/helpers/colored-links/). This creates a colored link using our color mode responsive emphasis color.
+- Added new `.link-body-emphasis` helper alongside our [colored links](/utilities/link/#coloring-links). This creates a colored link using our color mode responsive emphasis color.
 
 - Added new link utilities for link color opacity, underline offset, underline color, and underline opacity. [Explore the new links utilities.](/utilities/link/)
 


### PR DESCRIPTION
Thirteen links scrolled nowhere. `astro-broken-links-checker` does not see them — it verifies that the page exists, not the fragment — so they had been accumulating quietly as headings were renamed and pages merged.

Each one, and where it goes now:

| was | is |
| --- | --- |
| `#variables` (popover, tooltip) | `#css-variables` |
| `#sizes` (switch → checkbox, radio) | `#sizing` |
| `#sass` (grid, self) | `#sass-variables` |
| `#css` (CSS variables → navbar) | `#css-variables` |
| `#dark-variant` (v5 migration → close button) | `#on-a-dark-surface` |
| `#using-bootstrap-as-a-module` (menu → JavaScript) | `#using-coreui-for-bootstrap-as-a-module` |
| `/helpers/colored-links/` ×2 (v5 migration) | `/utilities/link/#coloring-links` |
| `/utilities/flex/#horizontal-alignment` (nav) | `/utilities/justify-content/` |

Two more came from the header page being written against the navbar's outline without carrying its sections. `#responsive-behaviors` now points at the collapse component, which is what the sentence is about; `#placement` is dropped and the sentence stands on its own.

**`.header-sticky` exists in the stylesheet and is documented nowhere** — that is the gap the `#placement` link was reaching for. Handled separately.

The same sweep over the React and Vue docs found 8 and 46 more; companion PRs coreui/coreui-react-pro#190 and coreui/coreui-vue-pro#131.