### PR TITLE
docs: name variables that exist in the override examples

### DIFF
--- a/docs/src/content/docs/customize/sass.mdx
+++ b/docs/src/content/docs/customize/sass.mdx
@@ -125,8 +125,8 @@ Here's an example that changes the `background-color` and `color` for the `<body
 
 ```scss
 @use "@coreui/coreui/scss/coreui" with (
-  $body-bg: #000,
-  $body-color: #111
+  $bg-body: #000,
+  $fg-body: #111
 )
 ```
 

--- a/docs/src/content/docs/templates/customize.mdx
+++ b/docs/src/content/docs/templates/customize.mdx
@@ -46,8 +46,8 @@ Here's an example that changes the `background-color` and `color` for the `<body
 // _variables.scss
 
 // Default variable overrides
-$body-bg: #000;
-$body-color: #111;
+$bg-body: #000;
+$fg-body: #111;
 ```
 
 ## Custom styles and overrides


### PR DESCRIPTION
`customize/sass` and `templates/customize` both told readers to override `$body-bg` and `$body-color`. Neither exists in v6 — they are `$bg-body` and `$fg-body`.

Inside a `@use ... with ()` block that is **not a silent no-op**. Compiled against our own stylesheet:

```
Error: This variable was not declared with !default in the @used module.
```

So anyone following the documented customization example got a failing build, on the two pages whose whole job is to show how to customize. The corrected names compile clean.

**How it was found, and why it matters for the rest of the sweep:** the parity sweep walks upstream's sidebar, so our own-only pages — `templates/` (five of them), `AI Tools`, anything they do not have — are compared against nothing and this could never surface there. Instead: extract every Sass variable named in a code fence across the docs and check it against the 1548 declared in `scss/`. Five hits, three of them variables the examples define themselves (`$custom-colors`, `$all-colors`, `$subtle-backgrounds`) and two real.

Same fix in coreui/coreui-react-pro#197 and coreui/coreui-vue-pro#138.