### PR TITLE
fix: release listeners, timers and generated DOM on dispose in the pickers, rating, focus trap, sidebar and navigation

### DIFF
--- a/js/src/calendar.ts
+++ b/js/src/calendar.ts
@@ -275,6 +275,13 @@ class Calendar extends BaseComponent {
     this._createCalendar()
   }
 
+  override dispose(): void {
+    this._element.innerHTML = ''
+    this._element.classList.remove(CLASS_NAME_CALENDARS, CLASS_NAME_SHOW_WEEK_NUMBERS, `select-${this._config.selectionType}`)
+
+    super.dispose()
+  }
+
   // Private
   _focusOnFirstAvailableCell(): void {
     const cell = SelectorEngine.findOne(SELECTOR_CALENDAR_CELL_CLICKABLE, this._element as ParentNode)
@@ -962,7 +969,7 @@ class Calendar extends BaseComponent {
     this._createCalendar()
 
     if (callback) {
-      setTimeout(callback, 1)
+      callback()
     }
   }
 

--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -138,6 +138,7 @@ class DatePicker extends BaseComponent {
   protected declare _footerTemplate: any
   protected declare _cleanerElement: HTMLElement | null
   protected declare _indicatorElement: HTMLElement
+  protected declare _fieldElement: HTMLElement
   protected declare _initialDate: any
   protected declare _input: any
   protected declare _calendar: any
@@ -233,13 +234,21 @@ class DatePicker extends BaseComponent {
   }
 
   override dispose(): void {
-    if (this._addedGroupClass) {
-      this._element.classList.remove(CLASS_NAME_INPUT_GROUP)
+    for (const element of [this._menu, this._indicatorElement, this._cleanerElement]) {
+      EventHandler.off(element, EVENT_KEY)
     }
 
     this._popup.dispose()
     this._input.dispose()
     this._calendar?.dispose()
+    this._fieldElement.remove()
+    this._cleanerElement?.remove()
+    this._indicatorElement.remove()
+
+    if (this._addedGroupClass) {
+      this._element.classList.remove(CLASS_NAME_INPUT_GROUP)
+    }
+
     super.dispose()
   }
 
@@ -295,7 +304,7 @@ class DatePicker extends BaseComponent {
     }
 
     const inputEl = document.createElement('div')
-    appendControlGroupField(inputGroup, inputEl, this._config.floatingLabel, `${this.constructor.NAME}-`)
+    this._fieldElement = appendControlGroupField(inputGroup, inputEl, this._config.floatingLabel, `${this.constructor.NAME}-`)
 
     const action = (className: string, icon: string, label: string) => createControlGroupAction({
       className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => this._sanitizeIcon(value)

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -162,6 +162,9 @@ class DateRangePicker extends BaseComponent {
   protected declare _indicatorElement: HTMLElement
   protected declare _startInputElement: HTMLElement
   protected declare _endInputElement: HTMLElement
+  protected declare _startFieldElement: HTMLElement
+  protected declare _endFieldElement: HTMLElement
+  protected declare _separatorElement: HTMLElement
   protected declare _rangesTemplate: any
   protected declare _startInput: any
   protected declare _endInput: any
@@ -269,14 +272,24 @@ class DateRangePicker extends BaseComponent {
   }
 
   override dispose(): void {
-    if (this._addedGroupClass) {
-      this._element.classList.remove(CLASS_NAME_INPUT_GROUP)
+    for (const element of [this._menu, this._indicatorElement, this._cleanerElement, this._startInputElement, this._endInputElement]) {
+      EventHandler.off(element, EVENT_KEY)
     }
 
     this._popup.dispose()
     this._startInput.dispose()
     this._endInput.dispose()
     this._calendar?.dispose()
+    this._startFieldElement.remove()
+    this._separatorElement.remove()
+    this._endFieldElement.remove()
+    this._cleanerElement?.remove()
+    this._indicatorElement.remove()
+
+    if (this._addedGroupClass) {
+      this._element.classList.remove(CLASS_NAME_INPUT_GROUP)
+    }
+
     super.dispose()
   }
 
@@ -379,18 +392,19 @@ class DateRangePicker extends BaseComponent {
     const start = this._createInput(this._config.startDate, this._config.startName, this._floatingLabel(0) ?? this._ariaLabel(0))
     this._startInput = start.input
     this._startInputElement = start.inputEl
-    appendControlGroupField(inputGroup, start.inputEl, this._floatingLabel(0), `${this.constructor.NAME}-`)
+    this._startFieldElement = appendControlGroupField(inputGroup, start.inputEl, this._floatingLabel(0), `${this.constructor.NAME}-`)
 
     const separator = document.createElement('span')
     separator.classList.add(CLASS_NAME_SEPARATOR)
     separator.setAttribute('aria-hidden', 'true')
     separator.innerHTML = this._sanitizeIcon(this._resolveSeparatorIcon())
     inputGroup.append(separator)
+    this._separatorElement = separator
 
     const end = this._createInput(this._config.endDate, this._config.endName, this._floatingLabel(1) ?? this._ariaLabel(1))
     this._endInput = end.input
     this._endInputElement = end.inputEl
-    appendControlGroupField(inputGroup, end.inputEl, this._floatingLabel(1), `${this.constructor.NAME}-`)
+    this._endFieldElement = appendControlGroupField(inputGroup, end.inputEl, this._floatingLabel(1), `${this.constructor.NAME}-`)
 
     // See DatePicker — the bridge from typed values back to the calendar
     EventHandler.on(start.inputEl, DateInput.eventName(DateInput.CHANGE_EVENT_NAME), (event: any) => {

--- a/js/src/date-time-picker.ts
+++ b/js/src/date-time-picker.ts
@@ -144,6 +144,7 @@ class DateTimePicker extends BaseComponent {
   protected declare _footerTemplate: any
   protected declare _cleanerElement: HTMLElement | null
   protected declare _indicatorElement: HTMLElement
+  protected declare _fieldElement: HTMLElement
   protected declare _initialDate: any
   protected declare _input: any
   protected declare _calendar: any
@@ -242,14 +243,22 @@ class DateTimePicker extends BaseComponent {
   }
 
   override dispose(): void {
-    if (this._addedGroupClass) {
-      this._element.classList.remove(CLASS_NAME_INPUT_GROUP)
+    for (const element of [this._menu, this._indicatorElement, this._cleanerElement]) {
+      EventHandler.off(element, EVENT_KEY)
     }
 
     this._popup.dispose()
     this._input.dispose()
     this._calendar?.dispose()
     this._selection?.dispose()
+    this._fieldElement.remove()
+    this._cleanerElement?.remove()
+    this._indicatorElement.remove()
+
+    if (this._addedGroupClass) {
+      this._element.classList.remove(CLASS_NAME_INPUT_GROUP)
+    }
+
     super.dispose()
   }
 
@@ -287,7 +296,7 @@ class DateTimePicker extends BaseComponent {
     }
 
     const inputEl = document.createElement('div')
-    appendControlGroupField(inputGroup, inputEl, this._config.floatingLabel, `${this.constructor.NAME}-`)
+    this._fieldElement = appendControlGroupField(inputGroup, inputEl, this._config.floatingLabel, `${this.constructor.NAME}-`)
 
     const action = (className: string, icon: string, label: string) => createControlGroupAction({
       className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => this._sanitizeIcon(value)

--- a/js/src/navigation.ts
+++ b/js/src/navigation.ts
@@ -7,7 +7,6 @@
 
 import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
-import Data from './dom/data.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { defineJQueryPlugin } from './util/index.js'
@@ -60,17 +59,11 @@ class Navigation extends BaseComponent {
     this._config = this._getConfig(config)
     this._setActiveLink()
     this._addEventListeners()
-
-    Data.set(element as Element, DATA_KEY, this)
   }
   // Getters
 
   static override get Default(): typeof Default {
     return Default
-  }
-
-  static override get DATA_KEY(): string {
-    return DATA_KEY
   }
 
   static override get DefaultType(): typeof DefaultType {

--- a/js/src/password-strength.ts
+++ b/js/src/password-strength.ts
@@ -20,6 +20,7 @@ const EVENT_KEY = `.${DATA_KEY}`
 const DATA_API_KEY = '.data-api'
 
 const EVENT_CHANGE = `change${EVENT_KEY}`
+const EVENT_INPUT = `input${EVENT_KEY}`
 
 const CLASS_NAME_BUSY = 'password-strength-busy'
 const CLASS_NAME_FEEDBACK = 'password-strength-feedback'
@@ -111,8 +112,8 @@ class PasswordStrength extends BaseComponent {
     this._createMeter()
 
     if (this._input) {
-      EventHandler.on(this._input, 'input', () => this._schedule())
-      EventHandler.on(this._input, 'change', () => this._schedule())
+      EventHandler.on(this._input, EVENT_INPUT, () => this._schedule())
+      EventHandler.on(this._input, EVENT_CHANGE, () => this._schedule())
       this._evaluate()
     }
   }
@@ -145,8 +146,7 @@ class PasswordStrength extends BaseComponent {
     }
 
     if (this._input) {
-      EventHandler.off(this._input, 'input')
-      EventHandler.off(this._input, 'change')
+      EventHandler.off(this._input, EVENT_KEY)
     }
 
     this._meterElement?.remove()

--- a/js/src/rating.ts
+++ b/js/src/rating.ts
@@ -45,6 +45,7 @@ const CLASS_NAME_RATING_ITEM_LABEL = 'rating-item-label'
 const CLASS_NAME_READONLY = 'readonly'
 
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="rating"]'
+const SELECTOR_RATING_ITEM = '.rating-item'
 const SELECTOR_RATING_ITEM_INPUT = '.rating-item-input'
 const SELECTOR_RATING_ITEM_LABEL = '.rating-item-label'
 
@@ -144,24 +145,38 @@ class Rating extends BaseComponent {
     this._config = this._getConfig(config)
     this._currentValue = this._config.value
 
+    this._disposeTooltips()
     this._element.innerHTML = ''
     this._createRating()
-    this._addEventListeners()
   }
 
   reset(value: number | null = null): void {
     this._currentValue = value
 
+    this._disposeTooltips()
     this._element.innerHTML = ''
     this._createRating()
-    this._addEventListeners()
 
     EventHandler.trigger(this._element, EVENT_CHANGE, {
       value
     })
   }
 
+  override dispose(): void {
+    this._disposeTooltips()
+
+    super.dispose()
+  }
+
   // Private
+  _disposeTooltips(): void {
+    for (const item of SelectorEngine.find(SELECTOR_RATING_ITEM, this._element as ParentNode)) {
+      Tooltip.getInstance(item)?.dispose()
+    }
+
+    this._tooltip = null
+  }
+
   _addEventListeners(): void {
     EventHandler.on(this._element, EVENT_CLICK, SELECTOR_RATING_ITEM_INPUT, ({ target }: any) => {
       if (this._config.disabled || this._config.readOnly) {

--- a/js/src/sidebar.ts
+++ b/js/src/sidebar.ts
@@ -213,6 +213,11 @@ class Sidebar extends BaseComponent {
   }
 
   override dispose(): void {
+    if (this._isMobile() && this._isVisible()) {
+      new ScrollBarHelper().reset()
+    }
+
+    this._backdrop.dispose()
     this._removeClickOutListener()
     EventHandler.off(window, EVENT_RESIZE, this._resizeHandler)
 

--- a/js/src/time-picker.ts
+++ b/js/src/time-picker.ts
@@ -128,6 +128,7 @@ class TimePicker extends BaseComponent {
   protected declare _footerTemplate: any
   protected declare _cleanerElement: HTMLElement | null
   protected declare _indicatorElement: HTMLElement
+  protected declare _fieldElement: HTMLElement
   protected declare _initialTime: any
   protected declare _input: any
   protected declare _selection: any
@@ -221,13 +222,21 @@ class TimePicker extends BaseComponent {
   }
 
   override dispose(): void {
-    if (this._addedGroupClass) {
-      this._element.classList.remove(CLASS_NAME_INPUT_GROUP)
+    for (const element of [this._menu, this._indicatorElement, this._cleanerElement]) {
+      EventHandler.off(element, EVENT_KEY)
     }
 
     this._popup.dispose()
     this._input.dispose()
     this._selection?.dispose()
+    this._fieldElement.remove()
+    this._cleanerElement?.remove()
+    this._indicatorElement.remove()
+
+    if (this._addedGroupClass) {
+      this._element.classList.remove(CLASS_NAME_INPUT_GROUP)
+    }
+
     super.dispose()
   }
 
@@ -265,7 +274,7 @@ class TimePicker extends BaseComponent {
     }
 
     const inputEl = document.createElement('div')
-    appendControlGroupField(inputGroup, inputEl, this._config.floatingLabel, `${this.constructor.NAME}-`)
+    this._fieldElement = appendControlGroupField(inputGroup, inputEl, this._config.floatingLabel, `${this.constructor.NAME}-`)
 
     const action = (className: string, icon: string, label: string) => createControlGroupAction({
       className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => this._sanitizeIcon(value)

--- a/js/src/util/focustrap.ts
+++ b/js/src/util/focustrap.ts
@@ -56,12 +56,16 @@ class FocusTrap extends Config {
   protected declare _config: FocusTrapConfig
   protected declare _isActive: boolean
   protected declare _lastTabNavDirection: string | null
+  protected declare _focusinHandler: (event: CoreUIEvent) => void
+  protected declare _keydownHandler: (event: CoreUIEvent) => void
 
   constructor(config?: Partial<FocusTrapConfig> | null) {
     super()
     this._config = this._getConfig(config) as FocusTrapConfig
     this._isActive = false
     this._lastTabNavDirection = null
+    this._focusinHandler = event => this._handleFocusin(event)
+    this._keydownHandler = event => this._handleKeydown(event)
   }
 
   // Getters
@@ -87,9 +91,8 @@ class FocusTrap extends Config {
       this._config.trapElement!.focus()
     }
 
-    EventHandler.off(document, EVENT_KEY) // guard against infinite focus loop
-    EventHandler.on(document, EVENT_FOCUSIN, event => this._handleFocusin(event))
-    EventHandler.on(document, EVENT_KEYDOWN_TAB, event => this._handleKeydown(event))
+    EventHandler.on(document, EVENT_FOCUSIN, this._focusinHandler)
+    EventHandler.on(document, EVENT_KEYDOWN_TAB, this._keydownHandler)
 
     this._isActive = true
   }
@@ -100,7 +103,8 @@ class FocusTrap extends Config {
     }
 
     this._isActive = false
-    EventHandler.off(document, EVENT_KEY)
+    EventHandler.off(document, EVENT_FOCUSIN, this._focusinHandler)
+    EventHandler.off(document, EVENT_KEYDOWN_TAB, this._keydownHandler)
   }
 
   // Private

--- a/js/src/util/form-control-group.ts
+++ b/js/src/util/form-control-group.ts
@@ -93,11 +93,12 @@ type ActionOptions = {
  * @param {HTMLElement} field The control to append.
  * @param {string | null} floatingLabel The label text, or null to append bare.
  * @param {string} uidPrefix Prefix for the generated id the label points at.
+ * @returns {HTMLElement} The node appended to the group — the field, or its `.form-floating` wrapper.
  */
-export const appendControlGroupField = (group: HTMLElement, field: HTMLElement, floatingLabel: string | null, uidPrefix: string): void => {
+export const appendControlGroupField = (group: HTMLElement, field: HTMLElement, floatingLabel: string | null, uidPrefix: string): HTMLElement => {
   if (!floatingLabel) {
     group.append(field)
-    return
+    return field
   }
 
   const wrapper = document.createElement('div')
@@ -109,6 +110,8 @@ export const appendControlGroupField = (group: HTMLElement, field: HTMLElement, 
   // Label first — a screen reader announces it before the field's value.
   wrapper.append(label, field)
   group.append(wrapper)
+
+  return wrapper
 }
 
 export const createControlGroupAction = (options: ActionOptions): HTMLButtonElement => {

--- a/js/tests/unit/calendar.spec.js
+++ b/js/tests/unit/calendar.spec.js
@@ -2649,6 +2649,40 @@ describe('Calendar', () => {
       // Should remove all event handlers
       expect(spy.calls.count()).toBeGreaterThan(0)
     })
+
+    it('should remove the panels it built', () => {
+      fixtureEl.innerHTML = '<div></div>'
+      const div = fixtureEl.querySelector('div')
+      const calendar = new Calendar(div, { calendars: 2, showWeekNumber: true })
+
+      calendar.dispose()
+
+      expect(div.children).toHaveLength(0)
+      expect(div.className).toBe('')
+    })
+
+    it('should build one set of panels when re-initialised on the same element', () => {
+      fixtureEl.innerHTML = '<div></div>'
+      const div = fixtureEl.querySelector('div')
+      new Calendar(div) // eslint-disable-line no-new
+      new Calendar(div) // eslint-disable-line no-new
+
+      expect(div.querySelectorAll('.calendar')).toHaveLength(1)
+    })
+  })
+
+  describe('_updateCalendar', () => {
+    it('should run the callback once the panels are rebuilt, before returning', () => {
+      fixtureEl.innerHTML = '<div></div>'
+      const div = fixtureEl.querySelector('div')
+      const calendar = new Calendar(div, { calendarDate: new Date(2023, 5, 1) })
+
+      div.querySelector('.btn-month').click()
+      div.querySelector('.calendar-cell[tabindex="0"]').click()
+
+      expect(calendar._view).toEqual('days')
+      expect(document.activeElement).toEqual(div.querySelector('.calendar-cell[tabindex="0"]'))
+    })
   })
 
   describe('calendarInterface', () => {

--- a/js/tests/unit/date-picker.spec.js
+++ b/js/tests/unit/date-picker.spec.js
@@ -515,4 +515,48 @@ describe('DatePicker', () => {
       expect(picker.getDate()).toBeNull()
     })
   })
+
+  describe('dispose', () => {
+    it('should drop the listeners on the controls it built', () => {
+      fixtureEl.innerHTML = '<div id="picker"></div>'
+      const picker = new DatePicker(fixtureEl.querySelector('#picker'))
+      const indicator = fixtureEl.querySelector('.form-control-action')
+      const cleaner = fixtureEl.querySelector('.form-control-cleaner')
+      const errors = []
+      const onError = event => {
+        event.preventDefault()
+        errors.push(event.error)
+      }
+
+      window.addEventListener('error', onError)
+      picker.dispose()
+      indicator.click()
+      cleaner.click()
+      window.removeEventListener('error', onError)
+
+      expect(errors).toEqual([])
+    })
+
+    it('should remove the controls it built', () => {
+      fixtureEl.innerHTML = '<div id="picker"></div>'
+      const el = fixtureEl.querySelector('#picker')
+      const picker = new DatePicker(el)
+
+      picker.dispose()
+
+      expect(el.children).toHaveLength(0)
+      expect(el.classList.contains('form-control-group')).toBe(false)
+    })
+
+    it('should build one set of controls when re-initialised on the same element', () => {
+      fixtureEl.innerHTML = '<div id="picker"></div>'
+      const el = fixtureEl.querySelector('#picker')
+      new DatePicker(el) // eslint-disable-line no-new
+      pickers.push(new DatePicker(el))
+
+      expect(el.querySelectorAll('.form-date-time')).toHaveLength(1)
+      expect(el.querySelectorAll('.form-control-cleaner')).toHaveLength(1)
+      expect(el.querySelectorAll('.form-control-action')).toHaveLength(1)
+    })
+  })
 })

--- a/js/tests/unit/date-range-picker.spec.js
+++ b/js/tests/unit/date-range-picker.spec.js
@@ -255,4 +255,49 @@ describe('DateRangePicker', () => {
       expect(picker.getEndDate()).toBeNull()
     })
   })
+
+  describe('dispose', () => {
+    it('should drop the listeners on the controls it built', () => {
+      fixtureEl.innerHTML = '<div id="picker"></div>'
+      const picker = new DateRangePicker(fixtureEl.querySelector('#picker'))
+      const indicator = fixtureEl.querySelector('.form-control-action')
+      const cleaner = fixtureEl.querySelector('.form-control-cleaner')
+      const errors = []
+      const onError = event => {
+        event.preventDefault()
+        errors.push(event.error)
+      }
+
+      window.addEventListener('error', onError)
+      picker.dispose()
+      indicator.click()
+      cleaner.click()
+      window.removeEventListener('error', onError)
+
+      expect(errors).toEqual([])
+    })
+
+    it('should remove the controls it built', () => {
+      fixtureEl.innerHTML = '<div id="picker"></div>'
+      const el = fixtureEl.querySelector('#picker')
+      const picker = new DateRangePicker(el)
+
+      picker.dispose()
+
+      expect(el.children).toHaveLength(0)
+      expect(el.classList.contains('form-control-group')).toBe(false)
+    })
+
+    it('should build one set of controls when re-initialised on the same element', () => {
+      fixtureEl.innerHTML = '<div id="picker"></div>'
+      const el = fixtureEl.querySelector('#picker')
+      new DateRangePicker(el) // eslint-disable-line no-new
+      pickers.push(new DateRangePicker(el))
+
+      expect(el.querySelectorAll('.form-date-time')).toHaveLength(2)
+      expect(el.querySelectorAll('.form-control-icon')).toHaveLength(1)
+      expect(el.querySelectorAll('.form-control-cleaner')).toHaveLength(1)
+      expect(el.querySelectorAll('.form-control-action')).toHaveLength(1)
+    })
+  })
 })

--- a/js/tests/unit/date-time-picker.spec.js
+++ b/js/tests/unit/date-time-picker.spec.js
@@ -223,4 +223,48 @@ describe('DateTimePicker', () => {
       expect(picker.getDate()).toBeNull()
     })
   })
+
+  describe('dispose', () => {
+    it('should drop the listeners on the controls it built', () => {
+      fixtureEl.innerHTML = '<div id="picker"></div>'
+      const picker = new DateTimePicker(fixtureEl.querySelector('#picker'))
+      const indicator = fixtureEl.querySelector('.form-control-action')
+      const cleaner = fixtureEl.querySelector('.form-control-cleaner')
+      const errors = []
+      const onError = event => {
+        event.preventDefault()
+        errors.push(event.error)
+      }
+
+      window.addEventListener('error', onError)
+      picker.dispose()
+      indicator.click()
+      cleaner.click()
+      window.removeEventListener('error', onError)
+
+      expect(errors).toEqual([])
+    })
+
+    it('should remove the controls it built', () => {
+      fixtureEl.innerHTML = '<div id="picker"></div>'
+      const el = fixtureEl.querySelector('#picker')
+      const picker = new DateTimePicker(el)
+
+      picker.dispose()
+
+      expect(el.children).toHaveLength(0)
+      expect(el.classList.contains('form-control-group')).toBe(false)
+    })
+
+    it('should build one set of controls when re-initialised on the same element', () => {
+      fixtureEl.innerHTML = '<div id="picker"></div>'
+      const el = fixtureEl.querySelector('#picker')
+      new DateTimePicker(el) // eslint-disable-line no-new
+      pickers.push(new DateTimePicker(el))
+
+      expect(el.querySelectorAll('.form-date-time')).toHaveLength(1)
+      expect(el.querySelectorAll('.form-control-cleaner')).toHaveLength(1)
+      expect(el.querySelectorAll('.form-control-action')).toHaveLength(1)
+    })
+  })
 })

--- a/js/tests/unit/navigation.spec.js
+++ b/js/tests/unit/navigation.spec.js
@@ -1,4 +1,5 @@
 import Navigation from '../../src/navigation.js'
+import Data from '../../src/dom/data.js'
 import { clearFixture, getFixture, jQueryMock } from '../helpers/fixture.js'
 
 describe('Navigation', () => {
@@ -265,6 +266,18 @@ describe('Navigation', () => {
         activeLinksExact: 'boolean',
         groupsAutoCollapse: '(string|boolean)'
       })
+    })
+  })
+
+  describe('dispose', () => {
+    it('should leave no instance behind for an element passed as a selector', () => {
+      fixtureEl.innerHTML = '<nav id="nav" data-coreui-navigation></nav>'
+      const navigation = new Navigation('#nav')
+
+      navigation.dispose()
+
+      expect(Navigation.getInstance('#nav')).toBeNull()
+      expect(Data.get('#nav', 'coreui.navigation')).toBeNull()
     })
   })
 })

--- a/js/tests/unit/password-strength.spec.js
+++ b/js/tests/unit/password-strength.spec.js
@@ -1,5 +1,6 @@
 import PasswordInput from '../../src/password-input.js'
 import PasswordStrength from '../../src/password-strength.js'
+import EventHandler from '../../src/dom/event-handler.js'
 import { getFixture, clearFixture } from '../helpers/fixture.js'
 
 describe('PasswordStrength', () => {
@@ -301,6 +302,18 @@ describe('PasswordStrength', () => {
       type(input, 'Str0ng!&Passphrase99')
 
       expect(element.querySelector('.password-strength-text')).toBeNull()
+    })
+
+    it('should leave other input listeners on the field alone', () => {
+      const { input, instance } = setup()
+      const spy = jasmine.createSpy('input')
+      EventHandler.on(input, 'input', spy)
+
+      instance.dispose()
+      type(input, 'Str0ng!&Passphrase99')
+
+      expect(spy).toHaveBeenCalledTimes(1)
+      EventHandler.off(input, 'input', spy)
     })
   })
 

--- a/js/tests/unit/rating.spec.js
+++ b/js/tests/unit/rating.spec.js
@@ -1,5 +1,6 @@
 
 import Rating from '../../src/rating.js'
+import Tooltip from '../../src/tooltip.js'
 import {
   getFixture, clearFixture, createEvent, jQueryMock
 } from '../helpers/fixture.js'
@@ -496,6 +497,39 @@ describe('Rating', () => {
       rating.update({ itemCount: 5, value: 4 })
       const checkedInput = div.querySelector('.rating-item-input:checked')
       expect(checkedInput.value).toEqual('4')
+    })
+
+    it('should keep one set of listeners across updates', () => {
+      fixtureEl.innerHTML = '<div></div>'
+      const div = fixtureEl.querySelector('div')
+      const rating = new Rating(div, { itemCount: 3 })
+      const spy = jasmine.createSpy('change')
+
+      rating.update({ itemCount: 3 })
+      rating.update({ itemCount: 3 })
+      div.addEventListener('change.coreui.rating', spy)
+
+      const input = div.querySelectorAll('.rating-item-input')[1]
+      input.checked = true
+      input.dispatchEvent(createEvent('change', { bubbles: true }))
+
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should dispose the tooltips of the items it replaces', () => {
+      fixtureEl.innerHTML = '<div></div>'
+      const div = fixtureEl.querySelector('div')
+      const rating = new Rating(div, { itemCount: 3, tooltips: true })
+
+      const label = div.querySelectorAll('.rating-item-label')[1]
+      label.dispatchEvent(createEvent('mouseover'))
+      const item = label.parentElement
+      expect(Tooltip.getInstance(item)).not.toBeNull()
+
+      rating.update({ itemCount: 3, tooltips: true })
+
+      expect(Tooltip.getInstance(item)).toBeNull()
+      expect(rating._tooltip).toBeNull()
     })
 
     it('should update disabled state', () => {
@@ -1285,6 +1319,22 @@ describe('Rating', () => {
       expect(Rating.getInstance(div)).not.toBeNull()
       rating.dispose()
       expect(Rating.getInstance(div)).toBeNull()
+    })
+
+    it('should dispose every tooltip created on the items', () => {
+      fixtureEl.innerHTML = '<div></div>'
+      const div = fixtureEl.querySelector('div')
+      const rating = new Rating(div, { itemCount: 3, tooltips: true })
+
+      const labels = div.querySelectorAll('.rating-item-label')
+      labels[0].dispatchEvent(createEvent('mouseover'))
+      labels[2].dispatchEvent(createEvent('mouseover'))
+      const items = [labels[0].parentElement, labels[2].parentElement]
+      expect(items.map(item => Tooltip.getInstance(item))).not.toContain(null)
+
+      rating.dispose()
+
+      expect(items.map(item => Tooltip.getInstance(item))).toEqual([null, null])
     })
   })
 

--- a/js/tests/unit/sidebar.spec.js
+++ b/js/tests/unit/sidebar.spec.js
@@ -691,6 +691,7 @@ describe('Sidebar', () => {
 
       const el = fixtureEl.querySelector('.sidebar')
       const sidebar = new Sidebar(el)
+      sidebar.dispose()
 
       // Watch the prototype and match on the receiver: `dispose()` nulls the
       // instance's own properties (an instance spy would be wiped), and other
@@ -706,7 +707,6 @@ describe('Sidebar', () => {
       }
 
       try {
-        sidebar.dispose()
         window.dispatchEvent(new Event('resize'))
       } finally {
         Sidebar.prototype._isMobile = original
@@ -739,6 +739,21 @@ describe('Sidebar', () => {
       window.dispatchEvent(new Event('load'))
 
       expect(spySidebarInterface).toHaveBeenCalledWith(sidebarEl)
+    })
+
+    it('should drop the backdrop and restore body scroll when disposed while shown on mobile', () => {
+      fixtureEl.innerHTML = '<div class="sidebar" style="--cui-is-mobile: true; position: fixed; top: 0; left: 0; width: 10px; height: 10px"></div>'
+      const sidebar = new Sidebar(fixtureEl.querySelector('.sidebar'))
+
+      sidebar.show()
+
+      expect(document.querySelector('.sidebar-backdrop')).not.toBeNull()
+      expect(document.body.style.overflow).toBe('hidden')
+
+      sidebar.dispose()
+
+      expect(document.querySelector('.sidebar-backdrop')).toBeNull()
+      expect(document.body.style.overflow).toBe('')
     })
   })
 })

--- a/js/tests/unit/time-picker.spec.js
+++ b/js/tests/unit/time-picker.spec.js
@@ -340,4 +340,48 @@ describe('TimePicker', () => {
       expect(document.activeElement).toEqual(first)
     })
   })
+
+  describe('dispose', () => {
+    it('should drop the listeners on the controls it built', () => {
+      fixtureEl.innerHTML = '<div id="picker"></div>'
+      const picker = new TimePicker(fixtureEl.querySelector('#picker'))
+      const indicator = fixtureEl.querySelector('.form-control-action')
+      const cleaner = fixtureEl.querySelector('.form-control-cleaner')
+      const errors = []
+      const onError = event => {
+        event.preventDefault()
+        errors.push(event.error)
+      }
+
+      window.addEventListener('error', onError)
+      picker.dispose()
+      indicator.click()
+      cleaner.click()
+      window.removeEventListener('error', onError)
+
+      expect(errors).toEqual([])
+    })
+
+    it('should remove the controls it built', () => {
+      fixtureEl.innerHTML = '<div id="picker"></div>'
+      const el = fixtureEl.querySelector('#picker')
+      const picker = new TimePicker(el)
+
+      picker.dispose()
+
+      expect(el.children).toHaveLength(0)
+      expect(el.classList.contains('form-control-group')).toBe(false)
+    })
+
+    it('should build one set of controls when re-initialised on the same element', () => {
+      fixtureEl.innerHTML = '<div id="picker"></div>'
+      const el = fixtureEl.querySelector('#picker')
+      new TimePicker(el) // eslint-disable-line no-new
+      pickers.push(new TimePicker(el))
+
+      expect(el.querySelectorAll('.form-date-time')).toHaveLength(1)
+      expect(el.querySelectorAll('.form-control-cleaner')).toHaveLength(1)
+      expect(el.querySelectorAll('.form-control-action')).toHaveLength(1)
+    })
+  })
 })

--- a/js/tests/unit/util/focustrap.spec.js
+++ b/js/tests/unit/util/focustrap.spec.js
@@ -270,4 +270,32 @@ describe('FocusTrap', () => {
       focustrap.deactivate()
     })
   })
+
+  describe('two active traps', () => {
+    it('should keep the other trap listening when one is deactivated', () => {
+      fixtureEl.innerHTML = [
+        '<a href="#" id="outside">outside</a>',
+        '<div id="first" tabindex="-1"><a href="#" id="inside-first">first</a></div>',
+        '<div id="second" tabindex="-1"><a href="#" id="inside-second">second</a></div>'
+      ].join('')
+
+      const first = new FocusTrap({ trapElement: fixtureEl.querySelector('#first'), autofocus: false })
+      const second = new FocusTrap({ trapElement: fixtureEl.querySelector('#second'), autofocus: false })
+      first.activate()
+      second.activate()
+      first.deactivate()
+
+      const focusinSpy = spyOn(second, '_handleFocusin').and.callThrough()
+      const keydownSpy = spyOn(second, '_handleKeydown').and.callThrough()
+
+      fixtureEl.querySelector('#outside').focus()
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }))
+
+      expect(focusinSpy).toHaveBeenCalled()
+      expect(keydownSpy).toHaveBeenCalled()
+      expect(document.activeElement).toEqual(fixtureEl.querySelector('#inside-second'))
+
+      second.deactivate()
+    })
+  })
 })


