### PR TITLE
fix(scss): let the highlight background follow --cui-yellow

### DIFF
--- a/scss/_colors.scss
+++ b/scss/_colors.scss
@@ -133,13 +133,6 @@ $min-contrast-ratio:   4.5 !default;
 $color-contrast-dark:      $black !default;
 $color-contrast-light:     $white !default;
 
-// fusv-disable
-
-$yellow-100: tint-color($yellow, 80%) !default;
-$yellow-800: shade-color($yellow, 60%) !default;
-
-// fusv-enable
-
 // The palette: the base colours, the grays, and their maps. The theme colour
 // system built on top of them lives in _theme.scss.
 //

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -81,7 +81,7 @@ $font-family-monospace:  SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mo
 
 // scss-docs-start type-variables
 $mark-color: var(--#{$prefix}fg-body) !default;
-$mark-bg:    light-dark($yellow-100, $yellow-800) !default;
+$mark-bg:    light-dark(var(--#{$prefix}yellow-100), var(--#{$prefix}yellow-800)) !default;
 // scss-docs-end type-variables
 
 $icon-size-base: 1rem !default;


### PR DESCRIPTION
Every yellow step is a `color-mix()` that names `var(--cui-yellow)`, so overriding that one token retints the whole scale in the browser. `--cui-highlight-bg` was the exception.

`$mark-bg` read `$yellow-100` and `$yellow-800` — two Sass variables computed with `tint-color()` / `shade-color()` at build time — so the token compiled to frozen literals:

```css
--cui-highlight-bg: light-dark(rgb(100%, 95.13%, 80.55%), rgb(40%, 30.27%, 1.09%));
```

`<mark>` therefore kept the old yellow while every other yellow followed the override. It reads the tokens directly now:

```css
--cui-highlight-bg: light-dark(var(--cui-yellow-100), var(--cui-yellow-800));
```

Measured in Chromium, setting `--cui-yellow: #ff0000` on `:root` after load:

| | background |
| --- | --- |
| before | `lab(96.42 2.75 16.49)` → unchanged by the override |
| after | `lab(96.42 2.75 16.49)` → `lab(90.86 16.18 13.98)` |

The two Sass variables had no other callers and go with the change, along with the `fusv-disable` that was keeping them out of the unused-variable check — which is what flagged them as suspicious in the first place.

`css-test` 62 passing, bundlewatch PASS, docs build green.