### PR TITLE
fix(Calendar): select weeks from the row and scan whole periods for disabled dates

### DIFF
--- a/js/src/calendar.ts
+++ b/js/src/calendar.ts
@@ -307,6 +307,13 @@ class Calendar extends BaseComponent {
     closest?.focus()
   }
 
+  _getEventTarget(event: any): HTMLElement | null {
+    // When weeks are the unit, the row is the focusable thing — a focus event
+    // then arrives with no cell above it, and the row stands in for one.
+    return event.target.closest(SELECTOR_CALENDAR_CELL) ??
+      event.target.closest(SELECTOR_CALENDAR_ROW)
+  }
+
   _getDate(target: HTMLElement): Date {
     if (this._config.selectionType === 'week') {
       const firstCell = SelectorEngine.findOne(SELECTOR_CALENDAR_CELL, target.closest(SELECTOR_CALENDAR_ROW) as ParentNode)
@@ -317,10 +324,15 @@ class Calendar extends BaseComponent {
   }
 
   _handleCalendarClick(event: any): void {
-    const target = event.target.closest(SELECTOR_CALENDAR_CELL)
+    const target = this._getEventTarget(event)
+
+    if (!target) {
+      return
+    }
+
     const date = this._getDate(target)
     const cloneDate = new Date(date)
-    const index = Manipulator.getDataAttribute(target.closest(SELECTOR_CALENDAR), 'calendar-index') as number
+    const index = Manipulator.getDataAttribute(target.closest(SELECTOR_CALENDAR) as HTMLElement, 'calendar-index') as number
 
     if (this._view === 'days') {
       this._setCalendarDate(index ? new Date(cloneDate.setMonth(cloneDate.getMonth() - index)) : date)
@@ -514,10 +526,7 @@ class Calendar extends BaseComponent {
   }
 
   _handleCalendarMouseEnter(event: any): void {
-    // When weeks are the unit, the row is the focusable thing — a focus event
-    // then arrives with no cell above it, and the row stands in for one.
-    const target = event.target.closest(SELECTOR_CALENDAR_CELL) ??
-      event.target.closest(SELECTOR_CALENDAR_ROW)
+    const target = this._getEventTarget(event)
 
     if (!target) {
       return
@@ -1193,8 +1202,8 @@ class Calendar extends BaseComponent {
 
     const isRangeHover = this._hoverDate && (
       this._selectEndDate ?
-        isYearInRange(date, this._startDate, this._hoverDate) :
-        isYearInRange(date, this._hoverDate, this._endDate)
+        isDateInRange(date, this._startDate, this._hoverDate) :
+        isDateInRange(date, this._hoverDate, this._endDate)
     )
 
     const classNames = this._classNames({

--- a/js/src/util/calendar.ts
+++ b/js/src/util/calendar.ts
@@ -108,6 +108,32 @@ const isOutsideRange = (value: number, min: number | null, max: number | null) :
 }
 
 /**
+ * Helper function to check if every day of a period is disabled.
+ * @param start - First day of the period.
+ * @param end - Last day of the period.
+ * @param min - Minimum allowed date.
+ * @param max - Maximum allowed date.
+ * @param disabledDates - Criteria for disabled dates.
+ * @returns True if no day between start and end (clamped to min/max) is selectable.
+ */
+const isPeriodDisabled = (start: Date, end: Date, min: Date | null | undefined, max: Date | null | undefined, disabledDates: DisabledDate | DisabledDate[]) : boolean => {
+  const startTime = min ? Math.max(start.getTime(), min.getTime()) : start.getTime()
+  const endTime = max ? Math.min(end.getTime(), max.getTime()) : end.getTime()
+
+  for (
+    const currentDate = new Date(startTime);
+    currentDate.getTime() <= endTime;
+    currentDate.setDate(currentDate.getDate() + 1)
+  ) {
+    if (!isDateDisabled(currentDate, min, max, disabledDates)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
  * Converts an ISO week string to a Date object representing the Monday of that week.
  * @param isoWeek - The ISO week string (e.g., "2023W05" or "2023w05").
  * @returns The Date object for the Monday of the specified week.
@@ -323,7 +349,7 @@ const generateDatePatterns = (locale: string, includeTime: boolean) : string[] =
 const buildDateRegexPattern = (formatString: string, includeTime: boolean) : string => {
   // First escape special regex characters
 
-  let regexPattern = formatString.replaceAll(/[.*+?^${}()|[\\]\\]/g, "\\$&")
+  let regexPattern = formatString.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&")
 
   // Then replace the date/time components with regex groups
   regexPattern = regexPattern
@@ -1031,24 +1057,10 @@ export const isMonthDisabled = (date: Date, min?: Date | null, max?: Date | null
     return false
   }
 
-  const startTime = min ?
-    Math.max(date.getTime(), min.getTime()) :
-    date.getTime()
-  const endTime = max ?
-    Math.min(date.getTime(), max.getTime()) :
-    new Date(new Date().getFullYear(), 11, 31).getTime()
+  const year = date.getFullYear()
+  const month = date.getMonth()
 
-  for (
-    const currentDate = new Date(startTime);
-    currentDate.getTime() <= endTime;
-    currentDate.setDate(currentDate.getDate() + 1)
-  ) {
-    if (!isDateDisabled(currentDate, min, max, disabledDates)) {
-      return false
-    }
-  }
-
-  return false
+  return isPeriodDisabled(new Date(year, month, 1), new Date(year, month + 1, 0), min, max, disabledDates)
 }
 
 /**
@@ -1113,33 +1125,10 @@ export const isQuarterDisabled = (date: Date, min?: Date | null, max?: Date | nu
     return false
   }
 
-  // Get the start and end of the quarter
-  const quarter = Math.floor(date.getMonth() / 3)
-  const quarterStartMonth = quarter * 3
-  const quarterEndMonth = quarterStartMonth + 2
   const year = date.getFullYear()
+  const quarterStartMonth = Math.floor(date.getMonth() / 3) * 3
 
-  const quarterStart = new Date(year, quarterStartMonth, 1)
-  const quarterEnd = new Date(year, quarterEndMonth + 1, 0) // Last day of the quarter
-
-  const startTime = min ?
-    Math.max(quarterStart.getTime(), min.getTime()) :
-    quarterStart.getTime()
-  const endTime = max ?
-    Math.min(quarterEnd.getTime(), max.getTime()) :
-    quarterEnd.getTime()
-
-  for (
-    const currentDate = new Date(startTime);
-    currentDate.getTime() <= endTime;
-    currentDate.setDate(currentDate.getDate() + 1)
-  ) {
-    if (!isDateDisabled(currentDate, min, max, disabledDates)) {
-      return false
-    }
-  }
-
-  return false
+  return isPeriodDisabled(new Date(year, quarterStartMonth, 1), new Date(year, quarterStartMonth + 3, 0), min, max, disabledDates)
 }
 
 /**
@@ -1240,24 +1229,7 @@ export const isYearDisabled = (date: Date, min?: Date | null, max?: Date | null,
     return false
   }
 
-  const startTime = min ?
-    Math.max(date.getTime(), min.getTime()) :
-    date.getTime()
-  const endTime = max ?
-    Math.min(date.getTime(), max.getTime()) :
-    new Date(new Date().getFullYear(), 11, 31).getTime()
-
-  for (
-    const currentDate = new Date(startTime);
-    currentDate.getTime() <= endTime;
-    currentDate.setDate(currentDate.getDate() + 1)
-  ) {
-    if (!isDateDisabled(currentDate, min, max, disabledDates)) {
-      return false
-    }
-  }
-
-  return false
+  return isPeriodDisabled(new Date(year, 0, 1), new Date(year, 11, 31), min, max, disabledDates)
 }
 
 /**

--- a/js/tests/unit/calendar.spec.js
+++ b/js/tests/unit/calendar.spec.js
@@ -308,6 +308,22 @@ describe('Calendar', () => {
       expect(div.classList).not.toContain('show-week-numbers')
       expect(div.querySelector('.calendar-cell-week-number')).toBeNull()
     })
+
+    it('should select the week when the week number cell is clicked', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const calendar = new Calendar(div, {
+        calendarDate: new Date(2023, 5, 1),
+        selectionType: 'week',
+        showWeekNumber: true
+      })
+
+      const row = div.querySelectorAll('.calendar-row[tabindex="0"]')[1]
+      row.querySelector('.calendar-cell-week-number').click()
+
+      expect(calendar._startDate).toEqual(new Date(row.querySelector('.calendar-cell').dataset.coreuiDate))
+    })
   })
 
   describe('accessibility', () => {
@@ -1420,21 +1436,31 @@ describe('Calendar', () => {
         calendarDate: new Date(2023, 5, 1)
       })
 
-      // In week mode, rows should be clickable/focusable
       const rows = div.querySelectorAll('.calendar-row[tabindex="0"]')
       expect(rows.length).toBeGreaterThan(0)
 
-      // Simulate keyboard Enter on a cell within a row to select a week
       const secondRow = rows[1]
-      const cell = secondRow.querySelector('.calendar-cell')
-      expect(cell).not.toBeNull()
-
       const event = {
-        target: cell, key: 'Enter', code: 'Space', preventDefault() {}
+        target: secondRow, key: 'Enter', code: 'Enter', preventDefault() {}
       }
       calendar._handleCalendarKeydown(event)
-      // After Enter on a week cell, the start date should be set
-      expect(calendar._startDate).toBeDefined()
+      expect(calendar._startDate).toEqual(new Date(secondRow.querySelector('.calendar-cell').dataset.coreuiDate))
+    })
+
+    it('should select the week on Enter keydown dispatched on the row', () => {
+      fixtureEl.innerHTML = '<div></div>'
+      const div = fixtureEl.querySelector('div')
+      const calendar = new Calendar(div, {
+        selectionType: 'week',
+        calendarDate: new Date(2023, 5, 1)
+      })
+
+      const row = div.querySelectorAll('.calendar-row[tabindex="0"]')[1]
+      const keydownEvent = createEvent('keydown')
+      keydownEvent.key = 'Enter'
+      row.dispatchEvent(keydownEvent)
+
+      expect(calendar._startDate).toEqual(new Date(row.querySelector('.calendar-cell').dataset.coreuiDate))
     })
   })
 
@@ -1960,6 +1986,30 @@ describe('Calendar', () => {
       calendar._updateClassNamesAndAriaLabels()
       const rangeHoverCells = div.querySelectorAll('.calendar-cell.range-hover')
       expect(rangeHoverCells.length).toBeGreaterThan(0)
+    })
+
+    it('should apply range-hover class only to rows inside the hovered range in week selection mode', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const calendar = new Calendar(div, {
+        calendarDate: new Date(2023, 5, 1),
+        range: true,
+        selectionType: 'week',
+        selectEndDate: true
+      })
+
+      const rows = div.querySelectorAll('.calendar-row')
+      const rowDate = row => new Date(row.querySelector('.calendar-cell').dataset.coreuiDate)
+      calendar._startDate = rowDate(rows[1])
+      calendar._hoverDate = rowDate(rows[2])
+      calendar._updateClassNamesAndAriaLabels()
+
+      const rangeHoverRows = div.querySelectorAll('.calendar-row.range-hover')
+      expect(rangeHoverRows.length).toBe(2)
+      expect(rows[1].classList).toContain('range-hover')
+      expect(rows[2].classList).toContain('range-hover')
+      expect(rows[3].classList).not.toContain('range-hover')
     })
 
     it('should apply range-hover class with endDate hover (selectEndDate false)', () => {

--- a/js/tests/unit/util/calendar.spec.js
+++ b/js/tests/unit/util/calendar.spec.js
@@ -22,6 +22,7 @@ import {
   isMonthDisabled,
   isMonthSelected,
   isMonthInRange,
+  isQuarterDisabled,
   isSameDateAs,
   isToday,
   isYearDisabled,
@@ -437,6 +438,26 @@ describe('Calendar Utilities', () => {
       const max = new Date(2023, 5, 1)
       expect(isMonthDisabled(date, min, max, undefined)).toBeFalse()
     })
+
+    it('should return true if disabledDates disables every day of the month', () => {
+      expect(isMonthDisabled(new Date(2023, 2, 1), null, null, () => true)).toBeTrue()
+    })
+
+    it('should return false if disabledDates leaves any day of the month enabled', () => {
+      const weekends = date => date.getDay() === 0 || date.getDay() === 6
+      expect(isMonthDisabled(new Date(2023, 2, 1), null, null, weekends)).toBeFalse()
+    })
+
+    it('should return true if the month lies entirely outside min/max', () => {
+      expect(isMonthDisabled(new Date(2023, 2, 1), new Date(2023, 3, 1), null, () => false)).toBeTrue()
+      expect(isMonthDisabled(new Date(2023, 2, 1), null, new Date(2023, 1, 1), () => false)).toBeTrue()
+    })
+
+    it('should return false if any day inside min/max is enabled', () => {
+      const onlyMarch20 = date => date.getDate() !== 20
+      expect(isMonthDisabled(new Date(2023, 2, 1), new Date(2023, 2, 15), null, onlyMarch20)).toBeFalse()
+      expect(isMonthDisabled(new Date(2023, 2, 1), null, new Date(2023, 2, 10), onlyMarch20)).toBeTrue()
+    })
   })
 
   describe('isMonthSelected', () => {
@@ -473,6 +494,36 @@ describe('Calendar Utilities', () => {
       const start = new Date(2023, 1, 1)
       const end = new Date(2023, 3, 1)
       expect(isMonthInRange(date, start, end)).toBeFalse()
+    })
+  })
+
+  describe('isQuarterDisabled', () => {
+    it('should return true if quarter is outside min/max', () => {
+      expect(isQuarterDisabled(new Date(2023, 0, 1), new Date(2023, 3, 1), null, undefined)).toBeTrue()
+      expect(isQuarterDisabled(new Date(2023, 6, 1), null, new Date(2023, 5, 30), undefined)).toBeTrue()
+    })
+
+    it('should return false if no disabledDates and within min/max', () => {
+      expect(isQuarterDisabled(new Date(2023, 3, 1), new Date(2023, 0, 1), new Date(2023, 11, 31), undefined)).toBeFalse()
+    })
+
+    it('should return true if disabledDates disables every day of the quarter', () => {
+      expect(isQuarterDisabled(new Date(2023, 3, 1), null, null, () => true)).toBeTrue()
+    })
+
+    it('should return false if disabledDates leaves any day of the quarter enabled', () => {
+      const weekends = date => date.getDay() === 0 || date.getDay() === 6
+      expect(isQuarterDisabled(new Date(2023, 3, 1), null, null, weekends)).toBeFalse()
+    })
+
+    it('should return true if the quarter lies entirely outside min/max', () => {
+      expect(isQuarterDisabled(new Date(2023, 3, 1), new Date(2023, 6, 1), null, () => false)).toBeTrue()
+    })
+
+    it('should return false if any day inside min/max is enabled', () => {
+      const onlyJune15 = date => !(date.getMonth() === 5 && date.getDate() === 15)
+      expect(isQuarterDisabled(new Date(2023, 3, 1), new Date(2023, 5, 1), null, onlyJune15)).toBeFalse()
+      expect(isQuarterDisabled(new Date(2023, 3, 1), null, new Date(2023, 4, 31), onlyJune15)).toBeTrue()
     })
   })
 
@@ -524,6 +575,25 @@ describe('Calendar Utilities', () => {
       const min = new Date(2023, 0, 1)
       const max = new Date(2023, 11, 31)
       expect(isYearDisabled(date, min, max, undefined)).toBeFalse()
+    })
+
+    it('should return true if disabledDates disables every day of the year', () => {
+      expect(isYearDisabled(new Date(2023, 0, 1), null, null, () => true)).toBeTrue()
+    })
+
+    it('should return false if disabledDates leaves any day of the year enabled', () => {
+      const weekends = date => date.getDay() === 0 || date.getDay() === 6
+      expect(isYearDisabled(new Date(2023, 0, 1), null, null, weekends)).toBeFalse()
+    })
+
+    it('should return true if the year lies entirely outside min/max', () => {
+      expect(isYearDisabled(new Date(2023, 0, 1), new Date(2024, 0, 1), null, () => false)).toBeTrue()
+    })
+
+    it('should return false if any day inside min/max is enabled', () => {
+      const onlyDecember24 = date => !(date.getMonth() === 11 && date.getDate() === 24)
+      expect(isYearDisabled(new Date(2023, 0, 1), new Date(2023, 11, 1), null, onlyDecember24)).toBeFalse()
+      expect(isYearDisabled(new Date(2023, 0, 1), null, new Date(2023, 10, 30), onlyDecember24)).toBeTrue()
     })
   })
 
@@ -690,6 +760,11 @@ describe('Calendar Utilities', () => {
       expect(result.getFullYear()).toBe(2023)
       expect(result.getMonth()).toBe(1) // February
       expect(result.getDate()).toBe(15)
+    })
+
+    it('should not treat the separator as a wildcard', () => {
+      expect(getLocalDateFromString('2x15x2023', 'en-US')).toBeNull()
+      expect(getLocalDateFromString('15x2x2023', 'de-DE')).toBeNull()
     })
 
     it('should parse date string with time when includeTime is true', () => {


### PR DESCRIPTION
## What was broken

1. **Week selection threw on keyboard and on the week-number cell.** With `selectionType: 'week'` the focusable element is the `<tr>`, and the click handler looked for a `.calendar-cell` above the event target. Enter/Space on a focused row, or a click on the `<th class="calendar-cell-week-number">`, found none and crashed on `_getDate(null)`. The existing spec masked it by dispatching on a cell instead of the row.
2. **`disabledDates` never disabled a month, quarter or year.** `isMonthDisabled`, `isQuarterDisabled` and `isYearDisabled` ended every branch in `return false`, so `disabledDates: () => true` still rendered every month/quarter/year cell as selectable. The month/year scan window was also wrong: it started at the period start and, with no `max`, ran to Dec 31 of the current year (thousands of callback calls per years-view render).
3. **Week-range hover lit the whole year.** `_rowWeekAttributes` computed `range-hover` with `isYearInRange` while `range` two lines above used `isDateInRange`.
4. **Date parsing treated separators as wildcards.** The escaper in `buildDateRegexPattern` had a character class that closed at the first `\]`, so it never matched; the alternative `.` separator became a regex wildcard and `getLocalDateFromString('2x15x2023', 'en-US')` parsed as a date.

## What the code does now

- `_handleCalendarClick` and `_handleCalendarMouseEnter` share `_getEventTarget`, which falls back to the `.calendar-row` when there is no cell above the target.
- A private `isPeriodDisabled(start, end, min, max, disabledDates)` scans the days of the period, clamped to min/max, and returns `true` only when none is selectable. The three period checks build their own bounds (first/last day of the month, quarter, year) and delegate to it — at most 366 callback calls per cell.
- Week rows compute `range-hover` with `isDateInRange`.
- `buildDateRegexPattern` uses the same escaper class as `generateDatePatterns`.

## Tests

- `calendar.spec.js`: the week keyboard spec now dispatches on the row; new specs for a real `keydown` on the `<tr>`, a click on the week-number cell (`showWeekNumber: true`), and week-range hover (only the rows inside the hovered range carry `range-hover`).
- `util/calendar.spec.js`: `isMonthDisabled` / `isQuarterDisabled` (new describe) / `isYearDisabled` — `() => true` → true, weekends-only callback → false, period fully outside min/max → true, period partially inside → false when any inside day is enabled; `getLocalDateFromString` rejects `2x15x2023` (en-US) and `15x2x2023` (de-DE).

All 11 new/changed specs fail on `v6-dev` and pass here; full unit suite green (3305 tests, coverage 95.5 / 88.9 / 94.2 / 95.5).

Found by workspace audit v6-js-pre-alpha-audit-2026-08 §1. Items 1, 3 and 4 are structured differently or already correct in the React/Vue ports (row handlers receive the date directly, week rows use `isDateInRange`, Vue's escaper is already correct); item 2 ships in coreui/coreui-react-pro and coreui/coreui-vue-pro, item 4 in coreui/coreui-react-pro — sibling PRs: coreui/coreui-react-pro#254, coreui/coreui-vue-pro#202.
