### PR TITLE
docs(architecture): map the token layers to the files they live in

### DIFF
--- a/docs/src/content/docs/customize/architecture.mdx
+++ b/docs/src/content/docs/customize/architecture.mdx
@@ -7,6 +7,17 @@ description: "How the v6 styling system is put together: cascade layers, design 
 
 Four mechanisms carry the whole v6 styling system. Each one has a page of its own for the details; this page shows how they fit together, and where your overrides plug in.
 
+Where each piece lives, from the raw hue up to the component:
+
+| Layer | File | What it defines |
+| --- | --- | --- |
+| Color scales | `scss/_colors.scss` | One base token per color, expanded into the `100`–`900` steps with `color-mix()` against `$tint-color` / `$shade-color`. The mix names the base token, not its value, so overriding `--cui-primary` retints the whole scale in the browser. The grays are hand-picked stops rather than a mix, because a neutral ramp has to stay neutral. |
+| Theme colors | `scss/_theme.scss` | `$theme-colors`, one nested map per role (`primary`, `danger`, …), each holding `base`, `fg`, `text-emphasis`, `bg`, `bg-subtle`, `bg-muted`, `border-subtle`, `focus-ring` and `contrast` |
+| Global tokens | `scss/_root.scss` | `$root-tokens`, everything emitted on `:root, :host` — spacing, radii, typography, z-index and the surface ladders |
+| Component tokens | the component's own partial | `$alert-tokens`, `$card-tokens` and the rest, emitted on the component's base class |
+
+Each layer reads the one below it, so a change low down travels upward: retint `--cui-blue-500` and every theme role built on blue follows, along with every component reading those roles.
+
 ## Cascade layers
 
 Every rule the library ships lives in a [cascade layer](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer). The order is declared once, at the top of the bundle:


### PR DESCRIPTION
The page explained how overriding works and never said where anything is, so the first question a reader has — which file do I open to change this — had no answer. Adds a four-row map from the color scales up to the component tokens, naming the file and the map at each level.

Every claim in it was checked against the source. The first draft said our scales come from an `oklch()` base the way upstream's do; `scss/_colors.scss` contains no `oklch()` at all. Ours mix in `lab` against the color's own **token** — `color-mix(in lab, var(--cui-white) 80%, var(--cui-primary))` — which is why overriding `--cui-primary` retints the whole scale at runtime. Upstream inlines the `oklch()` literal into every step instead of referencing the base token, so the same override does not propagate on their side.

The grays are hand-picked stops rather than a mix, and the table says why: a neutral ramp has to stay neutral.