### PR TITLE
feat(Calendar, TimePicker, Rating): read the theme slots

### DIFF
--- a/docs/src/content/docs/components/calendar.mdx
+++ b/docs/src/content/docs/components/calendar.mdx
@@ -117,6 +117,21 @@ Enable range selection by adding `data-coreui-range="true"` to allow users to pi
     ></div>
   </div>`} />
 
+## Theme colors
+
+Colour the selection with a [`.theme-*` class](/customize/components/#theme-variants) on the calendar: the selected day, the range tint, the range-hover outline and the date hover in the header all follow it.
+
+<Example pro code={`<div class="d-flex justify-content-center">
+    <div
+      class="border rounded theme-success"
+      data-coreui-locale="en-US"
+      data-coreui-start-date="2024/02/13"
+      data-coreui-end-date="2024/02/20"
+      data-coreui-range="true"
+      data-coreui-toggle="calendar"
+    ></div>
+  </div>`} />
+
 ## Disabled dates
 
 The Bootstrap Calendar component includes functionality to disable specific dates, such as weekends or holidays, using the `disabledDates` option. It accepts:

--- a/docs/src/content/docs/forms/rating.mdx
+++ b/docs/src/content/docs/forms/rating.mdx
@@ -89,6 +89,12 @@ Larger or smaller rating component? Add `data-coreui-size="lg"` or `data-coreui-
   <div data-coreui-toggle="rating" data-coreui-value="3"></div>
   <div data-coreui-size="lg" data-coreui-toggle="rating" data-coreui-value="3"></div>`} />
 
+## Theme colors
+
+Colour the active items with a [`.theme-*` class](/customize/components/#theme-variants) on the rating.
+
+<Example pro code={`<div class="theme-danger" data-coreui-toggle="rating" data-coreui-value="3"></div>`} />
+
 ## Custom icons
 
 Customize the Rating component with your choice of SVG icons by assigning new values to the `activeIcon` and `icon` properties in the JavaScript options. This allows for a unique look tailored to the design language of your site or application.

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -38,6 +38,16 @@ The default `roll` variant shows scrollable columns. Set
     </div>
   </div>`} />
 
+### Theme colors
+
+A [`.theme-*` class](/customize/components/#theme-variants) on the picker colours the selected cell of every roll.
+
+<Example pro code={`<div class="row">
+    <div class="col-lg-4">
+      <div class="theme-success" data-coreui-locale="en-US" data-coreui-time="14:30:00" data-coreui-toggle="time-picker"></div>
+    </div>
+  </div>`} />
+
 ### With footer
 
 There is no `footer` option — project a `<template data-coreui-template="footer">`

--- a/scss/_calendar.scss
+++ b/scss/_calendar.scss
@@ -196,7 +196,7 @@ $calendar-tokens: defaults(
       color: var(--#{$prefix}calendar-nav-date-color);
 
       &:hover {
-        color: var(--#{$prefix}calendar-nav-date-hover-color);
+        color: var(--#{$prefix}theme-bg, var(--#{$prefix}calendar-nav-date-hover-color));
       }
     }
   }
@@ -261,7 +261,7 @@ $calendar-tokens: defaults(
         width: 100%;
         height: 100%;
         content: "";
-        background: var(--#{$prefix}calendar-cell-range-bg);
+        background: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}calendar-cell-range-bg));
       }
     }
 
