### PR TITLE
fix(ButtonGroup): give hover, active and focus separate z-index steps

### DIFF
--- a/scss/buttons/_button-group.scss
+++ b/scss/buttons/_button-group.scss
@@ -18,19 +18,25 @@ $group-button: ":is(#{$btn-variant-selectors})" !default;
     > #{$group-button} {
       position: relative;
       flex: 1 1 auto;
+
+      &:hover {
+        z-index: 1;
+      }
     }
 
     // Bring the hover, focused, and "active" buttons to the front to overlay
     // the borders properly
     > #{$btn-check-deprecated}:checked + #{$group-button},
-    > #{$btn-check-deprecated}:focus + #{$group-button},
     > .btn-check:has(input:checked),
-    > .btn-check:has(input:focus),
-    > #{$group-button}:hover,
-    > #{$group-button}:focus,
     > #{$group-button}:active,
     > #{$group-button}.active {
-      z-index: 1;
+      z-index: 2;
+    }
+
+    > #{$btn-check-deprecated}:focus + #{$group-button},
+    > .btn-check:has(input:focus),
+    > #{$group-button}:focus {
+      z-index: 3;
     }
   }
 


### PR DESCRIPTION
All five state selectors in `.btn-group` shared `z-index: 1`, so nothing decided which button won when two states met on neighboring buttons. A button focused from the keyboard could have its focus ring clipped by the border of a hovered neighbour — the exact overlap this z-index exists to resolve.

Splits them onto the scale the rest of the library already uses:

| state | before | after |
| --- | --- | --- |
| `:hover` | 1 | 1 |
| `:active` / `.active` / `:checked` | 1 | 2 |
| `:focus` | 1 | 3 |

Focus sits highest because a focused element is the one in the user's attention and its ring has to be visible whole.

Verified in the compiled CSS — each state now resolves to its own step. `.pagination` and `.list-group` are untouched; they carry their own mappings and aligning those is a separate decision.