### PR TITLE
refactor(scss)!: finish renaming the theme colour tokens to the slot names

### DIFF
--- a/docs/src/content/docs/customize/color-modes.mdx
+++ b/docs/src/content/docs/customize/color-modes.mdx
@@ -97,7 +97,7 @@ $color-mode-type: data;
 
 @include color-mode(dark) {
   .element {
-    color: var(--cui-primary-text-emphasis);
+    color: var(--cui-primary-fg-emphasis);
     background-color: var(--cui-primary-bg-subtle);
   }
 }
@@ -107,7 +107,7 @@ Outputs to:
 
 ```css
 [data-coreui-theme=dark] .element {
-  color: var(--cui-primary-text-emphasis);
+  color: var(--cui-primary-fg-emphasis);
   background-color: var(--cui-primary-bg-subtle);
 }
 ```
@@ -119,7 +119,7 @@ $color-mode-type: media-query;
 
 @include color-mode(dark) {
   .element {
-    color: var(--cui-primary-text-emphasis);
+    color: var(--cui-primary-fg-emphasis);
     background-color: var(--cui-primary-bg-subtle);
   }
 }
@@ -130,7 +130,7 @@ Outputs to:
 ```css
 @media (prefers-color-scheme: dark) {
   .element {
-    color: var(--cui-primary-text-emphasis);
+    color: var(--cui-primary-fg-emphasis);
     background-color: var(--cui-primary-bg-subtle);
   }
 }
@@ -245,7 +245,7 @@ $theme-colors: map.merge($theme-colors, (
     "base":          #712cf9,
     "contrast":      #fff,
     "fg":            light-dark(var(--cui-custom-color-600), var(--cui-custom-color-400)),
-    "text-emphasis": light-dark(var(--cui-custom-color-800), var(--cui-custom-color-200)),
+    "fg-emphasis": light-dark(var(--cui-custom-color-800), var(--cui-custom-color-200)),
     "bg-subtle":     light-dark(var(--cui-custom-color-100), var(--cui-custom-color-900)),
     "bg-muted":      light-dark(var(--cui-custom-color-200), var(--cui-custom-color-800)),
     "border-subtle": light-dark(var(--cui-custom-color-300), var(--cui-custom-color-600)),

--- a/docs/src/content/docs/customize/color.mdx
+++ b/docs/src/content/docs/customize/color.mdx
@@ -126,18 +126,18 @@ To fade any of these colors, mix it toward `transparent` rather than reaching fo
     </tr>
     <tr>
       <td>
-        <div class="p-3 rounded-2" style="border: 5px var(--cui-primary-border-subtle) solid">&nbsp;</div>
+        <div class="p-3 rounded-2" style="border: 5px var(--cui-primary-border) solid">&nbsp;</div>
       </td>
       <td>
-        `--cui-primary-border-subtle`
+        `--cui-primary-border`
       </td>
     </tr>
     <tr>
       <td>
-        <div class="py-3 fw-bold h5" style="color: var(--cui-primary-text-emphasis)">Text</div>
+        <div class="py-3 fw-bold h5" style="color: var(--cui-primary-fg-emphasis)">Text</div>
       </td>
       <td>
-        `--cui-primary-text-emphasis`
+        `--cui-primary-fg-emphasis`
       </td>
     </tr>
     <tr>
@@ -161,18 +161,18 @@ To fade any of these colors, mix it toward `transparent` rather than reaching fo
     </tr>
     <tr>
       <td>
-        <div class="p-3 rounded-2" style="border: 5px var(--cui-success-border-subtle) solid">&nbsp;</div>
+        <div class="p-3 rounded-2" style="border: 5px var(--cui-success-border) solid">&nbsp;</div>
       </td>
       <td>
-        `--cui-success-border-subtle`
+        `--cui-success-border`
       </td>
     </tr>
     <tr>
       <td>
-        <div class="py-3 fw-bold h5" style="color: var(--cui-success-text-emphasis)">Text</div>
+        <div class="py-3 fw-bold h5" style="color: var(--cui-success-fg-emphasis)">Text</div>
       </td>
       <td>
-        `--cui-success-text-emphasis`
+        `--cui-success-fg-emphasis`
       </td>
     </tr>
     <tr>
@@ -196,18 +196,18 @@ To fade any of these colors, mix it toward `transparent` rather than reaching fo
     </tr>
     <tr>
       <td>
-        <div class="p-3 rounded-2" style="border: 5px var(--cui-danger-border-subtle) solid">&nbsp;</div>
+        <div class="p-3 rounded-2" style="border: 5px var(--cui-danger-border) solid">&nbsp;</div>
       </td>
       <td>
-        `--cui-danger-border-subtle`
+        `--cui-danger-border`
       </td>
     </tr>
     <tr>
       <td>
-        <div class="py-3 fw-bold h5" style="color: var(--cui-danger-text-emphasis)">Text</div>
+        <div class="py-3 fw-bold h5" style="color: var(--cui-danger-fg-emphasis)">Text</div>
       </td>
       <td>
-        `--cui-danger-text-emphasis`
+        `--cui-danger-fg-emphasis`
       </td>
     </tr>
     <tr>
@@ -231,18 +231,18 @@ To fade any of these colors, mix it toward `transparent` rather than reaching fo
     </tr>
     <tr>
       <td>
-        <div class="p-3 rounded-2" style="border: 5px var(--cui-warning-border-subtle) solid">&nbsp;</div>
+        <div class="p-3 rounded-2" style="border: 5px var(--cui-warning-border) solid">&nbsp;</div>
       </td>
       <td>
-        `--cui-warning-border-subtle`
+        `--cui-warning-border`
       </td>
     </tr>
     <tr>
       <td>
-        <div class="py-3 fw-bold h5" style="color: var(--cui-warning-text-emphasis)">Text</div>
+        <div class="py-3 fw-bold h5" style="color: var(--cui-warning-fg-emphasis)">Text</div>
       </td>
       <td>
-        `--cui-warning-text-emphasis`
+        `--cui-warning-fg-emphasis`
       </td>
     </tr>
     <tr>
@@ -266,18 +266,18 @@ To fade any of these colors, mix it toward `transparent` rather than reaching fo
     </tr>
     <tr>
       <td>
-        <div class="p-3 rounded-2" style="border: 5px var(--cui-info-border-subtle) solid">&nbsp;</div>
+        <div class="p-3 rounded-2" style="border: 5px var(--cui-info-border) solid">&nbsp;</div>
       </td>
       <td>
-        `--cui-info-border-subtle`
+        `--cui-info-border`
       </td>
     </tr>
     <tr>
       <td>
-        <div class="py-3 fw-bold h5" style="color: var(--cui-info-text-emphasis)">Text</div>
+        <div class="py-3 fw-bold h5" style="color: var(--cui-info-fg-emphasis)">Text</div>
       </td>
       <td>
-        `--cui-info-text-emphasis`
+        `--cui-info-fg-emphasis`
       </td>
     </tr>
     <tr>
@@ -301,18 +301,18 @@ To fade any of these colors, mix it toward `transparent` rather than reaching fo
     </tr>
     <tr>
       <td>
-        <div class="p-3 rounded-2" style="border: 5px var(--cui-inverse-border-subtle) solid">&nbsp;</div>
+        <div class="p-3 rounded-2" style="border: 5px var(--cui-inverse-border) solid">&nbsp;</div>
       </td>
       <td>
-        `--cui-inverse-border-subtle`
+        `--cui-inverse-border`
       </td>
     </tr>
     <tr>
       <td>
-        <div class="py-3 fw-bold h5" style="color: var(--cui-inverse-text-emphasis)">Text</div>
+        <div class="py-3 fw-bold h5" style="color: var(--cui-inverse-fg-emphasis)">Text</div>
       </td>
       <td>
-        `--cui-inverse-text-emphasis`
+        `--cui-inverse-fg-emphasis`
       </td>
     </tr>
   </tbody>
@@ -477,7 +477,7 @@ every theme color's emphasis tone (e.g., `.text-purple`, `.text-success`).
 @use "@coreui/coreui/scss/theme" as *;
 @use "@coreui/coreui/scss/utilities" as *;
 
-$all-colors: map-merge-multiple($colors, map-slot($theme-colors, "text-emphasis"));
+$all-colors: map-merge-multiple($colors, map-slot($theme-colors, "fg-emphasis"));
 
 $utilities: map.merge(
   $utilities,

--- a/docs/src/content/docs/customize/sass.mdx
+++ b/docs/src/content/docs/customize/sass.mdx
@@ -194,7 +194,7 @@ $custom-colors: (
     "base":          #900,
     "contrast":      #fff,
     "fg":            light-dark(var(--cui-custom-color-600), var(--cui-custom-color-400)),
-    "text-emphasis": light-dark(var(--cui-custom-color-800), var(--cui-custom-color-200)),
+    "fg-emphasis": light-dark(var(--cui-custom-color-800), var(--cui-custom-color-200)),
     "bg-subtle":     light-dark(var(--cui-custom-color-100), var(--cui-custom-color-900)),
     "bg-muted":      light-dark(var(--cui-custom-color-200), var(--cui-custom-color-800)),
     "border-subtle": light-dark(var(--cui-custom-color-300), var(--cui-custom-color-600)),
@@ -216,7 +216,7 @@ To remove colors from `$theme-colors`, or any other map, use `map-remove`. Be aw
 @use "@coreui/coreui/scss/theme" as *;
 
 $theme-colors: map-remove($theme-colors, "info", "light", "dark");
-$theme-colors-border-subtle: map.remove($theme-colors-border-subtle, "info", "light", "dark");
+$theme-colors-border: map.remove($theme-colors-border, "info", "light", "dark");
 
 @use "@coreui/coreui/scss/coreui";
 ```

