### PR TITLE
fix(Navbar): stack the dropdown under its link in the collapsed navbar

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -248,6 +248,10 @@ $navbar-dark-tokens: defaults(
       }
     }
 
+    .nav-item {
+      flex-direction: column;
+    }
+
     .dropdown-menu {
       position: static;
     }


### PR DESCRIPTION
`.nav-item` is a flex container since #916 (the only way to drop Safari's empty marker line under `list-style-type: ""`), and the collapsed navbar makes `.dropdown-menu` `position: static`, so the menu lined up in a row beside its toggle — Chromium at 500px: link `x=12 w=48`, menu `x=60` on the same `y`. In v5 the `<li>` was still a block, so the menu stacked.

`.navbar-nav .nav-item` now lays out as a column — the same fix the sidebar nav group got in #916. After: menu `x=12 y=48`, full width under the link, as in v5. The expanded navbar is untouched (the menu is absolute there; measured identical at 1200px), and `.menu` is unaffected in both states (always `position: absolute`, placed by Floating UI). Upstream has no such rule because it no longer flows a menu inline in the collapsed navbar.

From the file-by-file SCSS audit (A.1).