### PR TITLE
fix(Stepper, RangeSlider, LoadingButton): keyboard capture, reset after finish, step math, shared dispose and stale timers

### DIFF
--- a/js/src/loading-button.ts
+++ b/js/src/loading-button.ts
@@ -7,7 +7,6 @@
 
 import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
-import Data from './dom/data.js'
 import EventHandler from './dom/event-handler.js'
 import { defineJQueryPlugin } from './util/index.js'
 
@@ -49,6 +48,7 @@ const DefaultType = {
  */
 
 class LoadingButton extends BaseComponent {
+  protected declare _startTimeout: ReturnType<typeof setTimeout> | null
   protected declare _timeout: ReturnType<typeof setTimeout> | null
   protected declare _spinner: HTMLElement | null
   protected declare _state: string
@@ -57,13 +57,10 @@ class LoadingButton extends BaseComponent {
     super(element)
 
     this._config = this._getConfig(config)
-    this._timeout = this._config.timeout
+    this._startTimeout = null
+    this._timeout = null
     this._spinner = null
     this._state = 'idle'
-
-    if (this._element) {
-      Data.set(element as Element, DATA_KEY, this)
-    }
 
     this._createButton()
   }
@@ -85,28 +82,35 @@ class LoadingButton extends BaseComponent {
   // Public
 
   start(): void {
-    if (this._state !== 'loading') {
-      this._createSpinner()
-      this._state = 'loading'
+    if (this._state === 'loading') {
+      return
+    }
 
-      setTimeout(() => {
-        this._element.classList.add(CLASS_NAME_IS_LOADING)
-        EventHandler.trigger(this._element, EVENT_START)
+    this._createSpinner()
+    this._state = 'loading'
 
-        if (this._config.disabledOnLoading) {
-          this._element.setAttribute('disabled', true as unknown as string)
-        }
-      }, 1)
+    this._startTimeout = setTimeout(() => {
+      this._element.classList.add(CLASS_NAME_IS_LOADING)
+      EventHandler.trigger(this._element, EVENT_START)
 
-      if (this._config.timeout) {
-        setTimeout(() => {
-          this.stop()
-        }, this._config.timeout)
+      if (this._config.disabledOnLoading) {
+        this._element.setAttribute('disabled', true as unknown as string)
       }
+    }, 1)
+
+    if (this._config.timeout) {
+      this._timeout = setTimeout(() => {
+        this.stop()
+      }, this._config.timeout)
     }
   }
 
   stop(): void {
+    if (this._state !== 'loading') {
+      return
+    }
+
+    this._clearTimeouts()
     this._element.classList.remove(CLASS_NAME_IS_LOADING)
     const stoped = () => {
       this._removeSpinner()
@@ -125,6 +129,26 @@ class LoadingButton extends BaseComponent {
     }
 
     stoped()
+  }
+
+  override dispose(): void {
+    this._clearTimeouts()
+
+    super.dispose()
+  }
+
+  // Private
+
+  _clearTimeouts(): void {
+    if (this._startTimeout) {
+      clearTimeout(this._startTimeout)
+      this._startTimeout = null
+    }
+
+    if (this._timeout) {
+      clearTimeout(this._timeout)
+      this._timeout = null
+    }
   }
 
   _createButton(): void {

--- a/js/src/range-slider.ts
+++ b/js/src/range-slider.ts
@@ -121,6 +121,9 @@ class RangeSlider extends BaseComponent {
   protected declare _dragIndex: number
   protected declare _inputs: HTMLInputElement[]
   protected declare _isDragging: boolean
+  protected declare _onDocumentMouseMove: (event: any) => void
+  protected declare _onDocumentMouseUp: () => void
+  protected declare _onWindowResize: () => void
   protected declare _sliderTrack: any
   protected declare _tooltips: HTMLElement[]
 
@@ -135,6 +138,22 @@ class RangeSlider extends BaseComponent {
     this._isDragging = false
     this._sliderTrack = null
     this._tooltips = []
+
+    this._onDocumentMouseMove = event => {
+      if (!this._isDragging) {
+        return
+      }
+
+      this._updateValue(this._calculateMoveValue(event), this._dragIndex)
+    }
+
+    this._onDocumentMouseUp = () => {
+      this._isDragging = false
+    }
+
+    this._onWindowResize = () => {
+      this._updateLabelsContainerSize()
+    }
 
     this._initializeRangeSlider()
   }
@@ -161,8 +180,9 @@ class RangeSlider extends BaseComponent {
   }
 
   override dispose(): void {
-    EventHandler.off(window, EVENT_KEY)
-    EventHandler.off(document.documentElement, EVENT_KEY)
+    EventHandler.off(window, EVENT_RESIZE, this._onWindowResize)
+    EventHandler.off(document.documentElement, EVENT_MOUSEMOVE, this._onDocumentMouseMove)
+    EventHandler.off(document.documentElement, EVENT_MOUSEUP, this._onDocumentMouseUp)
 
     super.dispose()
   }
@@ -213,23 +233,9 @@ class RangeSlider extends BaseComponent {
       EventHandler.trigger(this._element, EVENT_INPUT, { value: this._currentValue })
     })
 
-    EventHandler.on(document.documentElement, EVENT_MOUSEUP, () => {
-      this._isDragging = false
-    })
-
-    EventHandler.on(document.documentElement, EVENT_MOUSEMOVE, (event: any) => {
-      if (!this._isDragging) {
-        return
-      }
-
-      const moveValue = this._calculateMoveValue(event)
-
-      this._updateValue(moveValue, this._dragIndex)
-    })
-
-    EventHandler.on(window, EVENT_RESIZE, () => {
-      this._updateLabelsContainerSize()
-    })
+    EventHandler.on(document.documentElement, EVENT_MOUSEUP, this._onDocumentMouseUp)
+    EventHandler.on(document.documentElement, EVENT_MOUSEMOVE, this._onDocumentMouseMove)
+    EventHandler.on(window, EVENT_RESIZE, this._onWindowResize)
   }
 
   _initializeRangeSlider(): void {
@@ -460,7 +466,7 @@ class RangeSlider extends BaseComponent {
       this._calculateHorizontalPosition(event.clientX, trackRect)
 
     if (typeof position === 'string') {
-      return position === 'max' ? this._config.max : this._config.min
+      return this._roundToStep(position === 'max' ? this._config.max : this._config.min, this._config.step)
     }
 
     const value = this._config.min + (position * (this._config.max - this._config.min))
@@ -599,9 +605,26 @@ class RangeSlider extends BaseComponent {
     return value
   }
 
-  _roundToStep(number: number, step: number): number {
-    const _step = step === 0 ? 1 : step
-    return Math.round(number / _step) * _step
+  _getDecimals(number: number): number {
+    const [mantissa, exponent = '0'] = `${number}`.split('e')
+
+    return Math.max(0, (mantissa.split('.')[1] || '').length - Number(exponent))
+  }
+
+  _roundToStep(number: number, step: number | string): number {
+    const { max, min } = this._config
+    const value = Math.min(Math.max(number, min), max)
+    const _step = Number(step)
+
+    if (Number.isNaN(_step)) {
+      return value
+    }
+
+    const size = _step === 0 ? 1 : _step
+    const decimals = Math.max(this._getDecimals(size), this._getDecimals(min))
+    const rounded = Number((min + (Math.round((value - min) / size) * size)).toFixed(decimals))
+
+    return rounded > max ? Math.max(min, Number((rounded - size).toFixed(decimals))) : rounded
   }
 
   override _configAfterMerge(config: any): any {

--- a/js/src/stepper.ts
+++ b/js/src/stepper.ts
@@ -96,7 +96,7 @@ class Stepper extends BaseComponent {
     this._updateStepButtonsDisabledState()
     this._setupAccessibilityAttributes()
 
-    EventHandler.on(this._element, EVENT_KEYDOWN, event => this._keydown(event))
+    EventHandler.on(this._element, EVENT_KEYDOWN, SELECTOR_STEPPER_STEP_BUTTON, event => this._keydown(event))
   }
 
   // Getters
@@ -232,8 +232,7 @@ class Stepper extends BaseComponent {
   }
 
   reset(): void {
-    const steps = this._getEnabledStepButtons()
-    if (!steps.length) {
+    if (!this._stepButtons.length) {
       return
     }
 
@@ -247,10 +246,9 @@ class Stepper extends BaseComponent {
       content.setAttribute('aria-hidden', 'true')
     }
 
-    for (const btn of steps) {
+    for (const btn of this._stepButtons) {
       btn.classList.remove(CLASS_NAME_ACTIVE, CLASS_NAME_COMPLETE)
       this._removeIndicatorIcon(btn)
-      btn.disabled = false
     }
 
     for (const form of this._element.querySelectorAll(`${SELECTOR_STEPPER_PANE} form, ${SELECTOR_STEPPER_STEP_CONTENT} form`)) {
@@ -263,7 +261,7 @@ class Stepper extends BaseComponent {
       }
     }
 
-    const firstStep = this._initialStepButton || steps[0]
+    const firstStep = this._initialStepButton || this._stepButtons[0]
     firstStep.classList.add(CLASS_NAME_ACTIVE)
 
     const pane = this._getTargetPane(firstStep)
@@ -636,13 +634,13 @@ class Stepper extends BaseComponent {
 
       case ARROW_RIGHT_KEY:
       case ARROW_DOWN_KEY: {
-        nextActiveElement = getNextActiveElement(children, event.target, true, true)
+        nextActiveElement = getNextActiveElement(children, event.delegateTarget, true, true)
         break
       }
 
       case ARROW_LEFT_KEY:
       case ARROW_UP_KEY: {
-        nextActiveElement = getNextActiveElement(children, event.target, false, true)
+        nextActiveElement = getNextActiveElement(children, event.delegateTarget, false, true)
         break
       }
 

--- a/js/tests/unit/loading-button.spec.js
+++ b/js/tests/unit/loading-button.spec.js
@@ -283,6 +283,40 @@ describe('LoadingButton', () => {
         loadingButton.start()
       })
     })
+
+    it('should clear the timeout so it cannot cut a later loading cycle short', () => {
+      jasmine.clock().install()
+
+      try {
+        fixtureEl.innerHTML = '<button>Click me</button>'
+        const button = fixtureEl.querySelector('button')
+        const loadingButton = new LoadingButton(button, { timeout: 100 })
+        let stopCount = 0
+        button.addEventListener('stop.coreui.loading-button', () => {
+          stopCount++
+        })
+
+        loadingButton.start()
+        jasmine.clock().tick(10)
+        loadingButton.stop()
+        expect(loadingButton._timeout).toBeNull()
+
+        jasmine.clock().tick(10)
+        expect(stopCount).toBe(1)
+        expect(loadingButton._state).toBe('idle')
+
+        loadingButton.start()
+        jasmine.clock().tick(95)
+        expect(loadingButton._state).toBe('loading')
+        expect(stopCount).toBe(1)
+
+        expect(() => jasmine.clock().tick(100)).not.toThrow()
+        expect(loadingButton._state).toBe('idle')
+        expect(stopCount).toBe(2)
+      } finally {
+        jasmine.clock().uninstall()
+      }
+    })
   })
 
   describe('dispose', () => {
@@ -296,6 +330,27 @@ describe('LoadingButton', () => {
       loadingButton.dispose()
 
       expect(Data.get(button, 'coreui.loading-button')).toBeNull()
+    })
+
+    it('should not let the timers fire after dispose', () => {
+      jasmine.clock().install()
+
+      try {
+        fixtureEl.innerHTML = '<button>Click me</button>'
+        const button = fixtureEl.querySelector('button')
+        const loadingButton = new LoadingButton(button, { timeout: 100 })
+        const startSpy = jasmine.createSpy('start')
+        button.addEventListener('start.coreui.loading-button', startSpy)
+
+        loadingButton.start()
+        loadingButton.dispose()
+
+        expect(() => jasmine.clock().tick(200)).not.toThrow()
+        expect(startSpy).not.toHaveBeenCalled()
+        expect(button.classList.contains('is-loading')).toBeFalse()
+      } finally {
+        jasmine.clock().uninstall()
+      }
     })
   })
 
@@ -518,17 +573,18 @@ describe('LoadingButton', () => {
       })
     })
 
-    it('should handle stop call without start', () => {
+    it('should ignore stop when not loading', () => {
       fixtureEl.innerHTML = '<button>Click me</button>'
       const button = fixtureEl.querySelector('button')
       const loadingButton = new LoadingButton(button)
+      const stopSpy = jasmine.createSpy('stop')
+      button.addEventListener('stop.coreui.loading-button', stopSpy)
 
-      // The stop method will throw when trying to call remove() on null spinner
       expect(() => {
         loadingButton.stop()
-      }).toThrow()
+      }).not.toThrow()
 
-      // Even after the error, the state should remain idle
+      expect(stopSpy).not.toHaveBeenCalled()
       expect(loadingButton._state).toBe('idle')
     })
 

--- a/js/tests/unit/range-slider.spec.js
+++ b/js/tests/unit/range-slider.spec.js
@@ -851,31 +851,93 @@ describe('RangeSlider', () => {
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, { value: 0, step: 5 })
 
-      // Access _roundToStep via input event
-      const input = element.querySelector('.range-slider-input')
-      input.value = 23
-      input.dispatchEvent(new Event('input', { bubbles: true }))
+      expect(element.querySelector('.range-slider-input').step).toBe('5')
+      expect(rangeSlider._roundToStep(23, 5)).toBe(25)
+      expect(rangeSlider._roundToStep(22, 5)).toBe(20)
+    })
 
-      // With step=5 and input value=23, value should stay as is because
-      // input events pass through directly. The rounding happens on click/move.
-      // Let's test with a step=10 slider
-      const element2 = document.createElement('div')
-      fixtureEl.append(element2)
-      const rangeSlider2 = new RangeSlider(element2, { value: 0, step: 10 })
+    it('should anchor the step grid at min and stay within max', () => {
+      fixtureEl.innerHTML = '<div id="slider"></div>'
+      const element = fixtureEl.querySelector('#slider')
+      const rangeSlider = new RangeSlider(element, {
+        min: 1, max: 10, step: 2, value: 1
+      })
 
-      const input2 = element2.querySelector('.range-slider-input')
-      expect(input2.step).toBe('10')
+      expect(rangeSlider._roundToStep(4, 2)).toBe(5)
+      expect(rangeSlider._roundToStep(5.9, 2)).toBe(5)
+      expect(rangeSlider._roundToStep(10, 2)).toBe(9)
+      expect(rangeSlider._roundToStep(50, 2)).toBe(9)
+      expect(rangeSlider._roundToStep(-5, 2)).toBe(1)
+    })
+
+    it('should round to the precision of the step', () => {
+      fixtureEl.innerHTML = '<div id="slider"></div>'
+      const element = fixtureEl.querySelector('#slider')
+      const rangeSlider = new RangeSlider(element, {
+        min: 0, max: 1, step: 0.1, value: 0
+      })
+
+      expect(rangeSlider._roundToStep(0.3, 0.1)).toBe(0.3)
+      expect(rangeSlider._roundToStep(0.26, 0.1)).toBe(0.3)
+      expect(rangeSlider._roundToStep(0.7, 0.1)).toBe(0.7)
+      expect(rangeSlider._roundToStep(1, 0.1)).toBe(1)
+    })
+
+    it('should only clamp when step is "any"', () => {
+      fixtureEl.innerHTML = '<div id="slider"></div>'
+      const element = fixtureEl.querySelector('#slider')
+      const rangeSlider = new RangeSlider(element, { step: 'any', value: 0 })
+
+      expect(element.querySelector('.range-slider-input').step).toBe('any')
+      expect(rangeSlider._roundToStep(33.3, 'any')).toBe(33.3)
+      expect(rangeSlider._roundToStep(120, 'any')).toBe(100)
+      expect(rangeSlider._roundToStep(-1, 'any')).toBe(0)
     })
 
     it('should treat step 0 as step 1', () => {
       fixtureEl.innerHTML = '<div id="slider"></div>'
       const element = fixtureEl.querySelector('#slider')
-      // step=0 should be treated as step=1 internally in _roundToStep
       const rangeSlider = new RangeSlider(element, { value: 0, step: 0 })
 
+      expect(element.querySelector('.range-slider-input').step).toBe('0')
+      expect(rangeSlider._roundToStep(2.4, 0)).toBe(2)
+      expect(rangeSlider._roundToStep(2.6, 0)).toBe(3)
+    })
+
+    it('should write a float-clean value to the tooltip and aria-valuenow while dragging', () => {
+      fixtureEl.innerHTML = '<div id="slider"></div>'
+      const element = fixtureEl.querySelector('#slider')
+      const rangeSlider = new RangeSlider(element, {
+        min: 0, max: 1, step: 0.1, value: 0
+      })
+
+      const track = element.querySelector('.range-slider-track')
+      spyOn(track, 'getBoundingClientRect').and.returnValue({
+        top: 0, bottom: 50, left: 0, right: 200, height: 50, width: 200
+      })
+
+      const container = element.querySelector('.range-slider-inputs-container')
+      const mousedownEvent = new MouseEvent('mousedown', {
+        bubbles: true,
+        button: 0,
+        clientX: 0,
+        clientY: 25
+      })
+      Object.defineProperty(mousedownEvent, 'target', { value: track })
+      container.dispatchEvent(mousedownEvent)
+
+      document.documentElement.dispatchEvent(new MouseEvent('mousemove', {
+        bubbles: true,
+        clientX: 60,
+        clientY: 25
+      }))
+      document.documentElement.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+
       const input = element.querySelector('.range-slider-input')
-      // step=0 should work (treated as 1)
-      expect(input.step).toBe('0')
+      expect(rangeSlider._currentValue).toEqual([0.3])
+      expect(input.value).toBe('0.3')
+      expect(input.getAttribute('aria-valuenow')).toBe('0.3')
+      expect(element.querySelector('.range-slider-tooltip-inner').textContent).toBe('0.3')
     })
   })
 
@@ -1961,6 +2023,25 @@ describe('RangeSlider', () => {
       }
 
       expect(calledOnDisposedInstance).toBeFalse()
+    })
+
+    it('should leave the listeners of other instances in place', () => {
+      fixtureEl.innerHTML = '<div id="first"></div><div id="second"></div>'
+
+      const first = new RangeSlider(fixtureEl.querySelector('#first'), { value: [10, 40] })
+      const second = new RangeSlider(fixtureEl.querySelector('#second'), { value: [10, 40] })
+      const resizeSpy = spyOn(second, '_updateLabelsContainerSize')
+
+      first.dispose()
+
+      second._isDragging = true
+      document.documentElement.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+      window.dispatchEvent(new Event('resize'))
+
+      expect(second._isDragging).toBeFalse()
+      expect(resizeSpy).toHaveBeenCalledTimes(1)
+
+      second.dispose()
     })
   })
 })

