### PR TITLE
fix(MultiSelect, Autocomplete, OTPInput, Sidebar): pre-alpha blockers from the JS audit

### DIFF
--- a/js/src/combobox.ts
+++ b/js/src/combobox.ts
@@ -321,7 +321,7 @@ class Combobox extends BaseComponent {
       }
 
       optionDiv.dataset.value = String(option.value)
-      optionDiv.tabIndex = 0
+      optionDiv.tabIndex = option.disabled ? -1 : 0
 
       this._decorateOption(optionDiv, option)
       this._renderOptionContent(optionDiv, option)
@@ -357,6 +357,10 @@ class Combobox extends BaseComponent {
       if (!element) {
         return
       }
+    }
+
+    if (element.classList.contains(CLASS_NAME_DISABLED)) {
+      return
     }
 
     this._onOptionActivate(String(element.dataset.value), element)

--- a/js/src/multi-select.ts
+++ b/js/src/multi-select.ts
@@ -1001,7 +1001,9 @@ class MultiSelect extends Combobox {
     if (!this._config.multiple) {
       this.hide()
       this.search('')
-      this._searchElement.value = null
+      if (this._config.search) {
+        this._searchElement.value = null
+      }
     }
 
     if (this._config.clearSearchOnSelect && this._config.search) {

--- a/js/src/otp-input.ts
+++ b/js/src/otp-input.ts
@@ -199,25 +199,23 @@ class OTPInput extends BaseComponent {
         return
       }
 
+      const inputs = this._getInputs()
+
+      if (!inputs.length) {
+        return
+      }
+
+      this._setHiddenInputValue(inputs.map((input: HTMLInputElement) => input.value).join(''))
+
       if (target!.value.length === 1) {
-        const inputs = this._getInputs()
-
-        if (!inputs.length) {
-          return
-        }
-
-        const currentValue = inputs.map((input: HTMLInputElement) => input.value).join('')
-
-        this._setHiddenInputValue(currentValue)
-
         const nextInput = getNextActiveElement(inputs, target as HTMLInputElement, true)
         if (nextInput) {
           nextInput.focus()
         }
-
-        this._setInputsTabIndexes()
-        this._checkAutoSubmit(inputs)
       }
+
+      this._setInputsTabIndexes()
+      this._checkAutoSubmit(inputs)
     })
 
     EventHandler.on(this._element, EVENT_KEYDOWN, SELECTOR_FORM_OTP_CONTROL, event => {
@@ -425,9 +423,7 @@ class OTPInput extends BaseComponent {
         input.placeholder = placeholder.length > 1 ? placeholder[index] || '' : placeholder
       }
 
-      if (this._config.required !== null) {
-        input.setAttribute('required', true as unknown as string)
-      }
+      input.required = this._config.required
 
       switch (this._config.type) {
         case 'number': {

--- a/js/src/sidebar.ts
+++ b/js/src/sidebar.ts
@@ -44,7 +44,7 @@ const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_DATA_CLOSE = '[data-coreui-close="sidebar"]'
-const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle]'
+const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="narrow"], [data-coreui-toggle="unfoldable"]'
 
 const SELECTOR_SIDEBAR = '.sidebar'
 

--- a/js/tests/unit/autocomplete.spec.js
+++ b/js/tests/unit/autocomplete.spec.js
@@ -2816,6 +2816,28 @@ describe('Autocomplete', () => {
       expect(optionEl.classList.contains('disabled')).toBe(true)
       expect(optionEl.getAttribute('aria-disabled')).toBe('true')
     })
+
+    it('should keep disabled options out of the tab order and not activate them', () => {
+      fixtureEl.innerHTML = '<div class="autocomplete"></div>'
+      const autocompleteEl = fixtureEl.querySelector('.autocomplete')
+      const autocomplete = new Autocomplete(autocompleteEl, {
+        options: [
+          { label: 'Option 1', value: '1', disabled: true },
+          { label: 'Option 2', value: '2' }
+        ]
+      })
+
+      autocomplete.show()
+      const optionEl = autocomplete._optionsElement.querySelector('[data-value="1"]')
+
+      expect(optionEl.tabIndex).toBe(-1)
+      expect(autocomplete._optionsElement.querySelector('[data-value="2"]').tabIndex).toBe(0)
+
+      optionEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      optionEl.click()
+
+      expect(autocomplete._selected).toEqual([])
+    })
   })
 
   describe('container mode', () => {

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -2539,6 +2539,27 @@ describe('MultiSelect', () => {
       expect(multiSelect._selected[0].value).toBe('1')
     })
 
+    it('should not activate a disabled option on click or Enter', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [
+          { value: '1', text: 'Opt 1' },
+          { value: '2', text: 'Opt 2', disabled: true }
+        ]
+      })
+
+      multiSelect.show()
+      const option = multiSelect._optionsElement.querySelector('[data-value="2"]')
+
+      expect(option.tabIndex).toBe(-1)
+
+      option.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      option.click()
+
+      expect(multiSelect._selected.length).toBe(0)
+    })
+
     it('should deselect option when clicking selected option in multiple mode', () => {
       fixtureEl.innerHTML = '<select></select>'
       const selectEl = fixtureEl.querySelector('select')
@@ -2600,6 +2621,26 @@ describe('MultiSelect', () => {
       const option = multiSelect._optionsElement.querySelector('[data-value="1"]')
       multiSelect._onOptionsClick(option)
 
+      expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
+    })
+
+    it('should select an option and hide dropdown in single mode without search', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [
+          { value: '1', text: 'Opt 1' },
+          { value: '2', text: 'Opt 2' }
+        ],
+        multiple: false
+      })
+
+      multiSelect.show()
+      const option = multiSelect._optionsElement.querySelector('[data-value="1"]')
+
+      expect(() => option.click()).not.toThrow()
+      expect(multiSelect._selected.length).toBe(1)
+      expect(multiSelect._selected[0].value).toBe('1')
       expect(multiSelect._wrapperElement.classList.contains('show')).toBe(false)
     })
 

