### PR TITLE
docs(modal): put accessibility outside the example list and fix two heading levels

### DIFF
--- a/docs/src/content/docs/components/modal.mdx
+++ b/docs/src/content/docs/components/modal.mdx
@@ -32,7 +32,7 @@ This component's animation effect relies on the `prefers-reduced-motion` media q
 </Callout>
 
 <Callout color="warning">
-#### Migrating from v5
+### Migrating from v5
 
 The v5 `<div class="modal">` markup (with its `.modal-dialog` and `.modal-content` wrappers) is upgraded to the native `<dialog>` structure automatically at runtime, with a console warning. This transitional layer will be removed in v7 — update your markup to the structure documented below.
 </Callout>
@@ -381,10 +381,6 @@ Modals animate by default. For modals that simply appear rather than fade in to 
 </dialog>
 ```
 
-### Accessibility
-
-Be sure to add `aria-labelledby="..."`, referencing the modal title, to the `<dialog>`. Additionally, you may give a description of your modal dialog with `aria-describedby`. Note that the native `<dialog>` element already provides the dialog role, `aria-modal` semantics, focus trapping, and background inertness — don't add `role`, `aria-modal`, `aria-hidden`, or `tabindex` yourself.
-
 ### Embedding YouTube videos
 
 Embedding YouTube videos in modals requires additional JavaScript not in CoreUI to automatically stop playback and more. [See this helpful Stack Overflow post](https://stackoverflow.com/questions/18622508/bootstrap-3-and-youtube-in-modal) for more information.
@@ -440,7 +436,7 @@ Our default modal without modifier class constitutes the "medium" size modal.
   </div>
 </dialog>
 
-## Fullscreen Modal
+## Fullscreen modal
 
 Another override is the option to pop up a modal that covers the user viewport, available via modifier classes that are placed on the `<dialog class="modal">`.
 
@@ -539,6 +535,10 @@ Another override is the option to pop up a modal that covers the user viewport, 
     <button type="button" class="btn-solid theme-secondary" data-coreui-dismiss="modal">Close</button>
   </div>
 </dialog>
+
+## Accessibility
+
+Be sure to add `aria-labelledby="..."`, referencing the modal title, to the `<dialog>`. Additionally, you may give a description of your modal dialog with `aria-describedby`. Note that the native `<dialog>` element already provides the dialog role, `aria-modal` semantics, focus trapping, and background inertness — don't add `role`, `aria-modal`, `aria-hidden`, or `tabindex` yourself.
 
 ## Usage
 


### PR DESCRIPTION
Three things on a page the upstream sweep never reaches, since `modal` is not in their v6 sidebar:

- `Accessibility` sat inside `## Examples`, between `Remove animation` and `Embedding YouTube videos` — listed as a thing to demo rather than a thing to observe. Lifted to `## Accessibility`, before `## Usage`.
- `Migrating from v5` was an `h4` directly under an `h2`.
- `Fullscreen Modal` capitalised a word mid-heading.

The `#fullscreen-modal` anchor is linked from the styling page; the slug is unchanged, since it lowercases either way.