### PR TITLE
docs: separate every heading from the paragraph under it

### DIFF
--- a/docs/src/content/docs/components/avatar.mdx
+++ b/docs/src/content/docs/components/avatar.mdx
@@ -80,6 +80,7 @@ Make avatars square by using the `.rounded-0` class, removing any rounded edges 
   <div class="avatar rounded-0 theme-warning">CUI</div>`} />
 
 ## Sizing
+
 Adjust the size of avatars using the `.avatar-xs`, `.avatar-sm`, `.avatar-md`, `.avatar-lg`, and `.avatar-xl` classes for larger or smaller versions. The status indicator scales with the avatar, so it stays proportional at every size.
 <Example code={`<div class="avatar avatar-xl">CUI</div>
   <div class="avatar avatar-lg">CUI</div>

--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -130,6 +130,7 @@ With a theme colour the text takes it, and the fill that appears on hover takes 
 <Example code={getData('theme-colors').map((c) => `<button type="button" class="btn-subtle theme-${c.name}">${c.title}</button>`)} />
 
 ## Sizing
+
 Larger or smaller buttons? Add `.btn-xs`, `.btn-sm` or `.btn-lg` for additional sizes.
 
 <Example code={`<button type="button" class="btn-solid theme-primary btn-lg">Large button</button>
@@ -163,6 +164,7 @@ You can even roll your own custom sizing with CSS variables:
 <Example code={getData('theme-colors').map((c) => `<button type="button" class="btn-solid theme-${c.name} rounded-0">${c.title}</button>`)} />
 
 ## Disabled
+
 Add the `disabled` boolean attribute to any `<button>` element to make buttons look inactive. Disabled button has `pointer-events: none` applied to, disabling hover and active states from triggering.
 
 <Example code={`<button type="button" class="btn-solid theme-primary btn-lg" disabled>Primary button</button>

--- a/docs/src/content/docs/components/chip.mdx
+++ b/docs/src/content/docs/components/chip.mdx
@@ -128,6 +128,7 @@ Add `.active` to make chips use the solid appearance (bg/contrast). This is usef
   </div>`} />
 
 ## Sizing
+
 Use `.chip-sm` or `.chip-lg` for different sizes.
 
 <Example code={`<div class="d-flex flex-wrap gap-1 mb-3">

--- a/docs/src/content/docs/components/close-button.mdx
+++ b/docs/src/content/docs/components/close-button.mdx
@@ -13,6 +13,7 @@ Provide an option to dismiss or close a component with `.btn-close`. The icon is
 <Example code={`<button type="button" class="btn-close" aria-label="Close"></button>`} />
 
 ## Disabled
+
 Disabled close buttons change their `opacity`. We've also applied `pointer-events: none` and `user-select: none` to preventing hover and active states from triggering.
 
 <Example code={`<button type="button" class="btn-close" disabled aria-label="Close"></button>`} />

--- a/docs/src/content/docs/components/dropdowns.mdx
+++ b/docs/src/content/docs/components/dropdowns.mdx
@@ -201,6 +201,7 @@ And putting it to use in a navbar:
 
 <Callout color="info">
 #### RTL
+
 Directions are mirrored when using CoreUI in RTL, meaning `.dropstart` will appear on the right side.
 </Callout>
 

--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -401,6 +401,7 @@ myToastEl.addEventListener('hidden.coreui.toast', () => {
 
 
 ## Customizing
+
 ### CSS variables
 
 Toasts use local CSS variables on `.toast` for enhanced real-time customization.

--- a/docs/src/content/docs/forms/autocomplete.mdx
+++ b/docs/src/content/docs/forms/autocomplete.mdx
@@ -179,6 +179,7 @@ Apply validation styling to indicate input validity.
 <Example pro code={`<div data-coreui-toggle="autocomplete" data-coreui-options="Angular, Bootstrap, React.js, Vue.js" data-coreui-placeholder="Invalid autocomplete..." data-coreui-invalid="true"></div>`} />
 
 ## Disabled
+
 Add the `data-coreui-disabled="true"` attribute to disable the component:
 
 <Example pro code={`<div data-coreui-toggle="autocomplete" data-coreui-disabled="true" data-coreui-options="" data-coreui-placeholder="Disabled autocomplete..." ></div>`} />

--- a/docs/src/content/docs/forms/checkbox.mdx
+++ b/docs/src/content/docs/forms/checkbox.mdx
@@ -82,6 +82,7 @@ There is no inline modifier: the control is an inline element, so a row is a fle
   </div>`} />
 
 ## Sizing
+
 `.check-sm` and `.check-lg` size the whole row — the box, its label, and the space they sit in. Each sets one font size: the box is `1em`, so it follows, and so does the alignment margin, which is computed from the line. Nothing needs re-tuning per size, and a size of your own is one custom property.
 
 <Example code={`<div class="d-flex align-items-start gap-3">

--- a/docs/src/content/docs/forms/chip-input.mdx
+++ b/docs/src/content/docs/forms/chip-input.mdx
@@ -75,6 +75,7 @@ The JavaScript below initializes the example:
 <Code code={chipVariants} lang="js" />
 
 ## Sizing
+
 Use `chip-input-sm` and `chip-input-lg` to match surrounding form controls. Default size is provided by `.chip-input` without a size modifier.
 
 <Example code={`<div class="chip-input chip-input-sm mb-3" data-coreui-chip-input data-coreui-placeholder="Add small tag...">

--- a/docs/src/content/docs/forms/number-input.mdx
+++ b/docs/src/content/docs/forms/number-input.mdx
@@ -63,6 +63,7 @@ on the input would put the margin inside the border.
   <input type="number" class="form-control form-control-lg" value="3" aria-label="Quantity" data-coreui-toggle="number-input">`} />
 
 ## Disabled
+
 <Example pro code={`<input type="number" class="form-control" value="3" aria-label="Quantity" disabled data-coreui-toggle="number-input">`} />
 
 ## Inside your own group

--- a/docs/src/content/docs/forms/otp-input.mdx
+++ b/docs/src/content/docs/forms/otp-input.mdx
@@ -251,6 +251,7 @@ One-time password input supports different sizes. You may choose from small, nor
   </div>`} />
 
 ## Disabled
+
 Disable the entire one-time password input by adding the `data-coreui-disabled="true"` attribute.
 
 <Example pro code={`<label class="form-label">Disabled OTP input</label>

--- a/docs/src/content/docs/forms/password-input.mdx
+++ b/docs/src/content/docs/forms/password-input.mdx
@@ -40,6 +40,7 @@ Bootstrap Password Input supports different sizes using Bootstrap's sizing utili
   <input type="password" class="form-control form-control-sm" placeholder="Small password input" data-coreui-toggle="password-input">`} />
 
 ## Disabled
+
 To make a Bootstrap Password Input non-interactive, add the `disabled` attribute to the `<input />` and the toggle `<button>`.
 
 <Example pro code={`<input type="password" class="form-control" placeholder="Disabled password input" disabled data-coreui-toggle="password-input">

--- a/docs/src/content/docs/forms/radio.mdx
+++ b/docs/src/content/docs/forms/radio.mdx
@@ -77,6 +77,7 @@ There is no inline modifier: the control is an inline element, so a row is a fle
   </div>`} />
 
 ## Sizing
+
 `.radio-sm` and `.radio-lg` size the whole row — the box, its label, and the space they sit in. Each sets one font size: the box is `1em`, so it follows, and so does the alignment margin, which is computed from the line. Nothing needs re-tuning per size, and a size of your own is one custom property.
 
 <Example code={`<div class="d-flex align-items-start gap-3">

--- a/docs/src/content/docs/forms/rating.mdx
+++ b/docs/src/content/docs/forms/rating.mdx
@@ -82,6 +82,7 @@ For custom messages, provide a comma-separated list of tooltips corresponding to
 <Example pro code={`<div data-coreui-toggle="rating" data-coreui-tooltips="Very bad, Bad, Meh, Good, Very good" data-coreui-value="3"></div>`} />
 
 ## Sizing
+
 Larger or smaller rating component? Add `data-coreui-size="lg"` or `data-coreui-size="sm"` for additional sizes.
 
 <Example pro code={`<div data-coreui-size="sm" data-coreui-toggle="rating" data-coreui-value="3"></div>

--- a/docs/src/content/docs/forms/switch.mdx
+++ b/docs/src/content/docs/forms/switch.mdx
@@ -37,6 +37,7 @@ Add `role="switch"` to convey the nature of the control to assistive technologie
   </div>`} />
 
 ## Sizing
+
 `.switch-sm`, `.switch-lg` and `.switch-xl` size the whole row — the track, its thumb, and the label beside it — the way [`.check-sm`](/forms/checkbox/#sizing) and [`.radio-lg`](/forms/radio/#sizing) do.
 
 Each sets **one** custom property. The track's width follows its height through the aspect ratio, the thumb follows the height minus the padding, and the alignment margin is computed from the line — so nothing needs re-tuning per size.

--- a/docs/src/content/docs/utilities/border-radius.mdx
+++ b/docs/src/content/docs/utilities/border-radius.mdx
@@ -22,6 +22,7 @@ Add classes to an element to easily round its corners.
   <svg class="docs-placeholder-img rounded-5 rounded-top-0" width="75" height="75" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Example extra large bottom rounded image" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Example extra large bottom rounded image</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>`} />
 
 ## Sizing
+
 Use the scaling classes for larger or smaller rounded corners. Sizes range from `0` to `5` including `circle` and `pill`, and can be configured by modifying the utilities API.
 
 <Example class="docs-example-rounded-utils" code={`<svg class="docs-placeholder-img rounded-0" width="75" height="75" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Example non-rounded image" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Example non-rounded image</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>


### PR DESCRIPTION
Sixteen headings across fifteen pages ran straight into their first line of prose with no blank line between them — one mechanical slip, found on the Button page and swept across the whole docs tree rather than left for whichever page runs into it next.

Formatting only; no rendered output changes.