### PR TITLE
feat(forms): add .form-field-content, .form-field-card and .form-group

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "70.5 kB"
+      "maxSize": "71 kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "65 kB"
+      "maxSize": "65.5 kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/forms/checkbox.mdx
+++ b/docs/src/content/docs/forms/checkbox.mdx
@@ -120,6 +120,17 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
     <label for="fieldCheck">Subscribe to the newsletter</label>
     <div class="form-text">We send one email a month, and never share your address.</div>
   </div>`} />
+## Description
+
+Add a description after the label and wrap both in a `.form-field-content`, so the description sits under the label rather than beside the checkbox.
+
+<Example code={`<div class="form-field">
+    <input type="checkbox" id="checkDescription" class="check" checked />
+    <div class="form-field-content">
+      <label for="checkDescription">Example checkbox</label>
+      <small class="form-text">Supporting description for the label above.</small>
+    </div>
+  </div>`} />
 
 ## Toggle buttons
 

--- a/docs/src/content/docs/forms/field.mdx
+++ b/docs/src/content/docs/forms/field.mdx
@@ -104,6 +104,47 @@ Feedback elements are children of the field like any other, so they inherit its 
 
 See [validation](/forms/validation/) for the full picture, including the server-side and browser-native flavours.
 
+## Descriptions
+
+Add a `<small class="form-text">` after the label and wrap both in a `.form-field-content` so the description sits under the label rather than beside the control.
+
+<Example class="d-flex flex-column gap-3" code={`<div class="form-field">
+    <input type="checkbox" id="fieldCheckDesc" class="check" />
+    <div class="form-field-content">
+      <label for="fieldCheckDesc">Subscribe to updates</label>
+      <small class="form-text">We'll send you a weekly digest of what's new.</small>
+    </div>
+  </div>
+  <div class="form-field">
+    <input type="radio" id="fieldRadioDesc" class="radio" name="fieldRadioDesc" checked />
+    <div class="form-field-content">
+      <label for="fieldRadioDesc">Standard shipping</label>
+      <small class="form-text">Arrives in three to five working days.</small>
+    </div>
+  </div>`} />
+
+### Cards
+
+Add `.form-field-card` to each field for a card treatment that highlights the selected option. The label's hit area covers the whole card, so the option is selected by clicking anywhere on it.
+
+<Example code={`<label class="form-label">Select a plan</label>
+  <div class="vstack gap-1">
+    <div class="form-field form-field-card">
+      <input type="radio" id="fieldRadioCard1" class="radio" name="fieldRadioCard" checked />
+      <div class="form-field-content">
+        <label for="fieldRadioCard1">Basic</label>
+        <small class="form-text">$9/month — for individuals.</small>
+      </div>
+    </div>
+    <div class="form-field form-field-card">
+      <input type="radio" id="fieldRadioCard2" class="radio" name="fieldRadioCard" />
+      <div class="form-field-content">
+        <label for="fieldRadioCard2">Pro</label>
+        <small class="form-text">$29/month — for teams.</small>
+      </div>
+    </div>
+  </div>`} />
+
 ## Customizing
 
 ### CSS variables

--- a/docs/src/content/docs/forms/field.mdx
+++ b/docs/src/content/docs/forms/field.mdx
@@ -125,25 +125,43 @@ Add a `<small class="form-text">` after the label and wrap both in a `.form-fiel
 
 ### Cards
 
-Add `.form-field-card` to each field for a card treatment that highlights the selected option. The label's hit area covers the whole card, so the option is selected by clicking anywhere on it.
+Add `.form-field-card` to each field for a card treatment that highlights the selected option. The label's hit area covers the whole card, so the option is selected by clicking anywhere on it. Wrap the set in a `.form-group` to carry its own label and keep the spacing tight.
 
