### PR TITLE
fix(Sidebar): restore the toggler's focus indicator

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -2261,9 +2261,18 @@ them. A state names a theme colour now, and every value is a slot of it.
   `--cui-focus-ring-opacity` at runtime moved the default ring. It is
   `var(--cui-primary-focus-ring)` now — the slot every `.theme-*` ring
   already mixed from. `$focus-ring` itself only restated
-  `--cui-focus-ring`, which `_root.scss` composes, so the two variables
-  that read it (`$btn-close-focus-shadow`, `$sidebar-toggler-focus-shadow`)
-  take the token instead.
+  `--cui-focus-ring`, which `_root.scss` composes, so the two variables that
+  read it — `$btn-close-focus-shadow` and `$sidebar-toggler-focus-shadow` —
+  are gone with it; the close button and the sidebar toggler draw their ring
+  with the shared `focus-ring()` mixin.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`--cui-sidebar-toggler-focus-shadow` is removed.** It fed a `box-shadow`
+  on `.sidebar-toggler:focus-visible` next to an `outline: 0`, and its value
+  was the `--cui-focus-ring` shorthand — `<width> solid <color>`, which
+  `box-shadow` does not accept. The declaration was dropped as invalid and
+  the toggler had no focus indicator at all. The ring is an `outline` now,
+  like everywhere else; restyle it through `--cui-focus-ring-width`,
+  `--cui-focus-ring-color` and `--cui-focus-ring-offset`.
 - **`form-validation-state()` takes `$theme` where it took `$color`**, and the
   variables moved from `scss/_config.scss` into the partials that use them
   alongside `$form-text-*` and `$form-feedback-*`.

--- a/scss/sidebar/_sidebar.scss
+++ b/scss/sidebar/_sidebar.scss
@@ -1,6 +1,7 @@
 @use "../functions/escape-svg" as *;
 @use "../mixins/backdrop" as *;
 @use "../mixins/border-radius" as *;
+@use "../mixins/focus-ring" as *;
 @use "../layout/breakpoints" as *;
 @use "../mixins/ltr-rtl" as *;
 @use "../mixins/transition" as *;
@@ -14,7 +15,6 @@ $sidebar-toggler-padding-y:         .25rem !default;
 $sidebar-toggler-bg:                transparent !default;
 $sidebar-toggler-color:             var(--#{$prefix}fg-3) !default;
 $sidebar-toggler-icon:              url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cg xmlns='http://www.w3.org/2000/svg' transform='matrix(-1 0 0 -1 512 512)'%3E%3Cpath fill='%23000' d='M472,16H40A24.028,24.028,0,0,0,16,40V200H48V48H464V464H48V304H16V472a24.028,24.028,0,0,0,24,24H472a24.028,24.028,0,0,0,24-24V40A24.028,24.028,0,0,0,472,16Z'/%3E%3Cpolygon fill='%23000' points='209.377 363.306 232.004 385.933 366.627 251.31 232.004 116.687 209.377 139.313 305.374 235.311 16 235.311 16 267.311 305.372 267.311 209.377 363.306'/%3E%3C/g%3E%3C/svg%3E") !default;
-$sidebar-toggler-focus-shadow:      var(--#{$prefix}focus-ring) !default;
 $sidebar-toggler-hover-color:       var(--#{$prefix}fg-2) !default;
 $sidebar-toggler-focus-color:       var(--#{$prefix}fg-2) !default;
 $sidebar-toggler-transition:        transform .15s !default;
@@ -228,7 +228,6 @@ $sidebar-widths: (
     --#{$prefix}sidebar-toggler-color: #{$sidebar-toggler-color};
     --#{$prefix}sidebar-toggler-icon: #{escape-svg($sidebar-toggler-icon)};
     --#{$prefix}sidebar-toggler-hover-color: #{$sidebar-toggler-hover-color};
-    --#{$prefix}sidebar-toggler-focus-shadow: #{$sidebar-toggler-focus-shadow};
     --#{$prefix}sidebar-toggler-focus-color: #{$sidebar-toggler-focus-color};
     --#{$prefix}sidebar-toggler-transition: #{$sidebar-toggler-transition};
     // scss-docs-end sidebar-toggler-css-vars
@@ -266,8 +265,7 @@ $sidebar-widths: (
     }
 
     &:focus-visible {
-      outline: 0;
-      box-shadow: var(--#{$prefix}sidebar-toggler-focus-shadow);
+      @include focus-ring(true);
 
       &::before {
         background-color: var(--#{$prefix}sidebar-toggler-focus-color);


### PR DESCRIPTION
`.sidebar-toggler:focus-visible` set `outline: 0` and replaced it with `box-shadow: var(--cui-sidebar-toggler-focus-shadow)`, whose value was the `--cui-focus-ring` shorthand — `<width> solid <color>`. `box-shadow` does not accept the `solid` keyword, so the declaration was invalid and dropped, and the `outline: 0` next to it removed the native ring.

Measured in Chromium on a focused toggler:

| | before | after |
| --- | --- | --- |
| `box-shadow` | `none` | `none` |
| `outline-width` | `0px` | **`4px`** |
| `outline-style` | `none` | **`solid`** |

So keyboard users had **no focus indicator at all** on the control that opens the sidebar — WCAG 2.4.7.

It draws the ring with the shared `focus-ring()` mixin now, like the other 25 places in the stylesheet. The close button had already moved to the mixin; the sidebar was the last consumer of the `box-shadow` mechanism, which is why `--cui-sidebar-toggler-focus-shadow` was the only `*-focus-shadow` token left in the library. It and `$sidebar-toggler-focus-shadow` are removed.

The migration guide named `$btn-close-focus-shadow` and `$sidebar-toggler-focus-shadow` as taking the token instead — neither variable exists any more. That sentence is corrected and the removed token documented.

`--cui-focus-ring` stays: it has no consumer of ours now, but it is documented public API and upstream reads it in their focus-ring mixin. Ours composes the outline by hand because it carries the theme slot the shorthand has no room for.