### PR TITLE
docs(pagination): announce the current page on the link, not the list item

### DIFF
--- a/docs/src/content/docs/components/pagination.mdx
+++ b/docs/src/content/docs/components/pagination.mdx
@@ -58,8 +58,8 @@ While the `.disabled` class uses `pointer-events: none` to _try_ to disable the 
         <a class="page-link">Previous</a>
       </li>
       <li class="page-item"><a class="page-link" href="#">1</a></li>
-      <li class="page-item active" aria-current="page">
-        <a class="page-link" href="#">2</a>
+      <li class="page-item active">
+        <a class="page-link" href="#" aria-current="page">2</a>
       </li>
       <li class="page-item"><a class="page-link" href="#">3</a></li>
       <li class="page-item">
@@ -69,6 +69,8 @@ While the `.disabled` class uses `pointer-events: none` to _try_ to disable the 
   </nav>`} />
 
 You can optionally swap out active or disabled anchors for `<span>`, or omit the anchor in the case of the prev/next arrows, to remove click functionality and prevent keyboard focus while retaining intended styles.
+
+`aria-current="page"` goes on the `<a>` a user can focus, so the current page is announced when they reach it. With a `<span>` there is nothing to focus, so it sits on the `.page-item` instead.
 
 <Example code={`<nav aria-label="...">
     <ul class="pagination">
@@ -94,7 +96,7 @@ A [theme class](/customize/components/#theme-variants) recolors the whole pagina
     <ul class="pagination theme-${c.name}">
       <li class="page-item"><a class="page-link" href="#">Previous</a></li>
       <li class="page-item"><a class="page-link" href="#">1</a></li>
-      <li class="page-item active" aria-current="page"><a class="page-link" href="#">2</a></li>
+      <li class="page-item active"><a class="page-link" href="#" aria-current="page">2</a></li>
       <li class="page-item"><a class="page-link" href="#">3</a></li>
       <li class="page-item"><a class="page-link" href="#">Next</a></li>
     </ul>


### PR DESCRIPTION
`aria-current="page"` sat on `.page-item` even where the page number is an `<a>`, so the state was announced on the list item while focus lands on the link inside it.

Measured across our docs, the anchor is the house placement and pagination was the outlier:

| placement | our docs | upstream |
| --- | --- | --- |
| on `<a>` | 41 | 48 |
| on `<li>` | 16 | 6 |

The `<li>` uses come from only two pages here — breadcrumb and pagination. **Breadcrumb is right**: its current item is a `<span>`, so the item is the only element to carry it, and upstream does the same there. Pagination was not.

Moved to the anchor in the two examples that have one. The three `<span>` examples keep it on the item, and a new sentence says why the two differ.