--- a/js/tests/unit/stepper.spec.js
+++ b/js/tests/unit/stepper.spec.js
@@ -309,9 +309,48 @@ describe('Stepper', () => {
 
       const event = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true })
       const spy = spyOn(event, 'preventDefault')
-      stepperElement.dispatchEvent(event)
+      fixtureEl.querySelector('.stepper-step-button').dispatchEvent(event)
 
       expect(spy).toHaveBeenCalled()
+    })
+
+    it('should leave keydown alone outside the step buttons', () => {
+      fixtureEl.innerHTML = `
+        <div class="stepper" data-coreui-toggle="stepper">
+          <ol class="stepper-steps">
+            <li class="stepper-step">
+              <button type="button" class="stepper-step-button active" data-coreui-target="#step1">
+                <span class="stepper-step-indicator">1</span>
+              </button>
+            </li>
+            <li class="stepper-step">
+              <button type="button" class="stepper-step-button" data-coreui-target="#step2">
+                <span class="stepper-step-indicator">2</span>
+              </button>
+            </li>
+          </ol>
+          <div id="step1" class="stepper-pane active show">
+            <input type="text" value="abc">
+          </div>
+          <div id="step2" class="stepper-pane"></div>
+        </div>
+      `
+      const stepperElement = fixtureEl.querySelector('.stepper')
+
+      // eslint-disable-next-line no-new
+      new Stepper(stepperElement)
+
+      const input = fixtureEl.querySelector('input')
+      input.focus()
+
+      for (const key of ['ArrowLeft', 'ArrowRight', 'Home', 'End']) {
+        const event = new KeyboardEvent('keydown', { key, bubbles: true })
+        const spy = spyOn(event, 'preventDefault')
+        input.dispatchEvent(event)
+
+        expect(spy).not.toHaveBeenCalled()
+        expect(document.activeElement).toBe(input)
+      }
     })
   })
 
