### PR TITLE
docs: color alerts with theme-{color} in the examples that still used the v5 spelling

### DIFF
--- a/docs/src/content/docs/components/drawer.mdx
+++ b/docs/src/content/docs/components/drawer.mdx
@@ -190,7 +190,7 @@ Responsive drawer classes hide content in a drawer below a specified breakpoint 
 
 <Example code={`<button class="btn-solid theme-primary d-lg-none" type="button" data-coreui-toggle="drawer" data-coreui-target="#drawerResponsive" aria-controls="drawerResponsive">Toggle drawer</button>
 
-  <div class="alert alert-info d-none d-lg-block">Resize your browser to show the responsive drawer toggle.</div>
+  <div class="alert theme-info d-none d-lg-block">Resize your browser to show the responsive drawer toggle.</div>
 
   <dialog class="drawer-lg drawer-end" id="drawerResponsive" aria-labelledby="drawerResponsiveLabel">
     <div class="drawer-header">

--- a/docs/src/content/docs/components/offcanvas.mdx
+++ b/docs/src/content/docs/components/offcanvas.mdx
@@ -162,7 +162,7 @@ Responsive offcanvas classes hide content that is outside the viewport from a sp
 
 <Example code={`<button class="btn-solid theme-primary d-lg-none" type="button" data-coreui-toggle="offcanvas" data-coreui-target="#offcanvasResponsive" aria-controls="offcanvasResponsive">Toggle offcanvas</button>
 
-  <div class="alert alert-info d-none d-lg-block">Resize your browser to show the responsive offcanvas toggle.</div>
+  <div class="alert theme-info d-none d-lg-block">Resize your browser to show the responsive offcanvas toggle.</div>
 
   <dialog class="offcanvas-lg offcanvas-end" id="offcanvasResponsive" aria-labelledby="offcanvasResponsiveLabel">
     <div class="offcanvas-header">

--- a/docs/src/content/docs/components/snippets/alert-live.js
+++ b/docs/src/content/docs/components/snippets/alert-live.js
@@ -2,7 +2,7 @@ const alertPlaceholder = document.getElementById('liveAlertPlaceholder')
 const appendAlert = (message, type) => {
   const wrapper = document.createElement('div')
   wrapper.innerHTML = [
-    `<div class="alert alert-${type} fade show" role="alert">`,
+    `<div class="alert theme-${type} fade show" role="alert">`,
     `   <div>${message}</div>`,
     '   <button type="button" class="btn-close" data-coreui-dismiss="alert" aria-label="Close"></button>',
     '</div>'


### PR DESCRIPTION
The live alert demo built each alert with `alert-${type}`, and the drawer and offcanvas pages carried `.alert-info` in their responsive hints. That spelling survives only under `$enable-deprecated-classes` and is slated for removal in v7, so the three examples were teaching an API the rest of the alert page tells readers to move off.

Every other alert on the page already uses `theme-{color}`.