### PR TITLE
fix(SectionInput, NumberInput, OTPInput): remove every listener in dispose()

### DIFF
--- a/js/src/number-input.ts
+++ b/js/src/number-input.ts
@@ -26,6 +26,10 @@ const EVENT_KEY = `.${DATA_KEY}`
 const DATA_API_KEY = '.data-api'
 
 const EVENT_CHANGE = `change${EVENT_KEY}`
+const EVENT_CLICK = `click${EVENT_KEY}`
+const EVENT_INPUT = `input${EVENT_KEY}`
+const EVENT_POINTERDOWN = `pointerdown${EVENT_KEY}`
+const EVENTS_STOP_REPEAT = ['pointerup', 'pointercancel', 'pointerleave'].map(event => `${event}${EVENT_KEY}`)
 
 const CLASS_NAME_ACTION = 'form-control-action'
 const CLASS_NAME_NUMBER_INPUT = 'number-input'
@@ -85,6 +89,7 @@ class NumberInput extends BaseComponent {
   private _group: ControlGroup | null = null
   private _repeatTimeout: ReturnType<typeof setTimeout> | null = null
   private _repeatInterval: ReturnType<typeof setInterval> | null = null
+  private _stopRepeatingHandler = (): void => this._stopRepeating()
 
   constructor(element: string | Element, config?: Partial<NumberInputConfig>) {
     super(element, config)
@@ -118,8 +123,15 @@ class NumberInput extends BaseComponent {
 
   override dispose(): void {
     this._stopRepeating()
-    this._decrementElement?.remove()
-    this._incrementElement?.remove()
+
+    for (const event of EVENTS_STOP_REPEAT) {
+      EventHandler.off(document, event, this._stopRepeatingHandler)
+    }
+
+    for (const button of [this._decrementElement, this._incrementElement]) {
+      EventHandler.off(button, EVENT_KEY)
+      button?.remove()
+    }
 
     if (this._group) {
       this._group.element.classList.remove(CLASS_NAME_NUMBER_INPUT)
@@ -191,10 +203,10 @@ class NumberInput extends BaseComponent {
         continue
       }
 
-      EventHandler.on(button, 'click', () => this._step(direction))
+      EventHandler.on(button, EVENT_CLICK, () => this._step(direction))
 
       if (this._config.repeat) {
-        EventHandler.on(button, 'pointerdown', (event: any) => {
+        EventHandler.on(button, EVENT_POINTERDOWN, (event: any) => {
           if (event.button !== 0) {
             return
           }
@@ -206,10 +218,10 @@ class NumberInput extends BaseComponent {
 
     // The value can change without the buttons — typing, a form reset, a script
     // — and the bounds have to follow it.
-    EventHandler.on(this._element, 'input', () => this._updateButtonState())
+    EventHandler.on(this._element, EVENT_INPUT, () => this._updateButtonState())
 
-    for (const event of ['pointerup', 'pointercancel', 'pointerleave', 'blur']) {
-      EventHandler.on(document, event, () => this._stopRepeating())
+    for (const event of EVENTS_STOP_REPEAT) {
+      EventHandler.on(document, event, this._stopRepeatingHandler)
     }
   }
 

--- a/js/src/otp-input.ts
+++ b/js/src/otp-input.ts
@@ -28,7 +28,7 @@ const EVENT_COMPLETE = `complete${EVENT_KEY}`
 const EVENT_FOCUS = `focus${EVENT_KEY}`
 const EVENT_INPUT = `input${EVENT_KEY}`
 const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
-const EVENT_PASTE = `paste`
+const EVENT_PASTE = `paste${EVENT_KEY}`
 const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_FORM_OTP_CONTROL = '.form-otp-control'
@@ -474,11 +474,16 @@ class OTPInput extends BaseComponent {
   }
 
   _setInputsTabIndexes(): void {
+    const inputs = this._getInputs()
+
     if (!this._config.linear) {
+      for (const input of inputs) {
+        input.removeAttribute('tabindex')
+      }
+
       return
     }
 
-    const inputs = this._getInputs()
     let foundEmpty = false
 
     for (const input of inputs) {

--- a/js/src/section-input.ts
+++ b/js/src/section-input.ts
@@ -158,6 +158,8 @@ class SectionInput extends BaseComponent {
   protected declare _error: any
   protected declare _inputElement: any
   protected declare _monthFormatter: any
+  protected declare _form: HTMLFormElement | null
+  protected declare _submitHandler: () => void
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
     super(element, config)
@@ -173,6 +175,8 @@ class SectionInput extends BaseComponent {
     this._error = null
     this._inputElement = null
     this._monthFormatter = new Intl.DateTimeFormat(this._config.locale, { month: 'long' })
+    this._form = null
+    this._submitHandler = () => this._onFormSubmit()
 
     this._createSectionInput()
     this._date = this._applyValidationState()
@@ -254,6 +258,11 @@ class SectionInput extends BaseComponent {
     // min/max must end up in the same state as a typed one
     this._date = previousDate
     this._updateDate()
+  }
+
+  override dispose(): void {
+    EventHandler.off(this._form, this.constructor.eventName('submit'), this._submitHandler)
+    super.dispose()
   }
 
   // Private
@@ -357,27 +366,10 @@ class SectionInput extends BaseComponent {
       }
     })
 
-    const form = this._element.closest('form')
+    this._form = this._element.closest('form')
 
-    if (form) {
-      EventHandler.on(form, eventName('submit'), () => {
-        // Defer to a microtask so a page handler adding `data-coreui-validate`
-        // during the same submit is taken into account regardless of
-        // listener order.
-        queueMicrotask(() => {
-          if (!form.matches(SELECTOR_FORM_VALIDATE)) {
-            return
-          }
-
-          // Keep a live out-of-range invalid state; otherwise the field is
-          // invalid only when required and empty.
-          const isInvalid = this._element.classList.contains(CLASS_NAME_IS_INVALID) ||
-            (this._config.required && this._date === null)
-
-          this._element.classList.toggle(CLASS_NAME_IS_INVALID, isInvalid)
-          this._element.classList.toggle(CLASS_NAME_IS_VALID, !isInvalid && form.matches(SELECTOR_FORM_VALIDATE_VALID))
-        })
-      })
+    if (this._form) {
+      EventHandler.on(this._form, eventName('submit'), this._submitHandler)
     }
 
     EventHandler.on(this._element, eventName('click'), (event: any) => {
@@ -392,6 +384,27 @@ class SectionInput extends BaseComponent {
       if (target) {
         target.focus()
       }
+    })
+  }
+
+  _onFormSubmit(): void {
+    const form = this._form!
+
+    // Defer to a microtask so a page handler adding `data-coreui-validate`
+    // during the same submit is taken into account regardless of
+    // listener order.
+    queueMicrotask(() => {
+      if (!form.matches(SELECTOR_FORM_VALIDATE)) {
+        return
+      }
+
+      // Keep a live out-of-range invalid state; otherwise the field is
+      // invalid only when required and empty.
+      const isInvalid = this._element.classList.contains(CLASS_NAME_IS_INVALID) ||
+        (this._config.required && this._date === null)
+
+      this._element.classList.toggle(CLASS_NAME_IS_INVALID, isInvalid)
+      this._element.classList.toggle(CLASS_NAME_IS_VALID, !isInvalid && form.matches(SELECTOR_FORM_VALIDATE_VALID))
     })
   }
 

--- a/js/tests/unit/date-input.spec.js
+++ b/js/tests/unit/date-input.spec.js
@@ -615,6 +615,41 @@ describe('DateInput', () => {
       expect(dateInput._element.classList.contains('is-valid')).toBeFalse()
     })
 
+    it('should stop listening to the form on dispose', async () => {
+      const dateInput = createInForm({ required: true })
+      const element = dateInput._element
+
+      dateInput.dispose()
+      fixtureEl.querySelector('form').dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+      await Promise.resolve()
+
+      expect(element.classList.contains('is-invalid')).toBeFalse()
+    })
+
+    it('should run the submit handler once after re-initialization', async () => {
+      const element = createInForm({ required: true })._element
+      new DateInput(element, { format: 'dd.MM.yyyy', required: true }) // eslint-disable-line no-new
+      const toggle = spyOn(element.classList, 'toggle').and.callThrough()
+
+      fixtureEl.querySelector('form').dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+      await Promise.resolve()
+
+      expect(toggle).toHaveBeenCalledTimes(2)
+      expect(element.classList.contains('is-invalid')).toBeTrue()
+    })
+
+    it('should keep the submit handler of another field in the same form', async () => {
+      fixtureEl.innerHTML = '<form data-coreui-validate><div id="first"></div><div id="second"></div></form>'
+      const first = new DateInput(fixtureEl.querySelector('#first'), { format: 'dd.MM.yyyy', required: true })
+      const second = new DateInput(fixtureEl.querySelector('#second'), { format: 'dd.MM.yyyy', required: true })
+
+      first.dispose()
+      fixtureEl.querySelector('form').dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+      await Promise.resolve()
+
+      expect(second._element.classList.contains('is-invalid')).toBeTrue()
+    })
+
     it('should emit errorChange with a reason when validation state changes', () => {
       const dateInput = createDateInput({
         date: new Date(2026, 6, 14),

--- a/js/tests/unit/number-input.spec.js
+++ b/js/tests/unit/number-input.spec.js
@@ -223,6 +223,35 @@ describe('NumberInput', () => {
       expect(buttons().length).toBe(0)
       expect(group.classList.contains('number-input')).toBe(false)
     })
+
+    it('should ignore input typed after dispose', () => {
+      const input = markup('value="1"')
+      const numberInput = new NumberInput(input)
+
+      numberInput.dispose()
+      input.value = '2'
+      input.dispatchEvent(new Event('input'))
+
+      expect(input.value).toBe('2')
+    })
+
+    it('should drop its document listeners', () => {
+      const stopRepeating = spyOn(NumberInput.prototype, '_stopRepeating').and.callThrough()
+      const release = () => {
+        stopRepeating.calls.reset()
+        document.dispatchEvent(new Event('pointerup'))
+        return stopRepeating.calls.count()
+      }
+
+      const idle = release()
+      const numberInput = new NumberInput(markup('value="1"'))
+
+      expect(release()).toBe(idle + 1)
+
+      numberInput.dispose()
+
+      expect(release()).toBe(idle)
+    })
   })
 
   describe('data-api', () => {

--- a/js/tests/unit/otp-input.spec.js
+++ b/js/tests/unit/otp-input.spec.js
@@ -386,6 +386,28 @@ describe('OTPInput', () => {
       }
     })
 
+    it('should put every slot back into the tab order when linear is switched off', () => {
+      fixtureEl.innerHTML = `
+        <div class="form-otp">
+          <input type="text" class="form-otp-control">
+          <input type="text" class="form-otp-control">
+          <input type="text" class="form-otp-control">
+        </div>
+      `
+
+      const otpContainer = fixtureEl.querySelector('.form-otp')
+      const otpInput = new OTPInput(otpContainer)
+      const inputs = otpContainer.querySelectorAll('.form-otp-control')
+
+      expect(inputs[2].getAttribute('tabindex')).toBe('-1')
+
+      otpInput.update({ linear: false })
+
+      for (const input of inputs) {
+        expect(input.hasAttribute('tabindex')).toBe(false)
+      }
+    })
+
     it('should handle non-object config gracefully', () => {
       fixtureEl.innerHTML = `
         <div class="form-otp">
@@ -702,6 +724,52 @@ describe('OTPInput', () => {
       expect(inputs[0].value).toBe('')
       expect(inputs[1].value).toBe('2')
       expect(inputs[2].value).toBe('3')
+    })
+  })
+
+  describe('paste after dispose', () => {
+    const paste = (input, text) => {
+      const pasteEvent = new ClipboardEvent('paste', {
+        clipboardData: new DataTransfer(),
+        bubbles: true
+      })
+      pasteEvent.clipboardData.setData('text', text)
+      input.dispatchEvent(pasteEvent)
+    }
+
+    beforeEach(() => {
+      fixtureEl.innerHTML = `
+        <div class="form-otp">
+          <input type="text" class="form-otp-control">
+          <input type="text" class="form-otp-control">
+        </div>
+      `
+    })
+
+    it('should stop handling paste once disposed', () => {
+      const otpContainer = fixtureEl.querySelector('.form-otp')
+      const inputs = otpContainer.querySelectorAll('.form-otp-control')
+
+      new OTPInput(otpContainer).dispose()
+      paste(inputs[0], '12')
+
+      expect(inputs[0].value).toBe('')
+      expect(inputs[1].value).toBe('')
+    })
+
+    it('should distribute a paste once after re-initialization', () => {
+      const otpContainer = fixtureEl.querySelector('.form-otp')
+      const inputs = otpContainer.querySelectorAll('.form-otp-control')
+      const changeSpy = jasmine.createSpy('change')
+
+      new OTPInput(otpContainer).dispose()
+      new OTPInput(otpContainer) // eslint-disable-line no-new
+      otpContainer.addEventListener('change.coreui.otp-input', changeSpy)
+      paste(inputs[0], '12')
+
+      expect(inputs[0].value).toBe('1')
+      expect(inputs[1].value).toBe('2')
+      expect(changeSpy).toHaveBeenCalledTimes(1)
     })
   })
 


### PR DESCRIPTION
## Symptom

`BaseComponent.dispose()` only removes the listeners registered on the component's own element under its namespace. These three components registered listeners elsewhere, or without the namespace, so they outlived `dispose()`, kept the instance alive through the module-level event registry and threw once the fields were nulled:

- **SectionInput** (DateInput, TimeInput, DateTimeInput): the form `submit` listener was never removed — every re-initialization stacked another one, and a disposed instance threw in the microtask on forms with `data-coreui-validate`.
- **NumberInput**: the `input` listener on the element and four document listeners (`pointerup`/`pointercancel`/`pointerleave`/`blur`) had no namespace and were never removed — typing after `dispose()` threw, and every instance left its document listeners behind. `blur` on `document` never fired at all (it does not bubble).
- **OTPInput**: `EVENT_PASTE` was a bare `paste`, so the handler survived `dispose()` and threw on the nulled config after re-initialization. Separately, `update({ linear: false })` left `tabindex="-1"` on empty slots.

## What the code does now

- SectionInput stores the submit handler per instance, registers it on the remembered form and removes it in `dispose()` by callable — so disposing one field leaves the submit handler of another field in the same form in place.
- NumberInput namespaces all of its listeners; `dispose()` removes the document listeners by callable and the button listeners before removing the buttons. The document `blur` listener is dropped.
- OTPInput's paste listener carries the namespace; `_setInputsTabIndexes()` removes `tabindex` from every slot when `linear` is off.

## Tests

- `date-input.spec.js`: submit after dispose does nothing, re-initialization runs the handler once, a sibling field keeps its handler.
- `number-input.spec.js`: `input` after dispose does not throw, the document listeners are gone after dispose.
- `otp-input.spec.js`: paste after dispose does nothing, paste after re-initialization distributes once, `update({ linear: false })` clears `tabindex`.

Each new test was checked to fail against the previous sources (unhandled `TypeError`s / stale attributes).

Workspace audit v6-js-pre-alpha-audit-2026-08 §2.

Sibling PRs (React/Vue tab-order parity): coreui/coreui-react-pro#257, coreui/coreui-vue-pro#205.