### PR TITLE
docs: give textarea a page of its own

### DIFF
--- a/docs/src/content/docs/forms/textarea.mdx
+++ b/docs/src/content/docs/forms/textarea.mdx
@@ -1,0 +1,56 @@
+---
+title: "Bootstrap 6 Textarea"
+name: "Textarea"
+description: "Style a multi-line text field with the same class as any other form control, and size it by rows rather than by CSS."
+otherFrameworks:
+  - textarea
+---
+
+## Example
+
+A textarea takes the same `.form-control` class as an input — it needs no class of its own. Set its height with the `rows` attribute rather than CSS, so the field grows in whole lines and stays legible at any font size.
+
+<Example class="vstack gap-3" code={`<div class="form-field">
+    <label for="exampleTextarea" class="form-label">Example textarea</label>
+    <textarea class="form-control" id="exampleTextarea"></textarea>
+  </div>
+  <div class="form-field">
+    <label for="exampleTextareaRows" class="form-label">Taller textarea</label>
+    <textarea class="form-control" id="exampleTextareaRows" rows="4"></textarea>
+  </div>`} />
+
+## Sizing
+
+`.form-control-sm` and `.form-control-lg` change the padding and font size, the same as on an input. `rows` still decides the height.
+
+<Example class="vstack gap-3" code={`<textarea class="form-control form-control-sm" aria-label="Small textarea" rows="2"></textarea>
+  <textarea class="form-control" aria-label="Default textarea" rows="2"></textarea>
+  <textarea class="form-control form-control-lg" aria-label="Large textarea" rows="2"></textarea>`} />
+
+## Disabled
+
+<Example code={`<div class="form-field">
+    <label for="disabledTextarea" class="form-label">Disabled textarea</label>
+    <textarea class="form-control" id="disabledTextarea" rows="3" disabled></textarea>
+  </div>`} />
+
+## Readonly
+
+<Example code={`<div class="form-field">
+    <label for="readonlyTextarea" class="form-label">Readonly textarea</label>
+    <textarea class="form-control" id="readonlyTextarea" rows="3" readonly>Text the reader can select and copy, but not change.</textarea>
+  </div>`} />
+
+## With form field
+
+Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label and description, and to get validation feedback in the right place.
+
+<Example code={`<div class="form-field">
+    <label for="textareaField" class="form-label">Message</label>
+    <textarea class="form-control" id="textareaField" rows="3"></textarea>
+    <small class="form-text">Tell us what happened, in as much detail as you can.</small>
+  </div>`} />
+
+## Customizing
+
+A textarea reads the [form control](/forms/form-control/#customizing) tokens — it declares none of its own.

--- a/docs/src/data/sidebar.yml
+++ b/docs/src/data/sidebar.yml
@@ -200,6 +200,8 @@
       badge:
         color: danger
         text: PRO
+    - title: Textarea
+      to: /forms/textarea/
     - title: Time Input
       to: /forms/time-input/
       badge:


### PR DESCRIPTION
Position 40 of the upstream sweep (`forms/form-control`).

The multi-line field had **no page in vanilla and no section on `form-control`**. The only mentions of `<textarea>` were incidental — inside examples about something else — so a reader looking for it found nothing. React has documented it on its own page all along, which is the edition being ahead of vanilla rather than behind for once.

Upstream keeps a `Textarea` section on `form-control`. A page instead, per @mrholek: it matches how the other controls are documented here, and leaves room for the states the section had no space for.

Sections: Example, Sizing, Disabled, Readonly, With form field, Customizing — the last one pointing at the form control tokens rather than repeating them, since a textarea declares none of its own.

## Also settled at this position

| their section | outcome |
| --- | --- |
| `Select` | ours is a page of its own — our structure, not a gap |
| `Ghost` (`.form-ghost`) | **rejected** (@mrholek) — an input stripped of all styling for a wrapper that supplies its own; recorded in the audit so it is not raised again |
| `States` / `Types` grouping | ours is flat; same content, different nesting |

Verified with `npm run docs-build` — no broken links, and the sidebar entry resolves.