### PR TITLE
ci(docs): build the CSS before the docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Build CSS
+        run: npm run css
+
       - name: Build docs
         run: npm run docs-build
 


### PR DESCRIPTION
The docs job ran `npm run docs-build` straight after `npm ci`, so the pages that read `dist/css/coreui.css` — CSS variables, and the generated utility class references — documented whichever stylesheet happened to be committed instead of the one the revision under test produces.

That is not hypothetical: the committed `dist` has been stale by whole releases before, and the failure is silent. The page renders fine, it just reports old values, so nobody looks.

This became load-bearing with #1066, which switched the CSS variables page from quoting a Sass partial to reading the compiled stylesheet.

One step, before `docs-build`.