### PR TITLE
fix(functions): drop empty entries in defaults()

### DIFF
--- a/docs/src/content/docs/customize/sass.mdx
+++ b/docs/src/content/docs/customize/sass.mdx
@@ -279,7 +279,7 @@ For example, we use the `primary`, `success`, and `danger` keys from `$theme-col
 
 ### Defaults
 
-`defaults()` is the merge behind every overridable map on this page — token maps, size maps, variant maps. It layers your overrides on top of the library's defaults, drops every key whose value is `null`, and accepts a plain list as the defaults (each item becomes a key set to `true`, which is how the size maps are written):
+`defaults()` is the merge behind every overridable map on this page — token maps, size maps, variant maps. It layers your overrides on top of the library's defaults, drops every key whose value is `null` (a `null` variable interpolated into a map arrives as an empty string and is dropped the same way), and accepts a plain list as the defaults (each item becomes a key set to `true`, which is how the size maps are written):
 
 <ScssDocs file="scss/functions/_defaults.scss" capture="defaults-function" />
 

--- a/scss/functions/_defaults.scss
+++ b/scss/functions/_defaults.scss
@@ -2,7 +2,7 @@
 @use "sass:meta";
 
 // scss-docs-start defaults-function
-// Merge overrides on top of defaults, stripping null entries.
+// Merge overrides on top of defaults, stripping null and empty entries.
 // Null values let users remove map keys via @use ... with().
 // Accepts a list as $defaults (converted to a map with `true` values).
 @function defaults($defaults, $overrides) {
@@ -15,7 +15,7 @@
   }
   $merged: map.merge($defaults, $overrides);
   @each $key, $value in $merged {
-    @if $value == null {
+    @if $value == null or $value == "" {
       $merged: map.remove($merged, $key);
     }
   }


### PR DESCRIPTION
Token maps interpolate their Sass variables (`--x: #{$x}`), so a `null` variable reaches `defaults()` as an empty string, survives the `null` strip and is emitted as an empty custom property (`--cui-x: ;`). Six tokens shipped that way: `--cui-nav-link-font-size`, `--cui-nav-link-font-weight`, `--cui-modal-footer-bg`, the dark `--cui-dropdown-box-shadow` and the two validation feedback tokens (`font-style`, `tooltip-line-height`).

`defaults()` now strips empty strings too. The compiled stylesheet differs only by those ten lines (diff of `sass scss/coreui.scss` before/after); the docs sentence describing the function is updated.

Found by the SCSS quality audit (`grep -E -- '--cui-[a-z0-9-]+: *;'` on the compiled stylesheet).