### PR TITLE
fix(InputGroup, RangeSlider): round the sibling after an ignored addon, drop a dead border

### DIFF
--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -1,5 +1,4 @@
 @use "sass:string";
-@use "forms/form-range" as *;
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/box-shadow" as *;
@@ -219,7 +218,6 @@ $range-slider-vertical-tokens: defaults(
       pointer-events: all;
       cursor: pointer;
       @include gradient-bg(var(--#{$prefix}range-slider-thumb-bg));
-      border: $form-range-thumb-border;
       border: var(--#{$prefix}range-slider-thumb-border);
       @include border-radius(var(--#{$prefix}range-slider-thumb-border-radius));
       @include box-shadow(var(--#{$prefix}range-slider-thumb-box-shadow));

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -150,7 +150,7 @@ $input-group-tokens: defaults(
   .input-group {
     $validation-messages: "";
     @each $state in map.keys($form-validation-states) {
-      $validation-messages: $validation-messages + ":not(." + string.unquote($state) + "-tooltip)" + ":not(." + string.unquote($state) + "-feedback)";
+      $validation-messages: $validation-messages + ", ." + string.unquote($state) + "-tooltip, ." + string.unquote($state) + "-feedback";
     }
 
     > :not(:last-child, .dropdown-toggle, .dropdown-menu, .input-group-ignore, .form-floating, :has(+ :is(.dropdown-menu, .input-group-ignore):last-child)),
@@ -160,13 +160,13 @@ $input-group-tokens: defaults(
       @include border-end-radius(0);
     }
 
-    > :not(:first-child):not(.dropdown-menu):not(.input-group-ignore)#{$validation-messages} {
+    > :not(:first-child, .dropdown-menu, .input-group-ignore#{$validation-messages}) {
       margin-inline-start: calc(-1 * var(--#{$prefix}btn-input-border-width));
       @include border-start-radius(0);
     }
 
     > :first-child:is(.input-group-ignore) + :not(.dropdown-menu, .input-group-ignore) {
-      @include border-start-radius(var(--#{$prefix}control-border-radius));
+      @include border-start-radius(var(--#{$prefix}btn-input-border-radius));
     }
 
     > .form-floating:not(:first-child) > .form-control,


### PR DESCRIPTION
- **Input group.** The rule rounding the element after a leading `.input-group-ignore` (`:168`) never won: the rule zeroing every non-first child chained seven `:not()` selectors — three exclusions plus the four validation-message classes — for a specificity of (0,9,0) against the ignore rule's (0,4,0). The exclusions are one `:not(a, b, …)` list now, the shape upstream writes, which counts as (0,2,0). The rounded corner also reads `--cui-btn-input-border-radius` (the shared field/button radius on `:root`, as upstream) instead of `--cui-control-border-radius`, which a `.btn` does not declare. Measured: `.btn` and `.form-control` after the addon go from `0px` to `8px` start radius; every other element, and the `.invalid-feedback` sibling's margin, unchanged.
- **Range slider.** The thumb wrote `border` twice, the first from `$form-range-thumb-border`, overwritten on the next line; the dead declaration and the `forms/form-range` import that existed for it are gone. Compiled diff: one dropped `border: 0`.

From the file-by-file SCSS audit (A.15, A.16).