### PR TITLE
fix(ListGroup): fill the active item with the theme's bg slot

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1836,6 +1836,13 @@ Multi Select's option indicators moved with it — they render as a decorative
   [`.contains-inline`](/utilities/container-queries/) on an ancestor, or the
   list stays vertical. Plain `.list-group-horizontal` is unconditional and
   needs no container.
+- **An active item under a `.theme-*` class is filled, like a page link.**
+  `.list-group-item.active` reads `--cui-theme-contrast` for its text and
+  `--cui-theme-bg` for its background and border — the same slots the
+  pagination, the badge and the button use — so the active item of a
+  `.theme-danger` list is the same red as the active page of a
+  `.theme-danger` pagination. A pressed action (`:active`) reads
+  `--cui-theme-bg-muted`, like hover. Without a theme class nothing changes.
 
 #### Tab
 

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -117,9 +117,9 @@ $list-group-tokens: defaults(
     // Include both here for `<a>`s and `<button>`s
     &.active {
       z-index: 2; // Place active items above their siblings for proper border styling
-      color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}list-group-active-color));
-      background-color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}list-group-active-bg));
-      border-color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}list-group-active-border-color));
+      color: var(--#{$prefix}theme-contrast, var(--#{$prefix}list-group-active-color));
+      background-color: var(--#{$prefix}theme-bg, var(--#{$prefix}list-group-active-bg));
+      border-color: var(--#{$prefix}theme-bg, var(--#{$prefix}list-group-active-border-color));
     }
 
     // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
@@ -155,7 +155,7 @@ $list-group-tokens: defaults(
 
       &:active {
         color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}list-group-action-active-color));
-        background-color: var(--#{$prefix}theme-border, var(--#{$prefix}list-group-action-active-bg));
+        background-color: var(--#{$prefix}theme-bg-muted, var(--#{$prefix}list-group-action-active-bg));
       }
     }
   }


### PR DESCRIPTION
`.list-group-item.active` read `--cui-theme-bg-subtle` for its text and `--cui-theme-fg-emphasis` for its background and border (since #852), so a `.theme-danger` active item came out as a dark red with pink text — a different red than the active page link, the badge or the button in the same theme. Measured: `bg=oklch(0.327 …)` vs pagination `oklch(0.639 …)`.

It reads `--cui-theme-contrast` / `--cui-theme-bg` now, the pair `_pagination.scss` already uses; after the change list-group, pagination and badge under `.theme-danger` share the same `bg` and `fg`. A pressed action (`:active`) reads `--cui-theme-bg-muted` like hover (was `--cui-theme-border`), as upstream does. Fallbacks are unchanged, so nothing moves without a theme class (the plain `.active` measured identical). Migration entry under List group.

Upstream's `.active` reads no slot at all and stays primary under any theme; we keep theming the active item because the list-group page promises the class works on the item. From the file-by-file SCSS audit (A.3).