### PR TITLE
refactor(scss): read the link decoration tokens, complete the mixins index

### DIFF
--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -359,12 +359,12 @@ $th-font-weight:       null !default;
 
   a {
     color: color-mix(in srgb, var(--#{$prefix}theme-fg, var(--#{$prefix}link-color)) calc(var(--#{$prefix}link-opacity, 1) * 100%), transparent);
-    text-decoration: $link-decoration;
+    text-decoration: var(--#{$prefix}link-decoration);
     text-underline-offset: var(--#{$prefix}link-underline-offset);
 
     &:hover {
       color: color-mix(in srgb, var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}link-hover-color)) calc(var(--#{$prefix}link-opacity, 1) * 100%), transparent);
-      text-decoration: $link-hover-decoration;
+      text-decoration: var(--#{$prefix}link-hover-decoration, var(--#{$prefix}link-decoration));
     }
   }
 

--- a/scss/mixins/index.scss
+++ b/scss/mixins/index.scss
@@ -1,11 +1,6 @@
-// Toggles
-//
-// Used in conjunction with global variables to enable certain theme features.
-
 // LTR & RTL
 @forward "ltr-rtl";
 
-// Vendor
 // Deprecate
 @forward "deprecate";
 
@@ -13,6 +8,7 @@
 @forward "../layout/breakpoints";
 @forward "color-mode";
 @forward "color-scheme";
+@forward "focus-ring";
 @forward "image";
 @forward "resize";
 @forward "visually-hidden";
@@ -26,6 +22,7 @@
 // Components
 @forward "backdrop";
 @forward "caret";
+@forward "chip";
 @forward "form-validation";
 @forward "icon";
 @forward "lists";


### PR DESCRIPTION
- **Links.** `:root` emitted `--cui-link-decoration` but `a` in Reboot wrote `text-decoration: $link-decoration` from Sass, so the token had zero readers and a runtime override changed nothing; `a:hover` wrote `$link-hover-decoration` (`null`) and emitted no declaration. Both read the tokens now — `var(--cui-link-decoration)` and `var(--cui-link-hover-decoration, var(--cui-link-decoration))` — the shape upstream ships. Measured: defaults identical (`underline` / `underline`); with `--cui-link-decoration: none; --cui-link-hover-decoration: underline` on `:root` the link goes from `underline`/`underline` (override ignored) to `none`/`underline`.
- **`mixins/index.scss`** forwards `focus-ring` and `chip` (`chip-size()`) like the other 24 partials, so `@use "…/scss/coreui" as *` exposes `focus-ring()` (verified on a scratch entry). Two empty section headings ("Toggles", "Vendor") removed.

From the file-by-file SCSS audit (C.3, C.4).