### PR TITLE
docs(install): document the ESM CDN path, SRI, pnpm and Yarn Berry

### DIFF
--- a/build/generate-sri.mjs
+++ b/build/generate-sri.mjs
@@ -46,6 +46,10 @@ const files = [
     configPropertyName: 'js_pro_bundle_hash'
   },
   {
+    file: 'dist/js/coreui.esm.min.js',
+    configPropertyName: 'js_pro_esm_hash'
+  },
+  {
     file: 'dist/js/bootstrap.min.js',
     configPropertyName: 'js_bs_pro_hash'
   },

--- a/config.yml
+++ b/config.yml
@@ -14,6 +14,8 @@ cdn:
   js_hash: "sha384-gf1tanjsJUdqpGpiHABhWprM/7/k8itp69MQWhJGblqf0/0EhOcPA5GPZZE83Br9"
   js_bundle: "https://cdn.jsdelivr.net/npm/@coreui/coreui@5.9.0/dist/js/coreui.bundle.min.js"
   js_bundle_hash: "sha384-FTek6QoTuxz6Bb078pS0kYQ0qH2LZVB5LWwZl8944mluH+TCk0q3OP4PqA+dHJRl"
+  js_esm: "https://cdn.jsdelivr.net/npm/@coreui/coreui@5.9.0/dist/js/coreui.esm.min.js"
+  js_esm_hash: "sha384-cCVKOjLm5MUL2D56ALmwdmVzR6wAAlGaMrM/6B5LVTJOKeylVmfGdUCHzO5r0uEF"
   floating_ui_core: "https://cdn.jsdelivr.net/npm/@floating-ui/core@1.8.0/dist/floating-ui.core.umd.min.js"
   floating_ui_core_hash: "sha384-HNCdK6HYLs4EKIDg2Ml3NdfNMVD/LcFbGXnagRABpWmpJjiEuhrtSIckScRnqDOD"
   floating_ui_dom: "https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.8.0/dist/floating-ui.dom.umd.min.js"
@@ -35,6 +37,8 @@ cdn_pro:
   js_pro_hash: "sha384-kUpSKa20uGjMrb8XIUCECbcTGyZ7WO4FUM9/Dad7olwxxV6JFZqNSNCwAb7OzSYc"
   js_pro_bundle: "https://cdn.jsdelivr.net/npm/@coreui/coreui-pro@5.27.0/dist/js/coreui.bundle.min.js"
   js_pro_bundle_hash: "sha384-5EIITWrYmdJ/lLrIJ/CAkKMbEDQmQ2tbtKex02fTpIPGDke4Gk/2ypdWo43vOvfj"
+  js_pro_esm: "https://cdn.jsdelivr.net/npm/@coreui/coreui-pro@5.27.0/dist/js/coreui.esm.min.js"
+  js_pro_esm_hash: "sha384-PsF+4u61iMi60YqmimN6qPBfr/4L1S96Yvb21YpB/JVqn6r7LboSAsIyANHzxmOi"
 
 cdn_pro_themes:
   css_bs_pro: "https://cdn.jsdelivr.net/npm/@coreui/coreui-pro@5.27.0/dist/css/themes/bootstrap/bootstrap.min.css"

