### PR TITLE
docs(card): tell the two ways of coloring a card apart

### DIFF
--- a/docs/src/content/docs/components/card.mdx
+++ b/docs/src/content/docs/components/card.mdx
@@ -392,6 +392,8 @@ Add `.card-row` to lay a card out along the inline axis. The sections sit side b
 
 Cards include various options for customizing their backgrounds, borders, and color.
 
+These are general-purpose utilities applied to the card as a whole: `.text-bg-*` fills the card's own background and leaves the header and footer on their neutral caps. To color the caps instead — or to color one section on its own — reach for [theme variants](#theme-variants).
+
 ### Background and color
 
 <AddedIn version="4.2.6" />


### PR DESCRIPTION
The page carries `## Card styles` (utilities) and `## Theme variants` (theme classes) one after the other with nothing between them, so a reader working top to bottom meets `.text-bg-danger` first and has no reason to read on.

They are not two depths of the same thing — measured in Chromium against the built stylesheet, they paint opposite parts:

| | card background | header background |
| --- | --- | --- |
| `.card.text-bg-danger` | red | neutral cap |
| `.card.theme-danger` | page surface | red |

One sentence in the utilities section saying what each one fills, and pointing at the other.