### PR TITLE
docs: Guides section parity — JS pipeline, tool intros, font swap

### DIFF
--- a/docs/src/content/docs/content/typography.mdx
+++ b/docs/src/content/docs/content/typography.mdx
@@ -12,9 +12,36 @@ CoreUI for Bootstrap sets basic global display, typography, and link styles. Whe
 - For a more inclusive and accessible type scale, we use the browser's default root `font-size` (typically 16px) so visitors can customize their browser defaults as needed.
 - Use the `$font-family-base`, `$font-size-base`, and `$line-height-base` attributes as our typographic base applied to the `<body>`.
 - Set the global link color via `$link-color` and the underline's distance from the text via `$link-underline-offset`.
-- Use `$body-bg` to set a `background-color` on the `<body>` (`#fff` by default).
+- Use `$bg-body` to set a `background-color` on the `<body>` — `light-dark()` picks white or `--cui-gray-975`, so one value covers both color modes.
 
 These styles can be found within `content/_reboot.scss`, and the global variables are defined in `_config.scss`. Make sure to set `$font-size-base` in `rem`.
+
+### Using a custom font
+
+The default is a [native font stack](/content/reboot/#native-font-stack), which needs no download and matches the host OS. To use a web font instead, load it and point the two font tokens at it — no Sass compilation involved.
+
+Add the font to your `<head>`, before CoreUI's CSS:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+```
+
+Then override the tokens, in a `<style>` tag or your own stylesheet:
+
+```css
+:root {
+  --cui-font-sans-serif: "Inter", system-ui, sans-serif;
+  --cui-font-monospace: "JetBrains Mono", ui-monospace, monospace;
+}
+```
+
+Keep the generic families at the end of each stack: they are what renders while the web font loads, and what renders if it fails.
+
+`--cui-body-font-family` reads `--cui-font-sans-serif`, so setting the stack covers the body and everything inheriting from it. Set `--cui-body-font-family` directly only when you want the body to differ from the rest.
+
+The same works from Sass if you compile your own build — set `$font-family-sans-serif` and `$font-family-monospace` before importing CoreUI.
 
 ## Headings
 

--- a/docs/src/content/docs/guides/build-tools.mdx
+++ b/docs/src/content/docs/guides/build-tools.mdx
@@ -34,9 +34,17 @@ Dart Sass uses a rounding precision of 10 and for efficiency reasons does not al
 
 ## Autoprefixer
 
-CoreUI for Bootstrap uses [Autoprefixer](https://github.com/postcss/autoprefixer) (included in our build process) to automatically add vendor prefixes to some CSS properties at build time. Doing so saves us time and code by allowing us to write key parts of our CSS a single time while eliminating the need for vendor mixins like those found in v3.
+CoreUI for Bootstrap uses [Autoprefixer](https://github.com/postcss/autoprefixer) (included in our build process) to automatically add vendor prefixes to some CSS properties at build time, so we write each declaration once instead of maintaining prefixed copies of it.
 
 We maintain the list of browsers supported through Autoprefixer in a separate file within our GitHub repository. See [.browserslistrc](https://github.com/coreui/coreui/blob/v[[config:current_version]]/.browserslistrc) for details.
+
+## JavaScript
+
+Our JavaScript source is TypeScript and lives in `js/src/`. We bundle it with [Rolldown](https://rolldown.rs/), then minify the output with [terser](https://github.com/terser/terser). Rolldown strips the types and lowers the syntax itself, so there is no Babel step.
+
+Rolldown does not read `.browserslistrc`, so [build/browser-targets.mjs](https://github.com/coreui/coreui/blob/v[[config:current_version]]/build/browser-targets.mjs) resolves that file at build time and converts it into the target list the bundler expects. Both pipelines therefore honor one browser list — change `.browserslistrc` and the CSS prefixes and the JS syntax level move together.
+
+We ship our own type declarations, emitted by `npm run js-emit-types`, so no `@types/` package is needed. The bundler configuration is in [build/rolldown.config.mjs](https://github.com/coreui/coreui/blob/v[[config:current_version]]/build/rolldown.config.mjs).
 
 ## Local documentation
 

--- a/docs/src/content/docs/guides/django.mdx
+++ b/docs/src/content/docs/guides/django.mdx
@@ -43,7 +43,7 @@ If you only want the compiled files, you don't need Node.js at all: put `coreui.
    npm i --save-dev vite sass
    ```
 
-Now that we have all the necessary dependencies installed and setup, we can get to work creating the project files and importing CoreUI.
+Now that we have all the necessary dependencies installed and set up, we can get to work creating the project files and importing CoreUI.
 
 ## Project structure
 

--- a/docs/src/content/docs/guides/laravel.mdx
+++ b/docs/src/content/docs/guides/laravel.mdx
@@ -41,7 +41,7 @@ description: "The official guide for how to include and bundle CoreUI’s CSS an
    npm remove tailwindcss @tailwindcss/vite
    ```
 
-Now that we have all the necessary dependencies installed and setup, we can get to work creating the project files and importing CoreUI.
+Now that we have all the necessary dependencies installed and set up, we can get to work creating the project files and importing CoreUI.
 
 ## Project structure
 

--- a/docs/src/content/docs/guides/npm.mdx
+++ b/docs/src/content/docs/guides/npm.mdx
@@ -36,21 +36,21 @@ We're building a npm project with CoreUI from scratch, so there are some prerequ
    npm i --save-dev autoprefixer postcss postcss-cli sass
    ```
 
-4. **Install local development tools.** Lastly, to make life a little easier, we recommend some dev tools for running a local server with automatic rebuilds. We use `nodemon` to watch files for changes, `npm-run-all` to run multiple npm scripts at a time, and `sirv-cli` to run a local server.
+4. **Install local development tools.** Lastly, to make life a little easier, we recommend some dev tools for running a local server with automatic rebuilds. We use `nodemon` to watch files for changes, `npm-run-all` to run multiple npm scripts at a time, `sirv-cli` to run a local server, and `stylelint` to keep your Sass consistent with the style CoreUI is written in.
 
    ```sh
-   npm i --save-dev nodemon npm-run-all sirv-cli
+   npm i --save-dev nodemon npm-run-all sirv-cli stylelint stylelint-config-twbs-bootstrap
    ```
 
 Now that we have all the necessary dependencies installed, we can get to work creating the project files and importing CoreUI.
 
 ## Project structure
 
-We've already created the `my-project` folder and initialized npm. Now we'll also create our `scss` folder, stylesheet, and configuration file to round out the project structure. Run the following from `my-project`, or manually create the folder and file structure shown below.
+We've already created the `my-project` folder and initialized npm. Now we'll also create our `scss` folder, stylesheet, and configuration files to round out the project structure. Run the following from `my-project`, or manually create the folder and file structure shown below.
 
 ```sh
 mkdir {css,scss}
-touch index.html scss/styles.scss postcss.config.js
+touch index.html scss/styles.scss postcss.config.js stylelint.config.mjs
 ```
 
 When you're done, your project should look like this:
@@ -63,7 +63,8 @@ my-project/
 ├── index.html
 ├── package-lock.json
 ├── package.json
-└── postcss.config.js
+├── postcss.config.js
+└── stylelint.config.mjs
 ```
 
 At this point, everything is in the right place, but we'll need to configure our files and add some npm scripts to compile the CSS.
@@ -125,7 +126,7 @@ With dependencies installed and our project folder ready for us to start coding,
 
    *[Read our JavaScript docs](/getting-started/javascript/) for more information on how to use CoreUI's plugins.*
 
-4. **Add npm scripts to `package.json`.** Open `package.json` and add the following scripts. We use `sass` to compile our Sass (with `--load-path=node_modules` so it can resolve CoreUI), `postcss-cli` to apply Autoprefixer, `nodemon` to watch for changes, `npm-run-all` to run scripts in sequence or in parallel, and `sirv-cli` to serve our project.
+4. **Add npm scripts to `package.json`.** Open `package.json` and add the following scripts. We use `sass` to compile our Sass (with `--load-path=node_modules` so it can resolve CoreUI), `postcss-cli` to apply Autoprefixer, `nodemon` to watch for changes, `npm-run-all` to run scripts in sequence or in parallel, `sirv-cli` to serve our project, and `stylelint` to lint our Sass.
 
    ```json
    {
@@ -136,13 +137,23 @@ With dependencies installed and our project folder ready for us to start coding,
        "build": "npm-run-all --sequential css-compile css-prefix",
        "watch": "nodemon --watch scss/ --ext scss --exec \"npm run build\"",
        "serve": "sirv --port 8080 --dev .",
-       "start": "npm-run-all build --parallel watch serve"
+       "start": "npm-run-all build --parallel watch serve",
+       "lint": "stylelint \"scss/**/*.scss\""
      },
      // ...
    }
    ```
 
-5. **And finally, we can start the npm scripts.** From the `my-project` folder in your terminal, run that newly added npm script:
+5. **Configure `stylelint.config.mjs`.** `stylelint-config-twbs-bootstrap` is the shared config CoreUI's own stylesheets are linted with, so your Sass follows the same rules as the source you are extending.
+
+   ```js
+   /** @type {import('stylelint').Config} */
+   export default {
+     extends: 'stylelint-config-twbs-bootstrap',
+   }
+   ```
+
+6. **And finally, we can start the npm scripts.** From the `my-project` folder in your terminal, run that newly added npm script:
 
    ```sh
    npm start

--- a/docs/src/content/docs/guides/npm.mdx
+++ b/docs/src/content/docs/guides/npm.mdx
@@ -9,9 +9,9 @@ description: "The official guide for how to build a starter project with CoreUIâ
 
 ## Setup
 
-We're building a npm project with CoreUI from scratch, so there are some prerequisites and up front steps before we can really get started. This guide requires you to have Node.js installed and some familiarity with the terminal.
+We're building a npm project with CoreUI from scratch, so there are some prerequisites and upfront steps before we can really get started. This guide requires you to have Node.js installed and some familiarity with the terminal.
 
-1. **Create a project folder and setup npm.** We'll create the `my-project` folder and initialize npm with the `-y` argument to avoid it asking us all the interactive questions.
+1. **Create a project folder and set up npm.** We'll create the `my-project` folder and initialize npm with the `-y` argument to avoid it asking us all the interactive questions.
 
    ```sh
    mkdir my-project && cd my-project

--- a/docs/src/content/docs/guides/parcel.mdx
+++ b/docs/src/content/docs/guides/parcel.mdx
@@ -3,11 +3,15 @@ title: "CoreUI & Parcel"
 description: "The official guide for how to include and bundle CoreUI's CSS and JavaScript in your project using Parcel."
 ---
 
+## What is Parcel?
+
+[Parcel](https://parceljs.org/) is a web application bundler with a zero-configuration setup out of the box. It offers what the more advanced bundlers do while staying easy to start with.
+
 ## Setup
 
-We're building a Parcel project with CoreUI from scratch, so there are some prerequisites and up front steps before we can really get started. This guide requires you to have Node.js installed and some familiarity with the terminal.
+We're building a Parcel project with CoreUI from scratch, so there are some prerequisites and upfront steps before we can really get started. This guide requires you to have Node.js installed and some familiarity with the terminal.
 
-1. **Create a project folder and setup npm.** We'll create the `my-project` folder and initialize npm with the `-y` argument to avoid it asking us all the interactive questions.
+1. **Create a project folder and set up npm.** We'll create the `my-project` folder and initialize npm with the `-y` argument to avoid it asking us all the interactive questions.
 
    ```sh
    mkdir my-project && cd my-project

--- a/docs/src/content/docs/guides/vite.mdx
+++ b/docs/src/content/docs/guides/vite.mdx
@@ -3,11 +3,15 @@ title: "CoreUI & Vite"
 description: "The official guide for how to include and bundle CoreUI's CSS and JavaScript in your project using Vite."
 ---
 
+## What is Vite?
+
+[Vite](https://vite.dev/) is a modern frontend build tool built for speed: an unbundled dev server that starts instantly, and a production build on Rollup.
+
 ## Setup
 
-We're building a Vite project with CoreUI from scratch, so there are some prerequisites and up front steps before we can really get started. This guide requires you to have Node.js installed and some familiarity with the terminal.
+We're building a Vite project with CoreUI from scratch, so there are some prerequisites and upfront steps before we can really get started. This guide requires you to have Node.js installed and some familiarity with the terminal.
 
-1. **Create a project folder and setup npm.** We'll create the `my-project` folder and initialize npm with the `-y` argument to avoid it asking us all the interactive questions.
+1. **Create a project folder and set up npm.** We'll create the `my-project` folder and initialize npm with the `-y` argument to avoid it asking us all the interactive questions.
 
    ```sh
    mkdir my-project && cd my-project
@@ -38,7 +42,7 @@ We're building a Vite project with CoreUI from scratch, so there are some prereq
    npm i --save-dev sass
    ```
 
-Now that we have all the necessary dependencies installed and setup, we can get to work creating the project files and importing CoreUI.
+Now that we have all the necessary dependencies installed and set up, we can get to work creating the project files and importing CoreUI.
 
 ## Project structure
 

--- a/docs/src/content/docs/guides/webpack.mdx
+++ b/docs/src/content/docs/guides/webpack.mdx
@@ -3,11 +3,15 @@ title: "CoreUI & Webpack"
 description: "The official guide for how to include and bundle CoreUI's CSS and JavaScript in your project using Webpack."
 ---
 
+## What is Webpack?
+
+[Webpack](https://webpack.js.org/) is a JavaScript module bundler that processes modules and their dependencies to generate static assets. It simplifies managing complex web applications with multiple files and dependencies.
+
 ## Setup
 
-We're building a Webpack project with CoreUI from scratch, so there are some prerequisites and up front steps before we can really get started. This guide requires you to have Node.js installed and some familiarity with the terminal.
+We're building a Webpack project with CoreUI from scratch, so there are some prerequisites and upfront steps before we can really get started. This guide requires you to have Node.js installed and some familiarity with the terminal.
 
-1. **Create a project folder and setup npm.** We'll create the `my-project` folder and initialize npm with the `-y` argument to avoid it asking us all the interactive questions.
+1. **Create a project folder and set up npm.** We'll create the `my-project` folder and initialize npm with the `-y` argument to avoid it asking us all the interactive questions.
 
    ```sh
    mkdir my-project && cd my-project


### PR DESCRIPTION
The Guides pass of the upstream docs comparison, plus one fix on Typography that came out of it.

**The contributor page said nothing about how the JavaScript is built.** It covered Sass and Autoprefixer and stopped. Adds `## JavaScript`: TypeScript in `js/src/`, bundled with Rolldown, minified with terser, and `build/browser-targets.mjs` translating `.browserslistrc` into the target list the bundler expects — so one browser list drives the CSS prefixes and the JS syntax level together. Verified against our own build before writing it: `rolldown` and `terser` in the scripts, all three build files present.

**Webpack, Parcel and Vite dropped the reader straight into Setup** with no sentence saying what the tool is. The npm guide already had one, so this was inconsistent with our own docs as much as with upstream.

**The npm guide left the reader's Sass unchecked.** Adds stylelint with `stylelint-config-twbs-bootstrap` — the config our own stylesheets are linted with — plus the config file, the `lint` script and the project-structure entries. Upstream adds it only to the npm guide; the other three are left alone to match.

**Typography named `$body-bg`, which does not exist in v6** — it is `$bg-body`, with `--cui-body-bg` surviving as a deprecated alias. Sass accepts an unused variable declaration silently, so following that line did nothing. The other five variables the section names were checked and all exist.

**Nothing documented how to swap the font.** Adds it under Global settings, with our token names — upstream's snippet sets `--bs-font-mono`, a name that does not exist here.

Also: `setup` used as a verb in eleven places across the guides.

Kept as ours, deliberately: our `browserslist` step (upstream has none, and without it Autoprefixer silently skips prefixes our floor still needs), the `"type": "commonjs"` and `"main": "index.js"` troubleshooting notes with their exact error messages, the free/PRO snippets, and the simpler Webpack layout that needs no `html-webpack-plugin`.