### PR TITLE
fix(root, themes): follow the colour scheme in the focus border and the bootstrap fg ladder

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -298,7 +298,7 @@ $root-token-defaults: map.merge(
     --#{$prefix}btn-input-box-shadow: var(--#{$prefix}box-shadow-inset),
     --#{$prefix}btn-input-focus-color: var(--#{$prefix}btn-input-color),
     --#{$prefix}btn-input-focus-bg: var(--#{$prefix}btn-input-bg),
-    --#{$prefix}btn-input-focus-border-color: color-mix(in srgb, var(--#{$prefix}primary) 50%, var(--#{$prefix}white)),
+    --#{$prefix}btn-input-focus-border-color: color-mix(in srgb, var(--#{$prefix}primary) 50%, var(--#{$prefix}bg-body)),
     --#{$prefix}btn-input-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2),
     --#{$prefix}btn-input-xs-gap: $input-btn-gap-xs,
     --#{$prefix}btn-input-xs-padding-y: $input-btn-padding-y-xs,

--- a/scss/themes/bootstrap/bootstrap.scss
+++ b/scss/themes/bootstrap/bootstrap.scss
@@ -71,8 +71,8 @@ $inverse:       light-dark($gray-900, $gray-100) !default;
   $danger:                        $danger !default,
   $inverse:                       $inverse !default,
   $fg-body:                       light-dark($gray-900, $gray-300) !default,
-  $fg-1:                          light-dark(rgba($gray-900, .85), rgba($gray-300, .85)) !default,
-  $fg-2:                          light-dark(rgba($gray-900, .75), rgba($gray-300, .75)) !default,
-  $fg-3:                          light-dark(rgba($gray-900, .5), rgba($gray-300, .5)) !default,
-  $fg-4:                          light-dark(rgba($gray-900, .25), rgba($gray-300, .25)) !default,
+  $fg-1:                          light-dark(color-mix(in srgb, var(--bs-gray-900) 85%, transparent), color-mix(in srgb, var(--bs-gray-300) 85%, transparent)) !default,
+  $fg-2:                          light-dark(color-mix(in srgb, var(--bs-gray-900) 75%, transparent), color-mix(in srgb, var(--bs-gray-300) 75%, transparent)) !default,
+  $fg-3:                          light-dark(color-mix(in srgb, var(--bs-gray-900) 50%, transparent), color-mix(in srgb, var(--bs-gray-300) 50%, transparent)) !default,
+  $fg-4:                          light-dark(color-mix(in srgb, var(--bs-gray-900) 25%, transparent), color-mix(in srgb, var(--bs-gray-300) 25%, transparent)) !default,
 );


### PR DESCRIPTION
- **Focus border.** `--cui-btn-input-focus-border-color` was `color-mix(in srgb, var(--cui-primary) 50%, var(--cui-white))`, v5's `tint-color($primary, 50%)` carried over: white in both schemes, so in the dark scheme the focus border was a pastel lighter than the field and the page around it. It mixes with `--cui-bg-body` now. Measured: light `rgb(171 171 235)` before and after; dark `rgb(171 171 235)` → `rgb(51 51 118)` on a `rgb(15 17 21)` page. Upstream has no such token (focus is the ring only).
- **Bootstrap theme fg ladder.** `themes/bootstrap` defined `$fg-1` … `$fg-4` as `rgba($gray-900, .85)` etc., frozen at build time, while the core defines the same variables from tokens. They mix `var(--bs-gray-900)` / `var(--bs-gray-300)` at the same percentages into transparent now — the theme's translucent look is kept on purpose. Measured in both schemes: identical colours and alphas before and after (e.g. `fg-2` `rgba(33 37 41 / .75)` light, `rgba(222 226 230 / .75)` dark); the difference is that a `--bs-gray-*` override reaches them.

From the file-by-file SCSS audit (C.15, C.16).