### PR TITLE
refactor(Drawer): declare --cui-drawer-sheet-width

### DIFF
--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -43,6 +43,7 @@ $drawer-tokens: defaults(
     --#{$prefix}drawer-zindex: var(--#{$prefix}z-offcanvas),
     --#{$prefix}drawer-width: #{$drawer-width},
     --#{$prefix}drawer-height: #{$drawer-height},
+    --#{$prefix}drawer-sheet-width: #{$drawer-sheet-width},
     --#{$prefix}drawer-padding-x: #{$drawer-padding-x},
     --#{$prefix}drawer-padding-y: #{$drawer-padding-y},
     --#{$prefix}drawer-color: #{$drawer-color},
@@ -281,7 +282,7 @@ $drawer-tokens: defaults(
     border-end-end-radius: 0;
 
     @include media-breakpoint-up(lg) {
-      max-width: var(--#{$prefix}drawer-sheet-width, #{$drawer-sheet-width});
+      max-width: var(--#{$prefix}drawer-sheet-width);
     }
   }
 


### PR DESCRIPTION
`.drawer-sheet` read `max-width: var(--cui-drawer-sheet-width, #{$drawer-sheet-width})` — a hook nothing declared, with the Sass knob only ever reaching the fallback, so the token showed neither in devtools nor in the CSS variables section.

`--cui-drawer-sheet-width` is now in the drawer token map (`drawer-css-vars`, so the docs pick it up) and the rule reads it plainly. Same rendering; compiled diff is the one added declaration and the simplified read. One-line divergence from upstream, which keeps the bare hook. From the SCSS quality audit (undeclared hook tokens).