### PR TITLE
refactor(Button)!: drop the resting box-shadow

### DIFF
--- a/docs/src/content/docs/customize/options.mdx
+++ b/docs/src/content/docs/customize/options.mdx
@@ -12,7 +12,7 @@ You can find and customize these variables for key global options in CoreUI for 
 | `$spacer`                      | `1rem` (default), or any value > 0 | Specifies the default spacer value to programmatically generate our [margin](/utilities/margin/), [padding](/utilities/padding/) and [gap](/utilities/gap/) utilities. |
 | `$enable-dark-mode`            | `true` (default) or `false`        | Enables built-in [dark mode support](/customize/color-modes/#dark-mode) across the project and its components. |
 | `$enable-rounded`              | `true` (default) or `false`        | Enables predefined `border-radius` styles on various components. |
-| `$enable-shadows`              | `true` or `false` (default)        | Enables predefined decorative `box-shadow` styles on various components. Does not affect `box-shadow`s used for focus states. |
+| `$enable-shadows`              | `true` or `false` (default)        | Enables predefined decorative `box-shadow` styles on various components. The `--cui-*-box-shadow` component tokens are always declared, but they render only with this option on. Does not affect `box-shadow`s used for focus states. |
 | `$enable-gradients`            | `true` or `false` (default)        | Enables predefined gradients via `background-image` styles on various components. |
 | `$enable-transitions`          | `true` (default) or `false`        | Enables predefined `transition`s on various components. |
 | `$enable-reduced-motion`       | `true` (default) or `false`        | Enables the [`prefers-reduced-motion` media query](/getting-started/accessibility/#reduced-motion), which suppresses certain animations/transitions based on the users' browser/operating system preferences. |

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1391,6 +1391,12 @@ adornment in the library — so the button needs no icon markup at all:
   by design.
 - **`.btn-xs` (new).** A fourth size below `.btn-sm`, reading the shared
   `--cui-btn-input-xs-*` tokens.
+- **The resting button shadow is gone.** `$btn-box-shadow` and
+  `--cui-btn-box-shadow` are removed; a `.btn` draws no `box-shadow` at rest
+  even with `$enable-shadows: true`, only the pressed state keeps its inset
+  (`--cui-btn-active-shadow`). The removed default was the v4 bevel
+  (`inset 0 1px 0 rgba(white, .15), 0 1px 1px rgba(black, .075)`); put it back
+  with your own `.btn { box-shadow: … }` if you want it.
 
 #### Navbar
 

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -18,7 +18,6 @@ $btn-white-space:             nowrap !default; // Set to `normal` to let button 
 $btn-color:                   var(--#{$prefix}fg-body) !default;
 $btn-bg:                      var(--#{$prefix}bg-2) !default;
 $btn-hover-bg:                var(--#{$prefix}bg-3) !default;
-$btn-box-shadow:              inset 0 1px 0 color-mix(in srgb, var(--#{$prefix}white) 15%, transparent), 0 1px 1px color-mix(in srgb, var(--#{$prefix}black) 7.5%, transparent) !default;
 $btn-active-box-shadow:       inset 0 3px 5px color-mix(in srgb, var(--#{$prefix}black) 12.5%, transparent) !default;
 
 $btn-link-color:              var(--#{$prefix}link-color) !default;
@@ -60,7 +59,6 @@ $button-tokens: defaults(
     --#{$prefix}btn-border-color: transparent,
     --#{$prefix}btn-border-radius: var(--#{$prefix}btn-input-border-radius),
     --#{$prefix}btn-hover-border-color: transparent,
-    --#{$prefix}btn-box-shadow: #{$btn-box-shadow},
     --#{$prefix}btn-active-shadow: #{$btn-active-box-shadow},
     --#{$prefix}btn-disabled-opacity: var(--#{$prefix}btn-input-disabled-opacity),
     --#{$prefix}btn-transition-property: var(--#{$prefix}btn-input-action-transition-property),
@@ -169,8 +167,7 @@ $button-link-tokens: defaults(
     --#{$prefix}btn-active-border-color: transparent,
     --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color},
     --#{$prefix}btn-disabled-bg: transparent,
-    --#{$prefix}btn-disabled-border-color: transparent,
-    --#{$prefix}btn-box-shadow: none
+    --#{$prefix}btn-disabled-border-color: transparent
   ),
   $button-link-tokens
 );
@@ -269,7 +266,6 @@ $btn-check-deprecated: ".btn-check:not(#{$btn-variant-selectors})" !default;
     border: var(--#{$prefix}btn-border-width) solid var(--#{$prefix}btn-border-color);
     @include border-radius(var(--#{$prefix}btn-border-radius));
     @include gradient-bg(var(--#{$prefix}btn-bg, #{$btn-bg}));
-    @include box-shadow(var(--#{$prefix}btn-box-shadow));
     @include transition-props(
       var(--#{$prefix}btn-transition-property),
       var(--#{$prefix}btn-transition-duration),


### PR DESCRIPTION
`.btn` included `box-shadow(var(--cui-btn-box-shadow))` at rest, with the v4 bevel (`inset 0 1px 0 rgba(white, .15), 0 1px 1px rgba(black, .075)`) as the default. Nothing renders while `$enable-shadows` is `false`, and with the option on every button grew the bevel.

- `$btn-box-shadow`, the `--cui-btn-box-shadow` token (base map and the `.btn-link` `none` override) and the resting include are removed. The pressed state keeps `--cui-btn-active-shadow`.
- `customize/options` now says the `--cui-*-box-shadow` component tokens are always declared but render only with `$enable-shadows` on.
- Migration guide: entry under Button.

Compiled output with the default flag differs only by the two removed token declarations; with `$enable-shadows: true` the resting `box-shadow` on `.btn` is gone and the two active-state ones remain (checked on a scratch compile).

From the SCSS quality audit: the decision is to keep `$enable-shadows: false` as the opt-in and keep the shadow tokens as the runtime API for that mode.