### PR TITLE
chore(scss): drop add() and subtract()

### DIFF
--- a/docs/src/content/docs/customize/sass.mdx
+++ b/docs/src/content/docs/customize/sass.mdx
@@ -377,49 +377,7 @@ $subtle-backgrounds: map-slot($theme-colors, "bg-subtle");
 // => ("primary": …, "secondary": …, "success": …, …)
 ```
 
-`scss/functions/maps` also carries the general-purpose helpers the library uses internally: `map-get-multiple()` (pick several keys), `map-merge-multiple()` (merge several maps), and `map-get-nested()` (pull one sub-key out of every entry).
-
-### Add and Subtract functions
-
-We use the `add` and `subtract` functions to wrap the CSS `calc` function. The primary purpose of these functions is to avoid errors when a "unitless" `0` value is passed into a `calc` expression. Expressions like `calc(10px - 0)` will return an error in all browsers, despite being mathematically correct.
-
-Example where the calc is valid:
-
-```scss
-@use "@coreui/coreui/scss/functions/math" as *;
-
-$border-radius: .25rem;
-$border-width: 1px;
-
-.element {
-  // Output calc(.25rem - 1px) is valid
-  border-radius: calc($border-radius - $border-width);
-}
-
-.element {
-  // Output the same calc(.25rem - 1px) as above
-  border-radius: subtract($border-radius, $border-width);
-}
-```
-
-Example where the calc is invalid:
-
-```scss
-@use "@coreui/coreui/scss/functions/math" as *;
-
-$border-radius: .25rem;
-$border-width: 0;
-
-.element {
-  // Output calc(.25rem - 0) is invalid
-  border-radius: calc($border-radius - $border-width);
-}
-
-.element {
-  // Output .25rem
-  border-radius: subtract($border-radius, $border-width);
-}
-```
+`scss/functions/maps` also carries the general-purpose helpers the library uses internally: `map-get-multiple()` (pick several keys), `map-merge-multiple()` (merge several maps), `map-get-nested()` (pull one sub-key out of every entry), and `negativify-map()` (turn a scale into its negative counterpart, as the spacing utilities do).
 
 ## Mixins
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -2273,6 +2273,13 @@ them. A state names a theme colour now, and every value is a slot of it.
   the toggler had no focus indicator at all. The ring is an `outline` now,
   like everywhere else; restyle it through `--cui-focus-ring-width`,
   `--cui-focus-ring-color` and `--cui-focus-ring-offset`.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`add()` and `subtract()` are removed.** They wrapped `calc()` to keep a
+  unitless `0` from making the expression invalid. v6 computes derived values
+  in the browser, so the stylesheet reaches for `calc()` directly — 243 times,
+  and not once for these two. Write the `calc()` yourself; guard a possible
+  `0` with `if($value == 0, …)` where it can actually occur. `divide()` stays,
+  the grid still uses it.
 - **`form-validation-state()` takes `$theme` where it took `$color`**, and the
   variables moved from `scss/_config.scss` into the partials that use them
   alongside `$form-text-*` and `$form-feedback-*`.

--- a/scss/functions/_math.scss
+++ b/scss/functions/_math.scss
@@ -1,48 +1,5 @@
 @use "sass:map";
 @use "sass:math";
-@use "sass:meta";
-@use "sass:string";
-
-// Return valid calc
-@function add($value1, $value2, $return-calc: true) {
-  @if $value1 == null {
-    @return $value2;
-  }
-
-  @if $value2 == null {
-    @return $value1;
-  }
-
-  @if meta.type-of($value1) == number and meta.type-of($value2) == number and math.compatible($value1, $value2) {
-    @return $value1 + $value2;
-  }
-
-  @return if(sass($return-calc == true): calc(#{$value1} + #{$value2}); else: $value1 + string.unquote(" + ") + $value2);
-}
-
-@function subtract($value1, $value2, $return-calc: true) {
-  @if $value1 == null and $value2 == null {
-    @return null;
-  }
-
-  @if $value1 == null {
-    @return -$value2;
-  }
-
-  @if $value2 == null {
-    @return $value1;
-  }
-
-  @if meta.type-of($value1) == number and meta.type-of($value2) == number and math.compatible($value1, $value2) {
-    @return $value1 - $value2;
-  }
-
-  @if meta.type-of($value2) != number {
-    $value2: string.unquote("(") + $value2 + string.unquote(")");
-  }
-
-  @return if(sass($return-calc == true): calc(#{$value1} - #{$value2}); else: $value1 + string.unquote(" - ") + $value2);
-}
 
 @function divide($dividend, $divisor, $precision: 10) {
   // stylelint-disable-next-line scss/at-function-named-arguments


### PR DESCRIPTION
Found comparing our Sass page against upstream's: we documented two functions under their own heading that the library no longer uses anywhere.

Both wrapped `calc()` to keep a unitless `0` from making the expression invalid — the pre-v6 pattern, from when derived values were computed in Sass. v6 computes them in the browser and writes `calc()` directly.

Measured before removing:

| | uses in `scss/` |
| --- | --- |
| `add()` | **0** |
| `subtract()` | **0** |
| `calc()` | 243 |

No callers in `scss/`, none in the docs outside the section describing them, and **upstream deleted both in v6** as well.

`divide()` stays — the grid mixins use it three times. The `sass:meta` and `sass:string` imports go with the functions that needed them; `sass:map` and `sass:math` remain for `divide()`.

The Sass page's `### Add and Subtract functions` section is gone. In its place the Map helpers list is completed with `negativify-map()`, which the spacing utilities actually use and which was the one helper we shipped and never named.

Migration entry added. `npm run css-compile` clean, `css-test` 62 passing, docs build green.

Separately corrected in the workspace notes: our own `CLAUDE.md` still claimed stylelint bans `calc()` with "123 disables in SCSS" and told us to keep adding `// stylelint-disable-line`. `function-disallowed-list` lists only `lighten` and `darken` today, and there are **zero** such disables in `scss/`.