### PR TITLE
fix(Stepper): resolve the active indicator's theme slot on the step

### DIFF
--- a/scss/_stepper.scss
+++ b/scss/_stepper.scss
@@ -24,7 +24,7 @@ $stepper-step-indicator-border-width:           var(--#{$prefix}border-width) !d
 $stepper-step-indicator-border-color:           var(--#{$prefix}border-color) !default;
 $stepper-step-indicator-transition:             color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 $stepper-step-indicator-active-color:           var(--#{$prefix}primary) !default;
-$stepper-step-indicator-active-bg:              color-mix(in srgb, var(--#{$prefix}theme-bg, var(--#{$prefix}primary)) 5%, transparent) !default;
+$stepper-step-indicator-active-bg:              color-mix(in srgb, var(--#{$prefix}primary) 5%, transparent) !default;
 $stepper-step-indicator-active-border-color:    var(--#{$prefix}primary) !default;
 $stepper-step-indicator-complete-color:         var(--#{$prefix}primary-contrast) !default;
 $stepper-step-indicator-complete-bg:            var(--#{$prefix}primary) !default;
@@ -33,7 +33,7 @@ $stepper-step-indicator-disabled-color:         var(--#{$prefix}fg-3) !default;
 $stepper-step-indicator-disabled-bg:            transparent !default;
 $stepper-step-indicator-disabled-border-color:  var(--#{$prefix}border-color) !default;
 $stepper-step-indicator-icon:                   url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpolygon fill='var(--ci-primary-color, currentColor)' points='200.359 382.269 61.057 251.673 82.943 228.327 199.641 337.731 428.686 108.687 451.314 131.313 200.359 382.269' class='ci-primary'/%3E%3C/svg%3E") !default;
-$stepper-step-indicator-icon-color:             var(--#{$prefix}white) !default;
+$stepper-step-indicator-icon-color:             var(--#{$prefix}primary-contrast) !default;
 $stepper-step-indicator-icon-size:              1rem !default;
 
 $stepper-step-connector-height:                 .125rem !default;
@@ -150,7 +150,7 @@ $stepper-tokens: defaults(
     &.active {
       --#{$prefix}stepper-step-button-color: var(--#{$prefix}stepper-step-button-active-color);
       --#{$prefix}stepper-step-indicator-color: var(--#{$prefix}theme-fg, var(--#{$prefix}stepper-step-indicator-active-color));
-      --#{$prefix}stepper-step-indicator-bg: var(--#{$prefix}stepper-step-indicator-active-bg);
+      --#{$prefix}stepper-step-indicator-bg: color-mix(in srgb, var(--#{$prefix}theme-bg, var(--#{$prefix}stepper-step-indicator-active-color)) 5%, transparent);
       --#{$prefix}stepper-step-indicator-border-color: var(--#{$prefix}theme-bg, var(--#{$prefix}stepper-step-indicator-active-border-color));
     }
 


### PR DESCRIPTION
The active indicator's background was `color-mix(in srgb, var(--cui-theme-bg, var(--cui-primary)) 5%, transparent)` inside `$stepper-step-indicator-active-bg`, which lands in the token map declared on `.stepper` — so the slot resolved there, and a `.theme-*` class on `.stepper-step-button` never reached it. Measured: `.active.theme-danger` had red text and border with a blue tint behind them.

- The `.active` rule mixes the slot on the step itself now: `color-mix(in srgb, var(--cui-theme-bg, var(--cui-stepper-step-indicator-active-color)) 5%, transparent)`; the Sass variable keeps a plain 5% primary default. Plain `.active` measures identical; `.active.theme-danger` gets the red tint.
- `$stepper-step-indicator-icon-color` reads `--cui-primary-contrast` (as the complete state's text already does) instead of `--cui-white`, so the check stays readable on a light brand colour. Resolves to white with the default palette.

From the file-by-file SCSS audit (A.5).