### PR TITLE
docs(badge): say why a badge can confuse a screen reader

### DIFF
--- a/docs/src/content/docs/components/badge.mdx
+++ b/docs/src/content/docs/components/badge.mdx
@@ -38,9 +38,9 @@ Badges can be used as part of links or buttons to provide a counter.
     Notifications <span class="badge theme-danger">4</span>
   </button>`} />
 
-Remark that depending on how you use them, badges may be complicated for users of screen readers and related assistive technologies.
+Remark that depending on how you use them, badges may be complicated for users of screen readers and related assistive technologies. The styling gives sighted users a visual cue about the badge's purpose, but a screen reader announces only its content — so a badge can read as a stray word or number at the end of a sentence, link, or button.
 
-Unless the context is clear, consider including additional context with a visually hidden piece of additional text.
+Unless the context is clear — as in the Notifications example above, where the `4` is plainly a count — consider including additional context with a visually hidden piece of additional text.
 
 ### Positioned
 


### PR DESCRIPTION
The note warned that badges "may be complicated" for screen reader users and stopped there, leaving the reason out. It now states what actually happens — the styling carries the meaning visually, the screen reader announces only the content — and points at the Notifications example as the case where context already makes the number clear.