### PR TITLE
docs(validation): show the current control markup, not the deprecated one

### DIFF
--- a/docs/src/content/docs/forms/validation.mdx
+++ b/docs/src/content/docs/forms/validation.mdx
@@ -78,9 +78,9 @@ Custom feedback styles apply custom colors, borders, focus styles, and backgroun
       </div>
     </div>
     <div class="col-12">
-      <div class="form-check">
-        <input class="form-check-input" type="checkbox" value="" id="invalidCheck" required>
-        <label class="form-check-label" for="invalidCheck">
+      <div class="form-field">
+        <input class="check" type="checkbox" value="" id="invalidCheck" required>
+        <label for="invalidCheck">
           Agree to terms and conditions
         </label>
         <div class="invalid-feedback">
@@ -133,9 +133,9 @@ While these feedback styles cannot be styled with CSS, you can still customize t
       <input type="text" class="form-control" id="validationDefault05" required>
     </div>
     <div class="col-12">
-      <div class="form-check">
-        <input class="form-check-input" type="checkbox" value="" id="invalidCheck2" required>
-        <label class="form-check-label" for="invalidCheck2">
+      <div class="form-field">
+        <input class="check" type="checkbox" value="" id="invalidCheck2" required>
+        <label for="invalidCheck2">
           Agree to terms and conditions
         </label>
       </div>
@@ -205,9 +205,9 @@ For a validated input group, wrap the group in a [`.form-field`](/forms/field/) 
       </div>
     </div>
     <div class="col-12">
-      <div class="form-check">
-        <input class="form-check-input is-invalid" type="checkbox" value="" id="invalidCheck3" aria-describedby="invalidCheck3Feedback" required>
-        <label class="form-check-label" for="invalidCheck3">
+      <div class="form-field">
+        <input class="check is-invalid" type="checkbox" value="" id="invalidCheck3" aria-describedby="invalidCheck3Feedback" required>
+        <label for="invalidCheck3">
           Agree to terms and conditions
         </label>
         <div id="invalidCheck3Feedback" class="invalid-feedback">
@@ -226,7 +226,7 @@ Validation styles are available for the following form controls and components:
 
 - `<input />`s and `<textarea>`s with `.form-control` (including up to one `.form-control` in input groups)
 - `<select>`s with `.form-control`
-- `.form-check`s
+- checkboxes, radios and switches with `.check`, `.radio` or `.switch`, laid out by a [`.form-field`](/forms/field/)
 
 <Example code={`<form>
     <div class="mb-3">
@@ -237,22 +237,27 @@ Validation styles are available for the following form controls and components:
       </div>
     </div>
 
-    <div class="form-check mb-3">
-      <input type="checkbox" class="form-check-input is-invalid" id="validationFormCheck1" required aria-describedby="validationFormCheck1Feedback">
-      <label class="form-check-label" for="validationFormCheck1">Check this checkbox</label>
+    <div class="form-field mb-3">
+      <input type="checkbox" class="check is-invalid" id="validationFormCheck1" required aria-describedby="validationFormCheck1Feedback">
+      <label for="validationFormCheck1">Check this checkbox</label>
       <div id="validationFormCheck1Feedback" class="invalid-feedback">Example invalid feedback text</div>
     </div>
 
-    <div class="form-check">
-      <input type="radio" class="form-check-input is-invalid" id="validationFormCheck2" name="radio-stacked" required>
-      <label class="form-check-label" for="validationFormCheck2">Toggle this radio</label>
+    <div class="form-field">
+      <input type="radio" class="radio is-invalid" id="validationFormCheck2" name="radio-stacked" required>
+      <label for="validationFormCheck2">Toggle this radio</label>
     </div>
-    <div class="form-check mb-3">
-      <input type="radio" class="form-check-input is-invalid" id="validationFormCheck3" name="radio-stacked" required aria-describedby="validationFormCheck3Feedback">
-      <label class="form-check-label" for="validationFormCheck3">Or toggle this other radio</label>
+    <div class="form-field mb-3">
+      <input type="radio" class="radio is-invalid" id="validationFormCheck3" name="radio-stacked" required aria-describedby="validationFormCheck3Feedback">
+      <label for="validationFormCheck3">Or toggle this other radio</label>
       <div id="validationFormCheck3Feedback" class="invalid-feedback">More example invalid feedback text</div>
     </div>
 
+    <div class="form-field mb-3">
+      <input type="checkbox" class="switch is-invalid" role="switch" id="validationSwitch" required aria-describedby="validationSwitchFeedback">
+      <label for="validationSwitch">Accept the terms</label>
+      <div id="validationSwitchFeedback" class="invalid-feedback">You must accept before submitting.</div>
+    </div>
     <div class="mb-3">
       <select class="form-control is-invalid" required aria-label="select example" aria-describedby="validationSelectFeedback">
         <option value="">Open this select menu</option>


### PR DESCRIPTION
Position 54 of the upstream sweep (`forms/validation`).

## The defect

**Every checkbox and radio on the page was written as `.form-check` with `.form-check-input`** — the v5 spelling, deprecated in v6 — across four sections: Custom styles, Browser defaults, Server side and Supported elements.

The page a reader consults to learn what validation looks like was teaching markup we tell them to migrate away from.

They are `.form-field` with `.check` or `.radio` now — which is what the stylesheet has styled all along. `.check.is-invalid`, `.radio.is-invalid` and `.switch.is-invalid` each carry four rules; none of them appeared on the page.

## Also

`Supported elements` gains a switch. It was the one control with validation styling and no example, and the bullet list above it now names the three control classes instead of `.form-check`.

## How it surfaced

Comparing section lengths rather than headings. The two pages have the **same section set**, so a heading comparison called this page clean — but theirs is 501 lines to our 362, and `Supported elements` alone was 128 against 54. Their section covers select, textarea, check, radio, switch, range, email, file and text; ours covered five controls, three of them in the deprecated spelling.

## Left for a decision

`form-range` validation: upstream styles it, we do not (`.form-range.is-invalid` — zero rules). A feature question, not a docs one, so it is not in here.

Verified with `npm run docs-build` — no broken links.