### PR TITLE
docs(number-input): drop the PRO marking

### DIFF
--- a/docs/src/content/docs/forms/number-input.mdx
+++ b/docs/src/content/docs/forms/number-input.mdx
@@ -1,5 +1,4 @@
 ---
-pro: true
 title: "Bootstrap 6 Number Input"
 name: "Number Input"
 description: "Add accessible increment and decrement buttons to a Bootstrap number field, with min, max and step handled by the browser."

--- a/docs/src/data/sidebar.yml
+++ b/docs/src/data/sidebar.yml
@@ -165,9 +165,6 @@
         text: PRO
     - title: Number Input
       to: /forms/number-input/
-      badge:
-        color: danger
-        text: PRO
     - title: OTP Input
       to: /forms/otp-input/
     - title: Password Input


### PR DESCRIPTION
Completes the six-component PRO change on this side (coreui/coreui-react-pro#274, coreui/coreui-vue-pro#220).

Of Menu, Scrollspy, Number Input, OTP Input, Password Input and Password Strength, only **Number Input** still carried a PRO marking here — `pro: true` in the frontmatter and the badge in the sidebar. The other five were already unmarked in this edition.

The flag is what suppresses Carbon Ads and renders the PRO banner. Verified on the built page: `docs-banner-pro*` is gone and the Carbon script is there, while a still-PRO page (Multi Select) is unchanged.

I also cross-checked every sidebar entry against the frontmatter of the page it points at, in all three editions — no mismatches left anywhere.

Left alone on purpose: the `<Example pro>` flags on these pages (8 on Number Input, and 11/6/4 on OTP Input, Password Input and Password Strength, which were already carrying them while their pages read as free). That flag picks the package the StackBlitz scaffold installs — `@coreui/coreui-pro` vs `@coreui/coreui` — so flipping it before the components ship in the free package would scaffold sandboxes that do not build. Worth doing as one sweep across the three editions when they do.

`npm run docs-build` passes.