### PR TITLE
docs(alert): describe what close does in v6, not in v5

### DIFF
--- a/docs/src/content/docs/components/alerts.mdx
+++ b/docs/src/content/docs/components/alerts.mdx
@@ -221,7 +221,7 @@ This sets up an alert to listen for click events on descendant elements that hav
 
 | Method | Description |
 | --- | --- |
-| `close` | Closes an alert by removing it from the DOM. If the `.fade` and `.show` classes are present on the element, the alert will fade out before being removed. |
+| `close` | Closes an alert by removing it from the DOM. It fades out first unless the alert carries [`.alert-instant`](#dismissing). Returns a promise that resolves once the element is gone, so work that depends on the alert being removed can await it. |
 | `dispose` | Destroys an element's alert and removes any stored data associated with the DOM element. |
 | `getInstance` | A static method that allows you to retrieve the alert instance linked to a DOM element. For example: `coreui.Alert.getInstance(alert)`. |
 | `getOrCreateInstance` | A static method that returns the alert instance associated with a DOM element or creates a new one if it hasn't been initialized. You can use it as follows: `coreui.Alert.getOrCreateInstance(element)`. |


### PR DESCRIPTION
Position 56 of the upstream sweep (`components/alert`).

The page is otherwise ahead of theirs — 307 lines to 188, with `Solid` and `Deprecated markup` on top, and every shared section equal or longer. One row was stale.

## The methods table described v5

`close` said the alert fades out "if the `.fade` and `.show` classes are present on the element". That is the v5 condition. In v6 **every** alert fades unless it carries `.alert-instant` — which the `Dismissing` section on the same page already explains, so the table contradicted the prose above it.

It also left out that `close()` is `async` and resolves once the element is gone. A caller waiting for the alert to disappear had no way to learn it could await it.

## Also checked at this position

| their subsection | ours |
| --- | --- |
| `With icons`, `Dismiss` | our `Icons`, `Dismissing` — renames |
| `Via data attributes` | our `Triggers` covers `data-coreui-dismiss="alert"` |
| `Dependencies` | not applicable — the alert has none |

Verified with `npm run docs-build` — no broken links.