--- a/js/tests/unit/otp-input.spec.js
+++ b/js/tests/unit/otp-input.spec.js
@@ -104,7 +104,7 @@ describe('OTPInput', () => {
 
       const inputs = otpContainer.querySelectorAll('.form-otp-control')
       for (const [index, input] of [...inputs].entries()) {
-        expect(input.hasAttribute('required')).toBe(true)
+        expect(input.required).toBe(false)
         expect(input.inputMode).toBe('numeric')
         expect(input.pattern).toBe('[0-9]*')
         expect(input.getAttribute('autocorrect')).toBe('off')
@@ -113,6 +113,22 @@ describe('OTPInput', () => {
         expect(input.autocomplete).toBe(index === 0 ? 'one-time-code' : 'off')
         // The empty first slot has to fit a whole autofilled code
         expect(input.maxLength).toBe(index === 0 ? inputs.length : 1)
+      }
+    })
+
+    it('should set required on every input when required is true', () => {
+      fixtureEl.innerHTML = `
+        <div class="form-otp">
+          <input type="text" class="form-otp-control">
+          <input type="text" class="form-otp-control">
+        </div>
+      `
+
+      const otpContainer = fixtureEl.querySelector('.form-otp')
+      new OTPInput(otpContainer, { required: true }) // eslint-disable-line no-new
+
+      for (const input of otpContainer.querySelectorAll('.form-otp-control')) {
+        expect(input.required).toBe(true)
       }
     })
 
@@ -510,6 +526,27 @@ describe('OTPInput', () => {
         const inputEvent = createEvent('input')
         inputs[0].dispatchEvent(inputEvent)
       })
+    })
+
+    it('should update the hidden input and trigger change event when a digit is deleted', () => {
+      fixtureEl.innerHTML = `
+        <div class="form-otp">
+          <input type="text" class="form-otp-control">
+          <input type="text" class="form-otp-control">
+        </div>
+      `
+
+      const otpContainer = fixtureEl.querySelector('.form-otp')
+      const otpInput = new OTPInput(otpContainer, { value: '12' })
+      const changeSpy = jasmine.createSpy('change')
+      otpContainer.addEventListener('change.coreui.otp-input', event => changeSpy(event.value))
+
+      const inputs = otpContainer.querySelectorAll('.form-otp-control')
+      inputs[1].value = ''
+      inputs[1].dispatchEvent(createEvent('input'))
+
+      expect(otpInput._inputElement.value).toBe('1')
+      expect(changeSpy).toHaveBeenCalledWith('1')
     })
   })
 

--- a/js/tests/unit/sidebar.spec.js
+++ b/js/tests/unit/sidebar.spec.js
@@ -376,6 +376,46 @@ describe('Sidebar', () => {
     })
   })
 
