### PR TITLE
docs: sort the Forms and Components lists alphabetically

### DIFF
--- a/docs/src/data/sidebar.yml
+++ b/docs/src/data/sidebar.yml
@@ -130,14 +130,6 @@
       badge:
         color: danger
         text: PRO
-    - title: Date Time Picker
-      to: /forms/date-time-picker/
-      badge:
-        - color: success
-          text: NEW
-        - color: danger
-          text: PRO
-          className: ms-1
     - title: Date Range Picker
       to: /forms/date-range-picker/
       badge:
@@ -145,6 +137,14 @@
         text: PRO
     - title: Date Time Input
       to: /forms/date-time-input/
+      badge:
+        - color: success
+          text: NEW
+        - color: danger
+          text: PRO
+          className: ms-1
+    - title: Date Time Picker
+      to: /forms/date-time-picker/
       badge:
         - color: success
           text: NEW
@@ -202,13 +202,13 @@
         text: PRO
     - title: Select
       to: /forms/select/
-    - title: Switch
-      to: /forms/switch/
     - title: Stepper
       to: /forms/stepper/
       badge:
         color: danger
         text: PRO
+    - title: Switch
+      to: /forms/switch/
     - title: Textarea
       to: /forms/textarea/
     - title: Time Input
@@ -296,10 +296,10 @@
         text: NEW
     - title: Modal
       to: /components/modal/
-    - title: Navbar
-      to: /components/navbar/
     - title: Nav
       to: /components/nav/
+    - title: Navbar
+      to: /components/navbar/
     - title: Offcanvas
       to: /components/offcanvas/
     - title: Pagination


### PR DESCRIPTION
Reverses the direction of coreui/coreui-react-pro#278 / coreui/coreui-vue-pro#224 for the two component lists: instead of copying vanilla, all three editions now sort them.

| section | was | is |
| --- | --- | --- |
| Forms | … Date Picker, **Date Time Picker, Date Range Picker, Date Time Input** … Select, **Switch, Stepper** | … Date Picker, **Date Range Picker, Date Time Input, Date Time Picker** … Select, **Stepper, Switch** |
| Components | … **Navbar, Nav** … (framework editions also **Table, Tab**) | … **Nav, Navbar** … **Tab, Table** |

Forms keeps the three entries that are not components where they belong: `Overview` pinned at the top, `Layout` and `Validation` at the bottom.

Only Forms and Components are sorted. The narrative sections read in their own order and keep it — Getting started runs Introduction → Install → Browsers & devices, Customize opens with Overview and Architecture, Layout goes Breakpoints → Containers → Grid, Templates walks Download → Installation → Customize. Sorting those would be a regression, not a fix.

Same change in all three editions, so the lists stay identical across them.

`docs-build` / `docs:build` passes; broken-link checker clean.