### PR TITLE
refactor(Accordion)!: name the header tokens after the header

### DIFF
--- a/docs/src/content/docs/components/accordion.mdx
+++ b/docs/src/content/docs/components/accordion.mdx
@@ -240,9 +240,9 @@ Everything composes with it: in an exclusive accordion the browser closes the pr
 
 <AddedIn version="6.0.0" />
 
-The chevron is drawn by the header itself, from the `--cui-accordion-btn-icon` custom property, and rotated by `--cui-accordion-btn-icon-transform` while the item is open. Point the property at your own URL-escaped SVG to change it everywhere. The example takes `cil-chevron-right` from [CoreUI Icons](https://coreui.io/icons/) and turns it a quarter clockwise when the item opens.
+The chevron is drawn by the header itself, from the `--cui-accordion-header-icon` custom property, and rotated by `--cui-accordion-header-icon-transform` while the item is open. Point the property at your own URL-escaped SVG to change it everywhere. The example takes `cil-chevron-right` from [CoreUI Icons](https://coreui.io/icons/) and turns it a quarter clockwise when the item opens.
 
-<Example code={`<div class="accordion" style="--cui-accordion-btn-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23000' d='m183.505 496-97.268-97.27 143.175-143.174L86.237 112.38l97.268-97.27 143.227 143.228 11.316 11.209 85.9 85.9.051.05-11.311 11.419-85.9 85.9-.055-.054Zm-52.013-97.27 52.013 52.014L326.629 307.62l.055.054 52.116-52.118-52.127-52.128-11.308-11.2-131.86-131.862-52.013 52.014 143.175 143.176Z'/%3E%3C/svg%3E&quot;); --cui-accordion-btn-icon-transform: rotate(90deg);">
+<Example code={`<div class="accordion" style="--cui-accordion-header-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23000' d='m183.505 496-97.268-97.27 143.175-143.174L86.237 112.38l97.268-97.27 143.227 143.228 11.316 11.209 85.9 85.9.051.05-11.311 11.419-85.9 85.9-.055-.054Zm-52.013-97.27 52.013 52.014L326.629 307.62l.055.054 52.116-52.118-52.127-52.128-11.308-11.2-131.86-131.862-52.013 52.014 143.175 143.176Z'/%3E%3C/svg%3E&quot;); --cui-accordion-header-icon-transform: rotate(90deg);">
     <details class="accordion-item" name="accordionIconToken" open>
       <summary class="accordion-header">Accordion Item #1</summary>
       <div class="accordion-body">The icon comes from the custom property, so no item carries markup for it.</div>
@@ -293,9 +293,9 @@ An inline `<svg>` goes in the same slot, and nothing about it has to be URL esca
 
 ### A different icon when open
 
-A plus that becomes a minus is a swap, not a rotation. Set `--cui-accordion-btn-active-icon` to the open-state shape and turn the rotation off:
+A plus that becomes a minus is a swap, not a rotation. Set `--cui-accordion-header-active-icon` to the open-state shape and turn the rotation off:
 
-<Example code={`<div class="accordion" style="--cui-accordion-btn-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23000' d='M440 240H272V72h-32v168H72v32h168v168h32V272h168z'/%3E%3C/svg%3E&quot;); --cui-accordion-btn-active-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23000' d='M72 240h368v32H72z'/%3E%3C/svg%3E&quot;); --cui-accordion-btn-icon-transform: none;">
+<Example code={`<div class="accordion" style="--cui-accordion-header-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23000' d='M440 240H272V72h-32v168H72v32h168v168h32V272h168z'/%3E%3C/svg%3E&quot;); --cui-accordion-header-active-icon: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23000' d='M72 240h368v32H72z'/%3E%3C/svg%3E&quot;); --cui-accordion-header-icon-transform: none;">
     <details class="accordion-item" name="accordionIconPair" open>
       <summary class="accordion-header">Accordion Item #1</summary>
       <div class="accordion-body">Placeholder content for the first accordion item.</div>

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -230,7 +230,7 @@ finished, not whether the state changed.
 - **The indicator can be an element instead of a background image.** Put an
   `<svg class="accordion-icon">` in the `<summary>` and the header stops drawing
   its own icon, so any icon set or `<img>` can be used without URL escaping an
-  SVG into a custom property. `--cui-accordion-btn-active-icon` selects the
+  SVG into a custom property. `--cui-accordion-header-active-icon` selects the
   shape shown while the item is open, and a second element marked
   `.accordion-icon-active` does the same in markup — that is what a plus/minus
   accordion needs, where the icon is swapped rather than rotated. The default
@@ -257,7 +257,7 @@ finished, not whether the state changed.
 - **One padding token and one font size for the whole control.**
   `--cui-accordion-padding-x` / `-y` and `--cui-accordion-font-size` are read by
   the header and the body alike, so resizing an accordion is one declaration
-  instead of four. `--cui-accordion-btn-padding-*` and
+  instead of four. `--cui-accordion-header-padding-*` and
   `--cui-accordion-body-padding-*` are no longer declared by default, but they
   still override their part where they are set, so existing overrides keep
   working.
@@ -2980,16 +2980,16 @@ the accordion swapped in a second SVG, the carousel inverted the first with a
 Upstream v6 does the same, with a `mask-icon()` mixin.
 
 - **The accordion's icon is one shape recoloured per state, not two images.**
-  `--cui-accordion-btn-active-icon` no longer has to carry a second copy
-  of the artwork: it defaults to `--cui-accordion-btn-icon`, and the open
-  state changes `--cui-accordion-btn-active-icon-color` instead. Set it
+  `--cui-accordion-header-active-icon` no longer has to carry a second copy
+  of the artwork: it defaults to `--cui-accordion-header-icon`, and the open
+  state changes `--cui-accordion-header-active-icon-color` instead. Set it
   only when the open state is a genuinely different shape — a minus against a
-  plus. New tokens: `--cui-accordion-btn-icon-color` and
-  `--cui-accordion-btn-active-icon-color`.
+  plus. New tokens: `--cui-accordion-header-icon-color` and
+  `--cui-accordion-header-active-icon-color`.
 - **A custom icon is now a shape, not a coloured image.** Whatever colour you put
   inside `$accordion-button-icon` or `$carousel-control-prev-icon-bg` /
   `$carousel-control-next-icon-bg` is ignored — only the alpha of the SVG is used.
-  Set the colour through the token (`--cui-accordion-btn-icon-color`,
+  Set the colour through the token (`--cui-accordion-header-icon-color`,
   `--cui-carousel-control-color`).
 - **`$accordion-icon-color` and `$accordion-icon-active-color` are
   `currentcolor` now**, not Sass colours — Sass colour functions on them no

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -20,13 +20,13 @@ $accordion-border-color:                  var(--#{$prefix}border-color) !default
 $accordion-border-radius:                 var(--#{$prefix}radius-7) !default;
 $accordion-gap:                           var(--#{$prefix}spacer-2) !default;
 
-$accordion-button-color:                  var(--#{$prefix}fg-2) !default;
-$accordion-button-bg:                     var(--#{$prefix}accordion-bg) !default;
+$accordion-header-color:                  var(--#{$prefix}fg-2) !default;
+$accordion-header-bg:                     var(--#{$prefix}accordion-bg) !default;
 $accordion-transition-property:           #{var(--#{$prefix}btn-input-action-transition-property), border-radius} !default;
 $accordion-transition-duration:           var(--#{$prefix}btn-input-transition-duration) !default;
 $accordion-transition-timing:             var(--#{$prefix}btn-input-transition-timing) !default;
-$accordion-button-active-bg:              var(--#{$prefix}bg-2) !default;
-$accordion-button-active-color:           var(--#{$prefix}fg-body) !default;
+$accordion-header-active-bg:              var(--#{$prefix}bg-2) !default;
+$accordion-header-active-color:           var(--#{$prefix}fg-body) !default;
 $accordion-active-border-color:           $accordion-border-color !default;
 
 
@@ -39,8 +39,8 @@ $accordion-icon-active-color:             currentcolor !default;
 $accordion-icon-transition:               transform .2s ease-in-out !default;
 $accordion-icon-transform:                rotate(-180deg) !default;
 
-$accordion-button-icon:                   url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-linecap='round' stroke-linejoin='round'><path d='m2 5 6 6 6-6'/></svg>") !default;
-$accordion-button-active-icon:            var(--#{$prefix}accordion-btn-icon) !default;
+$accordion-header-icon:                   url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-linecap='round' stroke-linejoin='round'><path d='m2 5 6 6 6-6'/></svg>") !default;
+$accordion-header-active-icon:            var(--#{$prefix}accordion-header-icon) !default;
 // scss-docs-end accordion-variables
 
 $accordion-tokens: () !default;
@@ -53,6 +53,10 @@ $accordion-tokens: defaults(
   (
     --#{$prefix}accordion-padding-x: #{$accordion-padding-x},
     --#{$prefix}accordion-padding-y: #{$accordion-padding-y},
+    --#{$prefix}accordion-header-padding-x: var(--#{$prefix}accordion-padding-x),
+    --#{$prefix}accordion-header-padding-y: var(--#{$prefix}accordion-padding-y),
+    --#{$prefix}accordion-body-padding-x: var(--#{$prefix}accordion-padding-x),
+    --#{$prefix}accordion-body-padding-y: var(--#{$prefix}accordion-padding-y),
     --#{$prefix}accordion-font-size: #{$accordion-font-size},
     --#{$prefix}accordion-color: #{$accordion-color},
     --#{$prefix}accordion-bg: #{$accordion-bg},
@@ -63,17 +67,17 @@ $accordion-tokens: defaults(
     --#{$prefix}accordion-border-width: #{$accordion-border-width},
     --#{$prefix}accordion-border-radius: #{$accordion-border-radius},
     --#{$prefix}accordion-gap: #{$accordion-gap},
-    --#{$prefix}accordion-btn-color: #{$accordion-button-color},
-    --#{$prefix}accordion-btn-bg: #{$accordion-button-bg},
-    --#{$prefix}accordion-btn-icon: #{escape-svg($accordion-button-icon)},
-    --#{$prefix}accordion-btn-active-icon: #{escape-svg($accordion-button-active-icon)},
-    --#{$prefix}accordion-btn-icon-width: #{$accordion-icon-width},
-    --#{$prefix}accordion-btn-icon-color: #{$accordion-icon-color},
-    --#{$prefix}accordion-btn-active-icon-color: #{$accordion-icon-active-color},
-    --#{$prefix}accordion-btn-icon-transform: #{$accordion-icon-transform},
-    --#{$prefix}accordion-btn-icon-transition: #{$accordion-icon-transition},
-    --#{$prefix}accordion-active-color: #{$accordion-button-active-color},
-    --#{$prefix}accordion-active-bg: #{$accordion-button-active-bg},
+    --#{$prefix}accordion-header-color: #{$accordion-header-color},
+    --#{$prefix}accordion-header-bg: #{$accordion-header-bg},
+    --#{$prefix}accordion-header-icon: #{escape-svg($accordion-header-icon)},
+    --#{$prefix}accordion-header-active-icon: #{escape-svg($accordion-header-active-icon)},
+    --#{$prefix}accordion-header-icon-width: #{$accordion-icon-width},
+    --#{$prefix}accordion-header-icon-color: #{$accordion-icon-color},
+    --#{$prefix}accordion-header-active-icon-color: #{$accordion-icon-active-color},
+    --#{$prefix}accordion-header-icon-transform: #{$accordion-icon-transform},
+    --#{$prefix}accordion-header-icon-transition: #{$accordion-icon-transition},
+    --#{$prefix}accordion-active-color: #{$accordion-header-active-color},
+    --#{$prefix}accordion-active-bg: #{$accordion-header-active-bg},
     --#{$prefix}accordion-active-border-color: #{$accordion-active-border-color},
     --#{$prefix}accordion-content-duration: #{$accordion-content-duration},
     --#{$prefix}accordion-content-easing: #{$accordion-content-easing},
@@ -159,17 +163,17 @@ $accordion-tokens: defaults(
         box-shadow: inset 0 calc(-1 * var(--#{$prefix}accordion-border-width)) 0 var(--#{$prefix}theme-border, var(--#{$prefix}accordion-active-border-color));
 
         &::after {
-          mask-image: var(--#{$prefix}accordion-btn-active-icon);
+          mask-image: var(--#{$prefix}accordion-header-active-icon);
         }
 
         &::after,
         .accordion-icon {
-          color: var(--#{$prefix}accordion-btn-active-icon-color);
+          color: var(--#{$prefix}accordion-header-active-icon-color);
         }
 
         &:not(:has(.accordion-icon-active))::after,
         &:not(:has(.accordion-icon-active)) .accordion-icon {
-          transform: var(--#{$prefix}accordion-btn-icon-transform);
+          transform: var(--#{$prefix}accordion-header-icon-transform);
         }
 
         &:has(.accordion-icon-active) {
@@ -193,13 +197,13 @@ $accordion-tokens: defaults(
     display: flex;
     align-items: center;
     width: 100%;
-    padding: var(--#{$prefix}accordion-btn-padding-y, var(--#{$prefix}accordion-padding-y)) var(--#{$prefix}accordion-btn-padding-x, var(--#{$prefix}accordion-padding-x));
+    padding: var(--#{$prefix}accordion-header-padding-y) var(--#{$prefix}accordion-header-padding-x);
     font-size: var(--#{$prefix}accordion-font-size);
-    color: var(--#{$prefix}accordion-btn-color);
+    color: var(--#{$prefix}accordion-header-color);
     text-align: start;
     list-style: none;
     cursor: pointer;
-    background-color: var(--#{$prefix}accordion-btn-bg);
+    background-color: var(--#{$prefix}accordion-header-bg);
     @include transition-props(
       var(--#{$prefix}accordion-transition-property),
       var(--#{$prefix}accordion-transition-duration),
@@ -212,14 +216,14 @@ $accordion-tokens: defaults(
 
     &:not(:has(.accordion-icon))::after {
       flex-shrink: 0;
-      width: var(--#{$prefix}accordion-btn-icon-width);
-      height: var(--#{$prefix}accordion-btn-icon-width);
+      width: var(--#{$prefix}accordion-header-icon-width);
+      height: var(--#{$prefix}accordion-header-icon-width);
       margin-inline-start: auto;
-      color: var(--#{$prefix}accordion-btn-icon-color);
+      color: var(--#{$prefix}accordion-header-icon-color);
       content: "";
       background-color: currentcolor;
-      @include mask-icon(var(--#{$prefix}accordion-btn-icon), var(--#{$prefix}accordion-btn-icon-width), null);
-      @include transition(var(--#{$prefix}accordion-btn-icon-transition));
+      @include mask-icon(var(--#{$prefix}accordion-header-icon), var(--#{$prefix}accordion-header-icon-width), null);
+      @include transition(var(--#{$prefix}accordion-header-icon-transition));
     }
 
     .accordion-icon {
@@ -227,13 +231,13 @@ $accordion-tokens: defaults(
       flex-shrink: 0;
       align-items: center;
       justify-content: center;
-      width: var(--#{$prefix}accordion-btn-icon-width);
-      height: var(--#{$prefix}accordion-btn-icon-width);
+      width: var(--#{$prefix}accordion-header-icon-width);
+      height: var(--#{$prefix}accordion-header-icon-width);
       margin-inline-start: auto;
-      font-size: var(--#{$prefix}accordion-btn-icon-width);
+      font-size: var(--#{$prefix}accordion-header-icon-width);
       line-height: 1;
-      color: var(--#{$prefix}accordion-btn-icon-color);
-      @include transition(var(--#{$prefix}accordion-btn-icon-transition));
+      color: var(--#{$prefix}accordion-header-icon-color);
+      @include transition(var(--#{$prefix}accordion-header-icon-transition));
     }
 
     .accordion-icon-active {
@@ -262,7 +266,7 @@ $accordion-tokens: defaults(
   }
 
   .accordion-body {
-    padding: var(--#{$prefix}accordion-body-padding-y, var(--#{$prefix}accordion-padding-y)) var(--#{$prefix}accordion-body-padding-x, var(--#{$prefix}accordion-padding-x));
+    padding: var(--#{$prefix}accordion-body-padding-y) var(--#{$prefix}accordion-body-padding-x);
     font-size: var(--#{$prefix}accordion-font-size);
   }
 


### PR DESCRIPTION
The summary is not a button since the move to `<details>`, but its tokens were still `--cui-accordion-btn-*` and the Sass variables `$accordion-button-*`. Both are renamed to `accordion-header-*` (`-color`, `-bg`, `-icon`, `-active-icon`, `-icon-width`, `-icon-color`, `-active-icon-color`, `-icon-transform`, `-icon-transition`).

The header and body paddings were read through undeclared hooks (`var(--cui-accordion-btn-padding-y, var(--cui-accordion-padding-y))`), invisible in devtools and in the docs. `--cui-accordion-header-padding-*` and `--cui-accordion-body-padding-*` are now declared on `.accordion` as `var(--cui-accordion-padding-*)`, and the rules read them plainly. One behavioural consequence: they resolve on `.accordion`, so an override of `--cui-accordion-padding-*` on a single `.accordion-item` no longer reaches the header and the body. Migration guide: new Breaking entry for the rename, the padding entry rewritten.

Compiled diff is exactly the rename plus the four new declarations. Deliberate divergence from upstream, which kept `--accordion-btn-*` on its `<summary>`. React/Vue PRO docs follow in their own PRs.