### PR TITLE
fix(Popup): read the z-index scale

### DIFF
--- a/scss/_popup.scss
+++ b/scss/_popup.scss
@@ -6,7 +6,7 @@
 @use "config" as *;
 
 // scss-docs-start popup-variables
-$popup-zindex:              1000 !default;
+$popup-zindex:              var(--#{$prefix}z-dropdown) !default;
 $popup-bg:                  var(--#{$prefix}bg-body) !default;
 $popup-border-width:        var(--#{$prefix}border-width) !default;
 $popup-border-color:        var(--#{$prefix}border-color) !default;


### PR DESCRIPTION
`$popup-zindex` was the literal `1000` while the popover, the tooltip and the menu read their layer from the `--cui-z-*` scale; `1000` is exactly `--cui-z-dropdown`, so the popup reads that token now and follows a relayered page with the rest. Compiled value unchanged by default.

The in-component literals (`z-index: 1/2/3/5` for sibling stacking in list-group, pagination, input-group, validation, floating labels) stay — they are local stacking, upstream keeps the same literals, and neither tree reads the `--cui-z-0…3` scale for them. From the file-by-file SCSS audit (C.9).