### PR TITLE
fix(forms): validate the multi-select frame live, size the enclosed nav border from its token

### DIFF
--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -420,7 +420,7 @@ $tab-pane-tokens: defaults(
     .show > .nav-link {
       color: var(--#{$prefix}nav-enclosed-link-active-color);
       background-color: var(--#{$prefix}nav-enclosed-link-active-bg);
-      border: 1px solid var(--#{$prefix}nav-enclosed-link-active-border-color);
+      border: var(--#{$prefix}nav-enclosed-link-border-width) solid var(--#{$prefix}nav-enclosed-link-active-border-color);
 
       &:not(:focus-visible) {
         box-shadow: var(--#{$prefix}nav-enclosed-link-hover-box-shadow);

--- a/scss/forms/_validation.scss
+++ b/scss/forms/_validation.scss
@@ -105,20 +105,18 @@ $validated-controls: if(sass($enable-deprecated-form-check): ".check, .radio, .s
   // The state has to reach the group: a custom property set on the control
   // inside it only inherits downwards, never back up to the frame.
   .form-control-group.is-#{$state},
-  .form-control-group:has(> .form-control.is-#{$state}),
-  .autocomplete.is-#{$state} .form-control-group,
-  .form-multi-select.is-#{$state} .form-control-group {
+  .form-control-group:has(> .form-control.is-#{$state}) {
     @include form-control-group-validation-state($color, $border-color, $focus-ring-color);
   }
 
   @if $state == "invalid" {
     [data-coreui-validate] .form-control-group:has(> .form-control:user-invalid),
-    [data-coreui-validate] .form-multi-select:has(> select:user-invalid) .form-control-group {
+    [data-coreui-validate] .form-control-group:has(> select:user-invalid) {
       @include form-control-group-validation-state($color, $border-color, $focus-ring-color);
     }
   } @else if $state == "valid" {
     [data-coreui-validate~="valid"] .form-control-group:has(> .form-control:user-valid),
-    [data-coreui-validate~="valid"] .form-multi-select:has(> select:user-valid) .form-control-group {
+    [data-coreui-validate~="valid"] .form-control-group:has(> select:user-valid) {
       @include form-control-group-validation-state($color, $border-color, $focus-ring-color);
     }
   }


### PR DESCRIPTION
- **Multi-select live validation.** The rule looked for a `.form-control-group` *inside* `.form-multi-select`, but the wrapper `multi-select.ts` builds carries both classes itself and the native `<select>` is its first child (`wrapper.prepend(this._element)`), so `:user-invalid` never reached the frame. `.form-control-group:has(> select:user-invalid)` (and the `valid` twin) match now. Measured after a submit attempt on a required empty multi-select: the frame's `--cui-control-border-color` stays default before, turns to the danger foreground after.
- The two class-state selectors `.autocomplete.is-* .form-control-group` / `.form-multi-select.is-* .form-control-group` assumed the same nesting (`autocomplete.ts:527` puts both classes on one element too) and were dead; `.form-control-group.is-*` already covers both, measured unchanged.
- **`.nav-enclosed`** drew the active link's border `1px` wide while declaring `--cui-nav-enclosed-link-border-width`; it reads the token now (same default).

From the file-by-file SCSS audit (A.11, A.12).