### PR TITLE
refactor(Calendar)!: spell the adjacent-days options as selectAdjacentDays and showAdjacentDays

### DIFF
--- a/docs/src/content/docs/components/calendar.mdx
+++ b/docs/src/content/docs/components/calendar.mdx
@@ -351,9 +351,9 @@ Note that for security reasons the `sanitize`, `sanitizeFn`, and `allowList` opt
 | `renderYearCell` | function, null | `null` | Custom function to render year cells. Receives `date` and `meta` object (with `isDisabled`, `isInRange`, `isSelected`) as parameters and should return HTML string. |
 | `sanitize` | boolean | `true` | Enable or disable the sanitization. If activated `renderDayCell`, `renderMonthCell`, `renderQuarterCell`, and `renderYearCell` options will be sanitized. |
 | `sanitizeFn` | null, function | `null` | Here you can supply your own sanitize function. This can be useful if you prefer to use a dedicated library to perform sanitization. |
-| `selectAdjacementDays` | boolean | `false` | Set whether days in adjacent months shown before or after the current month are selectable. This only applies if the `showAdjacementDays` option is set to true. |
+| `selectAdjacentDays` | boolean | `false` | Set whether days in adjacent months shown before or after the current month are selectable. This only applies if the `showAdjacentDays` option is set to true. |
 | `selectionType` | `'day'`, `'week'`, `'month'`, `'quarter'`, `'year'` | `day` | Specify the type of date selection as day, week, month, quarter, or year. |
-| `showAdjacementDays` | boolean | `true` | Set whether to display dates in adjacent months (non-selectable) at the start and end of the current month. |
+| `showAdjacentDays` | boolean | `true` | Set whether to display dates in adjacent months (non-selectable) at the start and end of the current month. |
 | `showWeekNumber` | boolean | `false` | Set whether to display week numbers in the calendar. |
 | `startDate` | date, number, string, null | `null` | Initial selected date. |
 | `weekdayFormat` | number, `'long'`, `'narrow'`, `'short'` | `2` | Set length or format of day name. |

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -646,6 +646,11 @@ check, radio, carousel and toggler icons already work:
 
 #### Calendar
 
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`selectAdjacementDays` and `showAdjacementDays` are spelled `selectAdjacentDays`
+  and `showAdjacentDays`** — the option keys, the `data-coreui-select-adjacent-days`
+  / `data-coreui-show-adjacent-days` attributes and the picker passthrough alike. The
+  typo is fixed in the React and Vue libraries in the same release.
 - **Behavior change:** `update()` now **merges** the given options over the
   current configuration instead of resolving them against the defaults. A
   partial call like `calendar.update({ selectEndDate: true })` no longer resets