@@ -846,21 +885,42 @@ describe('Stepper', () => {
       expect(buttons[1].disabled).toBeFalse()
     })
 
-    it('should reset isFinished flag', () => {
+    it('should reset after finish', () => {
       fixtureEl.innerHTML = getThreeStepFixture({ activeStep: 3 })
       const stepperElement = fixtureEl.querySelector('.stepper')
       const stepper = new Stepper(stepperElement, { linear: false })
+      const buttons = [...fixtureEl.querySelectorAll('.stepper-step-button')]
 
       stepper.finish()
-      // After finish, _isFinished is true and all buttons are disabled
       expect(stepper._isFinished).toBeTrue()
-
-      // Manually re-enable a button so reset() can find enabled steps
-      const buttons = fixtureEl.querySelectorAll('.stepper-step-button')
-      buttons[0].disabled = false
+      expect(buttons.every(button => button.disabled)).toBeTrue()
 
       stepper.reset()
+
       expect(stepper._isFinished).toBeFalse()
+      expect(buttons.every(button => !button.disabled)).toBeTrue()
+      expect(buttons[2]).toHaveClass('active')
+      expect(buttons[2]).not.toHaveClass('complete')
+      expect(fixtureEl.querySelector('#step3')).toHaveClass('show')
+    })
+
+    it('should reapply the linear disabled state after finish', () => {
+      fixtureEl.innerHTML = getThreeStepFixture()
+      const stepperElement = fixtureEl.querySelector('.stepper')
+      const stepper = new Stepper(stepperElement, { skipValidation: true })
+      const buttons = [...fixtureEl.querySelectorAll('.stepper-step-button')]
+
+      stepper.next()
+      stepper.next()
+      stepper.finish()
+      expect(buttons.every(button => button.disabled)).toBeTrue()
+
+      stepper.reset()
+
+      expect(buttons[0]).toHaveClass('active')
+      expect(buttons[0].disabled).toBeFalse()
+      expect(buttons[1].disabled).toBeFalse()
+      expect(buttons[2].disabled).toBeTrue()
     })
 
     it('should reset panes to show only initial step pane', () => {
@@ -1537,7 +1597,7 @@ describe('Stepper', () => {
       })
 
       const spy = spyOn(event, 'preventDefault')
-      stepperElement.dispatchEvent(event)
+      fixtureEl.querySelector('.stepper-step-button').dispatchEvent(event)
 
       expect(spy).not.toHaveBeenCalled()
     })
@@ -1555,7 +1615,7 @@ describe('Stepper', () => {
       })
 
       const spy = spyOn(event, 'stopPropagation')
-      stepperElement.dispatchEvent(event)
+      fixtureEl.querySelector('.stepper-step-button').dispatchEvent(event)
 
       expect(spy).toHaveBeenCalled()
     })


