### PR TITLE
refactor(reboot): set the caption padding with padding-block

### DIFF
--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -468,8 +468,7 @@ $th-font-weight:       null !default;
   }
 
   caption {
-    padding-top: $caption-padding-y;
-    padding-bottom: $caption-padding-y;
+    padding-block: $caption-padding-y;
     color: $caption-color;
     text-align: start;
   }


### PR DESCRIPTION
`caption` set `padding-top` and `padding-bottom` separately from the same `$caption-padding-y`; one `padding-block` does the same, the way upstream writes it. Compiled output changes from two declarations to one with the same value.