### PR TITLE
chore(scss): realign the value column in seven variable blocks

### DIFF
--- a/scss/_popup.scss
+++ b/scss/_popup.scss
@@ -6,12 +6,12 @@
 @use "config" as *;
 
 // scss-docs-start popup-variables
-$popup-zindex:          1000 !default;
-$popup-bg:              var(--#{$prefix}bg-body) !default;
-$popup-border-width:    var(--#{$prefix}border-width) !default;
-$popup-border-color:    var(--#{$prefix}border-color) !default;
-$popup-border-radius:   var(--#{$prefix}radius-7) !default;
-$popup-box-shadow:      var(--#{$prefix}box-shadow) !default;
+$popup-zindex:              1000 !default;
+$popup-bg:                  var(--#{$prefix}bg-body) !default;
+$popup-border-width:        var(--#{$prefix}border-width) !default;
+$popup-border-color:        var(--#{$prefix}border-color) !default;
+$popup-border-radius:       var(--#{$prefix}radius-7) !default;
+$popup-box-shadow:          var(--#{$prefix}box-shadow) !default;
 $popup-transition-duration: .15s !default;
 $popup-transition-timing:   var(--#{$prefix}transition-timing-overlay) !default;
 // scss-docs-end popup-variables

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -92,18 +92,18 @@ $small-font-size:             .875em !default;
 $font-weight-base:            var(--#{$prefix}font-weight-normal) !default;
 
 // scss-docs-start input-btn-variables
-$input-btn-gap:               .375rem !default;
-$input-btn-padding-y:         .375rem !default;
-$input-btn-padding-x:         .75rem !default;
-$input-btn-font-family:       null !default;
-$input-btn-font-size:         var(--#{$prefix}body-font-size) !default;
-$input-btn-line-height:       var(--#{$prefix}body-line-height) !default;
-$input-btn-border-width:      var(--#{$prefix}border-width) !default;
-$input-btn-transition-duration:          .15s !default;
-$input-btn-transition-timing:            ease-in-out !default;
-$input-btn-transition-property:          "border-color, box-shadow" !default;
-$input-btn-action-transition-property:   "color, background-color, border-color, box-shadow" !default;
-$input-btn-disabled-opacity:  .65 !default;
+$input-btn-gap:                        .375rem !default;
+$input-btn-padding-y:                  .375rem !default;
+$input-btn-padding-x:                  .75rem !default;
+$input-btn-font-family:                null !default;
+$input-btn-font-size:                  var(--#{$prefix}body-font-size) !default;
+$input-btn-line-height:                var(--#{$prefix}body-line-height) !default;
+$input-btn-border-width:               var(--#{$prefix}border-width) !default;
+$input-btn-transition-duration:        .15s !default;
+$input-btn-transition-timing:          ease-in-out !default;
+$input-btn-transition-property:        "border-color, box-shadow" !default;
+$input-btn-action-transition-property: "color, background-color, border-color, box-shadow" !default;
+$input-btn-disabled-opacity:           .65 !default;
 
 $input-btn-gap-xs:            .25rem !default;
 $input-btn-padding-y-xs:      .125rem !default;

--- a/scss/forms/_chip-input.scss
+++ b/scss/forms/_chip-input.scss
@@ -5,16 +5,16 @@
 @use "../config" as *;
 
 // scss-docs-start chip-input-variables
-$chip-input-min-height:        var(--#{$prefix}btn-input-min-height) !default;
-$chip-input-padding-y:         .25rem !default;
-$chip-input-padding-x:         .75rem !default;
-$chip-input-font-size:         var(--#{$prefix}btn-input-font-size) !default;
-$chip-input-bg:                var(--#{$prefix}btn-input-bg) !default;
-$chip-input-color:             var(--#{$prefix}btn-input-color) !default;
-$chip-input-border-width:      var(--#{$prefix}btn-input-border-width) !default;
-$chip-input-border-color:      var(--#{$prefix}border-color) !default;
-$chip-input-border-radius:     var(--#{$prefix}radius-4) !default;
-$chip-input-gap:               .375rem !default;
+$chip-input-min-height:          var(--#{$prefix}btn-input-min-height) !default;
+$chip-input-padding-y:           .25rem !default;
+$chip-input-padding-x:           .75rem !default;
+$chip-input-font-size:           var(--#{$prefix}btn-input-font-size) !default;
+$chip-input-bg:                  var(--#{$prefix}btn-input-bg) !default;
+$chip-input-color:               var(--#{$prefix}btn-input-color) !default;
+$chip-input-border-width:        var(--#{$prefix}btn-input-border-width) !default;
+$chip-input-border-color:        var(--#{$prefix}border-color) !default;
+$chip-input-border-radius:       var(--#{$prefix}radius-4) !default;
+$chip-input-gap:                 .375rem !default;
 $chip-input-transition-property: var(--#{$prefix}btn-input-transition-property) !default;
 $chip-input-transition-duration: var(--#{$prefix}btn-input-transition-duration) !default;
 $chip-input-transition-timing:   var(--#{$prefix}btn-input-transition-timing) !default;

--- a/scss/forms/_form-control-group.scss
+++ b/scss/forms/_form-control-group.scss
@@ -8,19 +8,19 @@
 @use "form-control" as *;
 
 // scss-docs-start form-control-group-variables
-$form-control-group-gap:              .5rem !default;
-$form-control-group-icon-size:        1rem !default;
-$form-control-group-icon-size-sm:     .875rem !default;
-$form-control-group-icon-size-lg:     1.25rem !default;
-$form-control-group-icon-color:       var(--#{$prefix}fg-3) !default;
-$form-control-group-text-color:       var(--#{$prefix}fg-3) !default;
-$form-control-group-action-size:      1.5rem !default;
-$form-control-group-action-size-sm:   1.25rem !default;
-$form-control-group-action-size-lg:   1.75rem !default;
-$form-control-group-action-color:     var(--#{$prefix}fg-3) !default;
+$form-control-group-gap:                .5rem !default;
+$form-control-group-icon-size:          1rem !default;
+$form-control-group-icon-size-sm:       .875rem !default;
+$form-control-group-icon-size-lg:       1.25rem !default;
+$form-control-group-icon-color:         var(--#{$prefix}fg-3) !default;
+$form-control-group-text-color:         var(--#{$prefix}fg-3) !default;
+$form-control-group-action-size:        1.5rem !default;
+$form-control-group-action-size-sm:     1.25rem !default;
+$form-control-group-action-size-lg:     1.75rem !default;
+$form-control-group-action-color:       var(--#{$prefix}fg-3) !default;
 $form-control-group-action-hover-color: var(--#{$prefix}fg-body) !default;
-$form-control-group-action-bg:        transparent !default;
-$form-control-group-action-hover-bg:  var(--#{$prefix}bg-3) !default;
+$form-control-group-action-bg:          transparent !default;
+$form-control-group-action-hover-bg:    var(--#{$prefix}bg-3) !default;
 // scss-docs-end form-control-group-variables
 
 $form-control-group-sizes: () !default;

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -100,14 +100,14 @@ $form-control-tokens: defaults(
 // scss-docs-end form-control-frame-mixin
 
 // scss-docs-start form-control-select-variables
-$form-control-select-indicator-color:      $gray-800 !default;
-$form-control-select-indicator:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$form-control-select-indicator-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/></svg>") !default;
-$form-control-select-bg-position:          right var(--#{$prefix}control-padding-x) center !default;
-$form-control-select-bg-size:              16px 12px !default; // In pixels because image dimensions
-$form-control-select-padding-end:          calc(var(--#{$prefix}control-padding-x) * 3) !default;
+$form-control-select-indicator-color:           $gray-800 !default;
+$form-control-select-indicator:                 url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$form-control-select-indicator-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/></svg>") !default;
+$form-control-select-bg-position:               right var(--#{$prefix}control-padding-x) center !default;
+$form-control-select-bg-size:                   16px 12px !default; // In pixels because image dimensions
+$form-control-select-padding-end:               calc(var(--#{$prefix}control-padding-x) * 3) !default;
 $form-control-select-feedback-icon-padding-end: calc(var(--#{$prefix}control-padding-x) * 2.5 + var(--#{$prefix}control-select-padding-end)) !default;
-$form-control-select-feedback-icon-position: center right var(--#{$prefix}control-select-padding-end) !default;
-$form-control-select-feedback-icon-size:   $input-height-inner-half $input-height-inner-half !default;
+$form-control-select-feedback-icon-position:    center right var(--#{$prefix}control-select-padding-end) !default;
+$form-control-select-feedback-icon-size:        $input-height-inner-half $input-height-inner-half !default;
 // scss-docs-end form-control-select-variables
 
 // scss-docs-start form-control-select-dark-variables

--- a/scss/forms/_form-field.scss
+++ b/scss/forms/_form-field.scss
@@ -4,14 +4,14 @@
 @use "../mixins/border-radius" as *;
 
 // scss-docs-start form-field-variables
-$form-field-gap:            .5rem !default;
-$form-field-column-gap:     .5rem !default;
-$form-field-card-padding:   calc(var(--#{$prefix}spacer) * .75) !default;
-$form-field-card-radius:    var(--#{$prefix}radius-7) !default;
-$form-field-card-hover-bg:  var(--#{$prefix}bg-1) !default;
-$form-field-card-checked-bg: var(--#{$prefix}bg-1) !default;
+$form-field-gap:                       .5rem !default;
+$form-field-column-gap:                .5rem !default;
+$form-field-card-padding:              calc(var(--#{$prefix}spacer) * .75) !default;
+$form-field-card-radius:               var(--#{$prefix}radius-7) !default;
+$form-field-card-hover-bg:             var(--#{$prefix}bg-1) !default;
+$form-field-card-checked-bg:           var(--#{$prefix}bg-1) !default;
 $form-field-card-checked-border-color: var(--#{$prefix}border-color) !default;
-$form-group-gap:            .5rem !default;
+$form-group-gap:                       .5rem !default;
 // scss-docs-end form-field-variables
 
 $form-field-tokens: () !default;

--- a/scss/forms/_password-strength.scss
+++ b/scss/forms/_password-strength.scss
@@ -6,17 +6,17 @@
 @use "../config" as *;
 
 // scss-docs-start password-strength-variables
-$password-strength-gap:                  .5rem !default;
-$password-strength-meter-gap:            .25rem !default;
-$password-strength-segment-height:       .25rem !default;
-$password-strength-segment-bg:           var(--#{$prefix}bg-3) !default;
+$password-strength-gap:                   .5rem !default;
+$password-strength-meter-gap:             .25rem !default;
+$password-strength-segment-height:        .25rem !default;
+$password-strength-segment-bg:            var(--#{$prefix}bg-3) !default;
 $password-strength-segment-border-radius: var(--#{$prefix}radius-pill) !default;
-$password-strength-font-size:            var(--#{$prefix}font-size-sm) !default;
-$password-strength-text-font-weight:     600 !default;
-$password-strength-warning-color:        var(--#{$prefix}fg-2) !default;
-$password-strength-suggestions-color:    var(--#{$prefix}fg-3) !default;
-$password-strength-busy-opacity:         .65 !default;
-$password-strength-color:                var(--#{$prefix}fg-3) !default;
+$password-strength-font-size:             var(--#{$prefix}font-size-sm) !default;
+$password-strength-text-font-weight:      600 !default;
+$password-strength-warning-color:         var(--#{$prefix}fg-2) !default;
+$password-strength-suggestions-color:     var(--#{$prefix}fg-3) !default;
+$password-strength-busy-opacity:          .65 !default;
+$password-strength-color:                 var(--#{$prefix}fg-3) !default;
 // scss-docs-end password-strength-variables
 
 $password-strength-levels: () !default;


### PR DESCRIPTION
A longer name had been added to each of these blocks without moving its neighbours, so one or two rows stuck out of the value column: `$input-btn-*` in `_root.scss`, `$form-control-select-*`, `$form-field-*`, `$form-control-group-action-*`, `$chip-input-*`, `$password-strength-*` and `$popup-*`. Every row of a block now sits on the same column (longest name plus one space).

Whitespace only — compiled output is byte-identical (`cmp` on a scratch compile). From the SCSS quality audit.