### PR TITLE
chore(scss): drop the narrative comments from our own files

### DIFF
--- a/scss/_autocomplete.scss
+++ b/scss/_autocomplete.scss
@@ -6,8 +6,6 @@
     position: relative;
 
     &.show {
-      // The popup takes the focus away from the frame, but the control is
-      // still the one being operated — active treatment, no ring.
       @include form-control-group-active();
 
       // The chevron turns when the popup opens.
@@ -24,8 +22,6 @@
     inset-inline-start: 0;
     width: 100%;
     height: 100%;
-    // The group carries the frame padding and zeroes it on inner controls, so
-    // the overlay has to restate it or the ghost text starts at the frame edge.
     padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
     pointer-events: none;
     opacity: .5;

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -189,8 +189,7 @@ $dropdown-dark-tokens: defaults(
       $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
       .dropdown-menu#{$infix}-start {
-        // Read by the plugin, so the name cannot follow `$prefix` — the two
-        // sides would disagree in a build that changes it.
+        // Read by the plugin, so the name stays outside `$prefix`.
         --cui-position: start;
 
         &[data#{$data-infix}popper] {

--- a/scss/_popup.scss
+++ b/scss/_popup.scss
@@ -38,12 +38,6 @@ $popup-tokens: defaults(
 // stylelint-enable scss/dollar-variable-default
 
 @layer components {
-  // The floating surface of the field components — one chrome for the pickers'
-  // dropdowns and the combobox listbox, whatever body it holds. This is the
-  // anchored presentation; the fullscreen/modal one (the v1 pickers' mobile
-  // mode, coming back at the primitive level) is designed but lands
-  // separately. The popup borrows the *look* of a menu, never its interaction
-  // semantics: the body inside owns those.
   .popup {
     @include tokens($popup-tokens);
 
@@ -57,16 +51,7 @@ $popup-tokens: defaults(
     opacity: 0;
     @include box-shadow(var(--#{$prefix}popup-box-shadow));
 
-    // `display` is what makes a popup appear, and it cannot be interpolated,
-    // so `allow-discrete` lets it flip at the right end of the transition while
-    // opacity and transform carry the motion. `@starting-style` supplies the
-    // state to animate FROM: the element does not exist to be styled before it
-    // is shown, so the base rule cannot express it.
     //
-    // Opacity only, no scale. A popup carries no placement attribute, so a
-    // scale would need an origin we cannot know — and on a panel the size of a
-    // calendar even a 2% scale reads as the panel jumping rather than
-    // appearing. The combobox list hides it; the pickers do not.
     @include transition(
       opacity var(--#{$prefix}popup-transition-duration) var(--#{$prefix}popup-transition-timing),
       display var(--#{$prefix}popup-transition-duration) allow-discrete

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -152,11 +152,7 @@ $range-slider-vertical-tokens: defaults(
     height: var(--#{$prefix}range-slider-track-height);
     cursor: var(--#{$prefix}range-slider-track-cursor);
     background-color: var(--#{$prefix}range-slider-track-bg);
-    // The filled band, between the lowest and the highest handle. The edges are
-    // deliberately given no fallback: with `track: false` the plugin never
-    // writes them, the substitution fails and the whole declaration falls back
-    // to `none`, so nothing is painted. Their names sit outside `$prefix` for
-    // the same reason as the tooltip's position — the plugin writes them.
+    // No fallback on purpose: with `track: false` the plugin never writes the edges and the whole declaration must drop to `none`.
     background-image:
       linear-gradient(
         var(--cui-range-slider-track-direction, to right),
@@ -269,9 +265,7 @@ $range-slider-vertical-tokens: defaults(
   }
 
   .range-slider-tooltip {
-    // The thumb's centre: half a thumb in, then the track minus a thumb.
-    // Deliberately outside `$prefix`: the plugin writes this name, so a
-    // configurable one would let the two sides disagree.
+    // Outside `$prefix` on purpose: the plugin writes this name.
     position: absolute;
     inset-inline-start: calc(var(--#{$prefix}range-slider-thumb-width) * .5 + var(--cui-range-slider-tooltip-position, 0) * (100% - var(--#{$prefix}range-slider-thumb-width)));
     z-index: var(--#{$prefix}range-slider-tooltip-zindex);
@@ -307,9 +301,6 @@ $range-slider-vertical-tokens: defaults(
   }
 
   .range-slider:not(.range-slider-vertical) {
-    // Gradients take no logical direction, so the horizontal one is mirrored
-    // here. Scoped away from the vertical slider so neither rule depends on
-    // source order.
     @include rtl() {
       --cui-range-slider-track-direction: to left;
     }

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -67,15 +67,11 @@ $time-picker-tokens: defaults(
   .time-picker {
     position: relative;
 
-    // The popup takes the focus away from the group, but the control is still
-    // active — so the frame keeps its focus treatment while it is open.
     &.show {
       @include form-control-group-active();
     }
   }
 
-  // See .date-picker-popup: the panel owns its tokens so it survives being
-  // teleported or portaled away from the field.
   .time-picker-popup {
     @include tokens($time-picker-tokens);
   }

--- a/scss/buttons/_loading-button.scss
+++ b/scss/buttons/_loading-button.scss
@@ -3,8 +3,7 @@
 
 @layer components {
   .btn-loading {
-    // The spinner slides in on its own margins, so the button's gap would only
-    // add a fixed offset the animation cannot take back.
+    // No gap: the spinner slides in on its own margins and a gap would leave a fixed offset behind.
     --#{$prefix}btn-gap: 0;
 
     position: relative;

--- a/scss/forms/_form-date-time.scss
+++ b/scss/forms/_form-date-time.scss
@@ -38,8 +38,6 @@ $form-date-time-tokens: defaults(
 
     display: flex;
     align-items: center;
-    // The sections are injected by JS; without this the empty container
-    // collapses and flashes on load.
     min-height: var(--#{$prefix}btn-input-min-height);
     cursor: text;
 
@@ -100,8 +98,6 @@ $form-date-time-tokens: defaults(
     color: var(--#{$prefix}form-date-time-placeholder-color);
   }
 
-  // `:placeholder-shown` never matches a div, so the float is re-bound to
-  // `:focus-within` and the JS-managed `.form-date-time-filled`.
   .form-floating > .form-date-time {
     height: var(--#{$prefix}form-floating-height);
     min-height: var(--#{$prefix}form-floating-height);
@@ -133,25 +129,13 @@ $form-date-time-tokens: defaults(
     }
   }
 
-  // The label may sit either side of the control (see forms/_floating-labels.scss)
-  // — the block above catches the label written after it, this one the label
-  // written first, the order the docs use.
   .form-floating > label:has(~ .form-date-time:focus-within),
   .form-floating > label:has(~ .form-date-time.form-date-time-filled) {
     transform: var(--#{$prefix}form-floating-label-transform);
   }
 
-  // Per-field labels: with `startLabel` / `endLabel` set, the range picker
-  // wraps each of its controls in its own `.form-floating` inside the group,
-  // and the direct-child block above runs the states per field. What is left
-  // is geometry: the wrapper takes over the control's flex share, and the
-  // group gives up its block padding so the floating height fits inside the
-  // frame instead of stacking on top of it.
   .form-control-group:has(> .form-floating) {
     padding-block: 0;
-    // The inline start too: the field keeps its own inline padding, so the
-    // group's would stack under it and indent label and value twice. The end
-    // stays — that is the cleaner and toggle buttons' cushion.
     padding-inline-start: 0;
 
     > .form-floating {
@@ -167,13 +151,6 @@ $form-date-time-tokens: defaults(
     }
   }
 
-  // The pickers wrap this control in `.form-control-group` — one of them for
-  // Date/Time/DateTime Picker, two side by side for the range picker — so the
-  // direct-child block above never matches there. The group's shared rules in
-  // forms/_floating-labels.scss give it the height; this block re-binds the
-  // states the same way: focus is `:focus-within` on the group, so opening the
-  // calendar from the action button floats the label too, and filled is "any
-  // control inside carries the JS-managed class".
   .form-floating > .form-control-group:has(> .form-date-time) {
     &:focus-within > .form-date-time,
     &:has(.form-date-time-filled) > .form-date-time {
@@ -181,10 +158,6 @@ $form-date-time-tokens: defaults(
       padding-bottom: var(--#{$prefix}form-floating-input-padding-b);
     }
 
-    // Each control reveals its own mask — a control neither focused nor filled
-    // keeps it hidden even while its sibling floats the label. With one control
-    // that is exactly the old group-at-rest state; with two, the range's empty
-    // end no longer stands bare under no label once the start is set.
     > .form-date-time:not(:focus-within, .form-date-time-filled) {
       .form-date-time-section,
       .form-date-time-separator {
@@ -192,10 +165,6 @@ $form-date-time-tokens: defaults(
       }
     }
 
-    // The arrow shows only when there is something on both of its sides: while
-    // the group has focus, or once the end date is set. Blurred with only the
-    // start filled, the fields flex 50/50 and the arrow would hang mid-field
-    // over nothing — an orphan, not a hint.
     &:not(:focus-within) > .form-control-icon:has(+ .form-date-time:not(.form-date-time-filled)) {
       color: transparent;
     }
@@ -210,9 +179,6 @@ $form-date-time-tokens: defaults(
     }
   }
 
-  // Label-first over a picker group. Focus-forward comes from the shared block;
-  // what is missing there is "a following group holds a filled control" — as a
-  // descendant match, because `:has()` cannot nest inside `:has()`.
   .form-floating > label:has(~ .form-control-group .form-date-time-filled) {
     transform: var(--#{$prefix}form-floating-label-transform);
   }

--- a/scss/forms/_form-multi-select.scss
+++ b/scss/forms/_form-multi-select.scss
@@ -109,12 +109,6 @@ $form-multi-select-tokens: defaults(
     }
   }
 
-  // Multi Select has no input to ask, so the float is re-bound to the JS-managed
-  // `.form-multi-select-filled` on the component itself — the same shape the
-  // date input uses with `.form-date-time-filled`, and the only signal that
-  // covers search mode, where a single selection lives in the search input's
-  // placeholder attribute and the placeholder element never renders. The shared
-  // `.form-control-group` rules in forms/_floating-labels.scss cover the height.
   .form-floating > .form-multi-select {
     &:focus-within,
     &.form-multi-select-filled {
@@ -144,8 +138,6 @@ $form-multi-select-tokens: defaults(
     }
   }
 
-  // Label-first — the filled state is a class on the element itself, so both
-  // directions read it plainly.
   .form-floating > label:has(~ .form-multi-select:focus-within),
   .form-floating > label:has(~ .form-multi-select.form-multi-select-filled) {
     transform: var(--#{$prefix}form-floating-label-transform);

--- a/scss/forms/_number-input.scss
+++ b/scss/forms/_number-input.scss
@@ -1,8 +1,7 @@
 @use "../config" as *;
 
 @layer forms {
-  // Both rules are needed: `appearance` alone leaves Chromium's spinner
-  // painted on hover, the pseudo-element alone leaves Firefox's at rest.
+  // Both rules: `appearance` alone leaves Chromium's spinner on hover, the pseudo-element alone leaves Firefox's at rest.
   .number-input .form-control {
     appearance: textfield;
 

--- a/scss/forms/_password-strength.scss
+++ b/scss/forms/_password-strength.scss
@@ -110,8 +110,7 @@ $password-strength-tokens: defaults(
     color: var(--#{$prefix}password-strength-suggestions-color);
   }
 
-  // The component leaves these in place and empties them, so they must not
-  // hold the feedback row open between verdicts.
+  // The component empties these in place, so they must not hold the feedback row open.
   .password-strength-warning:empty,
   .password-strength-suggestions:empty {
     display: none;

--- a/scss/sidebar/_sidebar-narrow.scss
+++ b/scss/sidebar/_sidebar-narrow.scss
@@ -96,9 +96,6 @@
 @layer utilities {
   .sidebar-narrow {
     @include media-breakpoint-up($mobile-breakpoint) {
-      // The brand pair is the canonical CoreUI sidebar markup — every admin
-      // template ships a full logo and a narrow signet side by side — so these
-      // two aliases stay despite being deprecated. They cost two selectors.
       .d-narrow-none,
       .sidebar-brand-full,
       .d-sidebar-narrow-none {

--- a/scss/sidebar/_sidebar.scss
+++ b/scss/sidebar/_sidebar.scss
@@ -102,9 +102,7 @@ $sidebar-widths: (
     }
 
     @include media-breakpoint-down($mobile-breakpoint) {
-      // Read by the plugin to detect the sidebar's mobile behavior, so the name
-      // cannot follow `$prefix` — the two sides would disagree in a build that
-      // changes it.
+      // Read by the plugin, so the name stays outside `$prefix`.
       --cui-is-mobile: true;
 
       position: fixed;
@@ -293,9 +291,6 @@ $sidebar-widths: (
   }
 
   .sidebar-dark {
-    // Every color the sidebar would otherwise pin is a light-dark() pair on
-    // :root, so declaring the scheme is enough — the tokens and the native
-    // widgets both follow.
     color-scheme: dark;
   }
 }


### PR DESCRIPTION
Nineteen multi-line comments in our own files (`forms/_form-date-time` ×9, `_popup` ×3, `forms/_form-multi-select` ×2, `_time-picker` ×2, `_autocomplete` ×2, `_range-slider`, `sidebar/_sidebar`, `sidebar/_sidebar-narrow`) described what the rule next to them does or why it is arranged that way — that belongs to the commits that introduced them, and each of them has one.

Seven that state a constraint someone would otherwise "fix" are kept, compressed to one line: the two names kept outside `$prefix` because the plugin writes them (`_dropdown`, `sidebar/_sidebar`, `_range-slider`), the range-slider edges left without a fallback on purpose, the number input's two spinner rules, the password-strength placeholders and the loading button's missing gap.

Upstream comments (navbar flex, dropup, range pseudo-elements) and the `scss-docs` / stylelint lines are untouched. Compiled output is byte-identical. From the SCSS quality audit.