### PR TITLE
docs(calendar): say that a calendar brings no surface of its own

### DIFF
--- a/docs/src/content/docs/components/calendar.mdx
+++ b/docs/src/content/docs/components/calendar.mdx
@@ -16,6 +16,8 @@ import calendarCustomizeCells from './snippets/calendar-customize-cells.js?raw'
 
 Explore the Bootstrap 6 Calendar component's basic usage through sample code snippets demonstrating its core functionality.
 
+A calendar renders unadorned — it has no background, border, or padding of its own, so it takes the surface of whatever contains it. The examples below add `.border` and `.rounded` for that reason; a [card](/components/card/) works just as well.
+
 ### Days
 
 Select specific days using the Bootstrap Calendar component. The example below shows basic usage.


### PR DESCRIPTION
The calendar declares no `bg`, `border` or `padding` token — it takes the surface of whatever contains it. Every example on the page wraps it in `.border.rounded`, but nothing said why, so the border reads as decoration rather than as the thing supplying the surface, and markup written from scratch comes out as a grid floating on the page background.

One sentence in the intro, pointing at cards as the other option.