--- a/docs/src/content/docs/customize/theme.mdx
+++ b/docs/src/content/docs/customize/theme.mdx
@@ -38,10 +38,10 @@ Every entry defines the same slots, emitted as `--cui-{color}-{slot}` on `:root`
 | — | `--cui-primary-bg` | The action-background slot: what checked, active and filled states read; points at the base |
 | `contrast` | `--cui-primary-contrast` | Text and icons sitting on the solid base |
 | `fg` | `--cui-primary-fg` | The color readable as text, one step lighter than the emphasis |
-| `text-emphasis` | `--cui-primary-text-emphasis` | High-contrast foreground text |
+| `text-emphasis` | `--cui-primary-fg-emphasis` | High-contrast foreground text |
 | `bg-subtle` | `--cui-primary-bg-subtle` | Subtle background tint for low-emphasis surfaces |
 | `bg-muted` | `--cui-primary-bg-muted` | Muted background, between subtle and solid |
-| `border-subtle` | `--cui-primary-border-subtle` | Border color |
+| `border-subtle` | `--cui-primary-border` | Border color |
 | `focus-ring` | `--cui-primary-focus-ring` | The hue the color's focus ring mixes from |
 
 The slot values are `light-dark()` pairs of stops from the runtime scale, so a theme color reads correctly in both color modes without a second set of definitions:
