### PR TITLE
fix(utilities): register --cui-rounded-size and --cui-ratio as non-inheriting

### DIFF
--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -32,20 +32,31 @@
   @return $list;
 }
 
+@function collect-property-vars($list, $properties) {
+  @if meta.type-of($properties) == "map" {
+    @each $prop, $value in $properties {
+      @if meta.type-of($prop) == "string" and string.slice($prop, 1, 2) == "--" {
+        $list: append-unique($list, $prop);
+      }
+    }
+  } @else if meta.type-of($properties) == "list" {
+    @each $prop in $properties {
+      @if meta.type-of($prop) == "string" and string.slice($prop, 1, 2) == "--" {
+        $list: append-unique($list, $prop);
+      }
+    }
+  } @else if meta.type-of($properties) == "string" and string.slice($properties, 1, 2) == "--" {
+    $list: append-unique($list, $properties);
+  }
+  @return $list;
+}
+
 @mixin generate-utility-at-properties($utilities) {
   $names: ();
 
   @each $key, $utility in $utilities {
     @if meta.type-of($utility) == "map" and map.get($utility, enabled) != false and map.get($utility, at-property) != false {
-      $properties: map.get($utility, property);
-
-      @if meta.type-of($properties) == "map" {
-        @each $property, $declared in $properties {
-          @if string.slice($property, 1, 2) == "--" {
-            $names: append-unique($names, $property);
-          }
-        }
-      }
+      $names: collect-property-vars($names, map.get($utility, property));
     }
   }
 


### PR DESCRIPTION
`generate-utility-at-properties()` only collected custom-property names when a utility's `property` was a map; `rounded-size` and `aspect-ratio` declare theirs as a plain string (`property: --cui-rounded-size`), so those two never got an `@property … inherits: false` block and leaked into descendants — exactly the class of bug the mixin exists for. Measured: a nested `.rounded` inside `.rounded-size-4` rendered with `16px` corners (the container's value), it renders with its own `6px` now.

`collect-property-vars()` (the helper upstream added for the same reason) reads the map, list and string forms; the compiled stylesheet gains the two `@property` blocks and changes nothing else. From the file-by-file SCSS audit (A.13).