### PR TITLE
docs: name the new theme sections "Theme variants"

### DIFF
--- a/docs/src/content/docs/components/calendar.mdx
+++ b/docs/src/content/docs/components/calendar.mdx
@@ -117,7 +117,7 @@ Enable range selection by adding `data-coreui-range="true"` to allow users to pi
     ></div>
   </div>`} />
 
-## Theme colors
+## Theme variants
 
 Colour the selection with a [`.theme-*` class](/customize/components/#theme-variants) on the calendar: the selected day, the range tint, the range-hover outline and the date hover in the header all follow it.
 

--- a/docs/src/content/docs/forms/rating.mdx
+++ b/docs/src/content/docs/forms/rating.mdx
@@ -89,7 +89,7 @@ Larger or smaller rating component? Add `data-coreui-size="lg"` or `data-coreui-
   <div data-coreui-toggle="rating" data-coreui-value="3"></div>
   <div data-coreui-size="lg" data-coreui-toggle="rating" data-coreui-value="3"></div>`} />
 
-## Theme colors
+## Theme variants
 
 Colour the active items with a [`.theme-*` class](/customize/components/#theme-variants) on the rating.
 

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -38,7 +38,7 @@ The default `roll` variant shows scrollable columns. Set
     </div>
   </div>`} />
 
-### Theme colors
+### Theme variants
 
 A [`.theme-*` class](/customize/components/#theme-variants) on the picker colours the selected cell of every roll.
 


### PR DESCRIPTION
The sections #1117 added to the calendar, time-picker and rating pages were headed "Theme colors"; the pages that already document the `.theme-*` class (button-group, card, checkbox, radio, range, range-slider, stepper, switch) use "Theme variants", the name `customize/components#theme-variants` anchors on. Renamed (mrholek).