@@ -85,7 +85,7 @@ $theme-colors: map.merge($theme-colors, (
     "base":          #6f42c1,
     "contrast":      #fff,
     "fg":            light-dark(var(--cui-brand-600), var(--cui-brand-400)),
-    "text-emphasis": light-dark(var(--cui-brand-800), var(--cui-brand-200)),
+    "fg-emphasis": light-dark(var(--cui-brand-800), var(--cui-brand-200)),
     "bg-subtle":     light-dark(var(--cui-brand-100), var(--cui-brand-900)),
     "bg-muted":      light-dark(var(--cui-brand-200), var(--cui-brand-800)),
     "border-subtle": light-dark(var(--cui-brand-300), var(--cui-brand-600)),

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -238,7 +238,7 @@ finished, not whether the state changed.
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
   **The open item is neutral, and `.theme-{color}` is what tints it.**
   `--cui-accordion-active-bg` and `--cui-accordion-active-color` were fixed to
-  `--cui-primary-bg-subtle` / `--cui-primary-text-emphasis`, so every accordion
+  `--cui-primary-bg-subtle` / `--cui-primary-fg-emphasis`, so every accordion
   turned the brand colour on open whether or not that suited the page. They are
   `--cui-bg-4` and `--cui-fg-body` now, and the active tokens resolve
   through `--cui-theme-fg` / `-bg-subtle` / `-border` first — so the colour is a
@@ -2280,6 +2280,19 @@ them. A state names a theme colour now, and every value is a slot of it.
   and not once for these two. Write the `calc()` yourself; guard a possible
   `0` with `if($value == 0, …)` where it can actually occur. `divide()` stays,
   the grid still uses it.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The theme colour tokens finish the rename to the slot names.**
+  `--cui-{color}-text-emphasis` is `--cui-{color}-fg-emphasis` and
+  `--cui-{color}-border-subtle` is `--cui-{color}-border`. The theme slots
+  (`--cui-theme-fg-emphasis`, `--cui-theme-border`) already carried these
+  names; the colour tokens they read did not, so the two halves of the same
+  system spelled the same idea differently. `--cui-{color}-base` is added
+  alongside the bare `--cui-{color}`, which stays. The Sass keys move with
+  them: `"text-emphasis"` → `"fg-emphasis"` and `"border-subtle"` → `"border"`
+  in `$theme-colors`, `$theme-colors-text` → `$theme-colors-fg-emphasis`,
+  `$theme-colors-border-subtle` → `$theme-colors-border`. **No class names
+  change** — `.text-primary-emphasis` and `.border-primary-subtle` take their
+  suffix from the utility definition, not from the token.
 - **`form-validation-state()` takes `$theme` where it took `$color`**, and the
   variables moved from `scss/_config.scss` into the partials that use them
   alongside `$form-text-*` and `$form-feedback-*`.
@@ -2732,8 +2745,8 @@ pair, and `[data#{$data-infix}theme="dark"]` only declares `color-scheme: dark`.
   `$grays-dark` map. Every one of them was defined as exactly its light
   counterpart, so they generated nothing — read `$gray-*` directly. The bundled
   Bootstrap theme no longer passes `$grays-dark: ()` through its `with()` block.
-- **`$theme-colors-dark` is gone**, along with `$theme-colors-text-dark`,
-  `$theme-colors-bg-subtle-dark`, `$theme-colors-border-subtle-dark` and
+- **`$theme-colors-dark` is gone**, along with `$theme-colors-fg-emphasis-dark`,
+  `$theme-colors-bg-subtle-dark`, `$theme-colors-border-dark` and
   `$theme-colors-contrast-dark`, and the eight `$primary-dark` … `$dark-dark`
   variables behind them. Theme colours themselves no longer change
   between colour modes — the old dark variants were a 10% desaturation, which

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -23,70 +23,70 @@ $theme-colors: (
     "base":          $primary,
     "contrast":      $white,
     "fg":            light-dark(var(--#{$prefix}primary-600), var(--#{$prefix}primary-400)),
-    "text-emphasis": light-dark(var(--#{$prefix}primary-800), var(--#{$prefix}primary-200)),
+    "fg-emphasis":   light-dark(var(--#{$prefix}primary-800), var(--#{$prefix}primary-200)),
     "bg-subtle":     light-dark(var(--#{$prefix}primary-100), var(--#{$prefix}primary-900)),
     "bg-muted":      light-dark(var(--#{$prefix}primary-200), var(--#{$prefix}primary-800)),
-    "border-subtle": light-dark(var(--#{$prefix}primary-300), var(--#{$prefix}primary-600)),
+    "border":        light-dark(var(--#{$prefix}primary-300), var(--#{$prefix}primary-600)),
     "focus-ring":    color-mix(in srgb, var(--#{$prefix}primary) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
   ),
   "secondary": (
     "base":          $secondary,
     "contrast":      light-dark(var(--#{$prefix}gray-900), var(--#{$prefix}white)),
     "fg":            light-dark(var(--#{$prefix}gray-600), var(--#{$prefix}gray-400)),
-    "text-emphasis": light-dark(var(--#{$prefix}gray-800), var(--#{$prefix}gray-200)),
+    "fg-emphasis":   light-dark(var(--#{$prefix}gray-800), var(--#{$prefix}gray-200)),
     "bg-subtle":     light-dark(var(--#{$prefix}gray-025), var(--#{$prefix}gray-800)),
     "bg-muted":      light-dark(var(--#{$prefix}gray-050), var(--#{$prefix}gray-700)),
-    "border-subtle": light-dark(var(--#{$prefix}gray-300), var(--#{$prefix}gray-600)),
+    "border":        light-dark(var(--#{$prefix}gray-300), var(--#{$prefix}gray-600)),
     "focus-ring":    color-mix(in srgb, light-dark(var(--#{$prefix}gray-500), var(--#{$prefix}gray-300)) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
   ),
   "success": (
     "base":          $success,
     "contrast":      $black,
     "fg":            light-dark(var(--#{$prefix}success-600), var(--#{$prefix}success-400)),
-    "text-emphasis": light-dark(var(--#{$prefix}success-800), var(--#{$prefix}success-200)),
+    "fg-emphasis":   light-dark(var(--#{$prefix}success-800), var(--#{$prefix}success-200)),
     "bg-subtle":     light-dark(var(--#{$prefix}success-100), var(--#{$prefix}success-900)),
     "bg-muted":      light-dark(var(--#{$prefix}success-200), var(--#{$prefix}success-800)),
-    "border-subtle": light-dark(var(--#{$prefix}success-300), var(--#{$prefix}success-600)),
+    "border":        light-dark(var(--#{$prefix}success-300), var(--#{$prefix}success-600)),
     "focus-ring":    color-mix(in srgb, var(--#{$prefix}success) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
   ),
   "info": (
     "base":          $info,
     "contrast":      $black,
     "fg":            light-dark(var(--#{$prefix}info-700), var(--#{$prefix}info-300)),
-    "text-emphasis": light-dark(var(--#{$prefix}info-800), var(--#{$prefix}info-200)),
+    "fg-emphasis":   light-dark(var(--#{$prefix}info-800), var(--#{$prefix}info-200)),
     "bg-subtle":     light-dark(var(--#{$prefix}info-100), var(--#{$prefix}info-900)),
     "bg-muted":      light-dark(var(--#{$prefix}info-200), var(--#{$prefix}info-800)),
-    "border-subtle": light-dark(var(--#{$prefix}info-300), var(--#{$prefix}info-600)),
+    "border":        light-dark(var(--#{$prefix}info-300), var(--#{$prefix}info-600)),
     "focus-ring":    color-mix(in srgb, var(--#{$prefix}info) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
   ),
   "warning": (
     "base":          $warning,
     "contrast":      $black,
     "fg":            light-dark(var(--#{$prefix}warning-700), var(--#{$prefix}warning-300)),
-    "text-emphasis": light-dark(var(--#{$prefix}warning-800), var(--#{$prefix}warning-200)),
+    "fg-emphasis":   light-dark(var(--#{$prefix}warning-800), var(--#{$prefix}warning-200)),
     "bg-subtle":     light-dark(var(--#{$prefix}warning-100), var(--#{$prefix}warning-900)),
     "bg-muted":      light-dark(var(--#{$prefix}warning-200), var(--#{$prefix}warning-800)),
-    "border-subtle": light-dark(var(--#{$prefix}warning-300), var(--#{$prefix}warning-600)),
+    "border":        light-dark(var(--#{$prefix}warning-300), var(--#{$prefix}warning-600)),
     "focus-ring":    color-mix(in srgb, var(--#{$prefix}warning) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
   ),
   "danger": (
     "base":          $danger,
     "contrast":      $black,
     "fg":            light-dark(var(--#{$prefix}danger-600), var(--#{$prefix}danger-400)),
-    "text-emphasis": light-dark(var(--#{$prefix}danger-800), var(--#{$prefix}danger-200)),
+    "fg-emphasis":   light-dark(var(--#{$prefix}danger-800), var(--#{$prefix}danger-200)),
     "bg-subtle":     light-dark(var(--#{$prefix}danger-100), var(--#{$prefix}danger-900)),
     "bg-muted":      light-dark(var(--#{$prefix}danger-200), var(--#{$prefix}danger-800)),
-    "border-subtle": light-dark(var(--#{$prefix}danger-300), var(--#{$prefix}danger-600)),
+    "border":        light-dark(var(--#{$prefix}danger-300), var(--#{$prefix}danger-600)),
     "focus-ring":    color-mix(in srgb, var(--#{$prefix}danger) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
   ),
   "inverse": (
     "base":          $inverse,
     "contrast":      light-dark(var(--#{$prefix}white), var(--#{$prefix}gray-900)),
     "fg":            light-dark(var(--#{$prefix}gray-900), var(--#{$prefix}gray-200)),
-    "text-emphasis": light-dark(var(--#{$prefix}black), var(--#{$prefix}white)),
+    "fg-emphasis":   light-dark(var(--#{$prefix}black), var(--#{$prefix}white)),
     "bg-subtle":     light-dark(var(--#{$prefix}gray-100), var(--#{$prefix}gray-900)),
     "bg-muted":      light-dark(var(--#{$prefix}gray-200), var(--#{$prefix}gray-700)),
-    "border-subtle": light-dark(var(--#{$prefix}gray-400), var(--#{$prefix}gray-600)),
+    "border":        light-dark(var(--#{$prefix}gray-400), var(--#{$prefix}gray-600)),
     "focus-ring":    color-mix(in srgb, light-dark(var(--#{$prefix}gray-900), var(--#{$prefix}gray-100)) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
   ),
 ) !default;
@@ -107,17 +107,17 @@ $theme-colors: (
 // swaps ends of the scale between schemes, which a scale mixed from one base
 // cannot do.
 
-// scss-docs-start theme-text-map
-$theme-colors-text: map-slot($theme-colors, "text-emphasis") !default;
-// scss-docs-end theme-text-map
+// scss-docs-start theme-fg-emphasis-map
+$theme-colors-fg-emphasis: map-slot($theme-colors, "fg-emphasis") !default;
+// scss-docs-end theme-fg-emphasis-map
 
 // scss-docs-start theme-bg-subtle-map
 $theme-colors-bg-subtle: map-slot($theme-colors, "bg-subtle") !default;
 // scss-docs-end theme-bg-subtle-map
 
-// scss-docs-start theme-border-subtle-map
-$theme-colors-border-subtle: map-slot($theme-colors, "border-subtle") !default;
-// scss-docs-end theme-border-subtle-map
+// scss-docs-start theme-border-map
+$theme-colors-border: map-slot($theme-colors, "border") !default;
+// scss-docs-end theme-border-map
 
 // scss-docs-start theme-contrast-map
 $theme-colors-contrast: map-slot($theme-colors, "contrast") !default;
@@ -146,10 +146,10 @@ $theme-token-refs: (
   "bg": "",
   "contrast": "-contrast",
   "fg": "-fg",
-  "fg-emphasis": "-text-emphasis",
+  "fg-emphasis": "-fg-emphasis",
   "bg-subtle": "-bg-subtle",
   "bg-muted": "-bg-muted",
-  "border": "-border-subtle",
+  "border": "-border",
   "focus-ring": "-focus-ring"
 ) !default;
 // scss-docs-end theme-token-refs
@@ -231,6 +231,7 @@ $theme-state-colors: (
 
   @each $color, $slots in $theme-colors {
     $tokens: map.set($tokens, --#{$prefix}#{$color}, map.get($slots, "base"));
+    $tokens: map.set($tokens, --#{$prefix}#{$color}-base, var(--#{$prefix}#{$color}));
   }
 
   // The action-background slot: what checked, active and filled states read.
@@ -246,16 +247,16 @@ $theme-state-colors: (
     $tokens: map.merge($tokens, color-scale-tokens($color));
   }
 
-  @each $color, $value in $theme-colors-text {
-    $tokens: map.set($tokens, --#{$prefix}#{$color}-text-emphasis, $value);
+  @each $color, $value in $theme-colors-fg-emphasis {
+    $tokens: map.set($tokens, --#{$prefix}#{$color}-fg-emphasis, $value);
   }
 
   @each $color, $value in $theme-colors-bg-subtle {
     $tokens: map.set($tokens, --#{$prefix}#{$color}-bg-subtle, $value);
   }
 
-  @each $color, $value in $theme-colors-border-subtle {
-    $tokens: map.set($tokens, --#{$prefix}#{$color}-border-subtle, $value);
+  @each $color, $value in $theme-colors-border {
+    $tokens: map.set($tokens, --#{$prefix}#{$color}-border, $value);
   }
 
   @each $color, $value in $theme-colors-contrast {

--- a/scss/tests/mixins/_color-modes.test.scss
+++ b/scss/tests/mixins/_color-modes.test.scss
@@ -10,7 +10,7 @@
       @include output() {
         @include color-mode(dark) {
           .element {
-            color: var(--cui-primary-text-emphasis);
+            color: var(--cui-primary-fg-emphasis);
             background-color: var(--cui-primary-bg-subtle);
           }
         }
@@ -20,7 +20,7 @@
       }
       @include expect() {
         [data-coreui-theme=dark] .element {
-          color: var(--cui-primary-text-emphasis);
+          color: var(--cui-primary-fg-emphasis);
           background-color: var(--cui-primary-bg-subtle);
         }
         [data-coreui-theme=dark] {
@@ -39,7 +39,7 @@
       @include output() {
         @include color-mode(dark) {
           .element {
-            color: var(--cui-primary-text-emphasis);
+            color: var(--cui-primary-fg-emphasis);
             background-color: var(--cui-primary-bg-subtle);
           }
         }
@@ -50,7 +50,7 @@
       @include expect() {
         @media (prefers-color-scheme: dark) {
           .element {
-            color: var(--cui-primary-text-emphasis);
+            color: var(--cui-primary-fg-emphasis);
             background-color: var(--cui-primary-bg-subtle);
           }
         }


### PR DESCRIPTION
Caught while writing the audit note that said our slot vocabulary diverges from upstream's. It does — but not because we chose different names. **The rename was done halfway.**

`#938` renamed the theme *slots* to follow upstream (`--cui-theme-fg-emphasis`, `--cui-theme-border`) and stopped there. The colour tokens those slots read kept the old spelling, which is visible in the mapping itself:

```scss
"fg-emphasis": "-text-emphasis",   // slot renamed, token not
"border":      "-border-subtle",   // same
```

So one system spelled the same idea two ways depending on which half you looked at.

| | before | after |
| --- | --- | --- |
| emphasis | `--cui-primary-text-emphasis` | `--cui-primary-fg-emphasis` |
| border | `--cui-primary-border-subtle` | `--cui-primary-border` |
| base | `--cui-primary` only | `--cui-primary-base` added, bare form kept |

Comparing the compiled stylesheets, the nine slot names now match upstream exactly where three differed.

**No class names change.** `.text-primary-emphasis` and `.border-primary-subtle` take their suffix from the utility definition — `theme-color-refs("fg-emphasis", "-emphasis")` — not from the token. Verified by diffing every selector in the compiled CSS before and after: nothing added, nothing removed. (Upstream dropped both utilities in v6; ours stay.)

Unlike upstream we keep the bare `--cui-{color}` alongside `-base` — it has 116 uses in the stylesheet alone and is idiomatic since v5, so removing it would be a much larger break than the rename it would buy.

Left alone deliberately: `--cui-border-subtle` in `_config.scss`/`_root.scss` is the global border token, not a theme slot.

`css-test` 62 passing, class-API gate passed, bundlewatch PASS, docs build green. Migration entry added; 45 references updated across five docs pages, with `migration/v5` left on the v5 names it documents.