### PR TITLE
fix(Calendar, TimePicker): contrast text on the selection, live range border token

### DIFF
--- a/scss/_calendar.scss
+++ b/scss/_calendar.scss
@@ -47,7 +47,7 @@ $calendar-cell-hover-bg:                     var(--#{$prefix}bg-3) !default;
 $calendar-cell-disabled-color:               var(--#{$prefix}fg-3) !default;
 
 
-$calendar-cell-selected-color:               var(--#{$prefix}white) !default;
+$calendar-cell-selected-color:               var(--#{$prefix}primary-contrast) !default;
 $calendar-cell-selected-bg:                  var(--#{$prefix}primary) !default;
 
 $calendar-cell-range-bg:                     color-mix(in srgb, var(--#{$prefix}primary) 12.5%, transparent) !default;
@@ -271,8 +271,8 @@ $calendar-tokens: defaults(
         width: 100%;
         height: 100%;
         content: "";
-        border-block-start: 1px dashed var(--#{$prefix}calendar-cell-selected-bg);
-        border-block-end: 1px dashed var(--#{$prefix}calendar-cell-selected-bg);
+        border-block-start: var(--#{$prefix}border-width) dashed var(--#{$prefix}calendar-cell-range-hover-border-color);
+        border-block-end: var(--#{$prefix}border-width) dashed var(--#{$prefix}calendar-cell-range-hover-border-color);
         @include border-radius(0);
       }
     }
@@ -311,13 +311,13 @@ $calendar-tokens: defaults(
     &.range-hover:first-of-type,
     &:not(.range-hover) + &.range-hover {
       .calendar-cell-inner::before {
-        border-inline-start: 1px dashed var(--#{$prefix}calendar-cell-selected-bg);
+        border-inline-start: var(--#{$prefix}border-width) dashed var(--#{$prefix}calendar-cell-range-hover-border-color);
         @include border-start-radius($border-radius);
       }
     }
 
     &.range-hover:not(:has(~ .range-hover)) .calendar-cell-inner::before {
-      border-inline-end: 1px dashed var(--#{$prefix}calendar-cell-selected-bg);
+      border-inline-end: var(--#{$prefix}border-width) dashed var(--#{$prefix}calendar-cell-range-hover-border-color);
       @include border-end-radius($border-radius);
     }
 
@@ -331,7 +331,7 @@ $calendar-tokens: defaults(
       }
 
       &:nth-last-child(1 of .range-hover) .calendar-cell-inner::before {
-        border-inline-end: 1px dashed var(--#{$prefix}calendar-cell-selected-bg);
+        border-inline-end: var(--#{$prefix}border-width) dashed var(--#{$prefix}calendar-cell-range-hover-border-color);
         @include border-end-radius($border-radius);
       }
     }
@@ -383,11 +383,11 @@ $calendar-tokens: defaults(
     }
 
     &.range-hover .calendar-cell:first-of-type .calendar-cell-inner::before {
-      border-inline-start: 1px dashed var(--#{$prefix}calendar-cell-selected-bg);
+      border-inline-start: var(--#{$prefix}border-width) dashed var(--#{$prefix}calendar-cell-range-hover-border-color);
     }
 
     &.range-hover .calendar-cell:last-of-type .calendar-cell-inner::before {
-      border-inline-end: 1px dashed var(--#{$prefix}calendar-cell-selected-bg);
+      border-inline-end: var(--#{$prefix}border-width) dashed var(--#{$prefix}calendar-cell-range-hover-border-color);
     }
 
     &:focus-visible {

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -18,9 +18,9 @@ $time-picker-roll-cell-width:                 3rem !default;
 $time-picker-roll-cell-height:                2rem !default;
 $time-picker-roll-cell-hover-color:           var(--#{$prefix}fg-body) !default;
 $time-picker-roll-cell-hover-bg:              var(--#{$prefix}bg-3) !default;
-$time-picker-roll-cell-selected-color:        var(--#{$prefix}white) !default;
+$time-picker-roll-cell-selected-color:        var(--#{$prefix}primary-contrast) !default;
 $time-picker-roll-cell-selected-bg:           var(--#{$prefix}primary) !default;
-$time-picker-roll-cell-selected-hover-color:  var(--#{$prefix}white) !default;
+$time-picker-roll-cell-selected-hover-color:  var(--#{$prefix}primary-contrast) !default;
 $time-picker-roll-cell-selected-hover-bg:     oklch(from var(--#{$prefix}primary) calc(l * .85) c h) !default;
 
 $time-picker-inline-select-font-size:       var(--#{$prefix}btn-input-sm-font-size) !default;


### PR DESCRIPTION
- The selected calendar cell (`$calendar-cell-selected-color`) and the selected time-picker roll cell (`-selected-color`, `-selected-hover-color`) wrote their text in `--cui-white` on a `--cui-primary` fill, so a light brand colour lost the label. They read `--cui-primary-contrast` now, as pagination, list-group, menu and stepper do. Measured: default palette identical (white on primary); with `--cui-primary: #ffe066` the text goes from white to black.
- The calendar declared `--cui-calendar-cell-range-hover-border-color` (in the docs and devtools) but its seven dashed range-hover borders read `1px dashed var(--cui-calendar-cell-selected-bg)`, so the token did nothing. They read `var(--cui-border-width) dashed var(--cui-calendar-cell-range-hover-border-color)` now; the token's default is `--cui-primary`, the same colour, so the rendering is unchanged (measured).

From the file-by-file SCSS audit (A.9, A.10).