### PR TITLE
fix(Spinner): make the reduced-motion speed a plain knob

### DIFF
--- a/scss/_spinner.scss
+++ b/scss/_spinner.scss
@@ -15,7 +15,7 @@ $spinner-grow-animation-timing-function:   ease-in-out !default;
 $spinner-width-sm:                         .75em !default;
 $spinner-height-sm:                        $spinner-width-sm !default;
 
-$spinner-reduced-motion-animation-speed:   $spinner-animation-speed * 1.5 !default;
+$spinner-reduced-motion-animation-speed:   1.5s !default;
 // scss-docs-end spinner-variables
 
 $spinner-border-tokens: () !default;


### PR DESCRIPTION
`$spinner-reduced-motion-animation-speed` was derived from `$spinner-animation-speed` at build time (`* 1.5`), so a runtime override of `--cui-spinner-animation-speed` never reached the reduced-motion value. The reduced-motion override cannot read its own token (that would be a cycle), so the value is a plain `1.5s` default instead of an arithmetic result — the same shape upstream ships.

Compiled output is unchanged (`1.5s` before and after). Found by the SCSS quality audit (Sass arithmetic on tokenised sources).