--- a/docs/src/content/docs/getting-started/install.mdx
+++ b/docs/src/content/docs/getting-started/install.mdx
@@ -19,13 +19,34 @@ npm install @coreui/coreui
 npm install @coreui/coreui-pro
 ```
 
-`const coreui = require('@coreui/coreui')` or `import coreui from '@coreui/coreui'` will load all of CoreUI's plugins onto a `coreui` object.
-The `coreui` module itself exports all of our plugins. You can manually load CoreUI's plugins individually by loading the `/js/dist/*.js` files under the package's top-level directory.
+After installing, head to [our npm guide](/guides/npm/) for a full setup guide.
+
+Using `import * as coreui from '@coreui/coreui'` will load all of CoreUI's plugins onto a `coreui` object. You can also import plugins individually for automatic tree shaking:
+
+```js
+import { Tooltip, Toast, Popover } from '@coreui/coreui'
+```
+
+You can also import plugins directly by loading the `/js/dist/*.js` files under the package's top-level directory.
 
 CoreUI's `package.json` contains some additional metadata under the following keys:
 
 - `sass` - path to CoreUI's main [Sass](https://sass-lang.com/) source file
 - `style` - path to CoreUI's non-minified CSS that's been precompiled using the default settings (no customization)
+
+Additionally, CoreUI ships a `.browserslistrc` file at the package root, which defines browser targets for tools like Browserslist and Autoprefixer. See [Browsers & devices](/getting-started/browsers-devices/) for the full support policy.
+
+### pnpm
+
+Install CoreUI for Bootstrap in your Node.js powered apps with [pnpm](https://pnpm.io/):
+
+```sh tab={"label":"CoreUI"}
+pnpm add @coreui/coreui
+```
+
+```sh tab={"label":"CoreUI PRO"}
+pnpm add @coreui/coreui-pro
+```
 
 ### yarn
 
@@ -37,6 +58,14 @@ yarn add @coreui/coreui
 
 ```sh tab={"label":"CoreUI PRO"}
 yarn add @coreui/coreui-pro
+```
+
+Yarn 2+ (aka Yarn Berry) doesn't support the `node_modules` directory by default, so a Sass build that resolves our source files needs some adjustments:
+
+```sh
+yarn config set nodeLinker node-modules # Use the node_modules linker
+touch yarn.lock # Create an empty yarn.lock file
+yarn install # Install the dependencies
 ```
 
 ### Bun
@@ -87,6 +116,60 @@ If you're using our compiled JavaScript and prefer to include Floating UI separa
 <script src="[[config:cdn.floating_ui_core]]" integrity="[[config:cdn.floating_ui_core_hash]]" crossorigin="anonymous"></script>
 <script src="[[config:cdn.floating_ui_dom]]" integrity="[[config:cdn.floating_ui_dom_hash]]" crossorigin="anonymous"></script>
 <script src="[[config:cdn_pro.js_pro]]" integrity="[[config:cdn_pro.js_pro_hash]]" crossorigin="anonymous"></script>
+```
+
+### Using ES modules
+
+Our ES module build imports Floating UI by its bare specifier, so a `<script type="module">` needs an import map to resolve it:
+
+```html
+<script type="importmap">
+{
+  "imports": {
+    "@floating-ui/dom": "[[config:cdn.floating_ui_esm]]"
+  }
+}
+</script>
+<script type="module" src="[[config:cdn.js_esm]]" integrity="[[config:cdn.js_esm_hash]]" crossorigin="anonymous"></script>
+```
+
+**If you use CoreUI PRO please use following links**
+
+```html
+<script type="importmap">
+{
+  "imports": {
+    "@floating-ui/dom": "[[config:cdn.floating_ui_esm]]"
+  }
+}
+</script>
+<script type="module" src="[[config:cdn_pro.js_pro_esm]]" integrity="[[config:cdn_pro.js_pro_esm_hash]]" crossorigin="anonymous"></script>
+```
+
+An import map has to be declared before the first module script that relies on it, and only one is applied per document.
+
+### Using CDNs
+
+When using CDN links, be sure to use the `integrity` attribute to verify the correct files and versions. These hashes are unique to each file and version of CoreUI, so when you update to a new version, be sure the `integrity` attribute is also updated.
+
+We also include a `crossorigin="anonymous"` attribute to prevent [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) errors.
+
+### Alternative CDNs
+
+We recommend [jsDelivr](https://www.jsdelivr.com/) and use it ourselves in our documentation. However, in some cases—like in some specific countries or environments—you may need to use other CDN providers like [cdnjs](https://cdnjs.com/) or [unpkg](https://unpkg.com/).
+
+You'll find the same files on these CDN providers, albeit with different URLs.
+
+<Callout type="warning">
+**Security warning** — If the SRI hashes differ for a given file, you shouldn't use the files from that CDN, because it means that the file was modified by someone else.
+</Callout>
+
+Note that you should compare same length hashes, e.g. `sha384` with `sha384`, otherwise it's expected for them to be different.
+As such, you can use an online tool like [SRI Hash Generator](https://www.srihash.org/) to make sure that the hashes are the same for a given file.
+Alternatively, assuming you have OpenSSL installed, you can achieve the same from the CLI, for example:
+
+```sh
+openssl dgst -sha384 -binary coreui.min.js | openssl base64 -A
 ```
 
 ## Download

--- a/package.json
+++ b/package.json
@@ -145,7 +145,8 @@
     "js/dist/**/*.{js,map,d.ts}",
     "js/src/**/*.ts",
     "scss/**/*.scss",
-    "!scss/tests/**"
+    "!scss/tests/**",
+    ".browserslistrc"
   ],
   "jspm": {
     "registry": "npm",


### PR DESCRIPTION
The install page documented exactly one way to load from a CDN — the UMD build with Floating UI as globals — and never explained the `integrity` attribute it tells everyone to paste.

**Our ESM build could not be loaded from a CDN as documented.** `dist/js/coreui.esm.js` imports Floating UI by its bare specifier, so a `<script type="module">` needs an import map, and we never mentioned one. Adds that section for free and Pro, plus `cdn.js_esm` / `cdn_pro.js_pro_esm` URLs and hashes, and teaches `generate-sri.mjs` to refresh the Pro hash on release so the snippet cannot go stale.

Also added:

- `### Using CDNs` / `### Alternative CDNs` — what `integrity` and `crossorigin` do, that the hash changes with every version, cdnjs and unpkg, and how to verify a hash yourself
- pnpm alongside npm, yarn and Bun
- the Yarn Berry `nodeLinker` workaround
- named imports for tree shaking, replacing a CJS-first paragraph on an ESM-first library
- pointers to the npm guide and Browsers & devices

**`.browserslistrc` was not in the published package.** The new note says we ship it at the package root — `@coreui/coreui-pro@5.27.0/.browserslistrc` returns 404, because it was missing from `files`. `npm pack --dry-run` now lists it at 2.7 kB.

Not taken: RubyGems and NuGet — we do not publish those packages yet, so that section waits for the release. Their CDN file-listing table — our CDN section already spells the links out.