### PR TITLE
refactor(Avatar): declare --cui-avatar-font-size

### DIFF
--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -53,6 +53,7 @@ $avatar-tokens: () !default;
 $avatar-tokens: defaults(
   (
     --#{$prefix}avatar-size: #{$avatar-size},
+    --#{$prefix}avatar-font-size: calc(var(--#{$prefix}avatar-size) * #{$avatar-font-size-ratio}),
     --#{$prefix}avatar-color: var(--#{$prefix}theme-contrast, #{$avatar-color}),
     --#{$prefix}avatar-bg: var(--#{$prefix}theme-bg, #{$avatar-bg}),
     --#{$prefix}avatar-border-radius: #{$avatar-border-radius},
@@ -111,7 +112,7 @@ $avatar-variants: defaults(
     height: var(--#{$prefix}avatar-size);
     // Declared as a fallback rather than a token, so the derived size is the
     // default and an explicit one still wins.
-    font-size: var(--#{$prefix}avatar-font-size, calc(var(--#{$prefix}avatar-size) * #{$avatar-font-size-ratio}));
+    font-size: var(--#{$prefix}avatar-font-size);
     color: var(--#{$prefix}avatar-color);
     vertical-align: middle;
     background-color: var(--#{$prefix}avatar-bg);


### PR DESCRIPTION
The label size was read as `var(--cui-avatar-font-size, calc(var(--cui-avatar-size) * .4))`, an override hook nothing declared, so it was invisible in devtools and in the CSS variables section while the migration guide and the React styling docs present it as public.

`--cui-avatar-font-size` is now declared on `.avatar` as `calc(var(--cui-avatar-size) * $avatar-font-size-ratio)` and the rule reads it plainly. Same rendering: the size classes set `--cui-avatar-size` on the same element, so the derived value follows them; the stack reads `--cui-avatar-size` directly and is untouched. Compiled diff is the one added declaration and the simplified read.

Deliberate one-line divergence from upstream, which keeps the bare `calc()`. From the SCSS quality audit (undeclared hook tokens).