### PR TITLE
docs(breakpoints): name what is a query container

### DIFF
--- a/docs/src/content/docs/layout/breakpoints.mdx
+++ b/docs/src/content/docs/layout/breakpoints.mdx
@@ -187,4 +187,13 @@ Which results in:
 @container (width >= 768px) { ... }
 ```
 
-Our [CSS Grid](/layout/css-grid/) is built this way: every `.grid` is a query container, so `.g-col-md-*` follows the width of the grid rather than the browser window.
+Several parts of the library are built this way, which is worth knowing when a component responds to something other than the window:
+
+| Query container | What follows its width |
+| --- | --- |
+| `.grid` | `.g-col-md-*` and the rest of the [CSS Grid](/layout/css-grid/) column classes |
+| `.navbar` | `.navbar-expand-*` — a navbar in a sidebar collapses there while a full-width one on the same page stays expanded |
+| `.table-responsive`, `.table-responsive-*` | the scroll threshold of a [responsive table](/content/tables/#responsive-tables) |
+| `.stack-container` | the [stack helpers](/helpers/stacks/) inside it |
+
+You can make anything else one with `set-container()` in Sass, or the `.contains-inline` utility in markup.


### PR DESCRIPTION
The Container queries section explained the mechanism and named one consumer, so a reader whose navbar collapsed at an unexpected width had nothing telling them the navbar measures **itself**, not the window.

Lists the four, read out of the compiled stylesheet rather than guessed:

| Query container | What follows its width |
| --- | --- |
| `.grid` | the CSS Grid column classes |
| `.navbar` | `.navbar-expand-*` |
| `.table-responsive`, `.table-responsive-*` | the scroll threshold |
| `.stack-container` | the stack helpers inside it |

Upstream documents this on their breakpoints page under *Usage in Bootstrap* and lists two components; we use container queries in four places. Their second example — Stepper as a container — does not apply: ours does not establish one, so it is not in the list.

The rest of their container-query subtree (`Setting a container`, the four mixins, `Named containers`) is not missing here, it lives on [Container queries](/utilities/container-queries/) — a page named after what the reader is looking for.

Anchors verified in the built HTML.