### PR TITLE
fix(root): declare the --cui-spacer token

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -266,6 +266,7 @@ $root-token-defaults: map.merge(
     // drawer, menu and popup. One override restyles all four.
     --#{$prefix}transition-timing-overlay: $transition-timing-overlay,
     // scss-docs-end root-transition-variables
+    --#{$prefix}spacer: $spacer,
     // Focus styles
     // scss-docs-start root-focus-variables
     --#{$prefix}focus-ring-width: $focus-ring-width,


### PR DESCRIPTION
Components read `var(--cui-spacer)` as the base of the spacing scale, but `:root` only emitted the stops (`--cui-spacer-0` … `--cui-spacer-9`). The read was invalid at computed-value time, so `.form-field-card` resolved its padding token to nothing and rendered with zero padding.

`:root` now declares `--cui-spacer` from `$spacer`, next to the transition and focus tokens. The Sass customization docs already show `--cui-spacer: 1.5rem` as a `$root-tokens` override, so the documented knob now exists.

Found by the SCSS quality audit (declared ↔ read token diff on the compiled stylesheet).