### PR TITLE
fix(Progress): paint .progress-white white again

### DIFF
--- a/docs/src/content/docs/components/progress.mdx
+++ b/docs/src/content/docs/components/progress.mdx
@@ -127,7 +127,7 @@ Include multiple progress bars in a progress component if you need.
 
 ## On a colored surface
 
-Add `.progress-white` to draw the bar in the current text color and the track as a faint tint of it. That way a progress bar sitting on a solid or brand-colored surface takes its colors from the text around it rather than needing a color of its own.
+Add `.progress-white` to draw the bar in white and the track as translucent white. That way a progress bar sitting on a dark or brand-colored surface stays readable without a color of its own; the bar stays white even under a `.theme-*` class.
 
 <Example class="p-3 text-bg-primary" code={`<div class="progress progress-white">
     <div class="progress-bar" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1972,13 +1972,12 @@ Multi Select's option indicators moved with it — they render as a decorative
   `--cui-progress-height` if you want the stripe geometry to follow the height
   too.
 
-- **`.progress-white` sets tokens, and paints with `currentcolor` instead of
-  literal white.** It was painting `background-color` past
-  `--cui-progress-bg`, so nothing could adjust it and a theme class on the same
-  bar overrode the white. On the coloured cards it is made for, the surrounding
-  text colour is the readable one, so the bar renders exactly as before — and on
-  a surface whose text is dark, the bar now follows instead of disappearing into
-  the background.
+- **`.progress-white` sets tokens.** It was painting `background-color` past
+  `--cui-progress-bg`, so nothing could adjust it. It now sets
+  `--cui-progress-bg` (translucent white) and `--cui-progress-bar-bg`
+  (`--cui-white`) and lets the base rules paint; the bar stays white under a
+  `.theme-*` class, as the variant is meant for dark and brand-coloured
+  surfaces.
 
 #### Spinner
 

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -104,8 +104,8 @@ $progress-tokens: defaults(
   }
 
   .progress-white {
-    --#{$prefix}progress-bg: #{color-mix(in oklch, currentcolor $progress-contrast-track-opacity, transparent)};
-    --#{$prefix}progress-bar-bg: currentcolor;
+    --#{$prefix}progress-bg: #{color-mix(in oklch, var(--#{$prefix}white) $progress-contrast-track-opacity, transparent)};
+    --#{$prefix}progress-bar-bg: var(--#{$prefix}white);
 
     .progress-bar {
       background-color: var(--#{$prefix}progress-bar-bg);


### PR DESCRIPTION
`.progress-white` exists for dark and brand-coloured surfaces: a white bar on a translucent white track, as in v5 (`rgba(255, 255, 255, .2)` + `$white`). v6 had swapped both for `currentcolor`, so the bar took the surrounding text colour and stopped being white wherever that text was not.

`--cui-progress-bg` is `color-mix(in oklch, var(--cui-white) 20%, transparent)` and `--cui-progress-bar-bg` is `var(--cui-white)` now. The nested `.progress-bar` rule stays on purpose: it keeps the bar white under a `.theme-*` class, which is the point of the variant (mrholek). The docs sentence and the migration entry describe that instead of the `currentcolor` behaviour.

Compiled diff: the two token values. From the file-by-file SCSS audit (A.4), resolved the other way after review.