### PR TITLE
docs(collapse): name both directions the section documents

### DIFF
--- a/docs/src/content/docs/components/collapse.mdx
+++ b/docs/src/content/docs/components/collapse.mdx
@@ -59,10 +59,10 @@ Please note that while the example below has a `min-height` set to avoid excessi
     </div>
   </div>`} />
 
-## Multiple targets
+## Multiple toggles and targets
 
 A `<button>` or `<a>` can show and hide multiple elements by referencing them with a selector in its `href` or `data-coreui-target` attribute.
-Multiple `<button>` or `<a>` can show and hide an element if they each reference it with their `href` or `data-coreui-target` attribute
+Conversely, multiple `<button>` or `<a>` elements can show and hide the same element if they each reference it with their `href` or `data-coreui-target` attribute.
 
 <Example code={`<p class="d-inline-flex flex-wrap gap-1">
     <a class="btn-solid theme-primary" data-coreui-toggle="collapse" href="#multiCollapseExample1" role="button" aria-expanded="false" aria-controls="multiCollapseExample1">Toggle first element</a>


### PR DESCRIPTION
The heading said `Multiple targets`, but the section covers the reverse case too — several toggles pointing at one element — and shows an example of it. The sentence describing that case was also missing its noun (`multiple <button> or <a>` with nothing for the adjective to attach to) and its full stop.