### PR TITLE
feat(ScrollSpy)!: activate sections on a configurable activation line and keep the last link highlighted in gaps

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "./dist/js/coreui.bundle.js",
-      "maxSize": "127KB"
+      "maxSize": "128KB"
     },
     {
       "path": "./dist/js/coreui.bundle.min.js",
@@ -42,15 +42,15 @@
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "116KB"
+      "maxSize": "117KB"
     },
     {
       "path": "./dist/js/coreui.esm.min.js",
-      "maxSize": "83.5KB"
+      "maxSize": "84KB"
     },
     {
       "path": "./dist/js/coreui.js",
-      "maxSize": "117KB"
+      "maxSize": "118KB"
     },
     {
       "path": "./dist/js/coreui.min.js",

--- a/docs/src/content/docs/components/scrollspy.mdx
+++ b/docs/src/content/docs/components/scrollspy.mdx
@@ -6,26 +6,70 @@ description: "Automatically update Bootstrap navigation or list group components
 
 ## How it works
 
-Scrollspy has a few requirements to function properly:
+Scrollspy toggles the `.active` class on anchor (`<a>`) elements when the element with the `id` referenced by the anchor's `href` is scrolled into view. Scrollspy is best used in conjunction with a Bootstrap [nav component](/components/nav/) or [list group](/components/list-group/), but it will also work with any anchor elements in the current page. Here's how it works.
 
-- It must be used on a Bootstrap [nav component](/components/nav/) or [list group](/components/list-group/).
-- Scrollspy requires `position: relative;` on the element you're spying on, usually the `<body>`.
-- Anchors (`<a>`) are required and must point to an element with that `id`.
+- To start, scrollspy requires two things: a navigation, list group, or a simple set of links, plus a scrollable container. The scrollable container can be the `<body>` or a custom element with a set `height` and `overflow-y: scroll`.
+- On the scrollable container, add `data-coreui-spy="scroll"` and `data-coreui-target="#navId"` where `navId` is the unique `id` of the associated navigation. If there is no focusable element inside the element, be sure to also include a `tabindex="0"` to ensure keyboard access.
+- As you scroll the "spied" container, an `.active` class is added and removed from anchor links within the associated navigation. Links must have resolvable `id` targets, otherwise they're ignored. For example, a `<a href="#home">home</a>` must correspond to something in the DOM like `<div id="home"></div>`.
+- Target elements that are not visible will be ignored and their nav items won't receive an `.active` class. Call `refresh` once they become visible.
+- Target `id`s are looked up with `getElementById`, so an `id` containing dots, colons, slashes or percent-encoded characters resolves without escaping.
 
-When successfully implemented, your nav or list group will update accordingly, moving the `.active` class from one item to the next based on their associated targets.
+### Detection
+
+The plugin watches every section with an [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) and decides which one is current from a single rule: an invisible **activation line** drawn across the scroll container, `topMargin` below its top edge (`12%` of the container's height by default). The result depends only on where the container is scrolled to, never on which direction it got there.
+
+- **The active section is the lowest one whose top edge has moved up to or above the activation line.** When several sections are visible at once, the one you have scrolled furthest into wins.
+- **Between two sections nothing changes.** While the gap between one section's end and the next heading crosses the line, the previous link stays highlighted instead of the navigation going blank.
+- **Above the first section the first link is active**, so the navigation is never empty once the container has content.
+- **At the bottom of the container the last link is active**, even when the last section is too short for its top edge to ever reach the line.
+
+Move the line with `topMargin` — a percentage of the container's height or a pixel value, for example `96px` to put it just below a sticky navbar. To take over the observer's root box entirely, set `rootMargin` instead; when both are given, `rootMargin` wins. See [Options](#options).
 
 ### Scrollable containers and keyboard access
 
 If you're making a scrollable container (other than the `<body>`), be sure to have a `height` set and `overflow-y: scroll;` applied to it—alongside a `tabindex="0"` to ensure keyboard access.
 
-## Example in navbar
+## Examples
 
-Scroll the area below the navbar and watch the active class change. The dropdown items will be highlighted as well.
+### Navbar
 
-<Example html={[`<nav id="navbar-example2" class="navbar bg-3 px-3">`, `  <a class="navbar-brand" href="#">Navbar</a>`, `  <ul class="nav nav-pills">`, `    <li class="nav-item">`, `      <a class="nav-link" href="#scrollspyHeading1">First</a>`, `    </li>`, `    <li class="nav-item">`, `      <a class="nav-link" href="#scrollspyHeading2">Second</a>`, `    </li>`, `    <li class="nav-item dropdown">`, `      <a class="nav-link dropdown-toggle" data-coreui-toggle="dropdown" href="#" role="button" aria-expanded="false">Dropdown</a>`, `      <ul class="dropdown-menu">`, `        <li><a class="dropdown-item" href="#scrollspyHeading3">Third</a></li>`, `        <li><a class="dropdown-item" href="#scrollspyHeading4">Fourth</a></li>`, `        <li><hr class="dropdown-divider"></li>`, `        <li><a class="dropdown-item" href="#scrollspyHeading5">Fifth</a></li>`, `      </ul>`, `    </li>`, `  </ul>`, `</nav>`, `<div data-coreui-spy="scroll" data-coreui-target="#navbar-example2" class="scrollspy-example" tabindex="0">`, `  <h4 id="scrollspyHeading1">First heading</h4>`, `  <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `  <h4 id="scrollspyHeading2">Second heading</h4>`, `  <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `  <h4 id="scrollspyHeading3">Third heading</h4>`, `  <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `  <h4 id="scrollspyHeading4">Fourth heading</h4>`, `  <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `  <h4 id="scrollspyHeading5">Fifth heading</h4>`, `  <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `</div>`]} />
+Scroll the area below the navbar and watch the active class change. Open the menu and watch the menu items be highlighted as well.
+
+<Example html={`<nav id="navbar-example2" class="navbar bg-1 px-3 mb-3 rounded-2">
+    <a class="navbar-brand" href="#">Navbar</a>
+    <ul class="nav nav-pills">
+      <li class="nav-item">
+        <a class="nav-link" href="#scrollspyHeading1">First</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="#scrollspyHeading2">Second</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="#" role="button" data-coreui-toggle="menu" aria-expanded="false">Menu</a>
+        <div class="menu">
+          <a class="menu-item" href="#scrollspyHeading3">Third</a>
+          <a class="menu-item" href="#scrollspyHeading4">Fourth</a>
+          <hr class="menu-divider">
+          <a class="menu-item" href="#scrollspyHeading5">Fifth</a>
+        </div>
+      </li>
+    </ul>
+  </nav>
+  <div class="scrollspy-example bg-1 p-3 rounded-2" data-coreui-spy="scroll" data-coreui-target="#navbar-example2" data-coreui-smooth-scroll="true" tabindex="0">
+    <h4 id="scrollspyHeading1">First heading</h4>
+    <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+    <h4 id="scrollspyHeading2">Second heading</h4>
+    <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+    <h4 id="scrollspyHeading3">Third heading</h4>
+    <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+    <h4 id="scrollspyHeading4">Fourth heading</h4>
+    <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+    <h4 id="scrollspyHeading5">Fifth heading</h4>
+    <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+  </div>`} />
 
 ```html
-<nav id="navbar-example2" class="navbar bg-3 px-3">
+<nav id="navbar-example2" class="navbar bg-1 px-3 mb-3 rounded-2">
   <a class="navbar-brand" href="#">Navbar</a>
   <ul class="nav nav-pills">
     <li class="nav-item">
@@ -34,18 +78,18 @@ Scroll the area below the navbar and watch the active class change. The dropdown
     <li class="nav-item">
       <a class="nav-link" href="#scrollspyHeading2">Second</a>
     </li>
-    <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle" data-coreui-toggle="dropdown" href="#" role="button" aria-expanded="false">Dropdown</a>
-      <ul class="dropdown-menu">
-        <li><a class="dropdown-item" href="#scrollspyHeading3">Third</a></li>
-        <li><a class="dropdown-item" href="#scrollspyHeading4">Fourth</a></li>
-        <li><hr class="dropdown-divider"></li>
-        <li><a class="dropdown-item" href="#scrollspyHeading5">Fifth</a></li>
-      </ul>
+    <li class="nav-item">
+      <a class="nav-link" href="#" role="button" data-coreui-toggle="menu" aria-expanded="false">Menu</a>
+      <div class="menu">
+        <a class="menu-item" href="#scrollspyHeading3">Third</a>
+        <a class="menu-item" href="#scrollspyHeading4">Fourth</a>
+        <hr class="menu-divider">
+        <a class="menu-item" href="#scrollspyHeading5">Fifth</a>
+      </div>
     </li>
   </ul>
 </nav>
-<div data-coreui-spy="scroll" data-coreui-target="#navbar-example2" class="scrollspy-example" tabindex="0">
+<div data-coreui-spy="scroll" data-coreui-target="#navbar-example2" data-coreui-smooth-scroll="true" class="scrollspy-example bg-1 p-3 rounded-2" tabindex="0">
   <h4 id="scrollspyHeading1">First heading</h4>
   <p>...</p>
   <h4 id="scrollspyHeading2">Second heading</h4>
@@ -59,70 +103,231 @@ Scroll the area below the navbar and watch the active class change. The dropdown
 </div>
 ```
 
-## Example with nested nav
+### Nested nav
 
 Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its parents will also be `.active`. Scroll the area next to the navbar and watch the active class change.
 
-<Example html={[`<div class="row">`, `  <div class="col-4">`, `    <nav id="navbar-example3" class="navbar bg-3 flex-column align-items-stretch p-3">`, `      <a class="navbar-brand" href="#">Navbar</a>`, `      <nav class="nav nav-pills flex-column">`, `        <a class="nav-link" href="#item-1">Item 1</a>`, `        <nav class="nav nav-pills flex-column">`, `          <a class="nav-link ms-3 my-1" href="#item-1-1">Item 1-1</a>`, `          <a class="nav-link ms-3 my-1" href="#item-1-2">Item 1-2</a>`, `    </nav>`, `        <a class="nav-link" href="#item-2">Item 2</a>`, `        <a class="nav-link" href="#item-3">Item 3</a>`, `        <nav class="nav nav-pills flex-column">`, `          <a class="nav-link ms-3 my-1" href="#item-3-1">Item 3-1</a>`, `          <a class="nav-link ms-3 my-1" href="#item-3-2">Item 3-2</a>`, `        </nav>`, `        </nav>`, `      </nav>`, `</div>`, `  <div class="col-8">`, `    <div data-coreui-spy="scroll" data-coreui-target="#navbar-example3" class="scrollspy-example-2" tabindex="0">`, `      <h4 id="item-1">Item 1</h4>`, `      <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `      <h5 id="item-1-1">Item 1-1</h5>`, `      <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `      <h5 id="item-1-2">Item 1-2</h5>`, `      <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `      <h4 id="item-2">Item 2</h4>`, `      <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `      <h4 id="item-3">Item 3</h4>`, `      <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `      <h5 id="item-3-1">Item 3-1</h5>`, `      <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `      <h5 id="item-3-2">Item 3-2</h5>`, `      <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `  </div>`, `    </div>`, `  </div>`]} />
+<Example html={`<div class="row">
+    <div class="col-4">
+      <nav id="navbar-example3" class="h-100 flex-column align-items-stretch pe-4 border-end">
+        <nav class="nav nav-pills flex-column">
+          <a class="nav-link" href="#item-1">Item 1</a>
+          <nav class="nav nav-pills flex-column">
+            <a class="nav-link ms-3 my-1" href="#item-1-1">Item 1-1</a>
+            <a class="nav-link ms-3 my-1" href="#item-1-2">Item 1-2</a>
+          </nav>
+          <a class="nav-link" href="#item-2">Item 2</a>
+          <a class="nav-link" href="#item-3">Item 3</a>
+          <nav class="nav nav-pills flex-column">
+            <a class="nav-link ms-3 my-1" href="#item-3-1">Item 3-1</a>
+            <a class="nav-link ms-3 my-1" href="#item-3-2">Item 3-2</a>
+          </nav>
+        </nav>
+      </nav>
+    </div>
+    <div class="col-8">
+      <div data-coreui-spy="scroll" data-coreui-target="#navbar-example3" data-coreui-smooth-scroll="true" class="scrollspy-example-2" tabindex="0">
+        <div id="item-1">
+          <h4>Item 1</h4>
+          <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+          <p>Keep in mind that the JavaScript plugin tries to pick the right element among all that may be visible. Multiple visible scrollspy targets at the same time may cause some issues.</p>
+        </div>
+        <div id="item-1-1">
+          <h5>Item 1-1</h5>
+          <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+          <p>Keep in mind that the JavaScript plugin tries to pick the right element among all that may be visible. Multiple visible scrollspy targets at the same time may cause some issues.</p>
+        </div>
+        <div id="item-1-2">
+          <h5>Item 1-2</h5>
+          <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+          <p>Keep in mind that the JavaScript plugin tries to pick the right element among all that may be visible. Multiple visible scrollspy targets at the same time may cause some issues.</p>
+        </div>
+        <div id="item-2">
+          <h4>Item 2</h4>
+          <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+          <p>Keep in mind that the JavaScript plugin tries to pick the right element among all that may be visible. Multiple visible scrollspy targets at the same time may cause some issues.</p>
+        </div>
+        <div id="item-3">
+          <h4>Item 3</h4>
+          <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+          <p>Keep in mind that the JavaScript plugin tries to pick the right element among all that may be visible. Multiple visible scrollspy targets at the same time may cause some issues.</p>
+        </div>
+        <div id="item-3-1">
+          <h5>Item 3-1</h5>
+          <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+          <p>Keep in mind that the JavaScript plugin tries to pick the right element among all that may be visible. Multiple visible scrollspy targets at the same time may cause some issues.</p>
+        </div>
+        <div id="item-3-2">
+          <h5>Item 3-2</h5>
+          <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+          <p>Keep in mind that the JavaScript plugin tries to pick the right element among all that may be visible. Multiple visible scrollspy targets at the same time may cause some issues.</p>
+        </div>
+      </div>
+    </div>
+  </div>`} />
 
 ```html
-<nav id="navbar-example3" class="navbar bg-3 flex-column align-items-stretch p-3">
-  <a class="navbar-brand" href="#">Navbar</a>
-  <nav class="nav nav-pills flex-column">
-    <a class="nav-link" href="#item-1">Item 1</a>
-    <nav class="nav nav-pills flex-column">
-      <a class="nav-link ms-3 my-1" href="#item-1-1">Item 1-1</a>
-      <a class="nav-link ms-3 my-1" href="#item-1-2">Item 1-2</a>
+<div class="row">
+  <div class="col-4">
+    <nav id="navbar-example3" class="h-100 flex-column align-items-stretch pe-4 border-end">
+      <nav class="nav nav-pills flex-column">
+        <a class="nav-link" href="#item-1">Item 1</a>
+        <nav class="nav nav-pills flex-column">
+          <a class="nav-link ms-3 my-1" href="#item-1-1">Item 1-1</a>
+          <a class="nav-link ms-3 my-1" href="#item-1-2">Item 1-2</a>
+        </nav>
+        <a class="nav-link" href="#item-2">Item 2</a>
+        <a class="nav-link" href="#item-3">Item 3</a>
+        <nav class="nav nav-pills flex-column">
+          <a class="nav-link ms-3 my-1" href="#item-3-1">Item 3-1</a>
+          <a class="nav-link ms-3 my-1" href="#item-3-2">Item 3-2</a>
+        </nav>
+      </nav>
     </nav>
-    <a class="nav-link" href="#item-2">Item 2</a>
-    <a class="nav-link" href="#item-3">Item 3</a>
-    <nav class="nav nav-pills flex-column">
-      <a class="nav-link ms-3 my-1" href="#item-3-1">Item 3-1</a>
-      <a class="nav-link ms-3 my-1" href="#item-3-2">Item 3-2</a>
-    </nav>
-  </nav>
-</nav>
+  </div>
 
-<div data-coreui-spy="scroll" data-coreui-target="#navbar-example3" tabindex="0">
-  <h4 id="item-1">Item 1</h4>
-  <p>...</p>
-  <h5 id="item-1-1">Item 1-1</h5>
-  <p>...</p>
-  <h5 id="item-1-2">Item 1-2</h5>
-  <p>...</p>
-  <h4 id="item-2">Item 2</h4>
-  <p>...</p>
-  <h4 id="item-3">Item 3</h4>
-  <p>...</p>
-  <h5 id="item-3-1">Item 3-1</h5>
-  <p>...</p>
-  <h5 id="item-3-2">Item 3-2</h5>
-  <p>...</p>
+  <div class="col-8">
+    <div data-coreui-spy="scroll" data-coreui-target="#navbar-example3" data-coreui-smooth-scroll="true" class="scrollspy-example-2" tabindex="0">
+      <div id="item-1">
+        <h4>Item 1</h4>
+        <p>...</p>
+      </div>
+      <div id="item-1-1">
+        <h5>Item 1-1</h5>
+        <p>...</p>
+      </div>
+      <div id="item-1-2">
+        <h5>Item 1-2</h5>
+        <p>...</p>
+      </div>
+      <div id="item-2">
+        <h4>Item 2</h4>
+        <p>...</p>
+      </div>
+      <div id="item-3">
+        <h4>Item 3</h4>
+        <p>...</p>
+      </div>
+      <div id="item-3-1">
+        <h5>Item 3-1</h5>
+        <p>...</p>
+      </div>
+      <div id="item-3-2">
+        <h5>Item 3-2</h5>
+        <p>...</p>
+      </div>
+    </div>
+  </div>
 </div>
 ```
 
-## Example with list-group
+### List group
 
 Scrollspy also works with `.list-group`s. Scroll the area next to the list group and watch the active class change.
 
-<Example html={[`<div class="row">`, `  <div class="col-4">`, `    <div id="list-example" class="list-group">`, `      <a class="list-group-item list-group-item-action" href="#list-item-1">Item 1</a>`, `      <a class="list-group-item list-group-item-action" href="#list-item-2">Item 2</a>`, `      <a class="list-group-item list-group-item-action" href="#list-item-3">Item 3</a>`, `      <a class="list-group-item list-group-item-action" href="#list-item-4">Item 4</a>`, `</div>`, `  </div>`, `  <div class="col-8">`, `    <div data-coreui-spy="scroll" data-coreui-target="#list-example" class="scrollspy-example" tabindex="0">`, `      <h4 id="list-item-1">Item 1</h4>`, `      <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `      <h4 id="list-item-2">Item 2</h4>`, `      <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `      <h4 id="list-item-3">Item 3</h4>`, `      <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `      <h4 id="list-item-4">Item 4</h4>`, `      <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>`, `    </div>`, `    </div>`, `  </div>`]} />
+<Example html={`<div class="row">
+    <div class="col-4">
+      <div id="list-example" class="list-group">
+        <a class="list-group-item list-group-item-action" href="#list-item-1">Item 1</a>
+        <a class="list-group-item list-group-item-action" href="#list-item-2">Item 2</a>
+        <a class="list-group-item list-group-item-action" href="#list-item-3">Item 3</a>
+        <a class="list-group-item list-group-item-action" href="#list-item-4">Item 4</a>
+      </div>
+    </div>
+    <div class="col-8">
+      <div data-coreui-spy="scroll" data-coreui-target="#list-example" data-coreui-smooth-scroll="true" class="scrollspy-example" tabindex="0">
+        <h4 id="list-item-1">Item 1</h4>
+        <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+        <h4 id="list-item-2">Item 2</h4>
+        <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+        <h4 id="list-item-3">Item 3</h4>
+        <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+        <h4 id="list-item-4">Item 4</h4>
+        <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+      </div>
+    </div>
+  </div>`} />
 
 ```html
-<div id="list-example" class="list-group">
-  <a class="list-group-item list-group-item-action" href="#list-item-1">Item 1</a>
-  <a class="list-group-item list-group-item-action" href="#list-item-2">Item 2</a>
-  <a class="list-group-item list-group-item-action" href="#list-item-3">Item 3</a>
-  <a class="list-group-item list-group-item-action" href="#list-item-4">Item 4</a>
+<div class="row">
+  <div class="col-4">
+    <div id="list-example" class="list-group">
+      <a class="list-group-item list-group-item-action" href="#list-item-1">Item 1</a>
+      <a class="list-group-item list-group-item-action" href="#list-item-2">Item 2</a>
+      <a class="list-group-item list-group-item-action" href="#list-item-3">Item 3</a>
+      <a class="list-group-item list-group-item-action" href="#list-item-4">Item 4</a>
+    </div>
+  </div>
+  <div class="col-8">
+    <div data-coreui-spy="scroll" data-coreui-target="#list-example" data-coreui-smooth-scroll="true" class="scrollspy-example" tabindex="0">
+      <h4 id="list-item-1">Item 1</h4>
+      <p>...</p>
+      <h4 id="list-item-2">Item 2</h4>
+      <p>...</p>
+      <h4 id="list-item-3">Item 3</h4>
+      <p>...</p>
+      <h4 id="list-item-4">Item 4</h4>
+      <p>...</p>
+    </div>
+  </div>
 </div>
-<div data-coreui-spy="scroll" data-coreui-target="#list-example" class="scrollspy-example" tabindex="0">
-  <h4 id="list-item-1">Item 1</h4>
-  <p>...</p>
-  <h4 id="list-item-2">Item 2</h4>
-  <p>...</p>
-  <h4 id="list-item-3">Item 3</h4>
-  <p>...</p>
-  <h4 id="list-item-4">Item 4</h4>
-  <p>...</p>
+```
+
+### Simple anchors
+
+Scrollspy is not limited to nav components and list groups, so it will work on any `<a>` anchor elements in the current document. Scroll the area and watch the `.active` class change.
+
+<Example html={`<div class="row">
+    <div class="col-4">
+      <div id="simple-list-example" class="d-flex flex-column gap-2 simple-list-example-scrollspy text-center">
+        <a class="p-1 rounded" href="#simple-list-item-1">Item 1</a>
+        <a class="p-1 rounded" href="#simple-list-item-2">Item 2</a>
+        <a class="p-1 rounded" href="#simple-list-item-3">Item 3</a>
+        <a class="p-1 rounded" href="#simple-list-item-4">Item 4</a>
+        <a class="p-1 rounded" href="#simple-list-item-5">Item 5</a>
+      </div>
+    </div>
+    <div class="col-8">
+      <div data-coreui-spy="scroll" data-coreui-target="#simple-list-example" data-coreui-smooth-scroll="true" class="scrollspy-example" tabindex="0">
+        <h4 id="simple-list-item-1">Item 1</h4>
+        <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+        <h4 id="simple-list-item-2">Item 2</h4>
+        <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+        <h4 id="simple-list-item-3">Item 3</h4>
+        <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+        <h4 id="simple-list-item-4">Item 4</h4>
+        <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+        <h4 id="simple-list-item-5">Item 5</h4>
+        <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+      </div>
+    </div>
+  </div>`} />
+
+```html
+<div class="row">
+  <div class="col-4">
+    <div id="simple-list-example" class="d-flex flex-column gap-2 simple-list-example-scrollspy text-center">
+      <a class="p-1 rounded" href="#simple-list-item-1">Item 1</a>
+      <a class="p-1 rounded" href="#simple-list-item-2">Item 2</a>
+      <a class="p-1 rounded" href="#simple-list-item-3">Item 3</a>
+      <a class="p-1 rounded" href="#simple-list-item-4">Item 4</a>
+      <a class="p-1 rounded" href="#simple-list-item-5">Item 5</a>
+    </div>
+  </div>
+  <div class="col-8">
+    <div data-coreui-spy="scroll" data-coreui-target="#simple-list-example" data-coreui-smooth-scroll="true" class="scrollspy-example" tabindex="0">
+      <h4 id="simple-list-item-1">Item 1</h4>
+      <p>...</p>
+      <h4 id="simple-list-item-2">Item 2</h4>
+      <p>...</p>
+      <h4 id="simple-list-item-3">Item 3</h4>
+      <p>...</p>
+      <h4 id="simple-list-item-4">Item 4</h4>
+      <p>...</p>
+      <h4 id="simple-list-item-5">Item 5</h4>
+      <p>...</p>
+    </div>
+  </div>
 </div>
 ```
 
@@ -168,10 +373,11 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| `rootMargin` | string | `0px 0px -25%` | Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin) valid units, when calculating scroll position. |
-| `smoothScroll` | boolean | `false` | Enables smooth scrolling when a user clicks on a link that refers to ScrollSpy observables. |
+| `rootMargin` | string, null | `null` | Raw override of the Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin). When set it is passed to the observer as is and **takes precedence over `topMargin`** (for example `0px 0px -40%`). Leave it `null` to derive the activation line from `topMargin`. |
+| `smoothScroll` | boolean | `false` | Enables smooth scrolling when a user clicks on a link that refers to ScrollSpy observables. Once the scroll settles, the URL hash is updated and focus moves to the target section. |
 | `target` | string, DOM element | `null`  | Specifies element to apply Scrollspy plugin. |
-| `threshold` | array | `[0.1, 0.5, 1]` | Intersection Observer [threshold](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds) values, at which fractions of a section's visibility the observer reports back. |
+| `threshold` | array | `[0]` | Intersection Observer [threshold](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds) values, at which fractions of a section's visibility the observer reports back. |
+| `topMargin` | string | `12%` | Position of the [activation line](#detection), measured from the top of the scroll container. Accepts a percentage of the container's height (`12%`) or pixels (`96px`, for example to sit below a sticky navbar). Ignored when `rootMargin` is set. |
 
 ### Methods
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1092,9 +1092,32 @@ adornment in the library — so the button needs no icon markup at all:
 #### ScrollSpy
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The active link is chosen by an activation line, not by scroll
+  direction.** The plugin used to compare each section's offset with the
+  previous scroll position, so the same scroll offset could highlight a
+  different link depending on which way you arrived. It now activates the
+  lowest section whose top edge has crossed a line drawn `topMargin` below
+  the top of the scroll container — a pure function of the scroll position.
+  Two visible consequences: **the last active link stays highlighted while a
+  gap between sections crosses the line** (the navigation no longer goes
+  blank), and **a short last section is activated when the container is
+  scrolled to the bottom**, even though its top never reaches the line.
+- **New option `topMargin`** (default `12%`) places the activation line; it
+  takes a percentage of the container's height or a pixel value (`96px`).
+  A pixel line is recomputed on resize.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`rootMargin` defaults to `null` and is now the raw override.** Set it and
+  it is handed to the `IntersectionObserver` unchanged, taking precedence over
+  `topMargin`; a v5 configuration such as `rootMargin: '0px 0px -25%'` keeps
+  working as written. `threshold` defaults to `[0]` instead of
+  `[0.1, 0.5, 1]` — with an activation line a section only needs to report
+  whether it crosses it.
+- **`smoothScroll` finishes the navigation.** Once the scroll settles, the
+  URL hash is replaced with the link's target and focus moves to the section.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
   **The deprecated `offset` option is removed** — it has been a thin alias
-  since the IntersectionObserver rewrite. Use `rootMargin` instead; the exact
-  equivalence is `offset: 100` &rarr; `rootMargin: '100px 0px -30%'`.
+  since the IntersectionObserver rewrite. Use `topMargin` instead:
+  `offset: 100` &rarr; `topMargin: '100px'`.
 
 #### Tab
 

--- a/js/src/scrollspy.ts
+++ b/js/src/scrollspy.ts
@@ -9,9 +9,9 @@
  */
 
 import BaseComponent from './base-component.js'
-import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
+import type { ComponentConfig } from './util/config.js'
 import {
   defineJQueryPlugin, getElement, isDisabled, isVisible
 } from './util/index.js'
@@ -27,8 +27,12 @@ const DATA_API_KEY = '.data-api'
 
 const EVENT_ACTIVATE = `activate${EVENT_KEY}`
 const EVENT_CLICK = `click${EVENT_KEY}`
+const EVENT_SCROLL = `scroll${EVENT_KEY}`
+const EVENT_SCROLLEND = `scrollend${EVENT_KEY}`
+const EVENT_RESIZE = `resize${EVENT_KEY}`
 const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
+const CLASS_NAME_MENU_ITEM = 'menu-item'
 const CLASS_NAME_DROPDOWN_ITEM = 'dropdown-item'
 const CLASS_NAME_ACTIVE = 'active'
 
@@ -39,32 +43,44 @@ const SELECTOR_NAV_LINKS = '.nav-link'
 const SELECTOR_NAV_ITEMS = '.nav-item'
 const SELECTOR_LIST_ITEMS = '.list-group-item'
 const SELECTOR_LINK_ITEMS = `${SELECTOR_NAV_LINKS}, ${SELECTOR_NAV_ITEMS} > ${SELECTOR_NAV_LINKS}, ${SELECTOR_LIST_ITEMS}`
+const SELECTOR_MENU_TOGGLE = '[data-coreui-toggle="menu"]'
 const SELECTOR_DROPDOWN = '.dropdown'
 const SELECTOR_DROPDOWN_TOGGLE = '.dropdown-toggle'
 
+// How long (ms) to wait after the last scroll event before settling a pending
+// smooth-scroll navigation, when the native `scrollend` event is unavailable.
+const SCROLL_IDLE_TIMEOUT = 100
+// Debounce (ms) for rebuilding the observer on resize (px activation lines only).
+const RESIZE_DEBOUNCE = 100
+
+type ScrollSpyConfig = {
+  rootMargin: string | null
+  smoothScroll: boolean
+  target: string | Element | null
+  threshold: number[] | string
+  topMargin: string
+}
+
 const Default: ScrollSpyConfig = {
-  rootMargin: '0px 0px -25%',
+  // `rootMargin` is the raw IntersectionObserver root-box override. When set it
+  // takes precedence over `topMargin` and is passed straight to the observer.
+  // Leave it null and use `topMargin` for everyday use.
+  rootMargin: null,
   smoothScroll: false,
   target: null,
-  threshold: [0.1, 0.5, 1]
+  threshold: [0],
+  // Position of the activation line, measured from the top of the scroll root.
+  // The active section is the deepest one whose top has scrolled to/above it.
+  // Accepts a percentage (`12%`) or pixels (`96px`, e.g. below a sticky navbar).
+  topMargin: '12%'
 }
 
 const DefaultType = {
-  rootMargin: 'string',
+  rootMargin: '(string|null)',
   smoothScroll: 'boolean',
   target: 'element',
-  threshold: 'array'
-}
-
-/**
- * Types
- */
-
-type ScrollSpyConfig = {
-  rootMargin: string
-  smoothScroll: boolean
-  target: string | Element | null
-  threshold: number[]
+  threshold: 'array',
+  topMargin: 'string'
 }
 
 /**
@@ -72,35 +88,59 @@ type ScrollSpyConfig = {
  */
 
 class ScrollSpy extends BaseComponent {
-  protected declare _targetLinks: Map<string, HTMLElement>
-  protected declare _observableSections: Map<string, HTMLElement>
-  protected declare _rootElement: HTMLElement | null
+  protected declare _config: ScrollSpyConfig
+  protected declare _sections: HTMLElement[]
+  protected declare _linkBySection: Map<HTMLElement, HTMLElement>
+  protected declare _sectionByLink: Map<HTMLElement, HTMLElement>
+  protected declare _intersecting: Set<Element>
   protected declare _activeTarget: HTMLElement | null
+  protected declare _lastActive: HTMLElement | null
+  protected declare _atBottom: boolean
+  protected declare _rootElement: HTMLElement | null
   protected declare _observer: IntersectionObserver | null
-  protected declare _previousScrollData: { visibleEntryTop: number, parentScrollTop: number }
+  protected declare _sentinel: HTMLElement | null
+  protected declare _sentinelObserver: IntersectionObserver | null
+  protected declare _pendingNavigation: { hash: string, section: HTMLElement } | null
+  protected declare _settleTimeout: number | null
+  protected declare _settleHandler: (() => void) | null
+  protected declare _scrollIdleHandler: (() => void) | null
+  protected declare _resizeHandler: (() => void) | null
+  protected declare _resizeTimeout: number | null
 
   constructor(element?: string | Element | null, config?: Partial<ScrollSpyConfig> | null) {
     super(element, config)
 
     // this._element is the observablesContainer and config.target the menu links wrapper
-    this._targetLinks = new Map()
-    this._observableSections = new Map()
-    this._rootElement = getComputedStyle(this._element).overflowY === 'visible' ? null : this._element
+    this._sections = [] // observable section elements, in DOM order
+    this._linkBySection = new Map() // section element -> nav link
+    this._sectionByLink = new Map() // nav link -> section element (for smooth scroll)
+    this._intersecting = new Set() // sections currently crossing the activation line
     this._activeTarget = null
+    this._lastActive = null // last activated section (keep-last across gaps)
+    this._atBottom = false
+    this._rootElement = getComputedStyle(this._element).overflowY === 'visible' ? null : this._element
+
     this._observer = null
-    this._previousScrollData = {
-      visibleEntryTop: 0,
-      parentScrollTop: 0
-    }
+    this._sentinel = null
+    this._sentinelObserver = null
+
+    this._pendingNavigation = null
+    this._settleTimeout = null
+    this._settleHandler = null
+    this._scrollIdleHandler = null
+
+    this._resizeHandler = null
+    this._resizeTimeout = null
+
     this.refresh() // initialize
   }
 
   // Getters
-  static override get Default(): typeof Default {
+  static override get Default(): ScrollSpyConfig {
     return Default
   }
 
-  static override get DefaultType(): typeof DefaultType {
+  static override get DefaultType(): Record<string, string> {
     return DefaultType
   }
 
@@ -113,25 +153,34 @@ class ScrollSpy extends BaseComponent {
     this._initializeTargetsAndObservables()
     this._maybeEnableSmoothScroll()
 
-    if (this._observer) {
-      this._observer!.disconnect()
-    } else {
-      this._observer = this._getNewObserver()
+    // (Re)build the activation observer.
+    this._observer?.disconnect()
+    this._intersecting.clear()
+    this._observer = this._getNewObserver()
+    for (const section of this._sections) {
+      this._observer.observe(section)
     }
 
-    for (const section of this._observableSections.values()) {
-      this._observer!.observe(section)
-    }
+    // Detect the bottom-of-page case (a short last section whose top never
+    // reaches the activation line) natively, via a dedicated sentinel observer.
+    this._setUpSentinel()
+
+    // A px activation line doesn't track viewport height the way `%` does, so
+    // rebuild the observer (debounced) on resize when px units are in play.
+    this._maybeAddResizeListener()
   }
 
   override dispose(): void {
-    this._observer!.disconnect()
+    this._observer?.disconnect()
+    this._teardownSentinel()
+    this._disarmSettle()
+    this._removeResizeListener()
+    EventHandler.off(this._config.target as HTMLElement, EVENT_CLICK)
     super.dispose()
   }
 
   // Private
   override _configAfterMerge(config: ComponentConfig): ComponentConfig {
-    // TODO: on v6 target should be given explicitly & remove the {target: 'ss-target'} case
     config.target = getElement(config.target) || document.body
 
     if (typeof config.threshold === 'string') {
@@ -141,108 +190,356 @@ class ScrollSpy extends BaseComponent {
     return config
   }
 
-  _maybeEnableSmoothScroll(): void {
+  // --- Detection (IntersectionObserver-driven) -----------------------------
+
+  protected _getNewObserver(): IntersectionObserver {
+    const options = {
+      root: this._rootElement,
+      threshold: this._config.threshold as number[],
+      rootMargin: this._config.rootMargin ?? this._getDerivedRootMargin()
+    }
+
+    return new IntersectionObserver(entries => this._onIntersect(entries), options)
+  }
+
+  protected _onIntersect(entries: IntersectionObserverEntry[]): void {
+    for (const entry of entries) {
+      if (entry.isIntersecting) {
+        this._intersecting.add(entry.target)
+      } else {
+        this._intersecting.delete(entry.target)
+      }
+    }
+
+    this._computeActive()
+  }
+
+  // Single source of truth for active selection, derived only from IO state —
+  // no per-frame layout reads. The active section is the deepest (DOM-order)
+  // one currently crossing the activation line; in a gap we keep the last one;
+  // above the first section the first stays active; at the very bottom the last
+  // section wins.
+  protected _computeActive(): void {
+    // Guard against observer callbacks that outlive a disposed/detached instance.
+    if (!this._element?.isConnected || this._sections.length === 0) {
+      return
+    }
+
+    let active = null
+
+    if (this._atBottom) {
+      active = this._sections.at(-1)
+    } else {
+      for (const section of this._sections) {
+        if (this._intersecting.has(section)) {
+          active = section
+        }
+      }
+
+      // No section crosses the line: keep the last active (content gap), or fall
+      // back to the first section at the top of the page.
+      active ||= this._lastActive ?? this._sections.at(0)
+    }
+
+    if (!active) {
+      return
+    }
+
+    this._lastActive = active
+    const link = this._linkBySection.get(active)
+    if (link) {
+      this._process(link)
+    }
+  }
+
+  // Single source of truth for the `topMargin` option: its numeric value and
+  // whether it's expressed as a percentage of the root height or in pixels.
+  protected _parseTopMargin(): { value: number, unit: string } {
+    const value = String(this._config.topMargin)
+    return {
+      value: Number.parseFloat(value) || 0,
+      unit: value.endsWith('%') ? '%' : 'px'
+    }
+  }
+
+  // Collapse the observer root to a strip from the top down to the activation
+  // line, so a section is "intersecting" exactly while it crosses that line.
+  protected _getDerivedRootMargin(): string {
+    const { value, unit } = this._parseTopMargin()
+    let percent = value
+
+    // Express a pixel activation line as a percentage of the root height.
+    if (unit === 'px') {
+      const rootHeight = this._rootElement ?
+        this._rootElement.clientHeight :
+        (document.documentElement.clientHeight || window.innerHeight)
+      percent = rootHeight ? (value / rootHeight) * 100 : 12
+    }
+
+    // Clamp so the bottom inset stays a valid (non-negative) rootMargin even if
+    // the line sits outside the root box.
+    const bottom = Math.min(Math.max(100 - percent, 0), 100)
+    return `0px 0px -${bottom}% 0px`
+  }
+
+  // Whether the activation line is derived from a pixel `topMargin` (in which
+  // case it must be recomputed on resize). An explicit `rootMargin` is owned by
+  // the caller, and a `%` topMargin is recomputed by the browser automatically.
+  protected _usesPixelMargin(): boolean {
+    return !this._config.rootMargin && this._parseTopMargin().unit === 'px'
+  }
+
+  // --- Bottom sentinel -----------------------------------------------------
+
+  protected _setUpSentinel(): void {
+    this._teardownSentinel()
+
+    if (this._sections.length === 0) {
+      return
+    }
+
+    const sentinel = document.createElement('div')
+    sentinel.setAttribute('aria-hidden', 'true')
+    sentinel.style.cssText = 'position:relative;width:0;height:0;margin:0;padding:0;border:0;visibility:hidden;'
+    this._element.append(sentinel)
+    this._sentinel = sentinel
+
+    this._sentinelObserver = new IntersectionObserver(entries => this._onSentinel(entries), {
+      root: this._rootElement,
+      threshold: [0]
+    })
+    this._sentinelObserver.observe(sentinel)
+  }
+
+  protected _onSentinel(entries: IntersectionObserverEntry[]): void {
+    const entry = entries.at(-1)
+    // Only treat the sentinel as "bottom reached" when content actually
+    // overflows; otherwise everything is visible and there's nothing to spy.
+    this._atBottom = Boolean(entry?.isIntersecting) && this._isOverflowing()
+    this._computeActive()
+  }
+
+  protected _isOverflowing(): boolean {
+    const scroller = this._rootElement || document.scrollingElement || document.documentElement
+    return scroller.scrollHeight > scroller.clientHeight
+  }
+
+  protected _teardownSentinel(): void {
+    this._sentinelObserver?.disconnect()
+    this._sentinelObserver = null
+    this._sentinel?.remove()
+    this._sentinel = null
+    this._atBottom = false
+  }
+
+  // --- Resize (px activation lines only) -----------------------------------
+
+  protected _maybeAddResizeListener(): void {
+    this._removeResizeListener()
+
+    if (!this._usesPixelMargin()) {
+      return
+    }
+
+    this._resizeHandler = () => {
+      clearTimeout(this._resizeTimeout!)
+      this._resizeTimeout = setTimeout(() => this._rebuildObserver(), RESIZE_DEBOUNCE)
+    }
+
+    EventHandler.on(window, EVENT_RESIZE, this._resizeHandler)
+  }
+
+  protected _removeResizeListener(): void {
+    clearTimeout(this._resizeTimeout!)
+    this._resizeTimeout = null
+
+    if (this._resizeHandler) {
+      EventHandler.off(window, EVENT_RESIZE, this._resizeHandler)
+      this._resizeHandler = null
+    }
+  }
+
+  protected _rebuildObserver(): void {
+    if (!this._observer) {
+      return
+    }
+
+    this._observer.disconnect()
+    this._intersecting.clear()
+    this._observer = this._getNewObserver()
+    for (const section of this._sections) {
+      this._observer.observe(section)
+    }
+  }
+
+  // --- Smooth-scroll settle (hash + focus) ---------------------------------
+
+  protected _maybeEnableSmoothScroll(): void {
     if (!this._config.smoothScroll) {
       return
     }
 
-    // unregister any previous listeners
-    EventHandler.off(this._config.target, EVENT_CLICK)
+    // Unregister any previous listener so refresh() doesn't stack them.
+    EventHandler.off(this._config.target as HTMLElement, EVENT_CLICK)
 
-    EventHandler.on(this._config.target, EVENT_CLICK, SELECTOR_TARGET_LINKS, event => {
-      const observableSection = this._observableSections.get((event.target as HTMLAnchorElement).hash)
-      if (observableSection) {
-        event.preventDefault()
-        const root = this._rootElement || window
-        const height = (observableSection as HTMLElement).offsetTop - (this._element as HTMLElement).offsetTop
+    EventHandler.on(this._config.target as HTMLElement, EVENT_CLICK, SELECTOR_TARGET_LINKS, event => {
+      const link = (event.target as HTMLElement).closest<HTMLAnchorElement>(SELECTOR_TARGET_LINKS)
+      const section = link && this._sectionByLink.get(link)
+      if (!section || !this._element) {
+        return
+      }
+
+      event.preventDefault()
+
+      const root: any = this._rootElement || window
+      const height = section.offsetTop - this._element.offsetTop
+      const currentTop = this._rootElement ?
+        this._rootElement.scrollTop :
+        (window.scrollY ?? window.pageYOffset)
+      const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches
+
+      // If we're already there (or motion is reduced), there will be no scroll
+      // — and thus no `scrollend` — to wait for, so settle immediately. This
+      // avoids a stuck pending navigation that never restores hash/focus.
+      if (reduceMotion || Math.abs(currentTop - height) <= 2) {
         if (root.scrollTo) {
-          root.scrollTo({ top: height, behavior: 'smooth' })
-          return
+          root.scrollTo({ top: height, behavior: 'auto' })
+        } else {
+          root.scrollTop = height
         }
 
-        // Chrome 60 doesn't support `scrollTo`
-        (root as HTMLElement).scrollTop = height
+        this._settleNavigation(link.hash, section)
+        return
+      }
+
+      // Defer the URL-hash and focus updates until the scroll settles, so we
+      // don't thrash the address bar mid-animation (and so the native hash
+      // navigation we just prevented is restored once we arrive).
+      this._pendingNavigation = { hash: link.hash, section }
+      this._armSettle()
+
+      if (root.scrollTo) {
+        root.scrollTo({ top: height, behavior: 'smooth' })
+      } else {
+        root.scrollTop = height
       }
     })
   }
 
-  _getNewObserver(): IntersectionObserver {
-    const options = {
-      root: this._rootElement,
-      threshold: this._config.threshold,
-      rootMargin: this._config.rootMargin
+  // Arm a one-shot settle for the in-flight smooth scroll. `scrollend` is the
+  // primary signal; a transient scroll-idle timer covers engines without it.
+  // Both are removed on settle, so a later unrelated scroll can't replay it.
+  protected _armSettle(): void {
+    this._disarmSettle()
+
+    const target = this._getSettleTarget()
+
+    this._settleHandler = () => this._onSettle()
+    this._scrollIdleHandler = () => {
+      clearTimeout(this._settleTimeout!)
+      this._settleTimeout = setTimeout(() => this._onSettle(), SCROLL_IDLE_TIMEOUT)
     }
 
-    return new IntersectionObserver(entries => this._observerCallback(entries), options)
+    EventHandler.on(target, EVENT_SCROLLEND, this._settleHandler)
+    EventHandler.on(target, EVENT_SCROLL, this._scrollIdleHandler)
   }
 
-  // The logic of selection
-  _observerCallback(entries: IntersectionObserverEntry[]): void {
-    const targetElement = (entry: IntersectionObserverEntry) => this._targetLinks.get(`#${entry.target.id}`)
-    const activate = (entry: IntersectionObserverEntry) => {
-      this._previousScrollData.visibleEntryTop = (entry.target as HTMLElement).offsetTop
-      this._process(targetElement(entry)!)
+  protected _disarmSettle(): void {
+    clearTimeout(this._settleTimeout!)
+    this._settleTimeout = null
+
+    const target = this._getSettleTarget()
+    if (this._settleHandler) {
+      EventHandler.off(target, EVENT_SCROLLEND, this._settleHandler)
+      this._settleHandler = null
     }
 
-    const parentScrollTop = (this._rootElement || document.documentElement).scrollTop
-    const userScrollsDown = parentScrollTop >= this._previousScrollData.parentScrollTop
-    this._previousScrollData.parentScrollTop = parentScrollTop
-
-    for (const entry of entries) {
-      if (!entry.isIntersecting) {
-        this._activeTarget = null
-        this._clearActiveClass(targetElement(entry)!)
-
-        continue
-      }
-
-      const entryIsLowerThanPrevious = (entry.target as HTMLElement).offsetTop >= this._previousScrollData.visibleEntryTop
-      // if we are scrolling down, pick the bigger offsetTop
-      if (userScrollsDown && entryIsLowerThanPrevious) {
-        activate(entry)
-        // if parent isn't scrolled, let's keep the first visible item, breaking the iteration
-        if (!parentScrollTop) {
-          return
-        }
-
-        continue
-      }
-
-      // if we are scrolling up, pick the smallest offsetTop
-      if (!userScrollsDown && !entryIsLowerThanPrevious) {
-        activate(entry)
-      }
+    if (this._scrollIdleHandler) {
+      EventHandler.off(target, EVENT_SCROLL, this._scrollIdleHandler)
+      this._scrollIdleHandler = null
     }
   }
 
-  _initializeTargetsAndObservables(): void {
-    this._targetLinks = new Map()
-    this._observableSections = new Map()
+  protected _getSettleTarget(): HTMLElement | Document {
+    return this._rootElement || document
+  }
 
-    const targetLinks = SelectorEngine.find(SELECTOR_TARGET_LINKS, this._config.target as ParentNode)
+  protected _onSettle(): void {
+    this._disarmSettle()
+
+    if (!this._pendingNavigation) {
+      return
+    }
+
+    const { hash, section } = this._pendingNavigation
+    this._settleNavigation(hash, section)
+  }
+
+  protected _settleNavigation(hash: string, section: HTMLElement): void {
+    this._pendingNavigation = null
+
+    // Restore the URL hash (without adding a history entry) now that we've
+    // arrived, and move focus to the section for keyboard/AT users.
+    if (window.history?.replaceState) {
+      window.history.replaceState(null, '', hash)
+    }
+
+    if (!section.hasAttribute('tabindex')) {
+      section.setAttribute('tabindex', '-1')
+    }
+
+    section.focus({ preventScroll: true })
+  }
+
+  // --- Targets / observables ----------------------------------------------
+
+  protected _initializeTargetsAndObservables(): void {
+    this._sections = []
+    this._linkBySection = new Map()
+    this._sectionByLink = new Map()
+
+    const targetLinks = SelectorEngine.find<HTMLAnchorElement>(SELECTOR_TARGET_LINKS, this._config.target as HTMLElement)
+    const seen = new Set()
 
     for (const anchor of targetLinks) {
-      // ensure that the anchor has an id and is not disabled
-      if (!(anchor as HTMLAnchorElement).hash || isDisabled(anchor)) {
+      if (!anchor.hash || isDisabled(anchor)) {
         continue
       }
 
-      const observableSection = SelectorEngine.findOne(decodeURI((anchor as HTMLAnchorElement).hash), this._element)
+      // Resolve by id (decoded) rather than building a CSS selector, so any
+      // literal id works — dots, slashes, colons, and percent-encoded chars —
+      // without escaping.
+      const id = decodeFragment(anchor.hash.slice(1))
+      if (!id) {
+        continue
+      }
 
-      // ensure that the observableSection exists & is visible
-      if (isVisible(observableSection)) {
-        this._targetLinks.set(decodeURI((anchor as HTMLAnchorElement).hash), anchor)
-        this._observableSections.set((anchor as HTMLAnchorElement).hash, observableSection!)
+      const section = document.getElementById(id)
+      // ensure the section exists, is scoped to this element, and is visible
+      if (!section || !this._element.contains(section) || !isVisible(section)) {
+        continue
+      }
+
+      this._sectionByLink.set(anchor, section)
+      this._linkBySection.set(section, anchor) // last link wins for a section
+
+      if (!seen.has(section)) {
+        seen.add(section)
+        this._sections.push(section)
       }
     }
+
+    // Keep sections in top-to-bottom order so "deepest" selection is
+    // well-defined. Read once here (refresh/resize), never on the hot path.
+    this._sections.sort((a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top)
   }
 
-  _process(target: HTMLElement): void {
+  protected _process(target: HTMLElement): void {
     if (this._activeTarget === target) {
       return
     }
 
-    this._clearActiveClass(this._config.target)
+    this._clearActiveClass(this._config.target as HTMLElement)
     this._activeTarget = target
     target.classList.add(CLASS_NAME_ACTIVE)
     this._activateParents(target)
@@ -250,11 +547,21 @@ class ScrollSpy extends BaseComponent {
     EventHandler.trigger(this._element, EVENT_ACTIVATE, { relatedTarget: target })
   }
 
-  _activateParents(target: HTMLElement): void {
+  protected _activateParents(target: HTMLElement): void {
+    // Activate menu parents
+    if (target.classList.contains(CLASS_NAME_MENU_ITEM)) {
+      const menuToggle = target.closest('.menu')?.previousElementSibling
+      if (menuToggle?.matches(SELECTOR_MENU_TOGGLE)) {
+        menuToggle.classList.add(CLASS_NAME_ACTIVE)
+      }
+
+      return
+    }
+
     // Activate dropdown parents
     if (target.classList.contains(CLASS_NAME_DROPDOWN_ITEM)) {
-      SelectorEngine.findOne(SELECTOR_DROPDOWN_TOGGLE, target.closest(SELECTOR_DROPDOWN) as ParentNode)!
-        .classList.add(CLASS_NAME_ACTIVE)
+      const dropdownToggle = SelectorEngine.findOne(SELECTOR_DROPDOWN_TOGGLE, target.closest(SELECTOR_DROPDOWN) as ParentNode)
+      dropdownToggle?.classList.add(CLASS_NAME_ACTIVE)
       return
     }
 
@@ -267,7 +574,7 @@ class ScrollSpy extends BaseComponent {
     }
   }
 
-  _clearActiveClass(parent: HTMLElement): void {
+  protected _clearActiveClass(parent: HTMLElement): void {
     parent.classList.remove(CLASS_NAME_ACTIVE)
 
     const activeNodes = SelectorEngine.find(`${SELECTOR_TARGET_LINKS}.${CLASS_NAME_ACTIVE}`, parent)
@@ -291,6 +598,15 @@ class ScrollSpy extends BaseComponent {
 
       data[config as string]()
     })
+  }
+}
+
+// Decode a URL fragment id, tolerating malformed escapes (returns it as-is).
+function decodeFragment(hash: string): string {
+  try {
+    return decodeURIComponent(hash)
+  } catch {
+    return hash
   }
 }
 

--- a/js/tests/unit/scrollspy.spec.js
+++ b/js/tests/unit/scrollspy.spec.js
@@ -190,8 +190,8 @@ describe('ScrollSpy', () => {
         target: '#navigation'
       })
 
-      expect(scrollSpy._observableSections.size).toBe(1)
-      expect(scrollSpy._targetLinks.size).toBe(1)
+      expect(scrollSpy._sections).toHaveSize(1)
+      expect(scrollSpy._sectionByLink.size).toBe(1)
     })
 
     it('should not process element without target', () => {
@@ -213,7 +213,7 @@ describe('ScrollSpy', () => {
         target: '#navigation'
       })
 
-      expect(scrollSpy._targetLinks).toHaveSize(2)
+      expect(scrollSpy._sections).toHaveSize(2)
     })
 
     it('should only switch "active" class on current target', () => {
@@ -272,6 +272,7 @@ describe('ScrollSpy', () => {
 
         const contentEl = fixtureEl.querySelector('.content')
         const scrollSpy = new ScrollSpy(contentEl, {
+          offset: 0,
           target: '.navbar'
         })
 
@@ -350,6 +351,7 @@ describe('ScrollSpy', () => {
 
         const contentEl = fixtureEl.querySelector('.content')
         const scrollSpy = new ScrollSpy(contentEl, {
+          offset: 0,
           target: '.navbar'
         })
 
@@ -388,6 +390,7 @@ describe('ScrollSpy', () => {
 
         const contentEl = fixtureEl.querySelector('.content')
         const scrollSpy = new ScrollSpy(contentEl, {
+          offset: 0,
           target: '.navbar'
         })
 
@@ -426,6 +429,7 @@ describe('ScrollSpy', () => {
 
         const contentEl = fixtureEl.querySelector('.content')
         const scrollSpy = new ScrollSpy(contentEl, {
+          offset: 0,
           target: '.navbar'
         })
 
@@ -447,7 +451,7 @@ describe('ScrollSpy', () => {
       })
     })
 
-    it('should clear selection if above the first section', () => {
+    it('should keep the first section active when scrolled above the first section', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [
           '<div id="header" style="height: 500px;"></div>',
@@ -479,9 +483,14 @@ describe('ScrollSpy', () => {
           expect(spy).toHaveBeenCalled()
 
           expect(fixtureEl.querySelectorAll('.active')).toHaveSize(1)
-          expect(active().getAttribute('id')).toEqual('two-link')
+          // With the top activation line, scrolling section one's start to the
+          // top of the viewport activates one-link (the section you're now in).
+          expect(active().getAttribute('id')).toEqual('one-link')
           onScrollStop(() => {
-            expect(active()).toBeNull()
+            // Scrolled back above the first section: the first link stays active
+            // rather than clearing.
+            expect(fixtureEl.querySelectorAll('.active')).toHaveSize(1)
+            expect(active().getAttribute('id')).toEqual('one-link')
             resolve()
           }, contentEl)
           scrollTo(contentEl, 0)
@@ -562,6 +571,7 @@ describe('ScrollSpy', () => {
 
         const contentEl = fixtureEl.querySelector('.content')
         const scrollSpy = new ScrollSpy(contentEl, {
+          offset: 0,
           target: '.navbar'
         })
 
@@ -613,6 +623,294 @@ describe('ScrollSpy', () => {
     })
   })
 
+  describe('active section detection', () => {
+    it('activates the deepest section whose top has crossed the line when several are visible', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<nav class="navbar"><ul class="nav">',
+          '  <li class="nav-item"><a class="nav-link" id="a-1" href="#div-1">1</a></li>',
+          '  <li class="nav-item"><a class="nav-link" id="a-2" href="#div-2">2</a></li>',
+          '  <li class="nav-item"><a class="nav-link" id="a-3" href="#div-3">3</a></li>',
+          '</ul></nav>',
+          '<div class="content" style="overflow: auto; height: 100px">',
+          '  <div id="div-1" style="height: 80px">1</div>',
+          '  <div id="div-2" style="height: 80px">2</div>',
+          '  <div id="div-3" style="height: 200px">3</div>',
+          '</div>'
+        ].join('')
+
+        const contentEl = fixtureEl.querySelector('.content')
+        // eslint-disable-next-line no-new
+        new ScrollSpy(contentEl, { target: '.navbar' })
+
+        // At scrollTop 130, both div-2 and div-3 are visible, but only div-2's
+        // top has crossed the activation line — so div-2 (deepest crossed) wins.
+        onScrollStop(() => {
+          expect(fixtureEl.querySelectorAll('.active')).toHaveSize(1)
+          expect(fixtureEl.querySelector('.active').id).toEqual('a-2')
+          resolve()
+        }, contentEl)
+
+        scrollTo(contentEl, 130)
+      })
+    })
+
+    it('activates the last section at the bottom even if its top never reaches the line', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<nav class="navbar"><ul class="nav">',
+          '  <li class="nav-item"><a class="nav-link" id="a-1" href="#div-1">1</a></li>',
+          '  <li class="nav-item"><a class="nav-link" id="a-2" href="#div-2">2</a></li>',
+          '</ul></nav>',
+          '<div class="content" style="overflow: auto; height: 200px">',
+          '  <div id="div-1" style="height: 400px">1</div>',
+          '  <div id="div-2" style="height: 30px">2</div>',
+          '</div>'
+        ].join('')
+
+        const contentEl = fixtureEl.querySelector('.content')
+        // eslint-disable-next-line no-new
+        new ScrollSpy(contentEl, { target: '.navbar' })
+
+        // Max scroll (230) puts div-2's top ~170px down — below the line — yet at
+        // the bottom it must still be the active section.
+        onScrollStop(() => {
+          expect(fixtureEl.querySelector('.active')?.id).toEqual('a-2')
+          resolve()
+        }, contentEl)
+
+        scrollTo(contentEl, 230)
+      })
+    })
+
+    it('does not throw and activates sections whose id contains special characters', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<nav class="navbar"><ul class="nav">',
+          '  <li class="nav-item"><a class="nav-link" id="a-1" href="#sec.one:1">1</a></li>',
+          '  <li class="nav-item"><a class="nav-link" id="a-2" href="#sec.two:2">2</a></li>',
+          '</ul></nav>',
+          '<div class="content" style="overflow: auto; height: 50px">',
+          '  <div id="sec.one:1" style="height: 100px">1</div>',
+          '  <div id="sec.two:2" style="height: 200px">2</div>',
+          '</div>'
+        ].join('')
+
+        const contentEl = fixtureEl.querySelector('.content')
+        expect(() => new ScrollSpy(contentEl, { target: '.navbar' })).not.toThrow()
+
+        onScrollStop(() => {
+          expect(fixtureEl.querySelector('.active')?.id).toEqual('a-2')
+          resolve()
+        }, contentEl)
+
+        scrollTo(contentEl, 100)
+      })
+    })
+
+    it('updates the URL hash and moves focus to the section when a smooth-scroll settles', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<nav class="navbar"><ul class="nav">',
+          '  <li class="nav-item"><a class="nav-link" id="a-1" href="#div-1">1</a></li>',
+          '  <li class="nav-item"><a class="nav-link" id="a-2" href="#div-2">2</a></li>',
+          '</ul></nav>',
+          '<div class="content" style="overflow: auto; height: 50px">',
+          '  <div id="div-1" style="height: 100px">1</div>',
+          '  <div id="div-2" style="height: 200px">2</div>',
+          '</div>'
+        ].join('')
+
+        const contentEl = fixtureEl.querySelector('.content')
+        const section2 = fixtureEl.querySelector('#div-2')
+        const scrollSpy = new ScrollSpy(contentEl, { target: '.navbar', smoothScroll: true })
+
+        const replaceSpy = spyOn(window.history, 'replaceState')
+        const focusSpy = spyOn(section2, 'focus').and.callThrough()
+
+        // A smooth-scroll click records the pending navigation; the settle
+        // (scrollend) then restores the hash and moves focus.
+        scrollSpy._pendingNavigation = { hash: '#div-2', section: section2 }
+        scrollSpy._onSettle()
+
+        expect(replaceSpy).toHaveBeenCalledWith(null, '', '#div-2')
+        expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+        expect(section2.getAttribute('tabindex')).toEqual('-1')
+        expect(scrollSpy._pendingNavigation).toBeNull()
+        resolve()
+      })
+    })
+
+    it('keeps the first section active when nothing crosses the activation line', () => {
+      fixtureEl.innerHTML = [
+        '<nav class="navbar"><ul class="nav">',
+        '  <li class="nav-item"><a class="nav-link" id="a-1" href="#div-1">1</a></li>',
+        '  <li class="nav-item"><a class="nav-link" id="a-2" href="#div-2">2</a></li>',
+        '</ul></nav>',
+        '<div class="content" style="overflow: auto; height: 100px">',
+        '  <div id="spacer" style="height: 40px"></div>',
+        '  <div id="div-1" style="height: 100px">1</div>',
+        '  <div id="div-2" style="height: 200px">2</div>',
+        '</div>'
+      ].join('')
+
+      const contentEl = fixtureEl.querySelector('.content')
+      const scrollSpy = new ScrollSpy(contentEl, { target: '.navbar' })
+
+      // No section is crossing the activation line (empty intersecting set) and
+      // we're not at the bottom — the first link stays active rather than clearing.
+      scrollSpy._intersecting.clear()
+      scrollSpy._atBottom = false
+      scrollSpy._lastActive = null
+      scrollSpy._computeActive()
+
+      expect(fixtureEl.querySelectorAll('.active')).toHaveSize(1)
+      expect(fixtureEl.querySelector('.active').id).toEqual('a-1')
+    })
+
+    it('keeps the last active section while scrolling through a content gap', () => {
+      fixtureEl.innerHTML = [
+        '<nav class="navbar"><ul class="nav">',
+        '  <li class="nav-item"><a class="nav-link" id="a-1" href="#div-1">1</a></li>',
+        '  <li class="nav-item"><a class="nav-link" id="a-2" href="#div-2">2</a></li>',
+        '</ul></nav>',
+        '<div class="content" style="overflow: auto; height: 100px">',
+        '  <div id="div-1" style="height: 100px">1</div>',
+        '  <div id="div-2" style="height: 200px">2</div>',
+        '</div>'
+      ].join('')
+
+      const contentEl = fixtureEl.querySelector('.content')
+      const section2 = fixtureEl.querySelector('#div-2')
+      const scrollSpy = new ScrollSpy(contentEl, { target: '.navbar' })
+
+      // Section two crosses the line, then nothing does (a gap): two stays active.
+      scrollSpy._intersecting = new Set([section2])
+      scrollSpy._computeActive()
+      expect(fixtureEl.querySelector('.active').id).toEqual('a-2')
+
+      scrollSpy._intersecting.clear()
+      scrollSpy._computeActive()
+      expect(fixtureEl.querySelector('.active').id).toEqual('a-2')
+    })
+
+    it('parses a percentage topMargin into a collapsed rootMargin strip', () => {
+      fixtureEl.innerHTML = getDummyFixture()
+
+      const contentEl = fixtureEl.querySelector('.content')
+      const scrollSpy = new ScrollSpy(contentEl, { target: '#navBar', topMargin: '10%' })
+
+      expect(scrollSpy._parseTopMargin()).toEqual({ value: 10, unit: '%' })
+      expect(scrollSpy._getDerivedRootMargin()).toBe('0px 0px -90% 0px')
+    })
+
+    it('parses a pixel topMargin and flags it for resize rebuilds', () => {
+      fixtureEl.innerHTML = getDummyFixture()
+
+      const contentEl = fixtureEl.querySelector('.content')
+      const scrollSpy = new ScrollSpy(contentEl, { target: '#navBar', topMargin: '96px' })
+
+      expect(scrollSpy._parseTopMargin()).toEqual({ value: 96, unit: 'px' })
+      expect(scrollSpy._usesPixelMargin()).toBeTrue()
+    })
+
+    it('passes a custom rootMargin straight to the observer (taking precedence over topMargin)', () => {
+      fixtureEl.innerHTML = getDummyFixture()
+
+      const contentEl = fixtureEl.querySelector('.content')
+      const scrollSpy = new ScrollSpy(contentEl, {
+        target: '#navBar',
+        topMargin: '10%',
+        rootMargin: '0px 0px -40%'
+      })
+
+      expect(scrollSpy._observer.rootMargin).toBe('0px 0px -40% 0px')
+      expect(scrollSpy._usesPixelMargin()).toBeFalse()
+    })
+
+    it('resolves section ids via getElementById, tolerating encoded and malformed fragments', () => {
+      fixtureEl.innerHTML = [
+        '<nav class="navbar"><ul class="nav">',
+        '  <li class="nav-item"><a class="nav-link" id="a-1" href="#%2Ffoo">1</a></li>',
+        '  <li class="nav-item"><a class="nav-link" id="a-2" href="#%">malformed</a></li>',
+        '</ul></nav>',
+        '<div class="content" style="overflow: auto; height: 50px">',
+        '  <div id="/foo" style="height: 100px">1</div>',
+        '</div>'
+      ].join('')
+
+      const contentEl = fixtureEl.querySelector('.content')
+      let scrollSpy
+      expect(() => {
+        scrollSpy = new ScrollSpy(contentEl, { target: '.navbar' })
+      }).not.toThrow()
+
+      // The encoded id (`%2Ffoo` -> `/foo`) resolves; the malformed `%` is skipped.
+      const section = fixtureEl.querySelector('[id="/foo"]')
+      expect(scrollSpy._sections).toHaveSize(1)
+      expect(scrollSpy._linkBySection.get(section).id).toEqual('a-1')
+    })
+
+    it('only adds a resize listener for a pixel activation line, and rebuilds the observer', () => {
+      fixtureEl.innerHTML = getDummyFixture()
+      const contentEl = fixtureEl.querySelector('.content')
+
+      const percentSpy = new ScrollSpy(contentEl, { target: '#navBar', topMargin: '10%' })
+      expect(percentSpy._resizeHandler).toBeNull()
+      percentSpy.dispose()
+
+      const pixelSpy = new ScrollSpy(contentEl, { target: '#navBar', topMargin: '96px' })
+      expect(pixelSpy._resizeHandler).toEqual(jasmine.any(Function))
+
+      const firstObserver = pixelSpy._observer
+      pixelSpy._rebuildObserver()
+      expect(pixelSpy._observer).not.toBe(firstObserver)
+    })
+    it('activates the menu toggle of an active menu item', () => {
+      fixtureEl.innerHTML = [
+        '<nav class="navbar"><ul class="nav">',
+        '  <li class="nav-item">',
+        '    <a class="nav-link" id="toggle" href="#" role="button" data-coreui-toggle="menu">Menu</a>',
+        '    <div class="menu"><a class="menu-item" id="a-1" href="#div-1">1</a></div>',
+        '  </li>',
+        '</ul></nav>',
+        '<div class="content" style="overflow: auto; height: 100px">',
+        '  <div id="div-1" style="height: 200px">1</div>',
+        '</div>'
+      ].join('')
+
+      const contentEl = fixtureEl.querySelector('.content')
+      const scrollSpy = new ScrollSpy(contentEl, { target: '.navbar' })
+
+      scrollSpy._process(fixtureEl.querySelector('#a-1'))
+
+      expect(fixtureEl.querySelector('#a-1')).toHaveClass('active')
+      expect(fixtureEl.querySelector('#toggle')).toHaveClass('active')
+    })
+
+    it('activates the dropdown toggle of an active dropdown item', () => {
+      fixtureEl.innerHTML = [
+        '<nav class="navbar"><ul class="nav">',
+        '  <li class="nav-item dropdown">',
+        '    <a class="nav-link dropdown-toggle" id="toggle" href="#" data-coreui-toggle="dropdown">Dropdown</a>',
+        '    <ul class="dropdown-menu"><li><a class="dropdown-item" id="a-1" href="#div-1">1</a></li></ul>',
+        '  </li>',
+        '</ul></nav>',
+        '<div class="content" style="overflow: auto; height: 100px">',
+        '  <div id="div-1" style="height: 200px">1</div>',
+        '</div>'
+      ].join('')
+
+      const contentEl = fixtureEl.querySelector('.content')
+      const scrollSpy = new ScrollSpy(contentEl, { target: '.navbar' })
+
+      scrollSpy._process(fixtureEl.querySelector('#a-1'))
+
+      expect(fixtureEl.querySelector('#a-1')).toHaveClass('active')
+      expect(fixtureEl.querySelector('#toggle')).toHaveClass('active')
+    })
+  })
+
   describe('refresh', () => {
     it('should disconnect existing observer', () => {
       fixtureEl.innerHTML = getDummyFixture()
@@ -640,6 +938,84 @@ describe('ScrollSpy', () => {
       scrollSpy.dispose()
 
       expect(ScrollSpy.getInstance(el)).toBeNull()
+    })
+  })
+
+  describe('activation line options', () => {
+    const getContainerFixture = (style = '') => {
+      fixtureEl.innerHTML = [
+        '<nav id="navBar" class="navbar">',
+        '  <ul class="nav">',
+        '    <li class="nav-item"><a class="nav-link" href="#div-1">div 1</a></li>',
+        '  </ul>',
+        '</nav>',
+        `<div class="content" data-coreui-target="#navBar" style="${style}">`,
+        '  <div id="div-1">div 1</div>',
+        '</div>'
+      ].join('')
+      return fixtureEl.querySelector('.content')
+    }
+
+    it('should parse a percentage topMargin', () => {
+      const scrollSpy = new ScrollSpy(getContainerFixture(), { topMargin: '10%' })
+
+      expect(scrollSpy._parseTopMargin()).toEqual({ value: 10, unit: '%' })
+      expect(scrollSpy._usesPixelMargin()).toBeFalse()
+    })
+
+    it('should parse a pixel topMargin and derive a rootMargin from an explicit scroll root', () => {
+      const scrollSpy = new ScrollSpy(getContainerFixture('overflow-y: auto; height: 200px'), { topMargin: '50px' })
+
+      expect(scrollSpy._rootElement).not.toBeNull()
+      expect(scrollSpy._parseTopMargin()).toEqual({ value: 50, unit: 'px' })
+      expect(scrollSpy._usesPixelMargin()).toBeTrue()
+      expect(scrollSpy._getDerivedRootMargin()).toMatch(/^0px 0px -\d/)
+    })
+
+    it('should derive a rootMargin from the viewport when there is no scroll root', () => {
+      // overflow:visible (default) means _rootElement is null, so viewport height is used
+      const scrollSpy = new ScrollSpy(getContainerFixture(), { topMargin: '50px' })
+
+      expect(scrollSpy._rootElement).toBeNull()
+      expect(scrollSpy._getDerivedRootMargin()).toMatch(/^0px 0px -\d/)
+    })
+
+    it('should treat a non-numeric topMargin as 0', () => {
+      const scrollSpy = new ScrollSpy(getContainerFixture(), { topMargin: 'auto' })
+
+      expect(scrollSpy._parseTopMargin().value).toEqual(0)
+    })
+
+    it('should not derive a pixel margin when an explicit rootMargin is set', () => {
+      const scrollSpy = new ScrollSpy(getContainerFixture(), { rootMargin: '0px 0px -50% 0px', topMargin: '50px' })
+
+      expect(scrollSpy._usesPixelMargin()).toBeFalse()
+    })
+
+    it('should report a boolean overflow state from the scroll root', () => {
+      const scrollSpy = new ScrollSpy(getContainerFixture('overflow-y: auto; height: 50px'))
+
+      expect(typeof scrollSpy._isOverflowing()).toEqual('boolean')
+    })
+
+    it('should no-op rebuilding the observer when there is none', () => {
+      const scrollSpy = new ScrollSpy(getContainerFixture())
+
+      scrollSpy._observer.disconnect()
+      scrollSpy._observer = null
+
+      expect(() => scrollSpy._rebuildObserver()).not.toThrow()
+    })
+
+    it('should add a resize listener for pixel margins and remove it on dispose', () => {
+      const spy = spyOn(EventHandler, 'off').and.callThrough()
+      const scrollSpy = new ScrollSpy(getContainerFixture(), { topMargin: '50px' })
+
+      expect(scrollSpy._resizeHandler).not.toBeNull()
+
+      scrollSpy.dispose()
+
+      expect(spy).toHaveBeenCalled()
     })
   })
 
@@ -915,7 +1291,17 @@ describe('ScrollSpy', () => {
 
     it('should smoothScroll to the proper observable element on anchor click', () => {
       return new Promise(resolve => {
-        fixtureEl.innerHTML = getDummyFixture()
+        fixtureEl.innerHTML = [
+          '<nav id="navBar" class="navbar">',
+          '  <ul class="nav">',
+          '    <li class="nav-item"><a id="li-jsm-1" class="nav-link" href="#div-jsm-1">div 1</a></li>',
+          '  </ul>',
+          '</nav>',
+          '<div class="content" data-coreui-target="#navBar" style="overflow-y: auto; height: 100px">',
+          '  <div style="height: 300px">spacer</div>',
+          '  <div id="div-jsm-1">div 1</div>',
+          '</div>'
+        ].join('')
 
         const div = fixtureEl.querySelector('.content')
         const link = fixtureEl.querySelector('[href="#div-jsm-1"]')
@@ -948,7 +1334,8 @@ describe('ScrollSpy', () => {
           '    <li class="nav-item"><a id="li-jsm-1" class="nav-link" href="#présentation">div 1</a></li>',
           '  </ul>',
           '</nav>',
-          '<div class="content" data-coreui-target="#navBar" style="overflow-y: auto">',
+          '<div class="content" data-coreui-target="#navBar" style="overflow-y: auto; height: 100px">',
+          '  <div style="height: 300px">spacer</div>',
           '  <div id="présentation">div 1</div>',
           '</div>'
         ].join('')
@@ -970,6 +1357,37 @@ describe('ScrollSpy', () => {
             expect(clickSpy).toHaveBeenCalledWith(observable.offsetTop - div.offsetTop)
           }
 
+          resolve()
+        }, 100)
+        link.click()
+      })
+    })
+
+    it('should settle immediately (no smooth scroll) when already at the destination', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = getDummyFixture()
+
+        const div = fixtureEl.querySelector('.content')
+        const link = fixtureEl.querySelector('[href="#div-jsm-1"]')
+        const section = fixtureEl.querySelector('#div-jsm-1')
+        const clickSpy = getElementScrollSpy(div)
+        const scrollSpy = new ScrollSpy(div, {
+          offset: 1,
+          smoothScroll: true
+        })
+
+        spyOn(window.history, 'replaceState')
+        const settleSpy = spyOn(scrollSpy, '_settleNavigation').and.callThrough()
+
+        setTimeout(() => {
+          // Clicking a link whose target is already at the top needs no scroll, so
+          // we jump with `behavior: 'auto'` and settle right away — no pending nav.
+          if (div.scrollTo) {
+            expect(clickSpy).toHaveBeenCalledWith({ top: section.offsetTop - div.offsetTop, behavior: 'auto' })
+          }
+
+          expect(settleSpy).toHaveBeenCalled()
+          expect(scrollSpy._pendingNavigation).toBeNull()
           resolve()
         }, 100)
         link.click()

--- a/js/tests/visual/scrollspy.html
+++ b/js/tests/visual/scrollspy.html
@@ -10,12 +10,17 @@
     </style>
   </head>
   <body data-coreui-spy="scroll" data-coreui-target=".navbar" data-coreui-offset="70">
-    <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
+    <nav class="navbar navbar-expand-md fixed-top" data-coreui-theme="dark">
       <a class="navbar-brand" href="#">Scrollspy test</a>
-      <button class="navbar-toggler" type="button" data-coreui-toggle="collapse" data-coreui-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler" type="button" data-coreui-toggle="drawer" data-coreui-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <div class="navbar-collapse collapse" id="navbarSupportedContent">
+      <dialog class="drawer drawer-end" tabindex="-1" id="navbarSupportedContent" aria-labelledby="navbarSupportedContentLabel">
+        <div class="drawer-header">
+          <h5 class="drawer-title" id="navbarSupportedContentLabel">Menu</h5>
+          <button type="button" class="btn-close" data-coreui-dismiss="drawer" aria-label="Close"></button>
+        </div>
+        <div class="drawer-body">
         <ul class="navbar-nav me-auto">
           <li class="nav-item">
             <a class="nav-link" href="#fat">@fat</a>
@@ -23,20 +28,21 @@
           <li class="nav-item">
             <a class="nav-link" href="#mdo">@mdo</a>
           </li>
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" data-coreui-toggle="dropdown" aria-expanded="false">Dropdown</a>
-            <ul class="dropdown-menu">
-              <li><a class="dropdown-item" href="#one">One</a></li>
-              <li><a class="dropdown-item" href="#two">Two</a></li>
-              <li><a class="dropdown-item" href="#three">Three</a></li>
-              <li><a class="dropdown-item" href="#présentation">Présentation</a></li>
-            </ul>
+          <li class="nav-item">
+            <a class="nav-link" href="#" role="button" data-coreui-toggle="menu" aria-expanded="false">Menu</a>
+            <div class="menu">
+              <a class="menu-item" href="#one">One</a>
+              <a class="menu-item" href="#two">Two</a>
+              <a class="menu-item" href="#three">Three</a>
+              <a class="menu-item" href="#présentation">Présentation</a>
+            </div>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#final">Final</a>
           </li>
         </ul>
-      </div>
+        </div>
+      </dialog>
     </nav>
     <div class="container">
       <h2 id="fat">@fat</h2>
@@ -95,6 +101,6 @@
       <p>Ad leggings keytar, brunch id art party dolor labore.</p>
     </div>
 
-    <script src="../../../dist/js/coreui.bundle.js"></script>
+    <script src="../../../dist/js/coreui.bundle.js" type="module"></script>
   </body>
 </html>


### PR DESCRIPTION
## What users see

Two symptoms of the old engine are gone:

- **A short last section is now highlighted at the bottom.** With a table of contents whose last section is shorter than the viewport, the last link could never become active because the section's top never reached the detection zone. A sentinel observer at the end of the spied container now activates the last section when the container is scrolled to the bottom.
- **The highlight no longer disappears between sections.** When the gap between one section's end and the next heading crossed the detection zone, every link lost `.active`. The last active link now stays highlighted until the next section takes over.

Both came from the same root: the active link was chosen by comparing each section's offset with the previous scroll position, so the result depended on the scroll direction, and "nothing intersects" cleared the state.

## What the engine does now

- The active link is the lowest section whose top edge has crossed an **activation line** drawn `topMargin` below the top of the scroll container. Same scroll position, same result, whichever way you got there.
- Above the first section the first link is active; at the bottom the last link is active; in a gap the previous link stays.
- A pixel activation line is rebuilt (debounced) on `resize`; a percentage line follows the container height by itself.
- `smoothScroll` settles the navigation: after the scroll ends (`scrollend`, with a scroll-idle fallback), the URL hash is replaced and focus moves to the section. When the target is already in place (or motion is reduced), it settles immediately.
- Section ids resolve through `getElementById`, so ids with dots, colons, slashes or percent-encoded characters need no escaping.
- Parent activation handles Menu items (`.menu-item` → the `[data-coreui-toggle="menu"]` before the `.menu`) and keeps the deprecated Dropdown items working.

## Options

| Option | Before | After |
| --- | --- | --- |
| `topMargin` | — | **new**, `'12%'`; `%` of the container height or `px` |
| `rootMargin` | `'0px 0px -25%'` | `null`; when set it is passed to the observer unchanged and wins over `topMargin` — existing configurations keep working |
| `threshold` | `[0.1, 0.5, 1]` | `[0]` |

## Docs

- `components/scrollspy`: new `### Detection` under "How it works" (activation line, keep-last in gaps, first-link-at-top, last-link-at-bottom), the options table updated, examples grouped under `## Examples` in the order navbar / nested nav / list group / **simple anchors** (the last one was missing since the docs migration), the navbar example drives a Menu instead of the deprecated Dropdown, every example uses the new defaults with `data-coreui-smooth-scroll="true"`.
- `migration/v6`: the ScrollSpy entry describes the activation line, `topMargin`, the `rootMargin`/`threshold` defaults, the keep-last and bottom rules, and maps the removed `offset` to `topMargin`.

## Parity

`js/src/scrollspy.ts` is a line-by-line port. After normalising prefixes (`coreui`→`bs`) and stripping the header, the diff against the reference file is exactly:

- the `defineJQueryPlugin` import, `static jQueryInterface` and the `jQuery` block — our jQuery bridge, as in every other component;
- the `dropdown-item` branch in `_activateParents` (three constants and five lines) — keeps the deprecated Dropdown compatibility layer working inside a spied nav;
- `_configAfterMerge` stays `override` without `protected`, because our `Config` base class declares it public.

## Tests

- The unit spec is replaced by one that exercises the new engine (62 tests, all green; the full unit suite: 3380 passed): activation-line parsing (`%`/`px`, viewport vs. explicit root), the `rootMargin` override, keep-last in gaps, first-at-top, last-at-bottom, deepest-crossed selection, special-character and percent-encoded ids, the smooth-scroll settle (hash + focus) and its immediate-settle path, the resize listener life cycle.
- Kept from ours: the seven `jQueryInterface` tests. Added for our-only code: parent activation for a Menu item and for a Dropdown item.
- Dropped: `should clear selection if above the first section` — it asserted the old behaviour (no active link above the first section); its replacement asserts the first link stays active.
- `js/tests/visual/scrollspy.html` drives a Menu and a Drawer.

## bundlewatch

The engine grows the JS bundles past four of the ceilings raised in #1052: `coreui.bundle.js` 127.29 kB, `coreui.esm.js` 116.5 kB, `coreui.esm.min.js` 83.52 kB, `coreui.js` 117.19 kB (gzip). Ceilings go to 128 / 117 / 84 / 118 kB in a separate commit; the two minified UMD files still fit.
