### PR TITLE
fix(Sidebar): drop the dead toggler filter in .sidebar-dark

### DIFF
--- a/scss/sidebar/_sidebar.scss
+++ b/scss/sidebar/_sidebar.scss
@@ -297,9 +297,5 @@ $sidebar-widths: (
     // :root, so declaring the scheme is enough — the tokens and the native
     // widgets both follow.
     color-scheme: dark;
-
-    .sidebar-toggler {
-      filter: var(--#{$prefix}sidebar-toggler-white-filter);
-    }
   }
 }


### PR DESCRIPTION
`.sidebar-dark .sidebar-toggler` read `--cui-sidebar-toggler-white-filter`, a token nothing declares. `filter` does not inherit, so the declaration was invalid at computed-value time and resolved to `none` — the rule did nothing.

The toggler is a mask painted with `--cui-sidebar-toggler-color`, a `light-dark()` pair that already flips with the sidebar's `color-scheme`, so no filter is needed. The block is removed; `.sidebar-dark` keeps `color-scheme: dark`.

Found by the SCSS quality audit (declared ↔ read token diff on the compiled stylesheet). The same dead rule exists on the v5 line — listed in the backports plan.