### PR TITLE
docs(color): say how the scales are generated, before 300 lines of swatches

### DIFF
--- a/docs/src/content/docs/customize/color.mdx
+++ b/docs/src/content/docs/customize/color.mdx
@@ -9,9 +9,11 @@ import { getData, getSequence } from '@coreui/astro-docs/data'
 
 <AddedIn version="5.0.0" />
 
-The palette below covers two different jobs. `secondary` and `tertiary` text and background colors describe **surfaces** — the page, its dividers, its disabled states. The `{color}-bg-subtle`, `{color}-border-subtle`, and `{color}-text-emphasis` sets are **tinted variants of the theme colors**, so that a single theme color can carry a background, a border, and a readable text tone that all shift together between color modes.
+The palette below covers two different jobs. `secondary` and `tertiary` text and background colors describe **surfaces** — the page, its dividers, its disabled states. The `{color}-bg-subtle`, `{color}-border`, and `{color}-fg-emphasis` sets are **tinted variants of the theme colors**, so that a single theme color can carry a background, a border, and a readable text tone that all shift together between color modes.
 
 All of them are declared globally on `:root` and are available through Sass and CSS variables (but not through our color maps or utility classes).
+
+Each family is generated, not hand-listed: one base token per color, and the `100`–`900` steps mixed from it with `color-mix()`. The mix names the base token rather than its value, so **overriding `--cui-primary` retints its whole scale in the browser** — no rebuild, both color schemes at once. [Notes on Sass](#notes-on-sass) covers the stops and the mixing space, and [Architecture](/customize/architecture/) shows where this sits relative to the theme and component tokens.
 
 To fade any of these colors, mix it toward `transparent` rather than reaching for a channel triplet — `color-mix(in srgb, var(--cui-bg-4) 50%, transparent)`.
 

--- a/docs/src/content/docs/customize/options.mdx
+++ b/docs/src/content/docs/customize/options.mdx
@@ -9,7 +9,7 @@ You can find and customize these variables for key global options in CoreUI for 
 
 | Variable                       | Values                             | Description                                                                            |
 | ------------------------------ | ---------------------------------- | -------------------------------------------------------------------------------------- |
-| `$spacer`                      | `1rem` (default), or any value > 0 | Specifies the default spacer value to programmatically generate our [spacer utilities](/utilities/margin/). |
+| `$spacer`                      | `1rem` (default), or any value > 0 | Specifies the default spacer value to programmatically generate our [margin](/utilities/margin/), [padding](/utilities/padding/) and [gap](/utilities/gap/) utilities. |
 | `$enable-dark-mode`            | `true` (default) or `false`        | Enables built-in [dark mode support](/customize/color-modes/#dark-mode) across the project and its components. |
 | `$enable-rounded`              | `true` (default) or `false`        | Enables predefined `border-radius` styles on various components. |
 | `$enable-shadows`              | `true` or `false` (default)        | Enables predefined decorative `box-shadow` styles on various components. Does not affect `box-shadow`s used for focus states. |
@@ -17,7 +17,7 @@ You can find and customize these variables for key global options in CoreUI for 
 | `$enable-transitions`          | `true` (default) or `false`        | Enables predefined `transition`s on various components. |
 | `$enable-reduced-motion`       | `true` (default) or `false`        | Enables the [`prefers-reduced-motion` media query](/getting-started/accessibility/#reduced-motion), which suppresses certain animations/transitions based on the users' browser/operating system preferences. |
 | `$enable-grid-classes`         | `true` (default) or `false`        | Enables the generation of CSS classes for the grid system (e.g. `.row`, `.col-md-1`, etc.). |
-| `$enable-container-classes`    | `true` (default) or `false`        | Enables the generation of CSS classes for layout containers. (New in v4.2.6) |
+| `$enable-container-classes`    | `true` (default) or `false`        | Enables the generation of CSS classes for layout containers. |
 | `$enable-cssgrid`              | `true` (default) or `false`        | Enables the generation of the [CSS Grid layout](/layout/css-grid/) classes (e.g. `.grid`, `.g-col-6`). |
 | `$enable-caret`                | `true` (default) or `false`        | Enables pseudo element caret on `.dropdown-toggle`. |
 | `$enable-button-pointers`      | `true` (default) or `false`        | Add "hand" cursor to non-disabled button elements. |


### PR DESCRIPTION
The Color page opened with the palette and explained the mechanism at line 404, under a heading called *Notes on Sass* — so the one fact that changes how you customize anything sat past every swatch, framed as an aside.

It is in the lead now: one base token per color, the `100`–`900` steps mixed from it with `color-mix()`, and the mix names the **token** rather than its value — so overriding `--cui-primary` retints its whole scale in the browser, in both color schemes, with no rebuild. That is worth stating up front; it is also where we differ from upstream, who inline the `oklch()` literal into each step and therefore do not get the runtime retint.

The intro paragraph also still named `{color}-border-subtle` and `{color}-text-emphasis`. My rename in #1005 matched only the `--cui-`-prefixed spelling, so the bare form survived — the remaining occurrences are in the v5 and v6 migration guides, where they correctly describe what was renamed or removed.

**Options page**, same pass: drops a "(New in v4.2.6)" note from a v6 page, and points `$spacer` at the padding and gap utilities it also generates rather than margin alone.

Checked and left alone, because ours is right and upstream's differs: `$enable-cssgrid` is `true` by default here (`false` for them), and `$enable-caret` applies to `.dropdown-toggle` (they renamed Dropdown to Menu). Both verified in `_config.scss` and `_dropdown.scss`.

Anchor `#notes-on-sass` verified in the built HTML — the link checker does not follow fragments.