### PR TITLE
feat(Accordion): add the gap variant

### DIFF
--- a/docs/src/content/docs/components/accordion.mdx
+++ b/docs/src/content/docs/components/accordion.mdx
@@ -129,6 +129,29 @@ Add `.accordion-flush` to remove the default `background-color`, some borders, a
     </details>
   </div>`} />
 
+## Gap
+
+Add `.accordion-gap` to space the items apart. Each one keeps its full border radius, so the accordion reads as a stack of cards rather than one block.
+
+The gap sits on the accordion, not on the panel, so opening and closing still animates only the panel's height.
+
+<Example code={`<div class="accordion accordion-gap">
+    <details class="accordion-item" name="accordionGapExample" open>
+      <summary class="accordion-header">Accordion Item #1</summary>
+      <div class="accordion-body">Placeholder content for this accordion, which is intended to demonstrate the <code>.accordion-gap</code> class. Each item keeps a full border radius while the panel opens and closes.</div>
+    </details>
+    <details class="accordion-item" name="accordionGapExample">
+      <summary class="accordion-header">Accordion Item #2</summary>
+      <div class="accordion-body">Placeholder content for this accordion, which is intended to demonstrate the <code>.accordion-gap</code> class. This is the second item's accordion body.</div>
+    </details>
+    <details class="accordion-item" name="accordionGapExample">
+      <summary class="accordion-header">Accordion Item #3</summary>
+      <div class="accordion-body">Placeholder content for this accordion, which is intended to demonstrate the <code>.accordion-gap</code> class. This is the third item's accordion body.</div>
+    </details>
+  </div>`} />
+
+Set the distance with `--cui-accordion-gap`, which defaults to `--cui-spacer-2`.
+
 ## Always open
 
 Omit the `name` attribute on each `.accordion-item` to make accordion items stay open when another item is opened.

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -18,6 +18,7 @@ $accordion-bg:                            var(--#{$prefix}bg-body) !default;
 $accordion-border-width:                  var(--#{$prefix}border-width) !default;
 $accordion-border-color:                  var(--#{$prefix}border-color) !default;
 $accordion-border-radius:                 var(--#{$prefix}radius-7) !default;
+$accordion-gap:                           var(--#{$prefix}spacer-2) !default;
 
 $accordion-button-color:                  var(--#{$prefix}fg-2) !default;
 $accordion-button-bg:                     var(--#{$prefix}accordion-bg) !default;
@@ -61,6 +62,7 @@ $accordion-tokens: defaults(
     --#{$prefix}accordion-border-color: #{$accordion-border-color},
     --#{$prefix}accordion-border-width: #{$accordion-border-width},
     --#{$prefix}accordion-border-radius: #{$accordion-border-radius},
+    --#{$prefix}accordion-gap: #{$accordion-gap},
     --#{$prefix}accordion-btn-color: #{$accordion-button-color},
     --#{$prefix}accordion-btn-bg: #{$accordion-button-bg},
     --#{$prefix}accordion-btn-icon: #{escape-svg($accordion-button-icon)},
@@ -272,6 +274,32 @@ $accordion-tokens: defaults(
     --#{$prefix}accordion-border-radius: var(--#{$prefix}radius-5);
     --#{$prefix}accordion-font-size: var(--#{$prefix}font-size-sm);
     // scss-docs-end accordion-sm-css-vars
+  }
+
+  .accordion-gap {
+    display: flex;
+    flex-direction: column;
+    gap: var(--#{$prefix}accordion-gap);
+
+    > .accordion-item {
+      @include border-radius(var(--#{$prefix}accordion-border-radius));
+
+      &:not(:first-of-type) {
+        margin-block-start: 0;
+      }
+
+      > .accordion-header {
+        @include border-radius(calc(var(--#{$prefix}accordion-border-radius) - var(--#{$prefix}accordion-border-width)));
+      }
+
+      > .accordion-body {
+        @include border-bottom-radius(var(--#{$prefix}accordion-border-radius));
+      }
+
+      &[open] > .accordion-header {
+        @include border-bottom-radius(0);
+      }
+    }
   }
 
   .accordion-flush {


### PR DESCRIPTION
`.accordion-gap` spaces the items apart and gives each one a full border radius, so an accordion can read as a stack of cards instead of one block. The gap sits on the accordion, not the panel, so the open and close transition still animates only the panel's height.

Measured in Chromium rather than eyeballed:

| | `.accordion-gap` | default |
| --- | --- | --- |
| distance between items | **8px** | −1px (borders collapse) |
| radius on a middle item | **12px** | 0 |
| open item's header, bottom radius | 0 | 0 |

The default accordion is untouched — its items still overlap by one border width, and the open item's header keeps a square bottom edge because its body continues below.

Distance is `--cui-accordion-gap`, defaulting to `--cui-spacer-2`.

Ships as a `gap` prop in the framework editions (coreui/coreui-react-pro and coreui/coreui-vue-pro), because `flush` and `size` already are props there and a variant needing a manual `className` would be the odd one out.

`css-test` 62 passing, bundlewatch PASS at 69.54 kB.