### PR TITLE
refactor(Dropdown): declare --cui-dropdown-item-border-radius

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -35,6 +35,7 @@ $dropdown-link-disabled-color:      var(--#{$prefix}fg-3) !default;
 
 $dropdown-item-padding-y:           var(--#{$prefix}spacer-1) !default;
 $dropdown-item-padding-x:           var(--#{$prefix}spacer-3) !default;
+$dropdown-item-border-radius:       0 !default;
 
 $dropdown-header-color:             var(--#{$prefix}gray-600) !default;
 $dropdown-header-padding-x:         $dropdown-item-padding-x !default;
@@ -85,6 +86,7 @@ $dropdown-tokens: defaults(
     --#{$prefix}dropdown-link-active-bg: #{$dropdown-link-active-bg},
     --#{$prefix}dropdown-link-disabled-color: #{$dropdown-link-disabled-color},
     --#{$prefix}dropdown-item-padding-x: #{$dropdown-item-padding-x},
+    --#{$prefix}dropdown-item-border-radius: #{$dropdown-item-border-radius},
     --#{$prefix}dropdown-item-padding-y: #{$dropdown-item-padding-y},
     --#{$prefix}dropdown-header-color: #{$dropdown-header-color},
     --#{$prefix}dropdown-header-padding-x: #{$dropdown-header-padding-x},
@@ -291,7 +293,7 @@ $dropdown-dark-tokens: defaults(
     white-space: nowrap; // prevent links from randomly breaking onto new lines
     background-color: transparent; // For `<button>`s
     border: 0; // For `<button>`s
-    @include border-radius(var(--#{$prefix}dropdown-item-border-radius, 0));
+    @include border-radius(var(--#{$prefix}dropdown-item-border-radius));
 
     &:hover,
     &:focus {


### PR DESCRIPTION
`.dropdown-item` read its radius as `var(--cui-dropdown-item-border-radius, 0)`, a hook nothing declared, so it showed neither in devtools nor in the CSS variables section.

The token is now in the dropdown token map (`dropdown-css-vars`) with a `$dropdown-item-border-radius: 0` knob, and the rule reads it plainly. Same rendering; compiled diff is the one added declaration and the simplified read. Same shape as the menu change in #1084. From the SCSS quality audit (undeclared hook tokens).