### PR TITLE
fix(forms): reveal validation feedback that sits outside an input group

### DIFF
--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -275,6 +275,31 @@ $validated-controls: if(sass($enable-deprecated-form-check): ".check, .radio, .s
     }
   }
 
+  // Input group — feedback lives outside the input-group in the parent
+  // .form-field, so we use :has() to toggle display.
+  .form-field:has(.input-group .is-#{$state}) {
+    .#{$state}-feedback,
+    .#{$state}-tooltip {
+      display: block;
+    }
+  }
+
+  @if $state == "invalid" {
+    [data-coreui-validate] .form-field:has(.input-group :user-invalid) {
+      .invalid-feedback,
+      .invalid-tooltip {
+        display: block;
+      }
+    }
+  } @else if $state == "valid" {
+    [data-coreui-validate~="valid"] .form-field:has(.input-group :user-valid) {
+      .valid-feedback,
+      .valid-tooltip {
+        display: block;
+      }
+    }
+  }
+
   .input-group {
     > .autocomplete:focus-within,
     > .date-picker:focus-within,


### PR DESCRIPTION
## What

Validation feedback was revealed only through a sibling combinator from the control itself:

```css
.is-invalid ~ .invalid-feedback,
[data-coreui-validate] :user-invalid ~ .invalid-feedback { display: block }
```

So the message disappeared the moment anything wrapped the control. Every `.form-field` holding an `.input-group` hits this — the feedback is a sibling of the group, not of the input — and the field renders red with no text under it. Silent: nothing errors, the element is just `display: none`.

The docs' own server-side validation example ships that way today: `#validationServerUsername` carries `.is-invalid` and its `.invalid-feedback` is invisible on the live page.

This is the pattern the v6 migration guide tells everyone to move to (`Input group: .has-validation removed`), so it is the shape users will write.

## Change

The state now reaches the feedback from the field — `.form-field:has(.input-group .is-{state})` — for both the `.is-{state}` classes and the `:user-{state}` path under `[data-coreui-validate]`. Tooltips get the same treatment; `.form-field` is already `position: relative`, so an `.invalid-tooltip` anchors to the field.

The rule keys on the state rather than on a control class. A group holds `.form-select` and the picker frames as well as `.form-control`, and those carry the state on different elements — `.form-control-group.is-invalid` for a picker, `.form-multi-select.is-invalid` on the field root — so a class list would go stale with every new component. The generic sibling rule a few lines above does not qualify by control class either.

## Verification

Measured in Chromium on the built docs page, `forms/validation`:

| control | before | after |
| --- | --- | --- |
| `#validationServerUsername` (`.is-invalid`) | feedback `display: none` | `display: block`, 12px under the group |
| `#validationCustomUsername` (`:user-invalid` after submit) | `display: none` | `display: block` |
| `#validationTooltipUsername` (tooltip, after submit) | `display: none` | `display: block`, anchored to the field |

Corner radii unchanged (8px on the input's end side in all three).

And on a probe page covering the control shapes a group can hold — all four reveal, a group with no state stays hidden:

| markup in the group | feedback |
| --- | --- |
| `.form-control.is-invalid` | shown |
| `.form-select.is-invalid` | shown |
| `.date-picker > .form-control-group.is-invalid` | shown |
| `.form-multi-select.is-invalid` | shown |
| `.form-select:user-invalid` after submit | shown |
| no state | hidden |

Gates: `css-lint` clean, `css-test` 62/62, `js-test-visual` 119/119, bundlewatch PASS (`coreui.css` 70.21 kB < 71 kB), `@layer` declaration still first in the compiled sheet. The JS suites were not run — no JS changed.