### PR TITLE
refactor(forms)!: paint the validation tooltip with the state's -bg slot

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -2352,6 +2352,13 @@ them. A state names a theme colour now, and every value is a slot of it.
 - **`form-validation-state()` takes `$theme` where it took `$color`**, and the
   variables moved from `scss/_config.scss` into the partials that use them
   alongside `$form-text-*` and `$form-feedback-*`.
+- **The validation tooltip is opaque and sits on the state's `-bg` slot.**
+  It was `color-mix(in srgb, var(--cui-danger) 90%, transparent)`, with the
+  percentage frozen at build time from `$form-feedback-tooltip-opacity`. It
+  reads `var(--cui-danger-bg)` (`-success-bg`, or your state's `-bg`) now,
+  the same slot the alert and the badge use, so it follows a theme override
+  with them. `$form-feedback-tooltip-opacity` is removed; for a translucent
+  tooltip set `background-color` on `.invalid-tooltip` / `.valid-tooltip`.
 
 #### `$component-active-color` and `$component-active-bg` are removed
 

--- a/scss/forms/_validation.scss
+++ b/scss/forms/_validation.scss
@@ -33,7 +33,6 @@ $validated-controls: if(sass($enable-deprecated-form-check): ".check, .radio, .s
   $icon,
   $color: var(--#{$prefix}#{$theme}-fg),
   $tooltip-color: var(--#{$prefix}#{$theme}-contrast),
-  $tooltip-bg-color: color-mix(in srgb, var(--#{$prefix}#{$theme}) #{$form-feedback-tooltip-opacity * 100%}, transparent),
   $focus-ring-color: var(--#{$prefix}#{$theme}-focus-ring),
   $border-color: var(--#{$prefix}#{$theme}-fg)
 ) {
@@ -63,7 +62,7 @@ $validated-controls: if(sass($enable-deprecated-form-check): ".check, .radio, .s
     font-size: var(--#{$prefix}tooltip-font-size, var(--#{$prefix}form-feedback-tooltip-font-size));
     line-height: var(--#{$prefix}form-feedback-tooltip-line-height);
     color: $tooltip-color;
-    background-color: $tooltip-bg-color;
+    background-color: var(--#{$prefix}#{$theme}-bg);
     opacity: 1;
     @include border-radius(var(--#{$prefix}tooltip-border-radius, var(--#{$prefix}form-feedback-tooltip-border-radius)));
   }

--- a/scss/mixins/_form-validation.scss
+++ b/scss/mixins/_form-validation.scss
@@ -42,7 +42,6 @@ $form-feedback-tooltip-padding-y:     var(--#{$prefix}spacer-1) !default;
 $form-feedback-tooltip-padding-x:     var(--#{$prefix}spacer-2) !default;
 $form-feedback-tooltip-font-size:     var(--#{$prefix}font-size-sm) !default;
 $form-feedback-tooltip-line-height:   null !default;
-$form-feedback-tooltip-opacity:       .9 !default;
 $form-feedback-tooltip-border-radius: var(--#{$prefix}border-radius) !default;
 // scss-docs-end tooltip-feedback-variables
 


### PR DESCRIPTION
The validation tooltip background was `color-mix(in srgb, var(--cui-<state>) 90%, transparent)`, the percentage frozen at build time from `$form-feedback-tooltip-opacity` — a knob with no token and no docs, and the last Sass arithmetic on a tokenised colour in `forms/`.

It reads `var(--cui-<state>-bg)` now (the slot the alert and the badge already use, and what upstream does), so a theme override reaches the tooltip with them. `$form-feedback-tooltip-opacity` and the mixin's `$tooltip-bg-color` parameter are removed. Visible change: 90% → full opacity on the same hue — measured on the compiled stylesheet, `--cui-danger-bg` is `var(--cui-danger)` in both colour schemes, so only the translucency goes. Compiled diff is the two `background-color` lines. Migration guide: entry under the validation-state section.

From the SCSS quality audit (Sass arithmetic on derived values).