### PR TITLE
docs: name the theme section the same way everywhere

### DIFF
--- a/docs/src/content/docs/forms/checkbox.mdx
+++ b/docs/src/content/docs/forms/checkbox.mdx
@@ -196,7 +196,7 @@ The v5 toggle button — `.btn-check` on the input, with a sibling `.btn` label 
 
 See the [v6 migration guide](/migration/v6/) for the full picture.
 
-## Theme colors
+## Theme variants
 
 Modify the appearance of checked checkboxes by adding a [`.theme-{color}` class](/customize/components/#theme-variants) to the `.form-check` element. This sets the checked background and border color to the theme color.
 

--- a/docs/src/content/docs/forms/radio.mdx
+++ b/docs/src/content/docs/forms/radio.mdx
@@ -186,7 +186,7 @@ The v5 toggle button — `.btn-check` on the input, with a sibling `.btn` label 
 
 See the [v6 migration guide](/migration/v6/) for the full picture.
 
-## Theme colors
+## Theme variants
 
 Modify the appearance of checked radios by adding a [`.theme-{color}` class](/customize/components/#theme-variants) to the `.form-check` element. This sets the checked background and border color to the theme color.
 

--- a/docs/src/content/docs/forms/range-slider.mdx
+++ b/docs/src/content/docs/forms/range-slider.mdx
@@ -137,7 +137,7 @@ If you set `data-coreui-track` to `false`, the slider's track will not display a
   <div class="mb-3" data-coreui-toggle="range-slider" data-coreui-track="false" data-coreui-value="50, 75"></div>
   <div data-coreui-toggle="range-slider" data-coreui-track="false" data-coreui-value="25, 50, 75"></div>`} />
 
-## Theme colors
+## Theme variants
 
 Color the filled track and the handles by adding a [`.theme-{color}` class](/customize/components/#theme-variants) to the slider element.
 

--- a/docs/src/content/docs/forms/range.mdx
+++ b/docs/src/content/docs/forms/range.mdx
@@ -64,7 +64,7 @@ The value of the range input can be shown using the `output` element and a bit o
     });
   </script>`} />
 
-## Theme colors
+## Theme variants
 
 Color the thumb by adding a [`.theme-{color}` class](/customize/components/#theme-variants) to the input or a wrapper.
 

--- a/docs/src/content/docs/forms/stepper.mdx
+++ b/docs/src/content/docs/forms/stepper.mdx
@@ -618,7 +618,7 @@ myStepper.addEventListener('stepChange.coreui.stepper', event => {
 })
 ```
 
-## Theming
+## Theme variants
 
 A [theme class](/customize/components/#theme-variants) colors the active and completed step indicators and the connectors:
 

--- a/docs/src/content/docs/forms/switch.mdx
+++ b/docs/src/content/docs/forms/switch.mdx
@@ -106,7 +106,7 @@ The v5 spelling — `.form-check.form-switch` wrapping a `.form-check-input`, wi
 
 See the [v6 migration guide](/migration/v6/) for the full picture.
 
-## Theme colors
+## Theme variants
 
 Modify the appearance of checked switches by adding a [`.theme-{color}` class](/customize/components/#theme-variants) to the `.form-check` element. This sets the checked background and border color to the theme color.
 


### PR DESCRIPTION
Component and form pages called the same section three different things — `Theme colors`, `Theme variants` and `Theming` — for the one thing they all describe: adding a `.theme-*` class to color the component.

`Theme variants` is the term the tree had already settled on:

| anchor | links pointing at it | what it means |
| --- | --- | --- |
| `#theme-variants` | **31** | the mechanism, defined on `customize/components` |
| `#theme-colors` | 6 | the **palette**, on `customize/color` and `customize/theme` |
| `#theming` | 2 | (both added last week on the card page; retargeted here) |

`Theme colors` was the majority spelling on component pages and the worst of the three, because the name is taken — it means the palette elsewhere in the docs, so the same words pointed at two different subjects.

Left alone deliberately: `customize/components` keeps `## Theme variants` (it defines the term and owns the anchor everything links to), `customize/color` and `customize/theme` keep `## Theme colors` (the palette), and so does the migration entry about `light`/`dark`.

Nothing links to the renamed anchors — checked before the rename.