### PR TITLE
docs: drop the release-candidate banner

### DIFF
--- a/docs/src/content/docs/components/chip-set.mdx
+++ b/docs/src/content/docs/components/chip-set.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Bootstrap 6 Chip Set"
 name: "Chip set"
-preRelease: true
 description: "Bootstrap Chip set component for CoreUI — group chips into an accessible, keyboard-navigable container with single or multiple selection."
 ---
 

--- a/docs/src/content/docs/components/chip.mdx
+++ b/docs/src/content/docs/components/chip.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Bootstrap 6 Chip"
 name: "Chip"
-preRelease: true
 description: "Bootstrap Chip component for CoreUI — build removable tags, selectable labels, and filterable chips with icons, avatars, and full keyboard support."
 otherFrameworks:
   - chip

--- a/docs/src/content/docs/components/search-button.mdx
+++ b/docs/src/content/docs/components/search-button.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Bootstrap 6 Search Button"
 name: "Search Button"
-preRelease: true
 description: "Bootstrap Search Button for CoreUI is a keyboard-aware trigger component that can open search interfaces, modals, offcanvas panels, and custom flows from click or shortcut."
 otherFrameworks:
   - search-button

--- a/docs/src/content/docs/forms/chip-input.mdx
+++ b/docs/src/content/docs/forms/chip-input.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Bootstrap 6 Chip Input"
 name: "Chip input"
-preRelease: true
 description: "Bootstrap Chip Input component for CoreUI — create tag-like multi-value inputs for skills, categories, or recipients with keyboard support, selection, and form integration."
 otherFrameworks:
   - chip-input


### PR DESCRIPTION
Chip, Chip Set, Chip Input and Search Button carried `preRelease`, which renders the "Release Candidate (RC)" banner above the page — "its API is considered stable. Minor adjustments may still occur before the final release." Their APIs are settled, so the warning no longer says anything true.

Four pages in each edition, dropped in all three at once so no edition keeps warning about a component the others call done.

`docs-build` passes. Nothing in the built output renders that banner any more; the only remaining match is the class definition in the engine stylesheet.