### PR TITLE
fix(Combobox): read the v6 secondary foreground token for select-all

### DIFF
--- a/scss/_combobox.scss
+++ b/scss/_combobox.scss
@@ -24,7 +24,7 @@ $combobox-header-border-color: var(--#{$prefix}border-color) !default;
 
 $combobox-select-all-padding-y:       .5rem !default;
 $combobox-select-all-padding-x:       .75rem !default;
-$combobox-select-all-color:           var(--#{$prefix}body-secondary-color) !default;
+$combobox-select-all-color:           var(--#{$prefix}fg-2) !default;
 $combobox-select-all-bg:              transparent !default;
 $combobox-select-all-hover-color:     var(--#{$prefix}fg-body) !default;
 $combobox-select-all-hover-bg:        var(--#{$prefix}bg-3) !default;


### PR DESCRIPTION
`$combobox-select-all-color` pointed at `--cui-body-secondary-color`, a v5 name no longer declared in v6. The read was invalid at computed-value time and only looked right because `color` inherits. It now reads `--cui-fg-2`, the token the rest of the file already uses.

Found by the SCSS quality audit (declared ↔ read token diff on the compiled stylesheet).