### PR TITLE
fix(Stepper, RangeSlider, Avatar): stop painting graphics with the secondary surface

### DIFF
--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -16,7 +16,7 @@ $avatar-color:                 inherit !default;
 $avatar-bg:                    var(--#{$prefix}bg-2) !default;
 $avatar-border-radius:         50em !default;
 $avatar-status-size:           .5rem !default;
-$avatar-status-bg:             var(--#{$prefix}secondary) !default;
+$avatar-status-bg:             var(--#{$prefix}fg-4) !default;
 $avatar-status-border-radius:  50em !default;
 $avatar-status-border-width:   1px !default;
 $avatar-status-border-color:   var(--#{$prefix}bg-body) !default;

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -22,7 +22,7 @@ $range-slider-track-border-radius:         1rem !default;
 $range-slider-track-box-shadow:            var(--#{$prefix}box-shadow-inset) !default;
 
 $range-slider-track-in-range-bg:           color-mix(in srgb, var(--#{$prefix}theme-bg, var(--#{$prefix}primary)) 50%, transparent) !default;
-$range-slider-disabled-track-in-range-bg:  color-mix(in srgb, var(--#{$prefix}secondary) 37.5%, transparent) !default;
+$range-slider-disabled-track-in-range-bg:  var(--#{$prefix}fg-4) !default;
 
 $range-slider-label-padding-y:             0 !default;
 $range-slider-label-padding-x:             0 !default;
@@ -36,7 +36,7 @@ $range-slider-thumb-border:                0 !default;
 $range-slider-thumb-border-radius:         1rem !default;
 $range-slider-thumb-box-shadow:            0 .1rem .25rem color-mix(in srgb, var(--#{$prefix}black) 10%, transparent) !default;
 $range-slider-thumb-active-bg:             color-mix(in srgb, var(--#{$prefix}theme-bg, var(--#{$prefix}primary)) 30%, var(--#{$prefix}bg-body)) !default;
-$range-slider-thumb-disabled-bg:           color-mix(in srgb, var(--#{$prefix}secondary) 100%, transparent) !default;
+$range-slider-thumb-disabled-bg:           var(--#{$prefix}fg-3) !default;
 $range-slider-thumb-transition:            background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 
 $range-slider-tooltip-max-width:           200px !default;

--- a/scss/_stepper.scss
+++ b/scss/_stepper.scss
@@ -18,7 +18,7 @@ $stepper-step-button-complete-color:            var(--#{$prefix}fg-2) !default;
 $stepper-step-button-disabled-color:            var(--#{$prefix}fg-2) !default;
 $stepper-step-indicator-width:                  2rem !default;
 $stepper-step-indicator-height:                 2rem !default;
-$stepper-step-indicator-color:                  var(--#{$prefix}secondary) !default;
+$stepper-step-indicator-color:                  var(--#{$prefix}fg-3) !default;
 $stepper-step-indicator-bg:                     transparent !default;
 $stepper-step-indicator-border-width:           var(--#{$prefix}border-width) !default;
 $stepper-step-indicator-border-color:           var(--#{$prefix}border-color) !default;
@@ -29,7 +29,7 @@ $stepper-step-indicator-active-border-color:    var(--#{$prefix}primary) !defaul
 $stepper-step-indicator-complete-color:         var(--#{$prefix}primary-contrast) !default;
 $stepper-step-indicator-complete-bg:            var(--#{$prefix}primary) !default;
 $stepper-step-indicator-complete-border-color:  var(--#{$prefix}primary) !default;
-$stepper-step-indicator-disabled-color:         var(--#{$prefix}secondary) !default;
+$stepper-step-indicator-disabled-color:         var(--#{$prefix}fg-3) !default;
 $stepper-step-indicator-disabled-bg:            transparent !default;
 $stepper-step-indicator-disabled-border-color:  var(--#{$prefix}border-color) !default;
 $stepper-step-indicator-icon:                   url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpolygon fill='var(--ci-primary-color, currentColor)' points='200.359 382.269 61.057 251.673 82.943 228.327 199.641 337.731 428.686 108.687 451.314 131.313 200.359 382.269' class='ci-primary'/%3E%3C/svg%3E") !default;


### PR DESCRIPTION
Three components read `--cui-secondary` — the theme role's **base**, a surface colour — and used it as text or as a graphic. It measures **1.1:1** against the page, so in each case the thing simply was not there.

An audit of every `secondary` and `tertiary` read in `scss/` found exactly these four call sites and nothing else.

## Measured in Chromium, on the built docs pages

| | before | after |
| --- | --- | --- |
| Stepper — upcoming step's number | `243,244,247` — **1.1:1** vs page | `92,108,138` — **5.29:1** |
| Range slider — disabled fill vs empty track | **1.1:1** | **2.40:1** |
| Range slider — disabled thumb vs fill | **1.1:1** (and no border) | **1.83:1**, 4.39:1 vs the track |
| Avatar — status dot with no theme class | `243,244,247` — **1.1:1** | `140,152,177` — **2.9:1** |

The disabled slider was the worst of the three: its filled portion and the empty track were the same colour, so a disabled slider did not show its value at all.

## Why `--cui-fg-*` and not `--cui-secondary-fg`

`fg-*` is what the library already uses at this level. Component defaults reaching for a neutral foreground:

| token | uses |
| --- | --- |
| `--cui-fg-body` | 56 |
| `--cui-fg-3` | 36 |
| `--cui-fg-2` | 28 |
| `--cui-fg-1` | 3 |
| `--cui-fg-4` | 3 |
| `--cui-secondary-fg` | **0** |

The role's `fg` slot is for theme-coloured contexts (`.text-secondary`, the theme classes), not a component's own muted default. The stepper's label already uses `fg-2`, so its indicator sitting one rung dimmer at `fg-3` matches the file; the disabled slider and the neutral status dot take `fg-4`, the faintest rung. The disabled slider's thumb keeps `fg-3` so it stays distinct from its own fill, mirroring the enabled state where the thumb is the solid colour and the fill a tint of it.

Two dead `color-mix()` calls go with it: one mixed a colour with `transparent` at 100%, the other took 37.5% of a colour already indistinguishable from white.

**No component reads `--cui-secondary` any more.**

## Audit notes, not changed here

- `tertiary` is clean. Its only component use is `--cui-tertiary-bg-translucent` for the sidebar's hover and active backgrounds, at 3.06:1.
- `--cui-secondary-color`, `--cui-tertiary-color` and `--cui-tertiary-bg` are v5 compatibility aliases declared in `_root.scss` with zero internal readers, which is what they are for. Same for the systematic `--cui-<role>-base` / `--cui-<role>-bg` aliases, emitted for all seven roles.
- The stepper's ring is `--cui-border-color` at **1.34:1**, under the 3:1 WCAG asks of a non-text graphic. That token draws every card, table and divider, so it is a library-wide decision.
- `.btn-secondary` fills and outlines itself with the same 1.1:1 colour, so it has no edge on a white page. That is an appearance decision about the role's base, now fully separated from the accessibility defects above.

## Verification

stylelint and `fusv` clean, Sass suite 62/62, visual suite 119/119, `docs-build` 178 pages, bundlewatch PASS, local CI gate green.