### PR TITLE
refactor(Button): paint the background without the gradient mixin

### DIFF
--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -6,7 +6,6 @@
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
 @use "../mixins/focus-ring" as *;
-@use "../mixins/gradients" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
 @use "../theme" as *;
@@ -272,9 +271,9 @@ $btn-check-deprecated: ".btn-check:not(#{$btn-variant-selectors})" !default;
     // stylelint-disable-next-line scss/at-function-named-arguments
     cursor: if(sass($enable-button-pointers): pointer);
     user-select: none;
+    background-color: var(--#{$prefix}btn-bg);
     border: var(--#{$prefix}btn-border-width) solid var(--#{$prefix}btn-border-color);
     @include border-radius(var(--#{$prefix}btn-border-radius));
-    @include gradient-bg(var(--#{$prefix}btn-bg));
     @include transition-props(
       var(--#{$prefix}btn-transition-property),
       var(--#{$prefix}btn-transition-duration),
@@ -297,7 +296,7 @@ $btn-check-deprecated: ".btn-check:not(#{$btn-variant-selectors})" !default;
 
     &:focus-visible {
       color: var(--#{$prefix}btn-hover-color);
-      @include gradient-bg(var(--#{$prefix}btn-hover-bg));
+      background-color: var(--#{$prefix}btn-hover-bg);
       border-color: var(--#{$prefix}btn-hover-border-color);
       @include focus-ring(true);
     }


### PR DESCRIPTION
The base and hover backgrounds of `.btn` went through `gradient-bg()`, which with `$enable-gradients: false` only ever emitted `background-color`, and which upstream no longer uses in its button (plain `background-color`, with the `background-image: none` resets kept under `$enable-gradients` and the gradient itself living in `.btn-styled`, which we do not port). Plain `background-color` now; the compiled declarations are identical, the base one moves before `border` per the property-order rule. The unused `mixins/gradients` import goes with it.

Follow-up to #1110 (mrholek).