### PR TITLE
docs: list the token blocks the pages left out

### DIFF
--- a/docs/src/content/docs/components/buttons.mdx
+++ b/docs/src/content/docs/components/buttons.mdx
@@ -315,6 +315,10 @@ Buttons use local CSS variables on `.btn` for enhanced real-time customization.
 
 <ScssDocs file="scss/buttons/_button.scss" capture="btn-tokens" />
 
+`.btn-link` rewrites the ones that make it read as a link:
+
+<ScssDocs file="scss/buttons/_button.scss" capture="btn-link-tokens" />
+
 Each variant class rewrites those variables from the theme tokens, falling back to a neutral value, which is why one set of rules serves every colour — including a theme colour you add yourself, with no Sass to compile.
 
 A brand colour of your own is a theme, not a button: set the theme tokens anywhere above the buttons and every variant follows, in plain CSS. The tokens inherit, so one ancestor themes the whole subtree.

--- a/docs/src/content/docs/forms/date-input.mdx
+++ b/docs/src/content/docs/forms/date-input.mdx
@@ -359,6 +359,12 @@ document.addEventListener('dateChange.coreui.date-input', event => {
 
 ## Customizing
 
+### CSS variables
+
+The date, time, and date-time inputs share one set of styles under the `form-date-time` name; the tokens sit on the field and can be set on a single element.
+
+<ScssDocs file="scss/forms/_form-date-time.scss" capture="form-date-time-tokens" />
+
 ### Sass variables
 
 <DeprecatedIn version="6.0.0" />

--- a/docs/src/content/docs/forms/date-time-input.mdx
+++ b/docs/src/content/docs/forms/date-time-input.mdx
@@ -238,6 +238,12 @@ document.addEventListener('dateChange.coreui.date-time-input', event => {
 
 ## Customizing
 
+### CSS variables
+
+The date, time, and date-time inputs share one set of styles under the `form-date-time` name; the tokens sit on the field and can be set on a single element.
+
+<ScssDocs file="scss/forms/_form-date-time.scss" capture="form-date-time-tokens" />
+
 ### Sass variables
 
 <DeprecatedIn version="6.0.0" />

--- a/docs/src/content/docs/forms/field.mdx
+++ b/docs/src/content/docs/forms/field.mdx
@@ -189,6 +189,12 @@ Add `.form-field-card` to each field for a card treatment that highlights the se
 
 <ScssDocs file="scss/forms/_form-field.scss" capture="form-field-css-vars" />
 
+`.form-field-card` and `.form-group` carry their own sets:
+
+<ScssDocs file="scss/forms/_form-field.scss" capture="form-field-card-css-vars" />
+
+<ScssDocs file="scss/forms/_form-field.scss" capture="form-group-css-vars" />
+
 ### Sass variables
 
 <DeprecatedIn version="6.0.0" />

--- a/docs/src/content/docs/forms/time-input.mdx
+++ b/docs/src/content/docs/forms/time-input.mdx
@@ -240,6 +240,12 @@ document.addEventListener('timeChange.coreui.time-input', event => {
 
 ## Customizing
 
+### CSS variables
+
+The date, time, and date-time inputs share one set of styles under the `form-date-time` name; the tokens sit on the field and can be set on a single element.
+
+<ScssDocs file="scss/forms/_form-date-time.scss" capture="form-date-time-tokens" />
+
 ### Sass variables
 
 <DeprecatedIn version="6.0.0" />


### PR DESCRIPTION
Every `scss-docs` token block should be cited by the page of the component it belongs to (`comm -13` of the `capture=` list against the `scss-docs-start` list found these):

- **date-input, time-input, date-time-input**: the Customizing section had only "Sass variables", whose intro says "The CSS variables above reach the same values" — with no such section above. Each gets "### CSS variables" citing `form-date-time-tokens`.
- **field**: the page documents `.form-field-card` and `.form-group` but listed only `form-field-css-vars`; `form-field-card-css-vars` and `form-group-css-vars` follow.
- **buttons**: `btn-link-tokens` was cited nowhere; listed after the base set.

Docs only. From the file-by-file SCSS audit (C.8).