### PR TITLE
docs: name components in the singular

### DIFF
--- a/docs/src/content/docs/components/alerts.mdx
+++ b/docs/src/content/docs/components/alerts.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Bootstrap 6 Alerts"
-name: "Alerts"
+title: "Bootstrap 6 Alert"
+name: "Alert"
 description: "Bootstrap alerts give contextual feedback information for common user operations. The alert component is delivered with a bunch of usable and adjustable alert messages."
 otherFrameworks:
   - alert

--- a/docs/src/content/docs/components/badge.mdx
+++ b/docs/src/content/docs/components/badge.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Bootstrap 6 Badges"
-name: "Badges"
+title: "Bootstrap 6 Badge"
+name: "Badge"
 description: "Small components for indicating status and counts, or labelling items."
 otherFrameworks:
   - badge

--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Bootstrap 6 Buttons"
-name: "Buttons"
+title: "Bootstrap 6 Button"
+name: "Button"
 description: "Bootstrap button component for actions in tables, forms, cards, and more. CoreUI for Bootstrap provides various styles, states, and size. Ready to use and easy to customize."
 otherFrameworks:
   - button

--- a/docs/src/content/docs/components/dropdowns.mdx
+++ b/docs/src/content/docs/components/dropdowns.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Bootstrap 6 Dropdowns"
-name: "Dropdowns"
+title: "Bootstrap 6 Dropdown"
+name: "Dropdown"
 description: "Bootstrap dropdown component allows you to toggle contextual overlays for displaying lists, links, and more html elements."
 otherFrameworks:
   - dropdown

--- a/docs/src/content/docs/components/loading-buttons.mdx
+++ b/docs/src/content/docs/components/loading-buttons.mdx
@@ -1,7 +1,7 @@
 ---
 pro: true
-title: "Bootstrap 6 Loading Buttons"
-name: "Loading Buttons"
+title: "Bootstrap 6 Loading Button"
+name: "Loading Button"
 description: "Bootstrap loading buttons are interactive elements that provide visual feedback to users, indicating that an action is being processed. These buttons typically display a loading spinner or animation."
 otherFrameworks:
   - loading-button

--- a/docs/src/content/docs/components/placeholders.mdx
+++ b/docs/src/content/docs/components/placeholders.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Bootstrap 6 Placeholders"
-name: "Placeholders"
+title: "Bootstrap 6 Placeholder"
+name: "Placeholder"
 description: "Use loading placeholders for your components or pages to indicate something may still be loading."
 otherFrameworks:
   - placeholder

--- a/docs/src/content/docs/components/popovers.mdx
+++ b/docs/src/content/docs/components/popovers.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Bootstrap 6 Popovers"
-name: "Popovers"
+title: "Bootstrap 6 Popover"
+name: "Popover"
 description: "Documentation and examples for adding Bootstrap popovers, like those found in iOS, to any element on your site."
 otherFrameworks:
   - popover

--- a/docs/src/content/docs/components/spinners.mdx
+++ b/docs/src/content/docs/components/spinners.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Bootstrap 6 Spinners"
-name: "Spinners"
+title: "Bootstrap 6 Spinner"
+name: "Spinner"
 description: "Indicate the loading state of a component or page with Bootstrap spinners, built entirely with HTML, CSS, and no JavaScript."
 otherFrameworks:
   - spinner

--- a/docs/src/content/docs/components/tab.mdx
+++ b/docs/src/content/docs/components/tab.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Bootstrap 6 Tabs"
-name: "Tabs"
+title: "Bootstrap 6 Tab"
+name: "Tab"
 description: "Turn a nav into a tabbable interface with the tab plugin: panes of local content that swap without leaving the page."
 otherFrameworks:
   - navs-tabs

--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Bootstrap 6 Toasts"
-name: "Toasts"
+title: "Bootstrap 6 Toast"
+name: "Toast"
 description: "Send push notifications to your visitors with a toast, a lightweight and easily customizable alert message."
 otherFrameworks:
   - toast

