### PR TITLE
fix(Calendar): keep the themed range tint translucent

### DIFF
--- a/scss/_calendar.scss
+++ b/scss/_calendar.scss
@@ -51,8 +51,8 @@ $calendar-cell-disabled-color:               var(--#{$prefix}fg-3) !default;
 $calendar-cell-selected-color:               var(--#{$prefix}primary-contrast) !default;
 $calendar-cell-selected-bg:                  var(--#{$prefix}primary) !default;
 
-$calendar-cell-range-bg:                     color-mix(in srgb, var(--#{$prefix}primary) 12.5%, transparent) !default;
-$calendar-cell-range-hover-bg:               color-mix(in srgb, var(--#{$prefix}primary) 25%, transparent) !default;
+$calendar-cell-range-bg:                     color-mix(in srgb, var(--#{$prefix}theme-bg, var(--#{$prefix}primary)) 12.5%, transparent) !default;
+$calendar-cell-range-hover-bg:               color-mix(in srgb, var(--#{$prefix}theme-bg, var(--#{$prefix}primary)) 25%, transparent) !default;
 $calendar-cell-range-hover-border-color:     var(--#{$prefix}primary) !default;
 
 $calendar-cell-today-color:                  var(--#{$prefix}danger) !default;
@@ -261,7 +261,7 @@ $calendar-tokens: defaults(
         width: 100%;
         height: 100%;
         content: "";
-        background: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}calendar-cell-range-bg));
+        background: var(--#{$prefix}calendar-cell-range-bg);
       }
     }
 


### PR DESCRIPTION
#1117 painted the range with `--cui-theme-bg-subtle`, which is an opaque palette stop (`success-100`), and the range tint is a `::before` layer drawn above the cell content — so under `.theme-success` the day numbers and the two selected endpoints vanished behind the tint (mrholek's screenshot).

`$calendar-cell-range-bg` and `$calendar-cell-range-hover-bg` now mix `var(--cui-theme-bg, var(--cui-primary))` at the same 12.5% / 25% into transparent — the slot sits in the token because the theme class lands on the calendar that declares it — and the rule reads the token plainly again. Default build unchanged; screenshots of the docs example before/after in the first comment.