### PR TITLE
docs(sass): document mask-icon() and point at the mixins living elsewhere

### DIFF
--- a/docs/src/content/docs/customize/sass.mdx
+++ b/docs/src/content/docs/customize/sass.mdx
@@ -383,6 +383,8 @@ $subtle-backgrounds: map-slot($theme-colors, "bg-subtle");
 
 Our `scss/mixins/` directory has a ton of mixins that power parts of CoreUI for Bootstrap and can also be used across your own project.
 
+Two of the mixins you are most likely to reach for are documented elsewhere, next to the systems they belong to: `tokens()`, which turns a token map into custom properties on a class, in [Architecture](/customize/architecture/#component-tokens), and the theme class generator in [Theme](/customize/theme/#theme-classes).
+
 ### Color schemes
 
 A shorthand mixin for the `prefers-color-scheme` media query is available with support for `light`, `dark`, and custom color schemes.
@@ -402,3 +404,20 @@ A shorthand mixin for the `prefers-color-scheme` media query is available with s
   }
 }
 ```
+
+### Mask icons
+
+An icon carried as a `background-image` paints the colour baked into the SVG, so it cannot follow a theme. `mask-icon()` renders the shape through a CSS mask instead, which paints it with the element's `background-color` — so the icon takes whatever token that property reads.
+
+<ScssDocs file="scss/mixins/_mask-icon.scss" capture="mask-icon-mixin" />
+
+```scss
+@use "@coreui/coreui/scss/mixins/mask-icon" as *;
+
+.my-toggle {
+  @include mask-icon(url("data:image/svg+xml,…"));
+  background-color: var(--cui-theme-fg, var(--cui-fg-2));
+}
+```
+
+Pass `null` for the icon when the shape is applied conditionally — per state, or per direction — and set `mask-image` in the branch that needs it.


### PR DESCRIPTION
`mask-icon()` is how an icon follows a token instead of carrying its colour inside the SVG — a `background-image` paints what is baked into the file, a mask paints with the element's `background-color`. Our accordion, navbar, carousel, header and checkbox icons all rely on it, it ships with a `scss-docs` block ready to render, and no page described it. Anyone adding their own icon to a themed component had no way to learn the pattern.

The Mixins section also listed exactly one mixin. We ship 63; most are internal helpers that do not belong in a reference, but two of the ones a reader is most likely to want are documented next to the systems they belong to — `tokens()` on Architecture, the theme class generator on Theme — and nothing here said so. Both anchors verified in the built HTML, since the link checker does not follow fragments.