### PR TITLE
docs(drawer): show the dark variant

### DIFF
--- a/docs/src/content/docs/components/drawer.mdx
+++ b/docs/src/content/docs/components/drawer.mdx
@@ -148,6 +148,28 @@ Add `.drawer-no-backdrop` to hide the backdrop while keeping the drawer modal �
 
 Add `.drawer-instant` to a drawer that should appear and disappear at once, with no slide and no backdrop fade. It is the same opt-out that [`.alert-instant`](/components/alerts/#dismissing) provides, and it applies to both directions.
 
+### Dark
+
+Put `data-coreui-theme="dark"` on the drawer and it flips the tokens its own surface reads, so the panel and everything in it — including the close button — turns dark on a light page.
+
+<Example html={[`<button class="btn-solid theme-primary" type="button" data-coreui-toggle="drawer" data-coreui-target="#drawerDark">Dark drawer</button>`]} />
+
+<dialog class="drawer drawer-start" data-coreui-theme="dark" id="drawerDark" aria-labelledby="drawerDarkLabel">
+  <div class="drawer-header">
+    <h5 class="drawer-title" id="drawerDarkLabel">Dark drawer</h5>
+    <button type="button" class="btn-close" data-coreui-dismiss="drawer" aria-label="Close"></button>
+  </div>
+  <div class="drawer-body">
+    <p>The surface, the text and the dividers all read the flipped tokens.</p>
+  </div>
+</dialog>
+
+```html
+<dialog class="drawer drawer-start" data-coreui-theme="dark">
+  ...
+</dialog>
+```
+
 ## Body scrolling
 
 The page scroll is blocked while a drawer is open. Set `scroll: true` to open the drawer non-modally instead — the page stays interactive and scrollable. A visible backdrop requires the top layer, so `backdrop: true` (the default) takes precedence over `scroll: true` for the page-interactivity part.


### PR DESCRIPTION
A drawer reads the flipped tokens like any other surface, so `data-coreui-theme="dark"` turns it dark on a light page. Measured in Chromium against the built stylesheet:

| | background | title color |
| --- | --- | --- |
| `.drawer` | `rgb(255, 255, 255)` | `rgb(33, 38, 49)` |
| `.drawer[data-coreui-theme="dark"]` | `rgb(14, 17, 21)` | `rgb(248, 249, 251)` |

The page never mentioned it and had no example. Added as a `Variants` subsection, next to the other seven.

Third component in a row where the v6 successor lost a variant its predecessor documents — after `CDialog`/`CModal` (coreui-pro#1032), and the offcanvas page carries the same section this one was missing.