### PR TITLE
fix(Navbar): start-align the nav link text in the collapsed navbar

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -117,6 +117,7 @@ $navbar-nav-tokens: defaults(
     (
       --#{$prefix}nav-gap: #{$navbar-nav-gap},
       --#{$prefix}nav-link-padding-x: 0,
+      --#{$prefix}nav-link-justify: flex-start,
       --#{$prefix}nav-link-color: var(--#{$prefix}navbar-color),
       --#{$prefix}nav-link-hover-color: var(--#{$prefix}navbar-hover-color),
       --#{$prefix}nav-link-hover-bg: transparent,


### PR DESCRIPTION
#1095 handed `.navbar-nav` the full `.nav` token set, including `--cui-nav-link-justify: center`, and since #1094 the collapsed navbar stretches each link across the column — so the label moved to the middle (mrholek's screenshot). Upstream shares the `center` default but never shows it, because its `.nav-item` stays a row and the link is content-wide.

The navbar map now sets `--cui-nav-link-justify: flex-start`: full-width links with the text at the start, the v5 look. Chromium at 500px: text `x` back at the link's start edge; at 1200px identical before/after. `.nav.flex-column` is unaffected (its links are content-wide, measured).