--- a/docs/src/content/docs/components/tooltips.mdx
+++ b/docs/src/content/docs/components/tooltips.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Bootstrap 6 Tooltips"
-name: "Tooltips"
+title: "Bootstrap 6 Tooltip"
+name: "Tooltip"
 description: "Use Bootstrap Tooltips to add small, informative text boxes that appear when users hover or focus on an element. This feature enhances UX by providing contextual help without cluttering your interface."
 otherFrameworks:
   - tooltip

--- a/docs/src/data/sidebar.yml
+++ b/docs/src/data/sidebar.yml
@@ -221,7 +221,7 @@
   pages:
     - title: Accordion
       to: /components/accordion/
-    - title: Alerts
+    - title: Alert
       to: /components/alerts/
     - title: Avatar
       to: /components/avatar/
@@ -229,7 +229,7 @@
       to: /components/badge/
     - title: Breadcrumb
       to: /components/breadcrumb/
-    - title: Buttons
+    - title: Button
       to: /components/buttons/
     - title: Button group
       to: /components/button-group/
@@ -268,7 +268,7 @@
       badge:
         color: success
         text: NEW
-    - title: Dropdowns
+    - title: Dropdown
       to: /components/dropdowns/
     - title: Footer
       to: /components/footer/
@@ -278,7 +278,7 @@
       to: /components/jumbotron/
     - title: List group
       to: /components/list-group/
-    - title: Loading buttons
+    - title: Loading button
       to: /components/loading-buttons/
       badge:
         color: danger
@@ -295,9 +295,9 @@
       to: /components/offcanvas/
     - title: Pagination
       to: /components/pagination/
-    - title: Placeholders
+    - title: Placeholder
       to: /components/placeholders/
-    - title: Popovers
+    - title: Popover
       to: /components/popovers/
     - title: Progress
       to: /components/progress/
@@ -313,13 +313,13 @@
       badge:
         color: success
         text: NEW
-    - title: Spinners
+    - title: Spinner
       to: /components/spinners/
-    - title: Tabs
+    - title: Tab
       to: /components/tab/
-    - title: Toasts
+    - title: Toast
       to: /components/toasts/
-    - title: Tooltips
+    - title: Tooltip
       to: /components/tooltips/
 - title: Icons
   icon: <path fill="var(--ci-primary-color, currentColor)" d="M487.97,155.853a24.035,24.035,0,0,0-7-18.166L376.126,32.842a24,24,0,0,0-35.546,1.772L250.644,144.536,120.507,171.05a27.1,27.1,0,0,0-20.025,17.026L17.883,405.84a27.268,27.268,0,0,0,6.205,28.917l53.271,53.271a27.263,27.263,0,0,0,28.915,6.207L324.134,411.6a27.144,27.144,0,0,0,16.95-19.655l28.1-128.7L479.2,173.232A24.041,24.041,0,0,0,487.97,155.853Zm-177.6,226.741L97.807,463.222,84.665,450.079l99.36-99.36a56.061,56.061,0,1,0-22.268-22.986l-99.72,99.72L48.894,414.31,129.47,201.881l124.717-25.41,83.052,83.051ZM187.42,301.9a24,24,0,1,1,24,24A24,24,0,0,1,187.42,301.9Zm168.391-69.065L280.973,158,359.749,61.72l92.343,92.343Z" class="ci-primary"/>


### PR DESCRIPTION
Ten component pages were plural in the sidebar and in their own frontmatter — Alerts, Buttons, Dropdowns, Loading buttons, Placeholders, Popovers, Spinners, Tabs, Toasts, Tooltips — while every other page on the list was already singular. The Badges page title was plural too, though its sidebar entry was not. A page documents one component, so it is named after one.

Checked against upstream v6 before making the call: their Components section is singular throughout — Alert, Button, Close button, List group, Nav, Placeholder, Popover, Spinner, Tab, Tooltip. The single exception there is their own `Toasts`, which sits next to `toasts.mdx` and reads as the leftover rather than the rule; our React and Vue editions already say Toast.

Not touched: URLs (`/components/alerts/` and friends stay), prose, and plurals that name a group rather than a component — `Floating labels`, `Stacks`, `Containers`, `Images`, which upstream keeps plural too.

`npm run docs-build` passes; the rendered sidebar reads Alert, Button, Dropdown, Popover, Spinner, Tab, Toast, Tooltip.