### PR TITLE
docs: mark NEW only what v6 actually adds

### DIFF
--- a/docs/src/data/sidebar.yml
+++ b/docs/src/data/sidebar.yml
@@ -117,14 +117,14 @@
       to: /forms/checkbox/
     - title: Chip input
       to: /forms/chip-input/
-      badge:
-        color: success
-        text: NEW
     - title: Date Input
       to: /forms/date-input/
       badge:
-        color: danger
-        text: PRO
+        - color: success
+          text: NEW
+        - color: danger
+          text: PRO
+          className: ms-1
     - title: Date Picker
       to: /forms/date-picker/
       badge:
@@ -133,8 +133,11 @@
     - title: Date Time Picker
       to: /forms/date-time-picker/
       badge:
-        color: danger
-        text: PRO
+        - color: success
+          text: NEW
+        - color: danger
+          text: PRO
+          className: ms-1
     - title: Date Range Picker
       to: /forms/date-range-picker/
       badge:
@@ -143,10 +146,16 @@
     - title: Date Time Input
       to: /forms/date-time-input/
       badge:
-        color: danger
-        text: PRO
+        - color: success
+          text: NEW
+        - color: danger
+          text: PRO
+          className: ms-1
     - title: Field
       to: /forms/field/
+      badge:
+        color: success
+        text: NEW
     - title: Floating labels
       to: /forms/floating-labels/
     - title: Form control
@@ -165,6 +174,9 @@
         text: PRO
     - title: Number Input
       to: /forms/number-input/
+      badge:
+        color: success
+        text: NEW
     - title: OTP Input
       to: /forms/otp-input/
     - title: Password Input
@@ -202,8 +214,11 @@
     - title: Time Input
       to: /forms/time-input/
       badge:
-        color: danger
-        text: PRO
+        - color: success
+          text: NEW
+        - color: danger
+          text: PRO
+          className: ms-1
     - title: Time Picker
       to: /forms/time-picker/
       badge:
@@ -243,14 +258,8 @@
       to: /components/carousel/
     - title: Chip
       to: /components/chip/
-      badge:
-        color: success
-        text: NEW
     - title: Chip set
       to: /components/chip-set/
-      badge:
-        color: success
-        text: NEW
     - title: Close button
       to: /components/close-button/
     - title: Collapse
@@ -282,6 +291,9 @@
         text: PRO
     - title: Menu
       to: /components/menu/
+      badge:
+        color: success
+        text: NEW
     - title: Modal
       to: /components/modal/
     - title: Navbar
@@ -302,14 +314,8 @@
       to: /components/scrollspy/
     - title: Search Button
       to: /components/search-button/
-      badge:
-        color: success
-        text: NEW
     - title: Sidebar
       to: /components/sidebar/
-      badge:
-        color: success
-        text: NEW
     - title: Spinner
       to: /components/spinners/
     - title: Tab


### PR DESCRIPTION
The NEW badge had drifted into meaning "recently touched". Scrollspy carried it in the React edition though the component is as old as the library — what was new there was our port filling a gap, not the component. The badge now says one thing: **this component did not exist in v5**.

Derived rather than recalled: every sidebar entry was checked against the docs pages of the v5 line (`repos/` — vanilla, React and Vue together, since "existed in v5" means anywhere in the product, not in this edition).

**Gains NEW** — no page anywhere in v5: Menu, Dialog, Drawer, Field, Form Control Group, Date Input, Date Time Input, Date Time Picker, Time Input, Number Input, Password Strength.

**Loses NEW** — shipped in v5: Scrollspy, Autocomplete, Rating, Stepper, Range Slider, OTP Input, Password Input, Chip, Chip Set, Chip Input, Search Button, Sidebar, Tab.

One case needed a human rather than the script: v6 split the v5 `navs-tabs` page into **Nav** and **Tab**. Both look new to a URL comparison and neither is a new component, so both stay unbadged.

Badges also take one shape now — a lone badge as a mapping, NEW before PRO in a pair with `ms-1` on the second — instead of the three shapes that had accumulated across the editions. After this, React and Vue have identical NEW and PRO badges on every shared entry, and every PRO badge still matches the frontmatter of the page it points at.

Untouched: the `New` badge on Templates / Admin & Dashboard — not a component, and already identical in all three editions.

`docs-build` passes in all three; the built sidebar shows `NEW` next to Menu and nothing next to Scrollspy.