### PR TITLE
fix(Chip, ChipInput, Autocomplete, MultiSelect, Popup): release listeners and chip instances on dispose

### DIFF
--- a/js/src/autocomplete.ts
+++ b/js/src/autocomplete.ts
@@ -189,6 +189,19 @@ class Autocomplete extends Combobox {
 
   override dispose(): void {
     this._disposeFloating()
+
+    for (const element of [
+      this._menu,
+      this._inputElement,
+      this._cleanerElement,
+      this._indicatorElement,
+      this._optionsElement
+    ]) {
+      if (element) {
+        EventHandler.off(element, EVENT_KEY)
+      }
+    }
+
     this._menu?.remove()
 
     super.dispose()

--- a/js/src/chip-input.ts
+++ b/js/src/chip-input.ts
@@ -23,7 +23,12 @@ const DATA_KEY = 'coreui.chip-input'
 const EVENT_KEY = `.${DATA_KEY}`
 const DATA_API_KEY = '.data-api'
 
+const EVENT_BLUR = `blur${EVENT_KEY}`
+const EVENT_CLICK = `click${EVENT_KEY}`
+const EVENT_FOCUS = `focus${EVENT_KEY}`
 const EVENT_INPUT = `input${EVENT_KEY}`
+const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
+const EVENT_PASTE = `paste${EVENT_KEY}`
 
 const SELECTOR_DATA_CHIP_INPUT = '[data-coreui-chip-input]'
 const SELECTOR_CHIP = '.chip'
@@ -147,6 +152,8 @@ class ChipInput extends ChipSet {
       this._element.classList.remove(CLASS_NAME_GROUP)
     }
 
+    EventHandler.off(this._input, EVENT_KEY)
+
     super.dispose()
   }
 
@@ -202,7 +209,7 @@ class ChipInput extends ChipSet {
   }
 
   _addInputEventListeners(): void {
-    EventHandler.on(this._element, 'keydown', (event: any) => {
+    EventHandler.on(this._element, EVENT_KEYDOWN, (event: any) => {
       if (event.target === this._input) {
         return
       }
@@ -223,13 +230,13 @@ class ChipInput extends ChipSet {
         this._input.focus()
       }
     })
-    EventHandler.on(this._input, 'keydown', event => this._handleInputKeydown(event))
-    EventHandler.on(this._input, 'input', event => this._handleInput(event))
-    EventHandler.on(this._input, 'paste', event => this._handlePaste(event))
-    EventHandler.on(this._input, 'focus', () => this.clearSelection())
+    EventHandler.on(this._input, EVENT_KEYDOWN, event => this._handleInputKeydown(event))
+    EventHandler.on(this._input, EVENT_INPUT, event => this._handleInput(event))
+    EventHandler.on(this._input, EVENT_PASTE, event => this._handlePaste(event))
+    EventHandler.on(this._input, EVENT_FOCUS, () => this.clearSelection())
 
     if (this._config.createOnBlur) {
-      EventHandler.on(this._input, 'blur', (event: any) => {
+      EventHandler.on(this._input, EVENT_BLUR, (event: any) => {
         // Don't create chip if clicking on a chip
         if (!event.relatedTarget?.closest(SELECTOR_CHIP)) {
           this._createChipFromInput()
@@ -238,7 +245,7 @@ class ChipInput extends ChipSet {
     }
 
     // Focus input when clicking container background
-    EventHandler.on(this._element, 'click', (event: any) => {
+    EventHandler.on(this._element, EVENT_CLICK, (event: any) => {
       if (event.target === this._element) {
         this._input?.focus()
       }

--- a/js/src/chip.ts
+++ b/js/src/chip.ts
@@ -28,6 +28,8 @@ const EVENT_SELECT = `select${EVENT_KEY}`
 const EVENT_SELECTED = `selected${EVENT_KEY}`
 const EVENT_DESELECT = `deselect${EVENT_KEY}`
 const EVENT_DESELECTED = `deselected${EVENT_KEY}`
+const EVENT_CLICK = `click${EVENT_KEY}`
+const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
 
 const SELECTOR_CHIP_CHECK = '.chip-check'
 const SELECTOR_CHIP_REMOVE = '.chip-remove'
@@ -199,9 +201,9 @@ class Chip extends BaseComponent {
   }
 
   _addEventListeners(): void {
-    EventHandler.on(this._element, 'keydown', event => this._handleKeydown(event))
+    EventHandler.on(this._element, EVENT_KEYDOWN, event => this._handleKeydown(event))
 
-    EventHandler.on(this._element, 'click', event => {
+    EventHandler.on(this._element, EVENT_CLICK, event => {
       if (this._disabled) {
         return
       }
@@ -213,7 +215,7 @@ class Chip extends BaseComponent {
       this.toggle()
     })
 
-    EventHandler.on(this._element, 'click', SELECTOR_CHIP_REMOVE, event => {
+    EventHandler.on(this._element, EVENT_CLICK, SELECTOR_CHIP_REMOVE, event => {
       event.stopPropagation()
       this.remove()
     })

--- a/js/src/multi-select.ts
+++ b/js/src/multi-select.ts
@@ -294,33 +294,7 @@ class MultiSelect extends Combobox {
   }
 
   override dispose(): void {
-    this._disposeFloating()
-
-    for (const element of [
-      this._wrapperElement,
-      this._menu,
-      this._selectionElement,
-      this._togglerElement,
-      this._searchElement,
-      this._indicatorElement,
-      this._selectAllElement,
-      this._headerElement,
-      this._optionsElement
-    ]) {
-      if (element) {
-        EventHandler.off(element, EVENT_KEY)
-      }
-    }
-
-    if (this._menu) {
-      this._menu.remove()
-    }
-
-    if (this._wrapperElement) {
-      this._wrapperElement.before(this._element)
-      this._wrapperElement.remove()
-    }
-
+    this._destroySelect()
     this._element.removeAttribute('tabindex')
 
     super.dispose()
@@ -340,9 +314,7 @@ class MultiSelect extends Combobox {
     this._config = { ...this._config, ...this._configAfterMerge(config) }
     this._selected = []
     this._options = this._getOptions()
-    this._menu.remove()
-    this._wrapperElement.before(this._element)
-    this._wrapperElement.remove()
+    this._destroySelect()
     this._element.innerHTML = ''
     this._configureNativeSelect()
     this._createNativeOptions(this._element, this._options)
@@ -406,6 +378,36 @@ class MultiSelect extends Combobox {
   }
 
   // Private
+
+  _destroySelect(): void {
+    this._disposeFloating()
+    this._disposeSelection()
+
+    for (const element of [
+      this._wrapperElement,
+      this._menu,
+      this._selectionElement,
+      this._togglerElement,
+      this._searchElement,
+      this._indicatorElement,
+      this._selectAllElement,
+      this._headerElement,
+      this._optionsElement
+    ]) {
+      if (element) {
+        EventHandler.off(element, EVENT_KEY)
+      }
+    }
+
+    if (this._menu) {
+      this._menu.remove()
+    }
+
+    if (this._wrapperElement) {
+      this._wrapperElement.before(this._element)
+      this._wrapperElement.remove()
+    }
+  }
 
   _addEventListeners(): void {
     // Selections are real Chip instances: cancel the chip's own
@@ -1248,6 +1250,20 @@ class MultiSelect extends Combobox {
 
     selection.innerHTML = ''
     selection.append(placeholder)
+  }
+
+  _disposeSelection(): void {
+    if (!this._selectionElement) {
+      return
+    }
+
+    for (const chip of SelectorEngine.find(SELECTOR_CHIP, this._selectionElement)) {
+      Chip.getInstance(chip)?.dispose()
+    }
+
+    this._selectionChipSet?.dispose()
+    this._selectionChipSet = null
+    EventHandler.off(this._selectionElement, Chip.EVENT_KEY)
   }
 
   _updateSelectionCleaner(): void {

--- a/js/src/util/popup.ts
+++ b/js/src/util/popup.ts
@@ -439,7 +439,6 @@ class Popup extends Config {
     EventHandler.off(document, EVENT_KEYDOWN, this._keydownListener)
     this._clickListener = null
     this._keydownListener = null
-    this._anchorKeydownListener = null
   }
 }
 

--- a/js/tests/unit/autocomplete.spec.js
+++ b/js/tests/unit/autocomplete.spec.js
@@ -2253,6 +2253,45 @@ describe('Autocomplete', () => {
 
       expect(autocomplete._element).toBeNull()
     })
+
+    it('should remove the listeners of the generated elements on dispose', () => {
+      fixtureEl.innerHTML = '<div class="autocomplete"></div>'
+      const autocompleteEl = fixtureEl.querySelector('.autocomplete')
+      const autocomplete = new Autocomplete(autocompleteEl, {
+        cleaner: true,
+        indicator: true,
+        options: [{ label: 'Option 1', value: '1' }]
+      })
+
+      const input = autocomplete._inputElement
+      const cleaner = autocomplete._cleanerElement
+      const indicator = autocomplete._indicatorElement
+      const menu = autocomplete._menu
+      const options = autocomplete._optionsElement
+
+      autocomplete.dispose()
+
+      const showSpy = spyOn(autocomplete, 'show')
+      const toggleSpy = spyOn(autocomplete, 'toggle')
+      const searchSpy = spyOn(autocomplete, 'search')
+      const clearSpy = spyOn(autocomplete, 'clear')
+      const optionsClickSpy = spyOn(autocomplete, '_onOptionsClick')
+
+      input.value = 'O'
+      input.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowDown' }))
+      input.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, key: 'O' }))
+      input.dispatchEvent(new Event('blur'))
+      menu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'O' }))
+      indicator.click()
+      cleaner.click()
+      options.click()
+
+      expect(showSpy).not.toHaveBeenCalled()
+      expect(toggleSpy).not.toHaveBeenCalled()
+      expect(searchSpy).not.toHaveBeenCalled()
+      expect(clearSpy).not.toHaveBeenCalled()
+      expect(optionsClickSpy).not.toHaveBeenCalled()
+    })
   })
 
   describe('input blur', () => {

--- a/js/tests/unit/chip-input.spec.js
+++ b/js/tests/unit/chip-input.spec.js
@@ -1001,6 +1001,35 @@ describe('ChipInput', () => {
       expect(ChipInput.getInstance(el)).toBeNull()
     })
 
+    it('should stop reacting to the text input after dispose', () => {
+      fixtureEl.innerHTML = '<div class="chip-input"></div>'
+
+      const el = fixtureEl.querySelector('.chip-input')
+      const chipInput = new ChipInput(el)
+      const input = el.querySelector('input.chip-input-field')
+
+      chipInput.dispose()
+
+      const inputSpy = spyOn(chipInput, '_handleInput')
+      const keydownSpy = spyOn(chipInput, '_handleInputKeydown')
+      const pasteSpy = spyOn(chipInput, '_handlePaste')
+      const createSpy = spyOn(chipInput, '_createChipFromInput')
+
+      input.value = 'foo,'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      input.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' }))
+      input.dispatchEvent(new Event('paste', { bubbles: true }))
+      input.dispatchEvent(new Event('blur'))
+      el.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'a' }))
+      el.click()
+
+      expect(inputSpy).not.toHaveBeenCalled()
+      expect(keydownSpy).not.toHaveBeenCalled()
+      expect(pasteSpy).not.toHaveBeenCalled()
+      expect(createSpy).not.toHaveBeenCalled()
+      expect(el.querySelectorAll('.chip')).toHaveSize(0)
+    })
+
     it('should be an instance of ChipSet', () => {
       fixtureEl.innerHTML = '<div class="form-control-group chip-input"></div>'
 

--- a/js/tests/unit/chip.spec.js
+++ b/js/tests/unit/chip.spec.js
@@ -860,6 +860,28 @@ describe('Chip', () => {
 
       expect(Chip.getInstance(chipEl)).toBeNull()
     })
+
+    it('should remove its listeners on dispose', () => {
+      fixtureEl.innerHTML = '<span class="chip">Tag</span>'
+
+      const chipEl = fixtureEl.querySelector('.chip')
+      const chip = new Chip(chipEl, { removable: true, selectable: true })
+
+      chip.dispose()
+
+      const toggleSpy = spyOn(chip, 'toggle')
+      const removeSpy = spyOn(chip, 'remove')
+      const keydownSpy = spyOn(chip, '_handleKeydown')
+
+      chipEl.click()
+      chipEl.querySelector('.chip-remove').click()
+      chipEl.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Delete' }))
+
+      expect(toggleSpy).not.toHaveBeenCalled()
+      expect(removeSpy).not.toHaveBeenCalled()
+      expect(keydownSpy).not.toHaveBeenCalled()
+      expect(chipEl.isConnected).toBeTrue()
+    })
   })
 
   describe('jQueryInterface', () => {

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -1,4 +1,6 @@
 
+import Chip from '../../src/chip.js'
+import ChipSet from '../../src/chip-set.js'
 import MultiSelect from '../../src/multi-select.js'
 import EventHandler from '../../src/dom/event-handler.js'
 import {
@@ -3782,6 +3784,40 @@ describe('MultiSelect', () => {
 
       expect(multiSelect._wrapperElement).not.toBe(oldClone)
     })
+
+    it('should tear down the previous selection and menu on update', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const options = [{ value: '1', text: 'Option 1', selected: true }]
+      const multiSelect = new MultiSelect(selectEl, {
+        options,
+        search: 'global',
+        selectionType: 'tags'
+      })
+
+      const previousSelection = multiSelect._selectionElement
+      const previousChip = previousSelection.querySelector('.chip')
+      const previousMenu = multiSelect._menu
+
+      multiSelect.update({ options })
+      multiSelect.update({ options })
+
+      expect(Chip.getInstance(previousChip)).toBeNull()
+      expect(ChipSet.getInstance(previousSelection)).toBeNull()
+
+      const deselectSpy = spyOn(multiSelect, '_deselectOption')
+      const focusSpy = spyOn(multiSelect._searchElement, 'focus')
+
+      EventHandler.trigger(previousChip, 'remove.coreui.chip')
+      previousMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'a' }))
+
+      expect(deselectSpy).not.toHaveBeenCalled()
+      expect(focusSpy).not.toHaveBeenCalled()
+
+      EventHandler.trigger(multiSelect._selectionElement.querySelector('.chip'), 'remove.coreui.chip')
+
+      expect(deselectSpy).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('events', () => {
@@ -3854,6 +3890,26 @@ describe('MultiSelect', () => {
       expect(multiSelect._element).toEqual(selectEl)
       multiSelect.dispose()
       expect(multiSelect._element).toBeNull()
+    })
+
+    it('should dispose the selection chips and their chip set', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, {
+        options: [{ value: '1', text: 'Option 1', selected: true }],
+        selectionType: 'tags'
+      })
+
+      const selectionEl = multiSelect._selectionElement
+      const chipEl = selectionEl.querySelector('.chip')
+
+      expect(Chip.getInstance(chipEl)).not.toBeNull()
+      expect(ChipSet.getInstance(selectionEl)).not.toBeNull()
+
+      multiSelect.dispose()
+
+      expect(Chip.getInstance(chipEl)).toBeNull()
+      expect(ChipSet.getInstance(selectionEl)).toBeNull()
     })
 
     it('should dispose the positioning cleanup when disposing', () => {

--- a/js/tests/unit/util/popup.spec.js
+++ b/js/tests/unit/util/popup.spec.js
@@ -478,6 +478,22 @@ describe('Popup', () => {
       expect(popup._anchor).toBeNull()
       expect(popup._content).toBeNull()
     })
+
+    it('should stop opening from the anchor after a show, hide and dispose', () => {
+      const popup = buildPopup()
+      const anchor = fixtureEl.querySelector('#anchor')
+
+      popup.show()
+      popup.hide()
+      popup.dispose()
+
+      const showSpy = spyOn(popup, 'show')
+
+      anchor.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: 'F4' }))
+
+      expect(showSpy).not.toHaveBeenCalled()
+      expect(popup.isShown).toBeFalse()
+    })
   })
 
   describe('positioning', () => {


### PR DESCRIPTION
## Symptom

`BaseComponent.dispose()` removes only the listeners registered on the component's own element under its namespace. Five components registered listeners either without the namespace or on other elements, so they survived `dispose()`, kept the disposed instance alive through the closures held by the global event registry, and threw on the next interaction because every field had been nulled:

- **Chip** — `keydown`/`click` on the chip were not namespaced. MultiSelect disposes and removes a chip on every deselection, so the registry grew with every change of selection.
- **ChipInput** — the whole input-layer set (`keydown`/`input`/`paste`/`focus`/`blur` on the text input, `keydown`/`click` on the container) was neither namespaced nor removed; typing after dispose threw in `_canModify`.
- **Autocomplete** — `dispose()` removed only the menu node; the listeners on the input, cleaner, indicator, options list and menu stayed, and the first keystroke after dispose threw.
- **MultiSelect** — `dispose()` and `update()` never disposed the selection chip set nor the `Chip` instances (the strong `Data` map kept the removed elements alive); `update()` also left the listeners of the replaced menu and wrapper and the delegated `remove.coreui.chip` listener on the old selection in the registry.
- **Popup** — `_removeDismissListeners()` nulled `_anchorKeydownListener` without removing it, so after any show/hide `dispose()` could no longer detach it; F4 / Alt+ArrowDown on the anchor then drove a disposed popup.

## What the code does now

- **Chip** registers `keydown`/`click` under `.coreui.chip`, so the base `dispose()` removes them.
- **ChipInput** registers its listeners under `.coreui.chip-input`; `dispose()` removes the text input's set before the base removes the container's.
- **Autocomplete** `dispose()` removes the `.coreui.autocomplete` listeners on the menu, input, cleaner, indicator and options list (the same shape as MultiSelect).
- **MultiSelect** `dispose()` and `update()` share one `_destroySelect()` teardown: floating cleanup, `_disposeSelection()` (chip instances, chip set, `.coreui.chip` listeners on the selection), the `.coreui.multi-select` listeners on every generated element, then the menu and wrapper removal.
- **Popup** `hide()` keeps the anchor keydown listener reference; `dispose()` removes it as before.

## Tests

One spec per item, each failing on `v6-dev` before the fix:

- `Chip > dispose > should remove its listeners on dispose`
- `ChipInput > dispose > should stop reacting to the text input after dispose`
- `Autocomplete > dispose > should remove the listeners of the generated elements on dispose`
- `MultiSelect > dispose > should dispose the selection chips and their chip set`
- `MultiSelect > update > should tear down the previous selection and menu on update`
- `Popup > dispose > should stop opening from the anchor after a show, hide and dispose`

Full unit suite green (3293), visual suite green (119), bundlewatch PASS.

## Cross-framework parity

React and Vue bind these handlers as render props (`onClick`/`onKeyDown`, …) that the framework unbinds itself, and their `CPopup` removes the anchor keydown listener in the effect cleanup / `onBeforeUnmount` on every path — no sibling PRs needed.

Workspace audit v6-js-pre-alpha-audit-2026-08 §2.
