### PR TITLE
docs(field): show client-side validation, not only the server-side shape

### DIFF
--- a/docs/src/content/docs/forms/field.mdx
+++ b/docs/src/content/docs/forms/field.mdx
@@ -94,6 +94,26 @@ When a check, radio, or switch needs a field title above it, add a `.form-label`
 
 Feedback elements are children of the field like any other, so they inherit its gap and land under the control.
 
+### Client-side
+
+Add `data-coreui-validate` to the `<form>` to style fields from `:user-invalid`, which only matches after the user has interacted with a control — so a field is not marked wrong before it has been filled in. `novalidate` suppresses the browser's own tooltips while keeping the constraint validation API available.
+
+<Example code={`<form class="vstack gap-3" data-coreui-validate novalidate>
+    <div class="form-field">
+      <label for="fieldValidateEmail" class="form-label">Email address</label>
+      <input type="email" class="form-control" id="fieldValidateEmail" required>
+      <div class="invalid-feedback">Please enter a valid email address.</div>
+    </div>
+    <div class="form-field">
+      <input type="checkbox" id="fieldValidateTerms" class="check" required>
+      <label for="fieldValidateTerms">Accept the terms</label>
+      <div class="invalid-feedback">You must accept before submitting.</div>
+    </div>
+    <button class="btn-solid theme-primary" type="submit">Submit</button>
+  </form>`} />
+
+### Server-side
+
 <Example code={`<div class="form-field">
     <label for="fieldValidation" class="form-label">Username</label>
     <input type="text" class="form-control is-invalid" id="fieldValidation" value="jan kowalski" aria-describedby="fieldValidationFeedback">


### PR DESCRIPTION
Position 39 of the upstream sweep (`forms/field`).

Their page splits Validation into `Client-side` and `Server-side`. Ours had one unnamed section showing `.is-invalid` set by hand — the server-side case only.

`data-coreui-validate` is what a form usually wants: it styles from `:user-invalid`, so a field is not marked wrong before it has been filled in. We ship it, and `forms/validation` plus four other pages document it. This page — where the interaction with `.form-field` is the whole point — skipped it.

Both cases now have a heading, **client-side first**, which is the order our own validation page argues for ("We recommend using client-side validation").

## The rest of the page checked out

| their subsection | ours |
| --- | --- |
| `Radio` | present — our `Examples` shows `type="radio"`, without a heading of its own |
| `Combobox` | covered from the other side: `With form field` on the autocomplete and multi-select pages |
| `Group cards` | our `Cards` |

Verified with `npm run docs-build` — no broken links.