### PR TITLE
docs(dialog): show the dark variant

### DIFF
--- a/docs/src/content/docs/components/dialog.mdx
+++ b/docs/src/content/docs/components/dialog.mdx
@@ -229,6 +229,31 @@ Pop up a dialog that covers the user viewport, via modifier classes placed on th
 </dialog>
 ```
 
+## Dark variant
+
+Put `data-coreui-theme="dark"` on the `<dialog>` and it flips the tokens its own surface reads, so the dialog and everything in it — including the close button — turns dark on a light page.
+
+<dialog class="dialog" id="darkDialog" data-coreui-theme="dark" aria-labelledby="darkDialogLabel">
+  <div class="dialog-header">
+    <h5 class="dialog-title" id="darkDialogLabel">Dark dialog</h5>
+    <button type="button" class="btn-close" data-coreui-dismiss="dialog" aria-label="Close"></button>
+  </div>
+  <div class="dialog-body">
+    <p>The surface, the text and the dividers all read the flipped tokens.</p>
+  </div>
+  <div class="dialog-footer">
+    <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="dialog">Close</button>
+  </div>
+</dialog>
+
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="dialog" data-coreui-target="#darkDialog">`, `  Open dark dialog`, `</button>`]} />
+
+```html
+<dialog class="dialog" data-coreui-theme="dark">
+  ...
+</dialog>
+```
+
 ## Accessibility
 
 Be sure to add `aria-labelledby="..."`, referencing the dialog title, to the `<dialog>`. Additionally, you may give a description of your dialog with `aria-describedby`. The native `<dialog>` element already provides the dialog role, `aria-modal` semantics, focus trapping, and background inertness — don't add `role`, `aria-modal`, `aria-hidden`, or `tabindex` yourself.


### PR DESCRIPTION
A dialog reads the flipped tokens like any other surface, so `data-coreui-theme="dark"` on the `<dialog>` turns it dark on a light page. Measured in Chromium against the built stylesheet:

| | background | title color |
| --- | --- | --- |
| `.dialog` | `rgb(255, 255, 255)` | `rgb(33, 38, 49)` |
| `.dialog[data-coreui-theme="dark"]` | `rgb(14, 17, 21)` | `rgb(248, 249, 251)` |

The page never mentioned it and had no example. `Dark variant` is the heading the carousel and dropdown pages already use.