### PR TITLE
chore: raise the JS bundlewatch ceilings by 1 kB after the pre-alpha fix round

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,27 +34,27 @@
     },
     {
       "path": "./dist/js/coreui.bundle.js",
-      "maxSize": "126KB"
+      "maxSize": "127KB"
     },
     {
       "path": "./dist/js/coreui.bundle.min.js",
-      "maxSize": "81KB"
+      "maxSize": "82KB"
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "115KB"
-    },
-    {
-      "path": "./dist/js/coreui.esm.min.js",
-      "maxSize": "82.5KB"
-    },
-    {
-      "path": "./dist/js/coreui.js",
       "maxSize": "116KB"
     },
     {
+      "path": "./dist/js/coreui.esm.min.js",
+      "maxSize": "83.5KB"
+    },
+    {
+      "path": "./dist/js/coreui.js",
+      "maxSize": "117KB"
+    },
+    {
       "path": "./dist/js/coreui.min.js",
-      "maxSize": "75KB"
+      "maxSize": "76KB"
     }
   ],
   "ci": {


### PR DESCRIPTION
The five fix PRs merged today (#1047-#1051) each passed bundlewatch on
their own branch, but their sum on v6-dev crossed two ceilings
(coreui.bundle.js 126.09 kB > 126, coreui.esm.js 115.32 kB > 115) and
left the other four within 0.3 kB of theirs, so every push from v6-dev
is now blocked by the pre-push hook. The growth is the dispose
bookkeeping those fixes add (per-instance handler references, owned
element teardown, timer tracking). Size optimization is scheduled for
the end of the v6 line, not per PR.