### PR DESCRIPTION
Five functional defects in the form-control components, all from the pre-alpha JS audit.

## Stepper

**Symptom:** Arrow/Home/End typed in an `<input>` inside a step pane were `preventDefault`-ed and focus jumped to a step button; `reset()` after `finish()` did nothing.

**Now:** the keydown listener is delegated to `.stepper-step-button`, so keys outside the step buttons are never touched. `reset()` iterates every step button (not only the enabled ones), so it works after `finish()` disabled them all, and the linear disabled state is recomputed at the end. The spec no longer re-enables a button by hand before calling `reset()`.

## RangeSlider

**Symptom:** the step grid was anchored at 0 and unclamped (`min: 1, step: 2` produced even values and exceeded `max`), `step: 0.1` rendered `0.30000000000000004` into the tooltip and `aria-valuenow`, `step: "any"` produced `NaN`. `dispose()` of one slider removed the document/window handlers of every slider (`EventHandler.off(document.documentElement, EVENT_KEY)` removes by namespace).

**Now:** `_roundToStep()` anchors at `min`, clamps to `[min, max]`, steps down when the nearest grid point overshoots `max` (as the native input does), fixes the result to the precision of the step and `min`, and only clamps for a non-numeric step. A pointer beyond the track goes through the same rounding. The document/window handlers are per-instance functions; `dispose()` removes only its own, and `update()` no longer stacks duplicates.

