### PR TITLE
docs(password-strength): show the markup that works without the plugin

### DIFF
--- a/docs/src/content/docs/forms/password-strength.mdx
+++ b/docs/src/content/docs/forms/password-strength.mdx
@@ -234,6 +234,30 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
     <div class="form-text">At least 12 characters.</div>
   </div>`} />
 
+## Without JavaScript
+
+The meter is driven entirely by two hooks, so a server that already knows the
+score can render the result without loading the plugin: `data-coreui-strength`
+on the wrapper picks the colour, and `.active` on a segment fills it.
+
+The score runs `0`–`4` and there is one segment fewer than there are levels —
+four segments for the five default labels.
+
+<Example code={`<div class="password-strength" data-coreui-strength="2">
+    <div class="password-strength-meter" aria-hidden="true">
+      <span class="password-strength-segment active"></span>
+      <span class="password-strength-segment active"></span>
+      <span class="password-strength-segment"></span>
+      <span class="password-strength-segment"></span>
+    </div>
+    <div class="password-strength-feedback" role="status">
+      <span class="password-strength-text">Fair</span>
+    </div>
+  </div>`} />
+
+This is the same markup the plugin builds, so a field can start server-rendered
+and keep working once the script initializes it.
+
 ## Accessibility
 
 - The segmented bar is `aria-hidden`, because it carries no information the


### PR DESCRIPTION
Position 52 of the upstream sweep (`forms/password-strength`).

Upstream documents a CSS-only path. We support the same thing and never said so: the stylesheet keys off `data-coreui-strength` on the wrapper for the colour and `.active` on a segment to fill it, so a server that already knows the score can render the result without loading the plugin.

The example is the markup the plugin itself builds — verified against `_render()`, which sets `dataset.coreuiStrength` and toggles `.active` on `score` — so a field can start server-rendered and keep working once the script initializes it.

## A near-miss worth recording

Searching the plugin for `data-coreui-strength` found nothing, which briefly looked like a defect: the stylesheet colours `[data-coreui-strength]` and if nothing set it, every level would render the same colour. It is set — as `dataset.coreuiStrength`, in camelCase, which the attribute-name search could not match.

## The rest of the page

| their section | ours |
| --- | --- |
| `Strength criteria` — a scoring table | `What the built-in scorer is worth` — a warning that the scorer measures *composition*, not guessability, with `P@ssw0rd1` as the example. Ours is the better treatment, not a gap. |
| `Overview`, `Examples`, `Usage`, `Accessibility` | present |

Ours is 352 lines to their 317, with `Custom scorer` and `User inputs` on top.

Verified with `npm run docs-build` — no broken links.