+  describe('data-coreui-toggle', () => {
+    it('should toggle narrow and prevent the default on a narrow toggler', () => {
+      fixtureEl.innerHTML = '<div class="sidebar"><button type="button" data-coreui-toggle="narrow"></button></div>'
+      const sidebar = new Sidebar('.sidebar')
+      const spyToggleNarrow = spyOn(sidebar, 'toggleNarrow')
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+
+      fixtureEl.querySelector('button').dispatchEvent(event)
+
+      expect(spyToggleNarrow).toHaveBeenCalled()
+      expect(event.defaultPrevented).toBe(true)
+    })
+
+    it('should toggle unfoldable and prevent the default on an unfoldable toggler', () => {
+      fixtureEl.innerHTML = '<div class="sidebar"><button type="button" data-coreui-toggle="unfoldable"></button></div>'
+      const sidebar = new Sidebar('.sidebar')
+      const spyToggleUnfoldable = spyOn(sidebar, 'toggleUnfoldable')
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+
+      fixtureEl.querySelector('button').dispatchEvent(event)
+
+      expect(spyToggleUnfoldable).toHaveBeenCalled()
+      expect(event.defaultPrevented).toBe(true)
+    })
+
+    it('should leave the default of other togglers inside the sidebar alone', () => {
+      fixtureEl.innerHTML = '<div class="sidebar"><a href="#" data-coreui-toggle="tooltip">Link</a></div>'
+      const sidebar = new Sidebar('.sidebar')
+      const spyToggleNarrow = spyOn(sidebar, 'toggleNarrow')
+      const spyToggleUnfoldable = spyOn(sidebar, 'toggleUnfoldable')
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+
+      fixtureEl.querySelector('a').dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(false)
+      expect(spyToggleNarrow).not.toHaveBeenCalled()
+      expect(spyToggleUnfoldable).not.toHaveBeenCalled()
+    })
+  })
+
   describe('Private Methods', () => {
     describe('_initializeBackDrop', () => {
       it('should create backdrop with correct configuration', () => {


### PR DESCRIPTION
## Symptoms

- `MultiSelect` with `multiple: false` and no `search`: picking an option threw `TypeError` (`this._searchElement` is `null` without `search`), so the menu never closed.
- `MultiSelect` / `Autocomplete`: disabled options were reachable with Tab (`tabindex="0"`) and selectable with Enter/Space or a synthetic click — only the mouse was blocked, by `pointer-events: none` in the CSS.
- `OTPInput`: every slot carried `required` even with the default `required: false` (the check was `!== null` on a boolean), so a form with an optional code could not be submitted empty.
- `OTPInput`: deleting a digit with Backspace on a filled slot left the hidden input, the `change` event and the linear tab indexes stale until the next keystroke.
- `Sidebar`: the delegated click handler on the bare `[data-coreui-toggle]` selector called `preventDefault()` before looking at the value, killing the native default of every other toggler inside the sidebar — the docs' own `data-coreui-toggle="tooltip"` example link no longer navigated, checkbox/radio togglers had their state reverted.

## What the code does now

- `MultiSelect._onOptionActivate` clears the search field only when `config.search` is set (same guard as `_afterHideDispose`).
- `Combobox._createOptions` renders disabled options with `tabindex="-1"`; `Combobox._onOptionsClick` returns early for a `.disabled` option, which covers click, Enter and Space for both surfaces.
- `OTPInput` sets `input.required = config.required`; the `input` handler recomputes the joined value, updates the hidden input, fires `change` and refreshes the tab indexes for an emptied slot as well as for a filled one.
- `Sidebar`'s `SELECTOR_DATA_TOGGLE` is `[data-coreui-toggle="narrow"], [data-coreui-toggle="unfoldable"]`, so the handler (and its `preventDefault`) never runs for other togglers.

## Tests

- `multi-select.spec.js`: single mode without `search` selects and hides without throwing; disabled option has `tabIndex === -1` and ignores click/Enter.
- `autocomplete.spec.js`: disabled option has `tabIndex === -1`, enabled one `0`, click/Enter on the disabled one leaves `_selected` empty.
- `otp-input.spec.js`: default config leaves `required` off (the old assertion enshrined the bug); `required: true` sets it on every slot; deleting a digit updates the hidden input and fires `change` with the new value.
- `sidebar.spec.js`: `narrow`/`unfoldable` togglers still toggle and prevent the default; an `<a href data-coreui-toggle="tooltip">` inside the sidebar is not `defaultPrevented`.

Found by workspace audit v6-js-pre-alpha-audit-2026-08 §1.

Sibling PRs (disabled-option parity): coreui/coreui-react-pro#256, coreui/coreui-vue-pro#204.
