### PR TITLE
docs: mark Modal and Offcanvas deprecated, like Dropdown already is

### DIFF
--- a/docs/src/content/docs/components/modal.mdx
+++ b/docs/src/content/docs/components/modal.mdx
@@ -8,6 +8,10 @@ otherFrameworks:
 
 import varyingModalContent from './snippets/varying-modal-content.js?raw'
 
+<Callout color="warning">
+**Built on the same engine as Dialog — and heading for retirement.** Since v6 the Modal plugin is a compatibility layer over the dialog behavior [Dialog](/components/dialog/) is built on — same engine and dismissal, with the v5 markup, classes and `*.coreui.modal` events preserved, and the classic look. Existing modal markup keeps working unchanged throughout v6, but **Modal may be removed in v7** — we recommend using Dialog for new work and migrating when convenient.
+</Callout>
+
 ## How it works
 
 Bootstrap modals are lightweight and multi-purpose popups built on the native `<dialog>` element. Modals are split into three primary sections: header, body, and footer. Each has its role and so should be used accordingly. Before getting started with CoreUI for Bootstrap's modal component, be sure to read the following as our menu options have recently changed.

--- a/docs/src/content/docs/components/offcanvas.mdx
+++ b/docs/src/content/docs/components/offcanvas.mdx
@@ -6,6 +6,10 @@ otherFrameworks:
   - offcanvas
 ---
 
+<Callout color="warning">
+**Built on the same engine as Drawer — and heading for retirement.** Since v6 the Offcanvas plugin is a compatibility layer over the dialog behavior [Drawer](/components/drawer/) is built on — same engine and dismissal, with the v5 markup, classes and `*.coreui.offcanvas` events preserved, and the classic look. Existing offcanvas markup keeps working unchanged throughout v6, but **Offcanvas may be removed in v7** — we recommend using Drawer for new work and migrating when convenient.
+</Callout>
+
 ## How it works
 
 The Bootstrap Offcanvas component serves as a sidebar element that can be activated through JavaScript, allowing it to slide in from the left, right, top, or bottom of the viewport. Triggers, like buttons or anchors, are linked to the elements you want to toggle, and data attributes facilitate their activation in JavaScript.

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -639,8 +639,9 @@ check, radio, carousel and toggler icons already work:
   slide entry variants; Drawer is a floating, inset, rounded panel with
   translucent/sheet/fullscreen/fit-content variants and responsive classes
   (`.drawer-sm`…`.drawer-xxl`). Both share the DialogBase behavior with
-  Modal/Offcanvas (which keep the classic look and the v5 vocabulary) —
-  pick per surface, they are independent components. See the
+  Modal/Offcanvas, which keep the classic look and the v5 vocabulary as
+  **compatibility layers over it — deprecated in v6 and removable in v7**, so
+  reach for Dialog and Drawer in new work. See the
   [Dialog docs](/components/dialog/) and [Drawer docs](/components/drawer/).
 
 #### Calendar


### PR DESCRIPTION
All three compatibility layers carry the same status in code:

```
@deprecated 6.0.0 `CModal` may be removed in v7 — prefer `CDialog` for new work.
@deprecated 6.0.0 `COffcanvas` may be removed in v7 — prefer `CDrawer` for new work.
```

both described there as "a compatibility layer over the same dialog behavior". Only the **dropdown** page carried a notice saying so; the modal and offcanvas pages said nothing.

Worse, the migration guide said the opposite outright:

> Both share the DialogBase behavior with Modal/Offcanvas (which keep the classic look and the v5 vocabulary) — **pick per surface, they are independent components**.

That reads as an invitation to build new work on a deprecated component. It now says what the code says.

The two pages get the same callout the dropdown page has, worded for their own successor.