### PR DESCRIPTION
## Symptom

`BaseComponent.dispose()` removes only the listeners namespaced on the component's own element. Everything a component hangs on *other* elements, or registers *without* its namespace, survives `dispose()`: the handlers stay in the module-level event registry, keep the instance reachable through their closures, and throw `TypeError`s once the instance fields are nulled. Several components also leave the DOM they generated in place, so `new Component(el)` on the same element builds the UI twice.

## What changes

- **DatePicker, DateRangePicker, DateTimePicker, TimePicker** — `dispose()` removes the click listeners on the popup menu, the indicator and the cleaner (DateRangePicker: also the `focusin` listeners on the start/end fields), and removes the field, cleaner, indicator and separator it appended to the frame. A second `new DatePicker(el)` now builds one set of controls instead of two. `appendControlGroupField()` returns the node it appended (the field or its `.form-floating` wrapper) so the shells know what to remove.
- **Calendar** — `_updateCalendar()` runs its focus callback synchronously: the grid is rebuilt synchronously, and the 1 ms timer only opened a window in which `dispose()` left the callback running on nulled fields. New `dispose()` clears the panels and the classes it added, so re-initialising the same element no longer stacks panels.
- **PasswordStrength** — the `input`/`change` listeners on the paired field now carry the component namespace; `dispose()` removes those instead of every `input` listener on the field (third-party handlers were being stripped).
- **Rating** — the delegated listeners are registered once in the constructor; `update()`/`reset()` no longer re-add them (each call used to stack a fresh set, so `change.coreui.rating` fired N+1 times). The per-item tooltips created on hover/focus are disposed by `update()`, `reset()` and `dispose()`.
- **FocusTrap** — the `focusin`/`keydown` document listeners are bound per instance and only those are removed. Two active traps (a picker in a popover) no longer strip each other's handlers with the blanket `EventHandler.off(document, EVENT_KEY)`.
- **Sidebar** — `dispose()` of a sidebar shown on mobile disposes the backdrop (whose `mousedown` called `hide()` on the disposed instance) and restores body scroll.
- **Navigation** — drop the extra `Data.set()` on the raw constructor argument (a selector string created a registry entry no `dispose()` could remove) and the `DATA_KEY` getter that repeated what the base class derives.

## Tests

- pickers: disposing then clicking the old indicator/cleaner raises no error; the frame is empty after `dispose()`; two constructions on one element yield one field, cleaner, indicator (and separator).
- calendar: `dispose()` empties the element; two constructions yield one panel; the month-cell click focuses the day grid before the click handler returns.
- password strength: a foreign `input` handler on the field still fires after `dispose()`.
- rating: one `change.coreui.rating` per change after two `update()` calls; tooltips gone (`Tooltip.getInstance(item)` null) after `update()` and `dispose()`.
- focus trap: with two active traps, deactivating one leaves the other trapping `focusin` and Tab.
- sidebar: shown on a mobile-width element, `dispose()` leaves no `.sidebar-backdrop` and `body.style.overflow` is restored.
- navigation: after `dispose()` of an instance built from a selector, neither the element nor the selector string has a registry entry.

Workspace audit `v6-js-pre-alpha-audit-2026-08` §2 (dispose pattern) and §3 (re-init duplicating the picker/calendar UI).

Sibling PRs: coreui/coreui-react-pro#258 (React), coreui/coreui-vue-pro#206 (Vue)
