### PR TITLE
fix(Navbar): give .navbar-nav every token the flex nav link reads

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -259,8 +259,9 @@ $dropdown-dark-tokens: defaults(
     }
   }
 
-  // In a button the caret is a flex item, so the gap already sets it apart.
-  .btn.dropdown-toggle {
+  // In a button and a nav link the caret is a flex item, so the gap already sets it apart.
+  .btn.dropdown-toggle,
+  .nav-link.dropdown-toggle {
     &::after,
     &::before {
       margin-inline: 0;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -112,15 +112,18 @@ $navbar-nav-tokens: () !default;
 
 // scss-docs-start navbar-nav-css-vars
 $navbar-nav-tokens: defaults(
-  (
-    --#{$prefix}nav-gap: #{$navbar-nav-gap},
-    --#{$prefix}nav-link-padding-x: 0,
-    --#{$prefix}nav-link-padding-y: #{$nav-link-padding-y},
-    --#{$prefix}nav-link-font-size: #{$nav-link-font-size},
-    --#{$prefix}nav-link-font-weight: #{$nav-link-font-weight},
-    --#{$prefix}nav-link-color: var(--#{$prefix}navbar-color),
-    --#{$prefix}nav-link-hover-color: var(--#{$prefix}navbar-hover-color),
-    --#{$prefix}nav-link-disabled-color: var(--#{$prefix}navbar-disabled-color),
+  map.merge(
+    $nav-tokens,
+    (
+      --#{$prefix}nav-gap: #{$navbar-nav-gap},
+      --#{$prefix}nav-link-padding-x: 0,
+      --#{$prefix}nav-link-color: var(--#{$prefix}navbar-color),
+      --#{$prefix}nav-link-hover-color: var(--#{$prefix}navbar-hover-color),
+      --#{$prefix}nav-link-hover-bg: transparent,
+      --#{$prefix}nav-link-active-color: var(--#{$prefix}navbar-active-color),
+      --#{$prefix}nav-link-active-bg: transparent,
+      --#{$prefix}nav-link-disabled-color: var(--#{$prefix}navbar-disabled-color),
+    )
   ),
   $navbar-nav-tokens
 );


### PR DESCRIPTION
`.nav-link` is a flex container since v6 (`gap`, `align-items`, `justify-content` from `--cui-nav-link-*`), but the `.navbar-nav` token map declared seven of the seventeen tokens it reads — and navbar markup has never required `.nav` on the list (13 of 16 docs examples omit it). Without `.nav` those reads were invalid: links had no gap and `align-items: normal`, which parked the dropdown caret at the top edge of the link (Chromium: `align-items=normal gap=normal`; after: `center` / `8px`).

- `$navbar-nav-tokens` is now built on `$nav-tokens` (`map.merge`) and overrides only what the navbar changes: `nav-gap`, `nav-link-padding-x`, the three navbar colours, and transparent hover/active surfaces (upstream declares those two explicitly too; today they were invalid → transparent by accident). Any future `.nav-link` token reaches the navbar automatically.
- `.nav-link.dropdown-toggle::after` drops its inline-start margin, as `.btn.dropdown-toggle` already does — in a flex link the gap sets the caret apart.

Compiled diff: ten added declarations on `.navbar-nav` and the extended caret selector. Docs (`navbar-nav-css-vars`) pick the fuller map up automatically. From the navbar review after #1094.