### PR TITLE
chore(deps): bump @coreui/astro-docs to 0.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@astrojs/mdx": "^7.0.3",
-        "@coreui/astro-docs": "^0.1.10",
+        "@coreui/astro-docs": "^0.1.11",
         "@eslint/markdown": "^7.5.1",
         "@floating-ui/dom": "^1.8.0",
         "@rollup/plugin-replace": "^6.0.3",
@@ -917,9 +917,9 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.10.tgz",
-      "integrity": "sha512-o2egGMTwqlmK3SoDo00ffqWobcsEZ+miEskeZ2+/QJp+bk87S5JojTBw6Bk5L+JjuJXfEwbklRwtz+r1qXghDA==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.11.tgz",
+      "integrity": "sha512-H3RRoqDExoFbXHtqnbRrYOU5owzMTabNNzpKrJTHvK93i2yw2vF4VA3CgO61guXa7ZJs9MmBWX87sVSNe7M6RQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   },
   "devDependencies": {
     "@astrojs/mdx": "^7.0.3",
-    "@coreui/astro-docs": "^0.1.10",
+    "@coreui/astro-docs": "^0.1.11",
     "@eslint/markdown": "^7.5.1",
     "@floating-ui/dom": "^1.8.0",
     "@rollup/plugin-replace": "^6.0.3",


### PR DESCRIPTION
Unblocks the Docs job on `v6-dev`, which has been red since the palette moved to `oklch()` in #1068: the published engine ran Sass colour math on our palette variables and `color.mix()` refuses a non-legacy colour without a method. Fixed in coreui/astro-docs#89, released as 0.1.11.