@@ -273,15 +273,15 @@ $calendar-tokens: defaults(
         width: 100%;
         height: 100%;
         content: "";
-        border-block-start: var(--#{$prefix}border-width) dashed var(--#{$prefix}calendar-cell-range-hover-border-color);
-        border-block-end: var(--#{$prefix}border-width) dashed var(--#{$prefix}calendar-cell-range-hover-border-color);
+        border-block-start: var(--#{$prefix}border-width) dashed var(--#{$prefix}theme-bg, var(--#{$prefix}calendar-cell-range-hover-border-color));
+        border-block-end: var(--#{$prefix}border-width) dashed var(--#{$prefix}theme-bg, var(--#{$prefix}calendar-cell-range-hover-border-color));
         @include border-radius(0);
       }
     }
 
     &.selected:not(th, .next, .previous) .calendar-cell-inner {
-      color: var(--#{$prefix}calendar-cell-selected-color);
-      background-color: var(--#{$prefix}calendar-cell-selected-bg);
+      color: var(--#{$prefix}theme-contrast, var(--#{$prefix}calendar-cell-selected-color));
+      background-color: var(--#{$prefix}theme-bg, var(--#{$prefix}calendar-cell-selected-bg));
     }
 
     &.today .calendar-cell-inner {
@@ -313,13 +313,13 @@ $calendar-tokens: defaults(
     &.range-hover:first-of-type,
     &:not(.range-hover) + &.range-hover {
       .calendar-cell-inner::before {
-        border-inline-start: var(--#{$prefix}border-width) dashed var(--#{$prefix}calendar-cell-range-hover-border-color);
+        border-inline-start: var(--#{$prefix}border-width) dashed var(--#{$prefix}theme-bg, var(--#{$prefix}calendar-cell-range-hover-border-color));
         @include border-start-radius(var(--#{$prefix}calendar-cell-border-radius));
       }
     }
 
     &.range-hover:not(:has(~ .range-hover)) .calendar-cell-inner::before {
-      border-inline-end: var(--#{$prefix}border-width) dashed var(--#{$prefix}calendar-cell-range-hover-border-color);
+      border-inline-end: var(--#{$prefix}border-width) dashed var(--#{$prefix}theme-bg, var(--#{$prefix}calendar-cell-range-hover-border-color));
       @include border-end-radius(var(--#{$prefix}calendar-cell-border-radius));
     }
 
@@ -333,7 +333,7 @@ $calendar-tokens: defaults(
       }
 
       &:nth-last-child(1 of .range-hover) .calendar-cell-inner::before {
-        border-inline-end: var(--#{$prefix}border-width) dashed var(--#{$prefix}calendar-cell-range-hover-border-color);
+        border-inline-end: var(--#{$prefix}border-width) dashed var(--#{$prefix}theme-bg, var(--#{$prefix}calendar-cell-range-hover-border-color));
         @include border-end-radius(var(--#{$prefix}calendar-cell-border-radius));
       }
     }
@@ -385,11 +385,11 @@ $calendar-tokens: defaults(
     }
 
     &.range-hover .calendar-cell:first-of-type .calendar-cell-inner::before {
-      border-inline-start: var(--#{$prefix}border-width) dashed var(--#{$prefix}calendar-cell-range-hover-border-color);
+      border-inline-start: var(--#{$prefix}border-width) dashed var(--#{$prefix}theme-bg, var(--#{$prefix}calendar-cell-range-hover-border-color));
     }
 
     &.range-hover .calendar-cell:last-of-type .calendar-cell-inner::before {
-      border-inline-end: var(--#{$prefix}border-width) dashed var(--#{$prefix}calendar-cell-range-hover-border-color);
+      border-inline-end: var(--#{$prefix}border-width) dashed var(--#{$prefix}theme-bg, var(--#{$prefix}calendar-cell-range-hover-border-color));
     }
 
     &:focus-visible {

--- a/scss/_rating.scss
+++ b/scss/_rating.scss
@@ -111,11 +111,11 @@ $rating-tokens: defaults(
     }
 
     &.active {
-      color: var(--#{$prefix}rating-item-active-color);
+      color: var(--#{$prefix}theme-bg, var(--#{$prefix}rating-item-active-color));
       opacity: 1;
 
       .rating-item-icon {
-        background-color: var(--#{$prefix}rating-item-active-color);
+        background-color: var(--#{$prefix}theme-bg, var(--#{$prefix}rating-item-active-color));
       }
 
       .rating-item-custom-icon:has(+ .rating-item-custom-icon-active) {

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -162,13 +162,13 @@ $time-picker-tokens: defaults(
     }
 
     &.selected {
-      color: var(--#{$prefix}time-picker-roll-cell-selected-color);
-      background: var(--#{$prefix}time-picker-roll-cell-selected-bg);
+      color: var(--#{$prefix}theme-contrast, var(--#{$prefix}time-picker-roll-cell-selected-color));
+      background: var(--#{$prefix}theme-bg, var(--#{$prefix}time-picker-roll-cell-selected-bg));
 
       &:hover,
       &:focus-visible {
-        color: var(--#{$prefix}time-picker-roll-cell-selected-hover-color);
-        background: var(--#{$prefix}time-picker-roll-cell-selected-hover-bg);
+        color: var(--#{$prefix}theme-contrast, var(--#{$prefix}time-picker-roll-cell-selected-hover-color));
+        background: var(--#{$prefix}theme-bg, var(--#{$prefix}time-picker-roll-cell-selected-hover-bg));
       }
     }
 


### PR DESCRIPTION
The calendar, the time picker and the rating painted their selection, range and active items straight from `--cui-primary` / `--cui-warning` — no `--cui-theme-*` read in any of the three files — so a `.theme-*` class did nothing on them while every other component honours it (upstream's datepicker has the same gap).

The rules read the theme slots now with the component tokens as fallback (tokens are declared on the component and read on the cells, so the slot belongs in the rule): `theme-contrast` / `theme-bg` for the selected calendar cell and the selected time-picker cell (and its hover), `theme-bg-subtle` for the range tint, `theme-bg` for the seven dashed range-hover outlines, the header date hover and the active rating item. Defaults are unchanged — the brand colour stays the content of these components (audit 2026-08, rule 5).

Measured: plain calendar and rating identical before/after; `.calendar.theme-success` selected cell turns green with the contrast text and the range tint follows; `.rating.theme-danger` items turn red. Docs: a theme example on the calendar, time-picker and rating pages.

From the file-by-file SCSS audit (C.11).