## LoadingButton

**Symptom:** the `timeout` timer id was never stored or cleared: a manual `stop()` followed by the stale timer reached `_removeSpinner()` with `_spinner === null` and threw; after `dispose()` the timers touched nulled fields. `_timeout` held the config value and was never read.

**Now:** both timer ids (auto-stop and the start delay) are stored and cleared in `stop()` and in a `dispose()` override; `stop()` is a no-op when not loading. The redundant `Data.set()` in the constructor is gone (the base constructor registers the instance; with a selector string it created a string-keyed entry `dispose()` could never remove).

## Tests

- Stepper: keydown from an input inside a pane is not prevented and focus stays; reset after finish (non-linear and linear).
- RangeSlider: `_roundToStep` for min-anchored grid + clamp, step precision, `step: "any"`, step 0; float-clean tooltip/`aria-valuenow` during a drag; disposing one instance keeps the other's mouseup/resize handlers.
- LoadingButton: manual stop before the timeout does not cut the next cycle short; timers do not fire after dispose; `stop()` without `start()` no longer throws.

`npm run js-test-unit` green (3296 tests, coverage 95.5/88.9/94.1/95.6), `tsc --noEmit` and eslint clean.

Found by workspace audit v6-js-pre-alpha-audit-2026-08 §1.

Sibling PRs: coreui/coreui-react-pro#255 (step math), coreui/coreui-vue-pro#203 (step math + loading-button timer). Stepper keyboard/reset and the slider `dispose()` are vanilla-only: the ports already scope the keydown handler to the step buttons, derive the disabled state from `isFinished`, and register their document listeners per component.
