### PR TITLE
refactor(forms)!: drop the v5 token names read as fallback hooks

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -3234,7 +3234,12 @@ Nothing existing changes; these are additions. See
   `--cui-chip-input-padding-x` and the rest of their frame sets are now
   `--cui-control-*` on the same elements. Runtime overrides written against
   the old names must be updated. Component-specific tokens (indicators,
-  dropdowns, tags, cells, cleaner buttons) keep their names.
+  dropdowns, tags, cells, cleaner buttons) keep their names. Three v5 names
+  that survived as undeclared fallbacks are gone too:
+  `--cui-input-placeholder-color` (set `--cui-control-placeholder-color`),
+  `--cui-input-focus-border-color` in the combobox (set
+  `--cui-btn-input-focus-border-color`) and `--cui-table-caption-color` (the
+  caption reads `$caption-color`).
 - **Component Sass variables survive with new defaults**: `$date-picker-bg`,
   `$autocomplete-padding-y` and the rest now default to the shared knob
   (`var(--cui-btn-input-bg)` …). Untouched, the control follows the shared

--- a/scss/_combobox.scss
+++ b/scss/_combobox.scss
@@ -147,7 +147,7 @@ $combobox-tokens: defaults(
 
     &:focus-visible {
       z-index: 5;
-      border-color: var(--#{$prefix}input-focus-border-color, var(--#{$prefix}btn-input-focus-border-color));
+      border-color: var(--#{$prefix}btn-input-focus-border-color);
       @include focus-ring(true);
     }
   }
@@ -180,7 +180,7 @@ $combobox-tokens: defaults(
 
     &:focus-visible {
       z-index: 5;
-      border-color: var(--#{$prefix}input-focus-border-color, var(--#{$prefix}btn-input-focus-border-color));
+      border-color: var(--#{$prefix}btn-input-focus-border-color);
       @include focus-ring(true);
     }
 
@@ -222,7 +222,7 @@ $combobox-tokens: defaults(
 
       &:focus-visible {
         z-index: 5;
-        border-color: var(--#{$prefix}input-focus-border-color, var(--#{$prefix}btn-input-focus-border-color));
+        border-color: var(--#{$prefix}btn-input-focus-border-color);
         @include focus-ring(true);
       }
     }

--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -470,7 +470,7 @@ $th-font-weight:       null !default;
   caption {
     padding-top: $caption-padding-y;
     padding-bottom: $caption-padding-y;
-    color: var(--#{$prefix}table-caption-color, #{$caption-color});
+    color: $caption-color;
     text-align: start;
   }
 

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -54,7 +54,7 @@ $form-control-tokens: defaults(
     --#{$prefix}control-transition-property: var(--#{$prefix}btn-input-transition-property),
     --#{$prefix}control-transition-duration: var(--#{$prefix}btn-input-transition-duration),
     --#{$prefix}control-transition-timing: var(--#{$prefix}btn-input-transition-timing),
-    --#{$prefix}control-placeholder-color: var(--#{$prefix}input-placeholder-color, var(--#{$prefix}fg-3)),
+    --#{$prefix}control-placeholder-color: var(--#{$prefix}fg-3),
     --#{$prefix}control-focus-color: var(--#{$prefix}btn-input-focus-color),
     --#{$prefix}control-focus-bg: var(--#{$prefix}btn-input-focus-bg),
     --#{$prefix}control-focus-border-color: var(--#{$prefix}btn-input-focus-border-color),


### PR DESCRIPTION
Three v5 custom-property names survived only as the first argument of a `var()` nothing declares:

- `--cui-input-placeholder-color` inside the `--cui-control-placeholder-color` default (`forms/_form-control.scss`) — now `var(--cui-fg-3)`, as upstream.
- `--cui-input-focus-border-color` in the three combobox focus rules — now `var(--cui-btn-input-focus-border-color)`, the read every other control already uses.
- `--cui-table-caption-color` on `caption` in Reboot — now `$caption-color` (Reboot has no token map to declare it in; upstream reads `var(--fg-3)` directly).

Same rendering; compiled diff is the seven simplified reads. Migration guide: the three names listed under the `--cui-control-*` entry with their replacements. From the SCSS quality audit (undeclared hook tokens).