### PR TITLE
docs(badge): ring the positioned badges in the page background color

### DIFF
--- a/docs/src/content/docs/components/badge.mdx
+++ b/docs/src/content/docs/components/badge.mdx
@@ -48,7 +48,7 @@ Use utilities to modify a `.badge` and position it in the corner of a link or bu
 
 <Example code={`<button type="button" class="btn-solid theme-primary position-relative">
     Inbox
-    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill theme-danger">
+    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill border border-bg theme-danger">
       99+
       <span class="visually-hidden">unread messages</span>
     </span>
@@ -58,7 +58,7 @@ You can also replace the `.badge` class with a few more utilities without a coun
 
 <Example code={`<button type="button" class="btn-solid theme-primary position-relative">
     Profile
-    <span class="position-absolute top-0 start-100 translate-middle p-2 bg-danger border border-secondary rounded-circle">
+    <span class="position-absolute top-0 start-100 translate-middle p-2 bg-danger border border-bg rounded-circle">
       <span class="visually-hidden">New alerts</span>
     </span>
   </button>`} />


### PR DESCRIPTION
The corner badge sat flush against the button and the dot indicator carried a grey `.border-secondary` ring, so the two examples of the same pattern looked unrelated.

Both now use `.border-bg`, which draws the ring in the page background color and reads as the indicator being cut out of the button underneath it.