-<Example code={`<label class="form-label">Select a plan</label>
-  <div class="vstack gap-1">
-    <div class="form-field form-field-card">
-      <input type="radio" id="fieldRadioCard1" class="radio" name="fieldRadioCard" checked />
-      <div class="form-field-content">
-        <label for="fieldRadioCard1">Basic</label>
-        <small class="form-text">$9/month — for individuals.</small>
+<Example code={`<div class="form-group">
+    <label class="form-label">Select a plan</label>
+    <div class="vstack gap-1">
+      <div class="form-field form-field-card">
+        <input type="radio" id="fieldRadioCard1" class="radio" name="fieldRadioCard" checked />
+        <div class="form-field-content">
+          <label for="fieldRadioCard1">Basic</label>
+          <small class="form-text">$9/month — for individuals.</small>
+        </div>
       </div>
-    </div>
-    <div class="form-field form-field-card">
-      <input type="radio" id="fieldRadioCard2" class="radio" name="fieldRadioCard" />
-      <div class="form-field-content">
-        <label for="fieldRadioCard2">Pro</label>
-        <small class="form-text">$29/month — for teams.</small>
+      <div class="form-field form-field-card">
+        <input type="radio" id="fieldRadioCard2" class="radio" name="fieldRadioCard" />
+        <div class="form-field-content">
+          <label for="fieldRadioCard2">Pro</label>
+          <small class="form-text">$29/month — for teams.</small>
+        </div>
       </div>
     </div>
   </div>`} />
+
+### Groups
+
+`.form-group` lays out a set of related fields the way `.form-field` lays out one: a grid with the same gap, and a label or `<legend>` pinned to the start. Reach for it when several fields share a heading — the card example above uses it.
+
+<Example code={`<fieldset class="form-group">
+    <legend class="form-label">Notifications</legend>
+    <div class="form-field">
+      <input type="checkbox" id="groupCheck1" class="check" checked />
+      <label for="groupCheck1">Email</label>
+    </div>
+    <div class="form-field">
+      <input type="checkbox" id="groupCheck2" class="check" />
+      <label for="groupCheck2">Push</label>
+    </div>
+  </fieldset>`} />
 
 ## Customizing
 

--- a/docs/src/content/docs/forms/radio.mdx
+++ b/docs/src/content/docs/forms/radio.mdx
@@ -123,6 +123,17 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
       <div class="form-text">Next working day, where available.</div>
     </div>
   </div>`} />
+## Description
+
+Add a description after the label and wrap both in a `.form-field-content`, so the description sits under the label rather than beside the radio.
+
+<Example code={`<div class="form-field">
+    <input type="radio" id="radioDescription" class="radio" name="radioDescription" checked />
+    <div class="form-field-content">
+      <label for="radioDescription">Example radio</label>
+      <small class="form-text">Supporting description for the label above.</small>
+    </div>
+  </div>`} />
 
 ## Toggle buttons
 

