### PR TITLE
fix(Header): read the foreground ladder for the brand

### DIFF
--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -30,9 +30,8 @@ $header-transition:             box-shadow .15s ease-in-out !default;
 $header-brand-height:           calc(#{$header-brand-font-size} * var(--#{$prefix}body-line-height)) !default;
 $header-brand-padding-y:        calc((#{$nav-link-height} - #{$header-brand-height}) * .5) !default;
 $header-brand-margin-end:       1rem !default;
-$header-brand-font-size:        var(--#{$prefix}font-size-lg) !default;
-$header-brand-color:            var(--#{$prefix}gray-900) !default;
-$header-brand-hover-color:      color-mix(in $color-mix-space, var(--#{$prefix}black) 10%, var(--#{$prefix}gray-900)) !default;
+$header-brand-color:            var(--#{$prefix}fg-body) !default;
+$header-brand-hover-color:      var(--#{$prefix}fg-1) !default;
 
 $header-toggler-padding-y:      .25rem !default;
 $header-toggler-padding-x:      .75rem !default;


### PR DESCRIPTION
`.header-brand` read `--cui-gray-900` and mixed 10% black into it on hover. The gray palette is a single static declaration on `:root` (no `light-dark()`), so in the dark scheme the brand sat near-invisible on the header — measured contrast ~1.3:1 before. It reads `--cui-fg-body` / `--cui-fg-1` now, the pair every other text in the header follows; light mode keeps the same value (`fg-body` is `gray-900` there). The duplicated `$header-brand-font-size` line (defined twice, the second dead under `!default`) is removed.

Contrast measured in Chromium on a scratch page before/after, both colour schemes, in the PR checks below. From the file-by-file SCSS audit (A.2).