### PR TITLE
docs: surface the browser-floor rationale and refresh the a11y resources

### DIFF
--- a/docs/src/content/docs/getting-started/accessibility.mdx
+++ b/docs/src/content/docs/getting-started/accessibility.mdx
@@ -42,7 +42,7 @@ For visually hidden interactive controls, such as traditional "skip" links, use 
 
 ### Reduced motion
 
-CoreUI for Bootstrap includes support for the [`prefers-reduced-motion` media feature](https://drafts.csswg.org/mediaqueries-5/#prefers-reduced-motion). In browsers/environments that allow the user to specify their preference for reduced motion, most CSS transition effects in CoreUI for Bootstrap (for instance, when a modal dialog is opened or closed, or the sliding animation in carousels) will be disabled, and meaningful animations (such as spinners) will be slowed down.
+CoreUI for Bootstrap includes support for the [`prefers-reduced-motion` media feature](https://www.w3.org/TR/mediaqueries-5/#prefers-reduced-motion). In browsers/environments that allow the user to specify their preference for reduced motion, most CSS transition effects in CoreUI for Bootstrap (for instance, when a modal dialog is opened or closed, or the sliding animation in carousels) will be disabled, and meaningful animations (such as spinners) will be slowed down.
 
 On browsers that support `prefers-reduced-motion`, and where the user has *not* explicitly signaled that they'd prefer reduced motion (i.e. where `prefers-reduced-motion: no-preference`), CoreUI for Bootstrap enables smooth scrolling using the `scroll-behavior` property.
 
@@ -50,9 +50,10 @@ On browsers that support `prefers-reduced-motion`, and where the user has *not* 
 
 - [Web Content Accessibility Guidelines (WCAG) 2.2](https://www.w3.org/TR/WCAG/)
 - [The A11Y Project](https://www.a11yproject.com/)
+- [Introduction to Web Accessibility](https://www.w3.org/WAI/fundamentals/accessibility-intro/)
 - [MDN accessibility documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility)
 - [Tenon.io Accessibility Checker](https://tenon.io/)
-- [Color Contrast Analyser (CCA)](https://developer.paciellogroup.com/resources/contrastanalyser/)
+- [Color Contrast Analyser (CCA)](https://www.tpgi.com/color-contrast-checker/)
 - ["HTML Codesniffer" bookmarklet for identifying accessibility issues](https://github.com/squizlabs/HTML_CodeSniffer)
 - [Microsoft Accessibility Insights](https://accessibilityinsights.io/)
 - [Deque Axe testing tools](https://www.deque.com/axe/)

--- a/docs/src/content/docs/getting-started/browsers-devices.mdx
+++ b/docs/src/content/docs/getting-started/browsers-devices.mdx
@@ -14,6 +14,8 @@ shipped: **Chrome 123, Edge 123, Firefox 130, Safari 17.5 and iOS 17.5**.
 Together with the evergreen lines below, this covers about 89% of global usage
 as measured with `npx browserslist --coverage`.
 
+### Why these versions?
+
 Each floor is set by the newest feature v6 already requires, because the floor
 has to hold for the whole 6.x line:
 


### PR DESCRIPTION
The table explaining which platform feature sets which browser floor sat inside `## Supported browsers` with no heading of its own, so it never reached the table of contents — the one part of that page a reader goes looking for. It gets `### Why these versions?` now.

On the accessibility page:

- `prefers-reduced-motion` linked the CSSWG editor's draft instead of the stable TR
- the Color Contrast Analyser link still used the old Paciello Group domain, which only resolves through a redirect
- W3C's Introduction to Web Accessibility was missing from the resources

Checked while I was there and left alone: the contrast example uses `.text-danger`, which exists in our CSS — `.fg-danger` does not. And the coverage figure the page claims, "about 89%", matches `npx browserslist --coverage` at 88.88%.