--- a/docs/src/content/docs/forms/switch.mdx
+++ b/docs/src/content/docs/forms/switch.mdx
@@ -65,6 +65,16 @@ Any other size is that one property:
 ```
 
 The proportion is a Sass variable, `$switch-aspect-ratio`, so a squarer or longer track is set once for every size.
+## Custom width
+
+The switch reads its size from two tokens, so a wider switch with a larger thumb is two declarations — no new class.
+
+<Example class="d-flex flex-column gap-3" code={`<div class="form-field">
+    <div class="switch" style="--cui-switch-width: 2.75rem; --cui-switch-thumb-size: 1.5rem;">
+      <input type="checkbox" id="switchCustomWidth" role="switch" switch checked>
+    </div>
+    <label for="switchCustomWidth">Custom width switch</label>
+  </div>`} />
 
 ## With form field
 

--- a/scss/forms/_form-field.scss
+++ b/scss/forms/_form-field.scss
@@ -1,10 +1,16 @@
 @use "../functions/defaults" as *;
 @use "../mixins/tokens" as *;
 @use "../config" as *;
+@use "../mixins/border-radius" as *;
 
 // scss-docs-start form-field-variables
 $form-field-gap:            .5rem !default;
 $form-field-column-gap:     .5rem !default;
+$form-field-card-padding:   calc(var(--#{$prefix}spacer) * .75) !default;
+$form-field-card-radius:    var(--#{$prefix}radius-7) !default;
+$form-field-card-hover-bg:  var(--#{$prefix}bg-1) !default;
+$form-field-card-checked-bg: var(--#{$prefix}bg-1) !default;
+$form-field-card-checked-border-color: var(--#{$prefix}border-color) !default;
 // scss-docs-end form-field-variables
 
 $form-field-tokens: () !default;
@@ -20,6 +26,21 @@ $form-field-tokens: defaults(
   $form-field-tokens
 );
 // scss-docs-end form-field-css-vars
+
+$form-field-card-tokens: () !default;
+
+// scss-docs-start form-field-card-css-vars
+$form-field-card-tokens: defaults(
+  (
+    --#{$prefix}form-field-card-padding: #{$form-field-card-padding},
+    --#{$prefix}form-field-card-radius: #{$form-field-card-radius},
+    --#{$prefix}form-field-card-hover-bg: #{$form-field-card-hover-bg},
+    --#{$prefix}form-field-card-checked-bg: #{$form-field-card-checked-bg},
+    --#{$prefix}form-field-card-checked-border-color: #{$form-field-card-checked-border-color},
+  ),
+  $form-field-card-tokens
+);
+// scss-docs-end form-field-card-css-vars
 
 // stylelint-enable scss/dollar-variable-default
 
@@ -60,6 +81,38 @@ $form-field-control-children: if(sass($enable-deprecated-form-check): "> .check,
       > .form-label {
         grid-column: 1 / -1;
       }
+    }
+  }
+
+  .form-field-content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .form-field-card {
+    @include tokens($form-field-card-tokens);
+
+    position: relative;
+    padding: var(--#{$prefix}form-field-card-padding);
+    cursor: pointer;
+    border: var(--#{$prefix}border-width) solid transparent;
+    @include border-radius(var(--#{$prefix}form-field-card-radius));
+
+    &:hover {
+      background-color: var(--#{$prefix}form-field-card-hover-bg);
+    }
+
+    &:has(:checked) {
+      background-color: var(--#{$prefix}form-field-card-checked-bg);
+      border-color: var(--#{$prefix}form-field-card-checked-border-color);
+    }
+
+    // the pseudo-element makes the whole card the label's hit area
+    label::before {
+      position: absolute;
+      inset: 0;
+      content: "";
     }
   }
 }

--- a/scss/forms/_form-field.scss
+++ b/scss/forms/_form-field.scss
@@ -11,6 +11,7 @@ $form-field-card-radius:    var(--#{$prefix}radius-7) !default;
 $form-field-card-hover-bg:  var(--#{$prefix}bg-1) !default;
 $form-field-card-checked-bg: var(--#{$prefix}bg-1) !default;
 $form-field-card-checked-border-color: var(--#{$prefix}border-color) !default;
+$form-group-gap:            .5rem !default;
 // scss-docs-end form-field-variables
 
 $form-field-tokens: () !default;
@@ -41,6 +42,17 @@ $form-field-card-tokens: defaults(
   $form-field-card-tokens
 );
 // scss-docs-end form-field-card-css-vars
+
+$form-group-tokens: () !default;
+
+// scss-docs-start form-group-css-vars
+$form-group-tokens: defaults(
+  (
+    --#{$prefix}form-group-gap: #{$form-group-gap},
+  ),
+  $form-group-tokens
+);
+// scss-docs-end form-group-css-vars
 
 // stylelint-enable scss/dollar-variable-default
 
@@ -113,6 +125,20 @@ $form-field-control-children: if(sass($enable-deprecated-form-check): "> .check,
       position: absolute;
       inset: 0;
       content: "";
+    }
+  }
+
+  .form-group {
+    @include tokens($form-group-tokens);
+
+    display: grid;
+    gap: var(--#{$prefix}form-group-gap);
+
+    > label,
+    > .form-label,
+    > legend {
+      justify-self: start;
+      margin-bottom: 0;
     }
   }
 }


### PR DESCRIPTION
The three layout classes from upstream's `forms/_form-field.scss` that we did not have. Approved by @mrholek.

## `.form-field-content`

A field with a description had nowhere to put it. `.form-field` is a grid: the control takes column 1 and everything else column 2, so a label and a `<small class="form-text">` both land in column 2 side by side. This wrapper stacks them, putting the description under the label where it belongs.

Three upstream sections depend on it — `Description` on checkbox and radio, `Descriptions` on field — and all three are documented here now.

## `.form-field-card`

Turns a field into a selectable card: a border and fill that follow `:has(:checked)`, and a pseudo-element on the label so the whole card is the hit area rather than just the words.

## `.form-group`

Lays out a set of related fields the way `.form-field` lays out one — same grid, same gap, with a label or `<legend>` pinned to the start.

## One decision worth reading

**The card declares its own tokens instead of borrowing the field's.** My first version put them in the `.form-field` map. It compiles, and it works in upstream's own example, which writes `class="form-field form-field-card"`.

But a card used *without* `.form-field` would resolve none of them, and an invalid `var()` drops the whole declaration: no padding, no radius, no border — silently. The tokens are read on `.form-field-card`, so that is where they are declared. Same for `.form-group`.

## Also here

`Custom width` on the switch page — the size comes from `--cui-switch-width` and `--cui-switch-thumb-size`, so a wider switch is two declarations rather than a new class. Upstream names the second token `--switch-indicator-width`; ours is the thumb.

## Budgets

The bundlewatch ceilings go up 0.5 kB. `coreui.min.css` had **0.18 kB** of headroom before this change — the next change of any size would have hit the limit for being second in line, not for being large.

## Verification

- `npm run css-test-class-api` — passes
- `npm run css-test` — 62 specs, 0 failures
- `npm run css-lint` — clean
- `npm run docs-build` — no broken links
- `bundlewatch` — `coreui.css` 69.71KB, `coreui.min.css` 64.85KB, both inside budget