### PR TITLE
fix(Badge): carry the theme slot in the background token

### DIFF
--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -1,6 +1,6 @@
 @use "sass:map";
 @use "functions/defaults" as *;
-@use "mixins/gradients" as *;
+@use "mixins/border-radius" as *;
 @use "mixins/tokens" as *;
 @use "config" as *;
 
@@ -56,7 +56,7 @@ $badge-tokens: defaults(
     --#{$prefix}badge-font-size: clamp(#{$badge-font-size-floor}, #{$badge-font-size}, #{$badge-font-size}),
     --#{$prefix}badge-font-weight: #{$badge-font-weight},
     --#{$prefix}badge-color: var(--#{$prefix}theme-contrast, #{$badge-color}),
-    --#{$prefix}badge-bg: #{$badge-bg},
+    --#{$prefix}badge-bg: var(--#{$prefix}theme-bg, #{$badge-bg}),
     --#{$prefix}badge-border-width: #{$badge-border-width},
     --#{$prefix}badge-border-color: #{$badge-border-color},
     --#{$prefix}badge-border-radius: #{$badge-border-radius},
@@ -105,9 +105,9 @@ $badge-variants: defaults(
     text-decoration: none;
     white-space: nowrap;
     vertical-align: baseline;
+    background-color: var(--#{$prefix}badge-bg);
     border: var(--#{$prefix}badge-border-width) solid var(--#{$prefix}badge-border-color);
-    border-radius: var(--#{$prefix}badge-border-radius, 0); // stylelint-disable-line property-disallowed-list
-    @include gradient-bg(var(--#{$prefix}theme-bg, var(--#{$prefix}badge-bg)));
+    @include border-radius(var(--#{$prefix}badge-border-radius));
 
     // Empty badges collapse automatically
     &:empty {
@@ -133,8 +133,8 @@ $badge-variants: defaults(
       }
 
       color: var(--#{$prefix}badge-color);
+      background-color: var(--#{$prefix}badge-bg);
       border-color: var(--#{$prefix}badge-border-color);
-      @include gradient-bg(var(--#{$prefix}badge-bg));
     }
   }
   // scss-docs-end badge-modifiers


### PR DESCRIPTION
- `--cui-badge-bg` is declared and read on the same element, so per the rule from #910 the theme slot belongs inside the token — as it already is for `--cui-badge-color` one line above. With the slot in the rule (`var(--cui-theme-bg, var(--cui-badge-bg))`), a `--cui-badge-bg` override on a themed badge did nothing. Measured: `.badge.theme-danger` with `--cui-badge-bg: #0a0` was red, is green now; plain, themed, overridden-without-theme and `.badge-subtle.theme-danger` badges measure identical before/after. Deliberate divergence from upstream, which keeps the slot in the rule (and so has the dead override).
- The rule paints with plain `background-color` instead of `gradient-bg()` and rounds through the `border-radius` mixin instead of a raw `border-radius: var(…, 0)` with a stylelint disable — how upstream writes both; no change in the compiled output with `$enable-gradients: false` / `$enable-rounded: true`.

From the file-by-file SCSS audit (B.2).