### PR TITLE
docs(javascript): say how the plugins work inside a shadow root

### DIFF
--- a/docs/src/content/docs/getting-started/javascript.mdx
+++ b/docs/src/content/docs/getting-started/javascript.mdx
@@ -126,6 +126,29 @@ Nearly all CoreUI for Bootstrap plugins can be enabled and configured through HT
 Currently to query DOM elements we use the native methods `querySelector` and `querySelectorAll` for performance reasons, so you have to use [valid selectors](https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier).
 If you use special selectors, for example: `collapse:Example` be sure to escape them.
 
+## Shadow DOM
+
+Components work inside a shadow root, with two differences from normal use.
+
+**Initialize with JavaScript, not data attributes.** Our plugins listen on the document and match the event target against a selector. An event that crosses a shadow boundary is retargeted to the host element, so the listener sees the host rather than the button inside — `data-coreui-toggle` never resolves. Construct the component instead:
+
+```js
+const root = host.shadowRoot
+const dropdown = new coreui.Dropdown(root.querySelector('.dropdown-toggle'))
+```
+
+**Adopt the stylesheet into the root.** Document styles do not cross the boundary either, so a component renders unstyled without it:
+
+```js
+const sheet = new CSSStyleSheet()
+sheet.replaceSync(await (await fetch('/path/to/coreui.min.css')).text())
+
+const root = host.attachShadow({ mode: 'open' })
+root.adoptedStyleSheets = [sheet]
+```
+
+Design tokens need no extra work: the stylesheet declares them on `:host` alongside `:root`, so every `--cui-*` variable resolves inside the shadow root once the sheet is adopted.
+
 ## Events
 
 CoreUI for Bootstrap provides custom events for most plugins' unique actions. Generally, these come in an infinitive and past participle form - where the infinitive (ex. `show`) is triggered at the start of an event, and its past participle form (ex. `shown`) is triggered on the completion of an action.

--- a/js/tests/unit/shadow-dom.spec.js
+++ b/js/tests/unit/shadow-dom.spec.js
@@ -1,0 +1,48 @@
+import Dropdown from '../../src/dropdown.js'
+
+// Guards what getting-started/javascript documents: a component constructed
+// inside a shadow root works, the delegated data-attribute path does not reach
+// there, and the same markup in the document does.
+describe('shadow root', () => {
+  it('a dropdown constructed inside a shadow root opens', () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    const root = host.attachShadow({ mode: 'open' })
+    root.innerHTML = '<div class="dropdown"><button class="btn dropdown-toggle" type="button">Toggle</button><div class="dropdown-menu"><a class="dropdown-item" href="#">Item</a></div></div>'
+
+    const toggle = root.querySelector('.dropdown-toggle')
+    const dropdown = new Dropdown(toggle)
+    dropdown.show()
+
+    expect(toggle.classList.contains('show')).toBeTrue()
+    dropdown.dispose()
+    host.remove()
+  })
+
+  it('the data attribute path does NOT reach inside a shadow root', () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    const root = host.attachShadow({ mode: 'open' })
+    root.innerHTML = '<div class="dropdown"><button class="btn dropdown-toggle" type="button" data-coreui-toggle="dropdown">Toggle</button><div class="dropdown-menu"><a class="dropdown-item" href="#">Item</a></div></div>'
+
+    const toggle = root.querySelector('.dropdown-toggle')
+    toggle.click()
+
+    expect(toggle.classList.contains('show')).toBeFalse()
+    expect(Dropdown.getInstance(toggle)).toBeNull()
+    host.remove()
+  })
+
+  it('the same markup in the document DOES react to the data attribute', () => {
+    const wrap = document.createElement('div')
+    wrap.innerHTML = '<div class="dropdown"><button class="btn dropdown-toggle" type="button" data-coreui-toggle="dropdown">Toggle</button><div class="dropdown-menu"><a class="dropdown-item" href="#">Item</a></div></div>'
+    document.body.append(wrap)
+
+    const toggle = wrap.querySelector('.dropdown-toggle')
+    toggle.click()
+
+    expect(toggle.classList.contains('show')).toBeTrue()
+    Dropdown.getInstance(toggle).dispose()
+    wrap.remove()
+  })
+})


### PR DESCRIPTION
Position 50 of the upstream sweep (`forms/datepicker`).

## The gap

**Nothing in our docs mentioned shadow DOM.** No `attachShadow`, no `shadowRoot`, no `adoptedStyleSheets` — zero occurrences across every page. The hits for "shadow" are all box-shadows.

Meanwhile the stylesheet has carried `:host` beside `:root` since the token work, specifically so tokens resolve inside a shadow root. Verified in the compiled CSS: that selector declares **425** `--cui-*` tokens. The support was built and never explained.

## Checked against our code, not inherited

Upstream's section is about **their** datepicker; ours is our own, so the claims could not just be ported — @mrholek caught that the reasoning had not been checked here. `js/tests/unit/shadow-dom.spec.js` now proves both halves against this codebase:

| case | result |
| --- | --- |
| component constructed in JS inside a shadow root | works — the dropdown opens |
| `data-coreui-toggle` inside a shadow root | does not work — no instance, no `show` class |
| the same markup in the document | works — the control, so a passing "does not react" cannot come from a broken test |

Our JS is not generally shadow-aware: `findShadowRoot` exists in `util/index.ts` and only `tooltip.ts` uses it. The section documents the boundary rather than claiming there is none.

## What the section says

Two things differ inside a shadow root, and **both fail silently**:

- A delegated listener sees the host, not the element inside — an event crossing the boundary is retargeted — so `data-coreui-toggle` never resolves and the component simply does not react. Construct it in JavaScript instead.
- Document styles stop at the boundary, so the component renders unstyled until the sheet is adopted into the root.

Plus the part that needs no work: once the sheet is adopted, every token resolves, because it is declared on `:host` too. That sentence is ours — upstream has no equivalent.

## Placement

`getting-started/javascript`, not a component page — both points apply to every plugin. Upstream documents this on `forms/datepicker`, their **only** mention; a reader hitting the problem with a modal would have no reason to look there.

## Verification

- `npm run docs-build` — no broken links
- new spec passes, eslint clean