### PR TITLE
fix(theme): point the theme bg slot at the colour's -bg token

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -2214,6 +2214,13 @@ single place to retune what "filled with the theme colour" means without
 touching the base colour that text and borders derive from. (The `secondary`
 colour's slot takes over the name of the former surface alias — see the
 ladder entry above.)
+- **A `.theme-*` class reads the colour's `-bg` slot, not its base.**
+  `--cui-theme-bg` is `var(--cui-danger-bg)` now (was `var(--cui-danger)`),
+  so overriding `--cui-danger-bg` retunes every checked, active and filled
+  state under the class, as the colour slots page describes. The trade-off:
+  `--cui-danger-bg` resolves on `:root`, so a `--cui-danger` override on a
+  single element no longer reaches the theme class on it — override the
+  colour on `:root`, or set `--cui-danger-bg` on the element.
 
 #### Colour decisions are written, not computed
 

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -133,7 +133,7 @@ $theme-colors-focus-ring: map-slot($theme-colors, "focus-ring") !default;
 
 // scss-docs-start theme-token-refs
 $theme-token-refs: (
-  "bg": "",
+  "bg": "-bg",
   "contrast": "-contrast",
   "fg": "-fg",
   "fg-emphasis": "-fg-emphasis",


### PR DESCRIPTION
`$theme-token-refs` had `"bg": ""`, so every `.theme-*` class set `--cui-theme-bg` to the colour's base (`var(--cui-danger)`), skipping the `--cui-danger-bg` slot that `:root` emits and that `customize/theme` and the comment in `_theme.scss` describe as the action background. Overriding `--cui-danger-bg` reached nothing under the class; `--cui-{secondary,info,warning,inverse}-bg` had zero readers.

`"bg": "-bg"` now — the shape upstream ships (`--bs-theme-bg: var(--bs-danger-bg)`). Compiled diff: the 49 `--cui-theme-bg` declarations gain one indirection; defaults are unchanged because `-bg` aliases the base.

Measured (badge / check under a theme class): default identical; `--cui-danger-bg` override on the element goes from dead to working. Trade-off, chosen deliberately (mrholek): `--cui-danger-bg` resolves on `:root`, so a `--cui-danger` override on a single element no longer reaches the theme class on it (root-level overrides still do). Migration entry added. From the file-by-file SCSS audit (C.1).