### PR TITLE
fix(Menu, RangeSlider): declare the scroll tokens, prefix the track direction

### DIFF
--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -14,6 +14,8 @@
 $menu-zindex:                   var(--#{$prefix}z-dropdown) !default;
 $menu-gap:                      .125rem !default;
 $menu-min-width:                10rem !default;
+$menu-max-height:               none !default;
+$menu-overflow-y:               visible !default;
 $menu-padding-x:                .25rem !default;
 $menu-padding-y:                .25rem !default;
 $menu-spacer:                   .125rem !default;
@@ -59,6 +61,8 @@ $menu-tokens: defaults(
     --#{$prefix}menu-zindex: #{$menu-zindex},
     --#{$prefix}menu-gap: #{$menu-gap},
     --#{$prefix}menu-min-width: #{$menu-min-width},
+    --#{$prefix}menu-max-height: #{$menu-max-height},
+    --#{$prefix}menu-overflow-y: #{$menu-overflow-y},
     --#{$prefix}menu-padding-x: #{$menu-padding-x},
     --#{$prefix}menu-padding-y: #{$menu-padding-y},
     --#{$prefix}menu-spacer: #{$menu-spacer},
@@ -109,10 +113,10 @@ $menu-tokens: defaults(
     flex-direction: column;
     gap: var(--#{$prefix}menu-gap);
     min-width: var(--#{$prefix}menu-min-width);
-    max-height: var(--#{$prefix}menu-max-height, none);
+    max-height: var(--#{$prefix}menu-max-height);
     padding: var(--#{$prefix}menu-padding-y) var(--#{$prefix}menu-padding-x);
     margin: 0;
-    overflow-y: var(--#{$prefix}menu-overflow-y, initial);
+    overflow-y: var(--#{$prefix}menu-overflow-y);
     overscroll-behavior: contain;
     font-size: var(--#{$prefix}menu-font-size);
     color: var(--#{$prefix}menu-color);

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -155,7 +155,7 @@ $range-slider-vertical-tokens: defaults(
     // No fallback on purpose: with `track: false` the plugin never writes the edges and the whole declaration must drop to `none`.
     background-image:
       linear-gradient(
-        var(--cui-range-slider-track-direction, to right),
+        var(--#{$prefix}range-slider-track-direction, to right),
         transparent 0%,
         transparent var(--cui-range-slider-track-from),
         var(--#{$prefix}range-slider-track-in-range-bg) var(--cui-range-slider-track-from),
@@ -302,7 +302,7 @@ $range-slider-vertical-tokens: defaults(
 
   .range-slider:not(.range-slider-vertical) {
     @include rtl() {
-      --cui-range-slider-track-direction: to left;
+      --#{$prefix}range-slider-track-direction: to left;
     }
 
 
@@ -332,7 +332,7 @@ $range-slider-vertical-tokens: defaults(
   .range-slider-vertical {
     @include tokens($range-slider-vertical-tokens);
 
-    --cui-range-slider-track-direction: to top;
+    --#{$prefix}range-slider-track-direction: to top;
 
     flex-direction: row;
     height: var(--#{$prefix}range-slider-vertical-track-height);


### PR DESCRIPTION
- **Menu.** `.menu` read `--cui-menu-max-height` and `--cui-menu-overflow-y` through fallbacks while only `.menu-scrollable` declared them — the shape #1084 fixed for the three border tokens, missed then. Both are in `menu-css-vars` now (`$menu-max-height: none`, `$menu-overflow-y: visible`) and read plainly; `.menu-scrollable` keeps overriding them on the same element. `visible` rather than the old `initial` fallback because `initial` as a custom-property *value* is the guaranteed-invalid value. Measured: plain menu `none`/`visible`, scrollable `240px`/`auto`, identical before/after.
- **Range slider.** `--cui-range-slider-track-direction` sat outside `$prefix` next to the three tokens `range-slider.ts` writes, but nothing writes it (checked js/src, tests, React/Vue v6, docs): it is set under `[dir=rtl]` and in `.range-slider-vertical` and read by the track gradient, all in the stylesheet. It follows `$prefix` now; the `themes/bootstrap` build no longer carries a `--cui-` name for it (the three JS-written ones remain, on purpose). Default build unchanged.

From the file-by-file SCSS audit (C.6, C.10).