### PR TITLE
fix(Dropdown, Chip): follow the colour scheme in the dark theme

### DIFF
--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -34,7 +34,7 @@ $chip-active-bg:             var(--#{$prefix}primary) !default;
 $chip-active-border-color:   transparent !default;
 
 $chip-hover-color:           $chip-color !default;
-$chip-hover-bg:              color-mix(in srgb, var(--#{$prefix}bg-4) 95%, #000) !default;
+$chip-hover-bg:              color-mix(in oklch, var(--#{$prefix}bg-4) 95%, var(--#{$prefix}fg-body)) !default;
 $chip-hover-border-color:    transparent !default;
 
 $chip-font-size-sm:          .75rem !default;

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -37,7 +37,7 @@ $dropdown-item-padding-y:           var(--#{$prefix}spacer-1) !default;
 $dropdown-item-padding-x:           var(--#{$prefix}spacer-3) !default;
 $dropdown-item-border-radius:       0 !default;
 
-$dropdown-header-color:             var(--#{$prefix}gray-600) !default;
+$dropdown-header-color:             var(--#{$prefix}fg-3) !default;
 $dropdown-header-padding-x:         $dropdown-item-padding-x !default;
 $dropdown-header-padding-y:         $dropdown-padding-y !default;
 // scss-docs-end dropdown-variables


### PR DESCRIPTION
Two values that ignored the colour scheme:

- **Dropdown header** read `--cui-gray-600`, a single static palette stop (no `light-dark()`), so in the dark scheme it sat dark on dark. It reads `--cui-fg-3` now — the pair `_menu.scss` already uses for its header, and the same colour in light. Measured contrast on the menu surface: light 5.28:1 → 5.28:1, dark 3.58:1 → 6.52:1.
- **Chip hover** mixed 5% black into `--cui-bg-4`, the only black mix in `scss/`; black darkens in both schemes, so in dark the hover moved towards the page instead of away from it. It mixes `--cui-fg-body` now, which darkens in light and lightens in dark (numbers in the first comment). The `--cui-theme-bg-muted` slot in front of it is unchanged.

From the file-by-file SCSS audit (A.6, A.7).