### PR TITLE
fix(Dropdown): give the list item a display so Safari drops the marker line

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -161,6 +161,10 @@ $dropdown-dark-tokens: defaults(
     @include border-radius(var(--#{$prefix}dropdown-border-radius));
     @include box-shadow(var(--#{$prefix}dropdown-box-shadow));
 
+    > li {
+      display: block;
+    }
+
     &[data#{$data-infix}popper] {
       inset-inline-start: 0;
       top: 100%;


### PR DESCRIPTION
Under `list-style-type: ""` Safari still reserves a line for the marker of a `display: list-item` element whose child is a flex box holding an `<svg>` (the #916 condition). The default `.dropdown-item` is a block, so the plain menu was fine, but a `.dropdown-item.d-flex` with an icon — the admin-template shape — grew by a blank line. Measured in Safari (`li.offsetHeight − link.offsetHeight`): plain item 0, flex item with icon **24px**, `.menu` item 0 (fixed in #916). After: 0 / 0 / 0.

`.dropdown-menu > li` is `display: block` now — block rather than flex, because the item itself is a block and no list item holds a nested list here. Chromium and Firefox render identically. From the file-by-file SCSS audit (A.14).