### PR TITLE
refactor(scss)!: read the radius scale in every component

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -2162,7 +2162,12 @@ as such.
   (`--cui-card-border-radius: .375rem`); to retune the whole page, override
   the stops or `$radius`. The `$border-radius(-sm/-lg/-xl/-xxl/-pill)`
   variables and their tokens are unchanged and keep driving the `rounded-*`
-  utilities.
+  utilities — but no component reads them any more: the modal, the chip,
+  the switch, the chip input, the search button's key, the sidebar nav, the
+  header toggler, the password-strength segments and the validation tooltip
+  moved to the stop with the same value (`--cui-border-radius` →
+  `--cui-radius-4`, `-sm` → `-3`, `-lg` → `-5`, `-pill` → `--cui-radius-pill`),
+  so overriding `--cui-border-radius` now retunes the utilities only.
 
 #### Interaction surfaces sit two rungs lighter on the ladder
 

--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -15,7 +15,7 @@ $chip-font-weight:           var(--#{$prefix}font-weight-normal) !default;
 $chip-height:                1.75rem !default;
 $chip-padding-x:             .625rem !default;
 $chip-gap:                   .3125rem !default;
-$chip-border-radius:         var(--#{$prefix}border-radius-pill) !default;
+$chip-border-radius:         var(--#{$prefix}radius-pill) !default;
 $chip-icon-size:             1rem !default;
 $chip-img-size:              1.25rem !default;
 $chip-img-border-radius:     50% !default;

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -39,7 +39,7 @@ $header-toggler-padding-x:      .75rem !default;
 $header-toggler-font-size:      var(--#{$prefix}font-size-lg) !default;
 $header-toggler-color:          color-mix(in srgb, var(--#{$prefix}emphasis-color) 65%, transparent) !default;
 $header-toggler-bg:             transparent !default;
-$header-toggler-border-radius:  var(--#{$prefix}border-radius) !default;
+$header-toggler-border-radius:  var(--#{$prefix}radius-4) !default;
 $header-toggler-hover-color:    color-mix(in srgb, var(--#{$prefix}emphasis-color) 100%, transparent) !default;
 
 $header-toggler-icon-bg:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='black' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg>") !default;

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -23,7 +23,7 @@ $modal-content-color:               var(--#{$prefix}fg-body) !default;
 $modal-content-bg:                  var(--#{$prefix}bg-body) !default;
 $modal-content-border-color:        var(--#{$prefix}border-color-translucent) !default;
 $modal-content-border-width:        var(--#{$prefix}border-width) !default;
-$modal-content-border-radius:       var(--#{$prefix}border-radius-lg) !default;
+$modal-content-border-radius:       var(--#{$prefix}radius-5) !default;
 $modal-content-inner-border-radius: calc(#{$modal-content-border-radius} - #{$modal-content-border-width}) !default;
 $modal-content-box-shadow-xs:       var(--#{$prefix}box-shadow-sm) !default;
 $modal-content-box-shadow-sm-up:    var(--#{$prefix}box-shadow) !default;

--- a/scss/buttons/_search-button.scss
+++ b/scss/buttons/_search-button.scss
@@ -34,7 +34,7 @@ $search-button-key-height:          1.5rem !default;
 $search-button-key-padding-inline:  .25rem !default;
 $search-button-key-font-size:       .75rem !default;
 $search-button-key-bg:              var(--#{$prefix}bg-3) !default;
-$search-button-key-border-radius:   var(--#{$prefix}border-radius-sm) !default;
+$search-button-key-border-radius:   var(--#{$prefix}radius-3) !default;
 $search-button-key-active-bg:       var(--#{$prefix}bg-4) !default;
 
 $search-button-placeholder-margin-inline:  .55rem 2rem !default;

--- a/scss/forms/_chip-input.scss
+++ b/scss/forms/_chip-input.scss
@@ -13,7 +13,7 @@ $chip-input-bg:                var(--#{$prefix}btn-input-bg) !default;
 $chip-input-color:             var(--#{$prefix}btn-input-color) !default;
 $chip-input-border-width:      var(--#{$prefix}btn-input-border-width) !default;
 $chip-input-border-color:      var(--#{$prefix}border-color) !default;
-$chip-input-border-radius:     var(--#{$prefix}border-radius) !default;
+$chip-input-border-radius:     var(--#{$prefix}radius-4) !default;
 $chip-input-gap:               .375rem !default;
 $chip-input-transition-property: var(--#{$prefix}btn-input-transition-property) !default;
 $chip-input-transition-duration: var(--#{$prefix}btn-input-transition-duration) !default;
@@ -23,14 +23,14 @@ $chip-input-min-height-sm:     var(--#{$prefix}btn-input-sm-min-height) !default
 $chip-input-padding-y-sm:      .125rem !default;
 $chip-input-padding-x-sm:      .5rem !default;
 $chip-input-font-size-sm:      var(--#{$prefix}btn-input-sm-font-size) !default;
-$chip-input-border-radius-sm:  var(--#{$prefix}border-radius-sm) !default;
+$chip-input-border-radius-sm:  var(--#{$prefix}radius-3) !default;
 $chip-input-gap-sm:            .125rem !default;
 
 $chip-input-min-height-lg:     var(--#{$prefix}btn-input-lg-min-height) !default;
 $chip-input-padding-y-lg:      .375rem !default;
 $chip-input-padding-x-lg:      1rem !default;
 $chip-input-font-size-lg:      var(--#{$prefix}btn-input-lg-font-size) !default;
-$chip-input-border-radius-lg:  var(--#{$prefix}border-radius-lg) !default;
+$chip-input-border-radius-lg:  var(--#{$prefix}radius-5) !default;
 $chip-input-gap-lg:            .5rem !default;
 // scss-docs-end chip-input-variables
 

--- a/scss/forms/_password-strength.scss
+++ b/scss/forms/_password-strength.scss
@@ -10,7 +10,7 @@ $password-strength-gap:                  .5rem !default;
 $password-strength-meter-gap:            .25rem !default;
 $password-strength-segment-height:       .25rem !default;
 $password-strength-segment-bg:           var(--#{$prefix}bg-3) !default;
-$password-strength-segment-border-radius: var(--#{$prefix}border-radius-pill) !default;
+$password-strength-segment-border-radius: var(--#{$prefix}radius-pill) !default;
 $password-strength-font-size:            var(--#{$prefix}font-size-sm) !default;
 $password-strength-text-font-weight:     600 !default;
 $password-strength-warning-color:        var(--#{$prefix}fg-2) !default;

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -9,7 +9,7 @@
 // scss-docs-start switch-variables
 $switch-aspect-ratio:         1.75 !default;
 $switch-height:               1.25rem !default;
-$switch-border-radius:        var(--#{$prefix}border-radius-pill) !default;
+$switch-border-radius:        var(--#{$prefix}radius-pill) !default;
 $switch-transition-duration:  var(--#{$prefix}control-transition-duration) !default;
 $switch-transition-timing:    var(--#{$prefix}control-transition-timing) !default;
 $switch-bg:                   var(--#{$prefix}bg-3) !default;

--- a/scss/mixins/_form-validation.scss
+++ b/scss/mixins/_form-validation.scss
@@ -42,7 +42,7 @@ $form-feedback-tooltip-padding-y:     var(--#{$prefix}spacer-1) !default;
 $form-feedback-tooltip-padding-x:     var(--#{$prefix}spacer-2) !default;
 $form-feedback-tooltip-font-size:     var(--#{$prefix}font-size-sm) !default;
 $form-feedback-tooltip-line-height:   null !default;
-$form-feedback-tooltip-border-radius: var(--#{$prefix}border-radius) !default;
+$form-feedback-tooltip-border-radius: var(--#{$prefix}radius-4) !default;
 // scss-docs-end tooltip-feedback-variables
 
 // stylelint-disable scss/dollar-variable-default

--- a/scss/sidebar/_sidebar-nav.scss
+++ b/scss/sidebar/_sidebar-nav.scss
@@ -23,7 +23,7 @@ $sidebar-nav-link-color:                      var(--#{$prefix}fg-body) !default;
 $sidebar-nav-link-bg:                         transparent !default;
 $sidebar-nav-link-border-width:               0 !default;
 $sidebar-nav-link-border-color:               transparent !default;
-$sidebar-nav-link-border-radius:              var(--#{$prefix}border-radius) !default;
+$sidebar-nav-link-border-radius:              var(--#{$prefix}radius-4) !default;
 $sidebar-nav-link-transition:                 background .15s ease, color .15s ease, padding .15s ease !default;
 
 $sidebar-compact-nav-link-padding-y:          .5625rem !default;
@@ -63,7 +63,7 @@ $sidebar-nav-link-disabled-icon-bullet-border-color:  var(--#{$prefix}fg-3) !def
 $sidebar-nav-group-bg:                        transparent !default;
 $sidebar-nav-group-border-width:              0 !default;
 $sidebar-nav-group-border-color:              transparent !default;
-$sidebar-nav-group-border-radius:             var(--#{$prefix}border-radius) !default;
+$sidebar-nav-group-border-radius:             var(--#{$prefix}radius-4) !default;
 $sidebar-nav-group-transition:                background .15s ease-in-out !default;
 $sidebar-nav-group-toggle-show-color:         $sidebar-nav-link-color !default;
 


### PR DESCRIPTION
Twelve component tokens still read the v5 `--cui-border-radius(-sm/-lg/-pill)` set while the rest of the library sits on the `--cui-radius-N` stops, so new PRO files were picking a scale at random. Each moves to the stop with the same value:

| was | now | value |
| --- | --- | --- |
| `--cui-border-radius-sm` | `--cui-radius-3` | .25rem |
| `--cui-border-radius` | `--cui-radius-4` | .375rem |
| `--cui-border-radius-lg` | `--cui-radius-5` | .5rem |
| `--cui-border-radius-pill` | `--cui-radius-pill` | 50rem |

Affected: modal (content + inner), chip, switch, chip input (three sizes), search-button key, sidebar nav link and group, header toggler, password-strength segments, validation tooltip. Nothing renders differently by default; the old set keeps driving the `rounded-*` utilities, as the migration guide promises — its entry now says the components left it, so an override of `--cui-border-radius` retunes the utilities only. Compiled diff is the 17 token declarations.

Deliberate 1:1 mapping — aligning e.g. the modal with the dialog's `radius-7` is a visual decision for a separate PR. From the SCSS quality audit (two radius scales).