### PR TITLE
docs: document responsive placement, and name a breakpoint that exists

### DIFF
--- a/docs/src/content/docs/components/menu.mdx
+++ b/docs/src/content/docs/components/menu.mdx
@@ -137,7 +137,7 @@ All placements support `-start` and `-end` alignment modifiers (e.g., `bottom-st
 
 ### Responsive
 
-Change placement at different breakpoints using responsive prefixes. The syntax is `breakpoint:placement`, where breakpoint is one of `sm`, `md`, `lg`, `xl`, or `2xl`. Multiple breakpoints can be combined in a single attribute, space-separated.
+Change placement at different breakpoints using responsive prefixes. The syntax is `breakpoint:placement`, where breakpoint is one of `sm`, `md`, `lg`, `xl`, or `xxl`. Multiple breakpoints can be combined in a single attribute, space-separated.
 
 For example, `data-coreui-placement="bottom-start md:bottom-end lg:end-start"` will:
 

--- a/docs/src/content/docs/components/popovers.mdx
+++ b/docs/src/content/docs/components/popovers.mdx
@@ -79,6 +79,14 @@ Four options are available: top, right, bottom, and left aligned. Directions are
     Popover on left
   </button>`} sandboxJs={popoverDirections} />
 
+### Responsive placement
+
+Change placement at different breakpoints using responsive prefixes. The syntax is `breakpoint:placement`, where breakpoint is one of `sm`, `md`, `lg`, `xl`, or `xxl`. Multiple breakpoints can be combined in a single attribute, space-separated — a bare placement with no prefix is the one below the smallest listed breakpoint.
+
+<Example code={`<button type="button" class="btn-solid theme-secondary" data-coreui-container="body" data-coreui-toggle="popover" data-coreui-placement="top md:right lg:bottom" data-coreui-content="Responsive popover">
+    Top, then right, then bottom
+  </button>`} />
+
 ### Using the `container` option
 
 When you have some styles on a parent element that interfere with a popover, you'll want to specify a custom `container` so that the popover's HTML appears within that element instead.

--- a/docs/src/content/docs/components/tooltips.mdx
+++ b/docs/src/content/docs/components/tooltips.mdx
@@ -76,6 +76,14 @@ Bootstrap Tooltips support multiple placements: top, right, bottom, and left. Th
   <button type="button" class="btn-outline" data-coreui-toggle="tooltip" data-coreui-placement="bottom" title="Tooltip on bottom">Tooltip on bottom</button>
   <button type="button" class="btn-outline" data-coreui-toggle="tooltip" data-coreui-placement="left" title="Tooltip on left">Tooltip on left</button>`} />
 
+### Responsive placement
+
+Change placement at different breakpoints using responsive prefixes. The syntax is `breakpoint:placement`, where breakpoint is one of `sm`, `md`, `lg`, `xl`, or `xxl`. Multiple breakpoints can be combined in a single attribute, space-separated — a bare placement with no prefix is the one below the smallest listed breakpoint.
+
+<Example code={`<button type="button" class="btn-solid theme-secondary" data-coreui-toggle="tooltip" data-coreui-placement="top md:right lg:bottom" data-coreui-title="Responsive tooltip">
+    Top, then right, then bottom
+  </button>`} />
+
 ### Tooltips with HTML Content
 
 Bootstrap Tooltips support HTML content, allowing you to insert styled elements like `<em>`, `<strong>`, or `<u>` directly inside the tooltip. This feature is useful when you want to emphasize certain words, add inline formatting, or even insert icons.


### PR DESCRIPTION
Responsive placement (`data-coreui-placement="top md:right lg:bottom"`) is implemented in `tooltip.ts` and `menu.ts`, so it works for **menus, dropdowns, tooltips and popovers** — popover extends Tooltip and dropdown is built on Menu. Only the menu page documented it.

**And it named a breakpoint we do not have.** The page said the prefix is one of `sm`, `md`, `lg`, `xl`, or `2xl`; `BREAKPOINTS` in `util/floating-ui.ts` holds `sm md lg xl xxl`, and the parser skips anything not in that map — no error, no warning:

```
parse("bottom 2xl:top")  ->  { xs: "bottom" }          ← the prefix vanishes
parse("bottom xxl:top")  ->  { xs: "bottom", xxl: "top" }
```

The wording came from upstream, where v6 renamed the breakpoints to the `2xl` style; we kept `xxl`. (`2xl` stays correct elsewhere — `fs-2xl`, `border-radius-2xl` — it is only wrong as a breakpoint prefix.)

The tooltip and popover pages get the section they never had.