### PR TITLE
fix(breadcrumb): declare the divider tokens, and keep a custom divider in RTL

### DIFF
--- a/docs/src/content/docs/components/breadcrumb.mdx
+++ b/docs/src/content/docs/components/breadcrumb.mdx
@@ -95,10 +95,10 @@ Put an inline SVG inside the element. Nothing has to be URL escaped, and `curren
 
 ### Changing every divider
 
-The separators a breadcrumb writes for itself come from [`::before`](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) and [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content). Change them all at once with the `--cui-breadcrumb-divider` custom property, or with the `$breadcrumb-divider` Sass variable — and `$breadcrumb-divider-flipped` for its RTL counterpart. The Sass variable is the fallback of the custom property, so a global divider can be overridden per breadcrumb without recompiling.
+The separators a breadcrumb writes for itself come from [`::before`](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) and [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content). Change them all at once with the `--cui-breadcrumb-divider` custom property, or with the `$breadcrumb-divider` Sass variable — and `$breadcrumb-divider-flipped` for its RTL counterpart. The Sass variable sets the token's default, so a global divider can still be overridden on a single breadcrumb without recompiling. Set the property on the `<ol class="breadcrumb">` itself — the token is declared there, so a value put on a wrapping element is overridden rather than inherited.
 
-<Example code={`<nav style="--cui-breadcrumb-divider: '>';" aria-label="breadcrumb">
-    <ol class="breadcrumb">
+<Example code={`<nav aria-label="breadcrumb">
+    <ol class="breadcrumb" style="--cui-breadcrumb-divider: '>';">
       <li class="breadcrumb-item"><a href="#">Home</a></li>
       <li class="breadcrumb-item active" aria-current="page">Library</li>
     </ol>
@@ -120,8 +120,8 @@ It's also possible to use an **embedded SVG icon**. Apply it via our CSS custom 
 Inlining SVG as data URI requires to URL escape a few characters, most notably `<`, `>` and `#`. That's why the `$breadcrumb-divider` variable is passed through our [`escape-svg()` Sass function](/customize/sass/#escape-svg). When using the CSS custom property, you need to URL escape your SVG on your own. Read [Kevin Weber's explanations on CodePen](https://codepen.io/kevinweber/pen/dXWoRw ) for detailed information on what to escape.
 </Callout>
 
-<Example code={`<nav style="--cui-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M2.5 0L1 1.5 3.5 4 1 6.5 2.5 8l4-4-4-4z' fill='%236c757d'/%3E%3C/svg%3E&#34;);" aria-label="breadcrumb">
-    <ol class="breadcrumb">
+<Example code={`<nav aria-label="breadcrumb">
+    <ol class="breadcrumb" style="--cui-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M2.5 0L1 1.5 3.5 4 1 6.5 2.5 8l4-4-4-4z' fill='%236c757d'/%3E%3C/svg%3E&#34;);">
       <li class="breadcrumb-item"><a href="#">Home</a></li>
       <li class="breadcrumb-item active" aria-current="page">Library</li>
     </ol>
@@ -133,8 +133,8 @@ $breadcrumb-divider: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/
 
 You can also remove the divider setting `--cui-breadcrumb-divider: '';` (empty strings in CSS custom properties counts as a value), or setting the Sass variable to `$breadcrumb-divider: none;`.
 
-<Example code={`<nav style="--cui-breadcrumb-divider: '';" aria-label="breadcrumb">
-    <ol class="breadcrumb">
+<Example code={`<nav aria-label="breadcrumb">
+    <ol class="breadcrumb" style="--cui-breadcrumb-divider: '';">
       <li class="breadcrumb-item"><a href="#">Home</a></li>
       <li class="breadcrumb-item active" aria-current="page">Library</li>
     </ol>

--- a/docs/src/content/docs/components/breadcrumb.mdx
+++ b/docs/src/content/docs/components/breadcrumb.mdx
@@ -95,7 +95,9 @@ Put an inline SVG inside the element. Nothing has to be URL escaped, and `curren
 
 ### Changing every divider
 
-The separators a breadcrumb writes for itself come from [`::before`](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) and [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content). Change them all at once with the `--cui-breadcrumb-divider` custom property, or with the `$breadcrumb-divider` Sass variable — and `$breadcrumb-divider-flipped` for its RTL counterpart. The Sass variable sets the token's default, so a global divider can still be overridden on a single breadcrumb without recompiling. Set the property on the `<ol class="breadcrumb">` itself — the token is declared there, so a value put on a wrapping element is overridden rather than inherited.
+The separators a breadcrumb writes for itself come from [`::before`](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) and [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content). Change them all at once with the `--cui-breadcrumb-divider` custom property, or with the `$breadcrumb-divider` Sass variable. The Sass variable sets the token's default, so a global divider can still be overridden on a single breadcrumb without recompiling. Set the property on the `<ol class="breadcrumb">` itself — the token is declared there, so a value put on a wrapping element is overridden rather than inherited.
+
+A right-to-left breadcrumb follows the same divider unless you give it its own. Reach for `--cui-breadcrumb-divider-flipped` (or `$breadcrumb-divider-flipped`) when the separator points somewhere — `>` should become `<`, `→` should become `←` — and leave it alone for a symmetric one like `/`.
 
 <Example code={`<nav aria-label="breadcrumb">
     <ol class="breadcrumb" style="--cui-breadcrumb-divider: '>';">

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -273,6 +273,14 @@ finished, not whether the state changed.
   the one visible change is that a breadcrumb **given a background** now has
   rounded corners like every other surface. Set
   `--cui-breadcrumb-border-radius: 0` to square it off.
+- **`--cui-breadcrumb-divider` is now declared on `.breadcrumb`, so set it
+  there and not on a wrapper.** The property was read but never emitted, which
+  left it out of DevTools and out of the CSS variables table, and meant a value
+  set anywhere above the list reached the separators by inheritance. It is a
+  real token now — and a token declared on `.breadcrumb` beats one inherited
+  from an ancestor, so `<nav style="--cui-breadcrumb-divider: '>'">` stops
+  working. Move it onto the `<ol class="breadcrumb">`. Same for
+  `--cui-breadcrumb-divider-flipped`, its RTL counterpart.
 - **New: `.breadcrumb-link`, an opt-in class that gives a step a padded,
   hoverable target.** Bare links keep rendering as they always did. On a
   `<button>` it looks identical to a link, which is what lets one step toggle a

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -279,8 +279,12 @@ finished, not whether the state changed.
   set anywhere above the list reached the separators by inheritance. It is a
   real token now — and a token declared on `.breadcrumb` beats one inherited
   from an ancestor, so `<nav style="--cui-breadcrumb-divider: '>'">` stops
-  working. Move it onto the `<ol class="breadcrumb">`. Same for
-  `--cui-breadcrumb-divider-flipped`, its RTL counterpart.
+  working. Move it onto the `<ol class="breadcrumb">`.
+- **A custom divider now survives in RTL.** `--cui-breadcrumb-divider-flipped`
+  defaults to the main divider instead of to a second copy of the Sass default,
+  so setting only `--cui-breadcrumb-divider` no longer leaves right-to-left
+  pages on the built-in `/`. Set the flipped one only for a separator that
+  points somewhere — `>` becomes `<` — as before.
 - **New: `.breadcrumb-link`, an opt-in class that gives a step a padded,
   hoverable target.** Bare links keep rendering as they always did. On a
   `<button>` it looks identical to a link, which is what lets one step toggle a

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 @use "sass:string";
 @use "functions/defaults" as *;
 @use "functions/escape-svg" as *;
@@ -38,7 +39,9 @@ $breadcrumb-tokens: defaults(
     --#{$prefix}breadcrumb-margin-bottom: #{$breadcrumb-margin-bottom},
     --#{$prefix}breadcrumb-bg: #{$breadcrumb-bg},
     --#{$prefix}breadcrumb-border-radius: #{$breadcrumb-border-radius},
+    --#{$prefix}breadcrumb-divider: #{meta.inspect(escape-svg($breadcrumb-divider))},
     --#{$prefix}breadcrumb-divider-color: #{$breadcrumb-divider-color},
+    --#{$prefix}breadcrumb-divider-flipped: #{meta.inspect(escape-svg($breadcrumb-divider-flipped))},
     --#{$prefix}breadcrumb-item-padding-x: #{$breadcrumb-item-padding-x},
     --#{$prefix}breadcrumb-item-active-color: #{$breadcrumb-active-color},
     --#{$prefix}breadcrumb-link-padding-x: #{$breadcrumb-link-padding-x},
@@ -81,9 +84,9 @@ $breadcrumb-tokens: defaults(
         color: var(--#{$prefix}breadcrumb-divider-color);
         @include ltr-rtl(
           "content",
-          var(--#{$prefix}breadcrumb-divider, escape-svg($breadcrumb-divider)),
+          var(--#{$prefix}breadcrumb-divider),
           null,
-          var(--#{$prefix}breadcrumb-divider-flipped, escape-svg($breadcrumb-divider-flipped))
+          var(--#{$prefix}breadcrumb-divider-flipped)
         );
       }
     }
@@ -119,9 +122,9 @@ $breadcrumb-tokens: defaults(
     &:empty::before {
       @include ltr-rtl(
         "content",
-        var(--#{$prefix}breadcrumb-divider, escape-svg($breadcrumb-divider)),
+        var(--#{$prefix}breadcrumb-divider),
         null,
-        var(--#{$prefix}breadcrumb-divider-flipped, escape-svg($breadcrumb-divider-flipped))
+        var(--#{$prefix}breadcrumb-divider-flipped)
       );
     }
   }

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -23,7 +23,7 @@ $breadcrumb-link-hover-color:       var(--#{$prefix}fg-2) !default;
 $breadcrumb-link-hover-bg:          var(--#{$prefix}bg-1) !default;
 $breadcrumb-link-border-radius:     var(--#{$prefix}radius-7) !default;
 $breadcrumb-divider:                string.quote("/") !default;
-$breadcrumb-divider-flipped:        $breadcrumb-divider !default;
+$breadcrumb-divider-flipped:        var(--#{$prefix}breadcrumb-divider) !default;
 $breadcrumb-border-radius:          var(--#{$prefix}radius-5) !default;
 // scss-docs-end breadcrumb-variables
 


### PR DESCRIPTION
## The tokens were read but never emitted

`--cui-breadcrumb-divider` and `--cui-breadcrumb-divider-flipped` were read twice each and declared nowhere, so both lived only in the Sass fallback of the `var()` call — absent from DevTools, absent from the generated CSS variables table, discoverable only by already knowing the name. The component page meanwhile presents the property as *the* way to change every separator.

Both are tokens on `.breadcrumb` now, which puts them in that table.

**Behavior change, with a migration entry.** A token declared on the element beats one inherited from an ancestor, so a value set on a wrapping `<nav>` no longer reaches the separators. The three examples that did that now set it on the `<ol class="breadcrumb">`.

## A custom divider vanished in RTL

`$breadcrumb-divider-flipped` defaulted to a second copy of the Sass default, so the `[dir=rtl]` rule overrode whatever the custom property held with the built-in `/`. It defaults to the main token now, so one property covers both directions, and the flipped one is only for a separator that points somewhere (`>` → `<`).

Measured in Chromium against the built stylesheet, for both the automatic `::before` separator and an explicit `.breadcrumb-divider` element:

| | before | after |
| --- | --- | --- |
| default, LTR / RTL | `"/"` / `"/"` | `"/"` / `"/"` |
| `--cui-breadcrumb-divider: ">"`, LTR / RTL | `">"` / **`"/"`** | `">"` / `">"` |
| both set, RTL | `"<"` | `"<"` |
| `--cui-breadcrumb-divider: ""`, RTL | `""` | `""` |

The Sass path is unchanged: compiling with `$breadcrumb-divider-flipped: quote("<")` still emits `--cui-breadcrumb-divider-flipped: "<"`.

For the record, upstream dropped `$breadcrumb-divider-flipped` in v6 and does no RTL handling for the breadcrumb at all — their default chevron points the wrong way in right-to-left pages.