### PR TITLE
docs: name every locale section after the property it documents

### DIFF
--- a/docs/src/content/docs/components/calendar.mdx
+++ b/docs/src/content/docs/components/calendar.mdx
@@ -162,7 +162,7 @@ In this example:
 - `specificDates` is an array of specific dates to disable.
 - The `disabledDates` option combines both, allowing you to disable weekends and specific dates simultaneously.
 
-## Non-english locale
+## Locale
 
 The CoreUI Bootstrap Calendar allows users to display dates in non-English locales, making it suitable for international applications.
 

--- a/docs/src/content/docs/forms/date-input.mdx
+++ b/docs/src/content/docs/forms/date-input.mdx
@@ -102,7 +102,7 @@ Month names default to the grammatical form used inside a full date — e.g. Pol
   <div class="form-control form-date-time" data-coreui-date-input data-coreui-format="DD MMMM YYYY" data-coreui-locale="pl-PL"
        data-coreui-month-names='["styczeń", "luty", "marzec", "kwiecień", "maj", "czerwiec", "lipiec", "sierpień", "wrzesień", "październik", "listopad", "grudzień"]'></div>`} />
 
-## Locales
+## Locale
 
 Without an explicit format, the mask follows the locale set via `data-coreui-locale`.
 

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -225,7 +225,7 @@ Pass a function to disable every date that matches a rule.
 
 <Code code={datePickerWeekends} lang="js" />
 
-## Non-english locale
+## Locale
 
 ### Auto
 

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -187,7 +187,7 @@ yours.
 
 <Code code={dateRangePickerRanges} lang="js" />
 
-## Non-english locale
+## Locale
 
 ### Auto
 

--- a/docs/src/content/docs/forms/date-time-input.mdx
+++ b/docs/src/content/docs/forms/date-time-input.mdx
@@ -49,7 +49,7 @@ Combine [date tokens](/forms/date-input/#formats) and [time tokens](/forms/time-
     <div class="form-control form-date-time" data-coreui-date-time-input data-coreui-format="MMM D, YYYY h:mm A" data-coreui-locale="en-US"></div>
   </div>`} />
 
-## Locales
+## Locale
 
 Without an explicit format, the section order, separators, and hour cycle all derive from the locale set via `data-coreui-locale`.
 

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -103,7 +103,7 @@ The date time picker supports [floating labels](/forms/floating-labels/): set `f
     </div>
   </div>`} />
 
-## Non-english locale
+## Locale
 
 <Example pro code={`<div class="row mb-3">
     <div class="col-lg-6">

--- a/docs/src/content/docs/forms/time-input.mdx
+++ b/docs/src/content/docs/forms/time-input.mdx
@@ -49,7 +49,7 @@ Set an explicit format with the `data-coreui-format` attribute: `HH`/`H` for the
     <div class="form-control form-date-time" data-coreui-time-input data-coreui-format="hh:mm A" data-coreui-locale="en-US"></div>
   </div>`} />
 
-## Locales
+## Locale
 
 Without an explicit format, the hour cycle and layout follow the locale set via `data-coreui-locale` — `en-US` gets a 12-hour clock with an AM/PM section, `pl-PL` or `de-DE` a 24-hour one.
 

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -126,7 +126,7 @@ const picker = new coreui.TimePicker(element, {
 })
 ```
 
-## Non-english locale
+## Locale
 
 ### Auto
 


### PR DESCRIPTION
Eight pages carried two other spellings of the same heading.

- `Non-english locale` (calendar, date picker, date range picker, date time picker, time picker) named the one case the section does not cover: it opens with `Auto`, the browser default, which for most readers is English. It also spelled a proper noun in lowercase.
- `Locales` (date input, time input, date time input) named nothing — there is no such property, and those three sections are a single paragraph about `locale` with no subsections.

`Locale` is the property the sections document, so searching for it now lands on the heading. It was already the majority spelling across the React and Vue editions; the remaining pages there are renamed in the matching PRs.

Nothing links to the old anchors.