### PR TITLE
docs(PasswordStrength): title the page for Bootstrap 6 like the rest of the forms section

### DIFF
--- a/docs/src/content/docs/forms/password-strength.mdx
+++ b/docs/src/content/docs/forms/password-strength.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap 5 Password Strength"
+title: "Bootstrap 6 Password Strength"
 name: "Password Strength"
 description: "Show how strong a password is as it is typed — a segmented meter, a label, and a pluggable scorer that can be asynchronous so a real strength estimator or a breach check can drive it."
 ---


### PR DESCRIPTION
The page was the only one in the forms section still titled "Bootstrap 5 …" (every sibling says "Bootstrap 6 …"). Frontmatter-only change.