### PR TITLE
docs(progress): say what happens to a label longer than the bar

### DIFF
--- a/docs/src/content/docs/components/progress.mdx
+++ b/docs/src/content/docs/components/progress.mdx
@@ -49,6 +49,20 @@ Add labels to your progress bars by placing text within the `.progress-bar`.
     <div class="progress-bar" role="progressbar" style="width: 25%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">25%</div>
   </div>`} />
 
+### Long labels
+
+A `.progress-bar` clips what does not fit — it is `overflow: hidden` with `white-space: nowrap` — so a label wider than the bar is cut off rather than wrapped. Add [`.overflow-visible`](/utilities/overflow/) to let it spill over the track instead.
+
+<Example code={`<div class="progress">
+    <div class="progress-bar" role="progressbar" style="width: 25%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">Filling in your details</div>
+  </div>
+
+  <div class="progress">
+    <div class="progress-bar overflow-visible" role="progressbar" style="width: 25%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">Filling in your details</div>
+  </div>`} />
+
+Spilling over comes at a cost: the label then sits on two backgrounds at once, so its color has to contrast with both the bar and the track. Where it cannot, put the label outside the progress bar instead.
+
 ## Height
 
 We only set a `height` value on the `.progress`, so if you change that value the inner `.progress-bar` will automatically resize accordingly.

--- a/docs/src/content/docs/components/progress.mdx
+++ b/docs/src/content/docs/components/progress.mdx
@@ -54,11 +54,11 @@ Add labels to your progress bars by placing text within the `.progress-bar`.
 A `.progress-bar` clips what does not fit — it is `overflow: hidden` with `white-space: nowrap` — so a label wider than the bar is cut off rather than wrapped. Add [`.overflow-visible`](/utilities/overflow/) to let it spill over the track instead.
 
 <Example code={`<div class="progress">
-    <div class="progress-bar" role="progressbar" style="width: 25%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">Filling in your details</div>
+    <div class="progress-bar" role="progressbar" style="width: 10%;" aria-valuenow="10" aria-valuemin="0" aria-valuemax="100">Filling in your details</div>
   </div>
 
   <div class="progress">
-    <div class="progress-bar overflow-visible" role="progressbar" style="width: 25%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">Filling in your details</div>
+    <div class="progress-bar overflow-visible" role="progressbar" style="width: 10%;" aria-valuenow="10" aria-valuemin="0" aria-valuemax="100">Filling in your details</div>
   </div>`} />
 
 Spilling over comes at a cost: the label then sits on two backgrounds at once, so its color has to contrast with both the bar and the track. Where it cannot, put the label outside the progress bar instead.


### PR DESCRIPTION
A `.progress-bar` is `overflow: hidden` with `white-space: nowrap`, so a label wider than the bar is cut off. Nothing on the page said so. Measured against the built stylesheet:

| | overflow | label width | bar width |
| --- | --- | --- | --- |
| `.progress-bar` | `hidden` | 162px | 50px — clipped |
| `.progress-bar.overflow-visible` | `visible` | 162px | 50px — spills over the track |

The new subsection shows both and names the cost of the second: the label then sits on two backgrounds at once, so its color has to contrast with the bar **and** the track — otherwise put the label outside the bar.