--- a/js/src/calendar.ts
+++ b/js/src/calendar.ts
@@ -131,10 +131,10 @@ type CalendarConfig = {
   renderYearCell: ((date: Date) => string) | null
   sanitize: boolean
   sanitizeFn: ((unsafeHtml: string) => string) | null
-  selectAdjacementDays: boolean
+  selectAdjacentDays: boolean
   selectEndDate: boolean
   selectionType: string
-  showAdjacementDays: boolean
+  showAdjacentDays: boolean
   showWeekNumber: boolean
   startDate: Date | number | string | null
   weekdayFormat: number | string
@@ -169,10 +169,10 @@ const Default: CalendarConfig = {
   renderYearCell: null,
   sanitize: true,
   sanitizeFn: null,
-  selectAdjacementDays: false,
+  selectAdjacentDays: false,
   selectEndDate: false,
   selectionType: 'day',
-  showAdjacementDays: true,
+  showAdjacentDays: true,
   showWeekNumber: false,
   startDate: null,
   weekdayFormat: 2,
@@ -207,10 +207,10 @@ const DefaultType: Record<string, string> = {
   renderYearCell: '(function|null)',
   sanitize: 'boolean',
   sanitizeFn: '(null|function)',
-  selectAdjacementDays: 'boolean',
+  selectAdjacentDays: 'boolean',
   selectEndDate: 'boolean',
   selectionType: 'string',
-  showAdjacementDays: 'boolean',
+  showAdjacentDays: 'boolean',
   showWeekNumber: 'boolean',
   startDate: '(date|number|string|null)',
   weekdayFormat: '(number|string)',
@@ -848,7 +848,7 @@ class Calendar extends BaseComponent {
               }
               ${days.map(({ date, month }) => {
                 const cellAttributes = this._cellDayAttributes(date, month)
-                return month === 'current' || this._config.showAdjacementDays ?
+                return month === 'current' || this._config.showAdjacentDays ?
                   `<td
                     class="${cellAttributes.className}"
                     tabindex="${cellAttributes.tabIndex}"
@@ -1079,7 +1079,7 @@ class Calendar extends BaseComponent {
 
     const classNames = this._classNames({
       [CLASS_NAME_CALENDAR_CELL]: true,
-      clickable: !isCurrentMonth && this._config.selectAdjacementDays,
+      clickable: !isCurrentMonth && this._config.selectAdjacentDays,
       disabled: isDisabled,
       range: isInRange,
       'range-hover': isRangeHover,
@@ -1090,7 +1090,7 @@ class Calendar extends BaseComponent {
 
     return {
       className: classNames,
-      tabIndex: (isCurrentMonth || this._config.selectAdjacementDays) && !isDisabled ? 0 : -1,
+      tabIndex: (isCurrentMonth || this._config.selectAdjacentDays) && !isDisabled ? 0 : -1,
       ariaSelected: isSelected,
       ariaLabel: date.toLocaleDateString(this._config.locale),
       ariaCurrent: isTodayDate,

--- a/js/tests/unit/calendar.spec.js
+++ b/js/tests/unit/calendar.spec.js
@@ -339,8 +339,8 @@ describe('Calendar', () => {
     })
   })
 
-  describe('showAdjacementDays', () => {
-    it('should show adjacement days by default', () => {
+  describe('showAdjacentDays', () => {
+    it('should show adjacent days by default', () => {
       fixtureEl.innerHTML = '<div></div>'
 
       const div = fixtureEl.querySelector('div')
@@ -349,15 +349,15 @@ describe('Calendar', () => {
       const prevMonthCells = div.querySelectorAll('.calendar-cell.previous')
       const nextMonthCells = div.querySelectorAll('.calendar-cell.next')
 
-      // There should be adjacement day cells rendered
+      // There should be adjacent day cells rendered
       expect(prevMonthCells.length + nextMonthCells.length).toBeGreaterThan(0)
     })
 
-    it('should not show adjacement days when showAdjacementDays is false', () => {
+    it('should not show adjacent days when showAdjacentDays is false', () => {
       fixtureEl.innerHTML = '<div></div>'
 
       const div = fixtureEl.querySelector('div')
-      new Calendar(div, { showAdjacementDays: false, calendarDate: new Date(2023, 5, 1) }) // eslint-disable-line no-new
+      new Calendar(div, { showAdjacentDays: false, calendarDate: new Date(2023, 5, 1) }) // eslint-disable-line no-new
 
       const prevMonthCells = div.querySelectorAll('.calendar-cell.previous')
       const nextMonthCells = div.querySelectorAll('.calendar-cell.next')
@@ -367,13 +367,13 @@ describe('Calendar', () => {
     })
   })
 
-  describe('selectAdjacementDays', () => {
-    it('should make adjacement day cells clickable when selectAdjacementDays is true', () => {
+  describe('selectAdjacentDays', () => {
+    it('should make adjacent day cells clickable when selectAdjacentDays is true', () => {
       fixtureEl.innerHTML = '<div></div>'
 
       const div = fixtureEl.querySelector('div')
       new Calendar(div, { // eslint-disable-line no-new
-        selectAdjacementDays: true,
+        selectAdjacentDays: true,
         calendarDate: new Date(2023, 5, 1)
       })
 
@@ -2083,14 +2083,14 @@ describe('Calendar', () => {
       expect(attrs.className).toContain('disabled')
     })
 
-    it('should return tabIndex 0 for adjacement days when selectAdjacementDays is true', () => {
+    it('should return tabIndex 0 for adjacent days when selectAdjacentDays is true', () => {
       fixtureEl.innerHTML = '<div></div>'
 
       const div = fixtureEl.querySelector('div')
       const calendar = new Calendar(div, {
         selectionType: 'day',
         calendarDate: new Date(2023, 5, 1),
-        selectAdjacementDays: true
+        selectAdjacentDays: true
       })
       const date = new Date(2023, 4, 31) // previous month
       const attrs = calendar._cellDayAttributes(date, 'previous')
@@ -2098,14 +2098,14 @@ describe('Calendar', () => {
       expect(attrs.tabIndex).toEqual(0)
     })
 
-    it('should return tabIndex -1 for adjacement days when selectAdjacementDays is false', () => {
+    it('should return tabIndex -1 for adjacent days when selectAdjacentDays is false', () => {
       fixtureEl.innerHTML = '<div></div>'
 
       const div = fixtureEl.querySelector('div')
       const calendar = new Calendar(div, {
         selectionType: 'day',
         calendarDate: new Date(2023, 5, 1),
-        selectAdjacementDays: false
+        selectAdjacentDays: false
       })
       const date = new Date(2023, 4, 31) // previous month
       const attrs = calendar._cellDayAttributes(date, 'previous')


### PR DESCRIPTION
## What changes

`selectAdjacementDays` and `showAdjacementDays` carried a typo since the options appeared, and every framework port copied it. The option keys, the derived `data-coreui-select-adjacent-days` / `data-coreui-show-adjacent-days` attributes and the picker passthrough now read `Adjacent`. Straight rename, no alias — v6 is the one moment this can happen without a deprecation cycle.

Docs table and migration guide updated. Calendar unit spec renamed with it (192 tests green). The React and Vue libraries rename in the same release: coreui/coreui-react-pro and coreui/coreui-vue-pro, branch `refactor/props-naming-v6`.
