### PR TITLE
feat(scss)!: one backdrop model for the dialog and the drawer

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./dist/css/coreui-reboot.min.css",
-      "maxSize": "5.75 kB"
+      "maxSize": "6 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.css",
@@ -22,7 +22,7 @@
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",
-      "maxSize": "18.75 kB"
+      "maxSize": "19 kB"
     },
     {
       "path": "./dist/css/coreui.css",

--- a/docs/src/content/docs/components/dialog.mdx
+++ b/docs/src/content/docs/components/dialog.mdx
@@ -113,6 +113,28 @@ When backdrop is set to `static`, the dialog will not close when clicking outsid
 
 <Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialogStatic">`, `  Launch static backdrop dialog`, `</button>`]} />
 
+## Backdrop
+
+The backdrop reads three tokens from `:root` — `--cui-backdrop-color`, `--cui-backdrop-opacity` and `--cui-backdrop-blur` — and every overlay component paints it the same way. A dialog defaults to a dark scrim; the drawer defaults to a translucent tint of the page. Pick the other look with a [backdrop preset](/customize/components/#backdrop) on the element: `.backdrop-translucent` here, `.backdrop-scrim` on a drawer, `.backdrop-none` on either.
+
+<dialog class="dialog backdrop-translucent" id="exampleDialogTranslucent" aria-labelledby="exampleDialogTranslucentLabel">
+  <div class="dialog-header">
+    <h5 class="dialog-title" id="exampleDialogTranslucentLabel">Translucent backdrop</h5>
+    <button type="button" class="btn-close" data-coreui-dismiss="dialog" aria-label="Close"></button>
+  </div>
+  <div class="dialog-body">
+    <p>The page behind stays readable through a light tint instead of a dark scrim.</p>
+  </div>
+</dialog>
+
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="dialog" data-coreui-target="#exampleDialogTranslucent">`, `  Launch dialog with a translucent backdrop`, `</button>`]} />
+
+```html
+<dialog class="dialog backdrop-translucent" id="exampleDialogTranslucent" aria-labelledby="exampleDialogTranslucentLabel">
+  …
+</dialog>
+```
+
 ## Scrolling long content
 
 Add `.dialog-scrollable` — the header and footer stay fixed while the dialog body scrolls.

--- a/docs/src/content/docs/components/drawer.mdx
+++ b/docs/src/content/docs/components/drawer.mdx
@@ -140,6 +140,24 @@ Add a `.drawer-footer` below the `.drawer-body` for the panel's actions. It is a
 
 <Example html={[`<div class="drawer-footer">`, `  <button type="button" class="btn-outline theme-secondary" data-coreui-dismiss="drawer">Close</button>`, `  <button type="button" class="btn-solid theme-primary">Save changes</button>`, `</div>`]} />
 
+### Backdrop presets
+
+The backdrop reads `--cui-backdrop-color`, `--cui-backdrop-opacity` and `--cui-backdrop-blur`; a drawer defaults to a translucent tint of the page. For the dialog's dark scrim add `.backdrop-scrim`; the [presets](/customize/components/#backdrop) work on every overlay component.
+
+<Example code={`<button class="btn-solid theme-primary" type="button" data-coreui-toggle="drawer" data-coreui-target="#drawerScrim">
+    Toggle drawer with a dark backdrop
+  </button>
+
+  <dialog class="drawer drawer-start backdrop-scrim" id="drawerScrim" aria-labelledby="drawerScrimLabel">
+    <div class="drawer-header">
+      <h5 class="drawer-title" id="drawerScrimLabel">Dark backdrop</h5>
+      <button type="button" class="btn-close" data-coreui-dismiss="drawer" aria-label="Close"></button>
+    </div>
+    <div class="drawer-body">
+      The scrim the dialog uses, on a drawer.
+    </div>
+  </dialog>`} />
+
 ### No backdrop
 
 Add `.drawer-no-backdrop` to hide the backdrop while keeping the drawer modal — the panel still takes the top layer and traps focus, but nothing dims the page behind it.

--- a/docs/src/content/docs/customize/components.mdx
+++ b/docs/src/content/docs/customize/components.mdx
@@ -93,6 +93,22 @@ The second line is the part that is easy to miss. Set the token alone and the ba
 
 While no theme class is present the token behaves as an override point; under one, the theme wins.
 
+## Backdrop
+
+Every overlay that dims the page — the dialog and the drawer through their native `::backdrop` — paints that layer from three tokens on `:root`:
+
+<ScssDocs file="scss/_root.scss" capture="root-backdrop-variables" />
+
+The colour and the opacity are mixed on the element (`color-mix(in oklch, var(--cui-backdrop-color) var(--cui-backdrop-opacity), transparent)`), so either can be changed alone, globally on `:root` or on one overlay. The dialog keeps the defaults, a dark scrim that deepens in the dark scheme; the drawer sets its own tint of the page (`--cui-bg-body` at 25%). Three presets pick a look from the markup:
+
+| Class | Backdrop |
+| --- | --- |
+| `.backdrop-scrim` | Black at 50% (65% in the dark scheme) — the dialog's default |
+| `.backdrop-translucent` | The page colour at 25% — the drawer's default |
+| `.backdrop-none` | No backdrop; the overlay still takes the top layer and traps focus |
+
+Put the class on the overlay element itself, next to `.dialog` or `.drawer`.
+
 ## Responsive
 
 These Sass loops aren't limited to color maps, either. You can also generate responsive variations of your components. Take for example our responsive alignment of the dropdowns where we mix an `@each` loop for the `$grid-breakpoints` Sass map with a media query include.

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -642,6 +642,16 @@ check, radio, carousel and toggler icons already work:
 
 #### Dialog (new) and Drawer (new)
 
+- **One backdrop model for both.** `:root` emits `--cui-backdrop-color`,
+  `--cui-backdrop-opacity` and `--cui-backdrop-blur`; the dialog's and the
+  drawer's `::backdrop` mix colour and opacity from them, so either can be
+  retuned alone. The looks are unchanged (dialog: black at 50%/65%, drawer:
+  the page colour at 25%), and `.backdrop-scrim`, `.backdrop-translucent` and
+  `.backdrop-none` swap them from the markup. `.dialog-no-backdrop` and
+  `.drawer-no-backdrop` keep working. The sidebar's backdrop tokens are
+  `--cui-sidebar-backdrop-zindex/-bg/-opacity` now (were unprefixed
+  `--cui-backdrop-*`, which the new root tokens would have shadowed).
+
 - **New components: Dialog and Drawer** — the native-`<dialog>` popup and
   side panel with the Bootstrap 6 look and `dialog-*` / `drawer-*` classes:
   Dialog is a centered floating panel over a blurred backdrop with optional

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -1,5 +1,6 @@
 @use "sass:map";
 @use "functions/defaults" as *;
+@use "mixins/backdrop" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/box-shadow" as *;
 @use "layout/breakpoints" as *;
@@ -24,8 +25,8 @@ $dialog-transition-duration:        .3s !default;
 $dialog-transition-timing:          var(--#{$prefix}transition-timing-overlay) !default;
 $dialog-slide-distance:             3rem !default;
 $dialog-scale-transform:            scale(1.02) !default;
-$dialog-backdrop-bg:                light-dark(rgb(0 0 0 / 50%), rgb(0 0 0 / 65%)) !default;
-$dialog-backdrop-blur:              8px !default;
+$dialog-backdrop-bg:                color-mix(in oklch, var(--#{$prefix}backdrop-color) var(--#{$prefix}backdrop-opacity), transparent) !default;
+$dialog-backdrop-blur:              var(--#{$prefix}backdrop-blur) !default;
 $dialog-header-padding:             var(--#{$prefix}spacer-3) !default;
 $dialog-header-border-color:        var(--#{$prefix}border-color-translucent) !default;
 $dialog-header-border-width:        var(--#{$prefix}border-width) !default;
@@ -146,10 +147,7 @@ $dialog-tokens: defaults(
       &::backdrop {
         background-color: var(--#{$prefix}dialog-backdrop-bg);
         backdrop-filter: blur(var(--#{$prefix}dialog-backdrop-blur));
-        @include transition(
-          background-color var(--#{$prefix}dialog-transition-duration) var(--#{$prefix}dialog-transition-timing),
-          backdrop-filter var(--#{$prefix}dialog-transition-duration) var(--#{$prefix}dialog-transition-timing)
-        );
+        @include backdrop-transitions(var(--#{$prefix}dialog-transition-duration), var(--#{$prefix}dialog-transition-timing));
       }
 
       // Exit: fade the native backdrop out alongside the dialog — it is still

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -1,5 +1,6 @@
 @use "sass:map";
 @use "functions/defaults" as *;
+@use "mixins/backdrop" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/box-shadow" as *;
 @use "layout/breakpoints" as *;
@@ -27,8 +28,10 @@ $drawer-transition-duration:        .3s !default;
 $drawer-transition-timing:          var(--#{$prefix}transition-timing-overlay) !default;
 $drawer-scale-transform:            scale(1.02) !default;
 $drawer-title-line-height:          var(--#{$prefix}body-line-height) !default;
-$drawer-backdrop-bg:                color-mix(in oklch, var(--#{$prefix}bg-body) 25%, transparent) !default;
-$drawer-backdrop-blur:              8px !default;
+$drawer-backdrop-color:             var(--#{$prefix}bg-body) !default;
+$drawer-backdrop-opacity:           25% !default;
+$drawer-backdrop-bg:                color-mix(in oklch, var(--#{$prefix}backdrop-color) var(--#{$prefix}backdrop-opacity), transparent) !default;
+$drawer-backdrop-blur:              var(--#{$prefix}backdrop-blur) !default;
 $drawer-sheet-width:                760px !default;
 // scss-docs-end drawer-variables
 
@@ -56,6 +59,8 @@ $drawer-tokens: defaults(
     --#{$prefix}drawer-transition-duration: #{$drawer-transition-duration},
     --#{$prefix}drawer-transition-timing: #{$drawer-transition-timing},
     --#{$prefix}drawer-title-line-height: #{$drawer-title-line-height},
+    --#{$prefix}backdrop-color: #{$drawer-backdrop-color},
+    --#{$prefix}backdrop-opacity: #{$drawer-backdrop-opacity},
     --#{$prefix}drawer-backdrop-bg: #{$drawer-backdrop-bg},
     --#{$prefix}drawer-backdrop-blur: #{$drawer-backdrop-blur},
   ),
@@ -184,10 +189,7 @@ $drawer-tokens: defaults(
           &::backdrop {
             background-color: var(--#{$prefix}drawer-backdrop-bg);
             backdrop-filter: blur(var(--#{$prefix}drawer-backdrop-blur));
-            @include transition(
-              background-color var(--#{$prefix}drawer-transition-duration) var(--#{$prefix}drawer-transition-timing),
-              backdrop-filter var(--#{$prefix}drawer-transition-duration) var(--#{$prefix}drawer-transition-timing)
-            );
+            @include backdrop-transitions(var(--#{$prefix}drawer-transition-duration), var(--#{$prefix}drawer-transition-timing));
           }
 
           &.hiding::backdrop {

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -72,6 +72,15 @@ $focus-ring-color:            var(--#{$prefix}primary-focus-ring) !default;
 $focus-ring-offset:           0 !default;
 // scss-docs-end focus-ring-variables
 
+// scss-docs-start backdrop-variables
+$backdrop-color:              var(--#{$prefix}black) !default;
+$backdrop-opacity:            50% !default;
+$backdrop-opacity-dark:       65% !default;
+$backdrop-blur:               8px !default;
+// scss-docs-end backdrop-variables
+// scss-docs-start focus-ring-variables
+// scss-docs-end focus-ring-variables
+
 // scss-docs-start font-variables
 // stylelint-disable value-keyword-case
 $font-family-sans-serif: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
@@ -275,6 +284,11 @@ $root-token-defaults: map.merge(
     --#{$prefix}focus-ring-offset: $focus-ring-offset,
     --#{$prefix}focus-ring: var(--#{$prefix}focus-ring-width) solid var(--#{$prefix}focus-ring-color),
     // scss-docs-end root-focus-variables
+    // scss-docs-start root-backdrop-variables
+    --#{$prefix}backdrop-color: $backdrop-color,
+    --#{$prefix}backdrop-opacity: $backdrop-opacity,
+    --#{$prefix}backdrop-blur: $backdrop-blur,
+    // scss-docs-end root-backdrop-variables
     // scss-docs-start root-btn-input-variables
     // Sizing shared by buttons and form controls, so neither has to reach for
     // the other's Sass variables to line up.
@@ -366,6 +380,7 @@ $root-tokens: defaults($root-token-defaults, $root-tokens);
       // surface swallows the same alpha, so the strength rises instead of the
       // colour changing.
       --#{$prefix}shadow-strength: #{$shadow-strength-dark};
+      --#{$prefix}backdrop-opacity: #{$backdrop-opacity-dark};
       // scss-docs-end root-dark-mode-vars
 
       color-scheme: dark;

--- a/scss/helpers/_backdrop.scss
+++ b/scss/helpers/_backdrop.scss
@@ -1,0 +1,26 @@
+@use "../config" as *;
+@use "../mixins/color-mode" as *;
+
+@layer helpers {
+  .backdrop-scrim {
+    --#{$prefix}backdrop-color: var(--#{$prefix}black);
+    --#{$prefix}backdrop-opacity: 50%;
+  }
+
+  @if $enable-dark-mode {
+    @include color-mode(dark) {
+      .backdrop-scrim {
+        --#{$prefix}backdrop-opacity: 65%;
+      }
+    }
+  }
+
+  .backdrop-translucent {
+    --#{$prefix}backdrop-color: var(--#{$prefix}bg-body);
+    --#{$prefix}backdrop-opacity: 25%;
+  }
+
+  .backdrop-none::backdrop {
+    display: none;
+  }
+}

--- a/scss/helpers/index.scss
+++ b/scss/helpers/index.scss
@@ -1,3 +1,4 @@
+@forward "backdrop";
 @forward "clearfix";
 @forward "color-bg";
 @forward "focus-ring";

--- a/scss/mixins/_backdrop.scss
+++ b/scss/mixins/_backdrop.scss
@@ -1,4 +1,5 @@
 @use "../config" as *;
+@use "transition" as *;
 
 // The full-viewport scrim behind an overlay. Used by the sidebar; exported for
 // anything else that needs the same surface.
@@ -15,4 +16,11 @@
   // Fade for backdrop
   &.fade { opacity: 0; }
   &.show { opacity: $backdrop-opacity; }
+}
+
+@mixin backdrop-transitions($duration, $timing) {
+  @include transition(
+    background-color $duration $timing,
+    backdrop-filter $duration $timing
+  );
 }

--- a/scss/sidebar/_sidebar.scss
+++ b/scss/sidebar/_sidebar.scss
@@ -280,13 +280,13 @@ $sidebar-widths: (
 
   .sidebar-backdrop {
     // scss-docs-start sidebar-backdrop-css-vars
-    --#{$prefix}backdrop-zindex: var(--#{$prefix}z-sidebar-backdrop);
-    --#{$prefix}backdrop-bg: #{$sidebar-backdrop-bg};
-    --#{$prefix}backdrop-opacity: #{$sidebar-backdrop-opacity};
+    --#{$prefix}sidebar-backdrop-zindex: var(--#{$prefix}z-sidebar-backdrop);
+    --#{$prefix}sidebar-backdrop-bg: #{$sidebar-backdrop-bg};
+    --#{$prefix}sidebar-backdrop-opacity: #{$sidebar-backdrop-opacity};
     // scss-docs-end sidebar-backdrop-css-vars
 
     @include media-breakpoint-down($mobile-breakpoint) {
-      @include overlay-backdrop(var(--#{$prefix}backdrop-zindex), var(--#{$prefix}backdrop-bg), var(--#{$prefix}backdrop-opacity));
+      @include overlay-backdrop(var(--#{$prefix}sidebar-backdrop-zindex), var(--#{$prefix}sidebar-backdrop-bg), var(--#{$prefix}sidebar-backdrop-opacity));
     }
   }
 


### PR DESCRIPTION
The dialog and the drawer painted their `::backdrop` from two unrelated recipes — `light-dark(rgb(0 0 0 / 50%), rgb(0 0 0 / 65%))` and `color-mix(in oklch, var(--cui-bg-body) 25%, transparent)` — so giving a drawer the dialog's dark scrim meant rewriting a whole expression (mrholek: *users will ask for a dark backdrop on the drawer*).

- **`:root`** emits `--cui-backdrop-color` (black), `--cui-backdrop-opacity` (50%, 65% in the dark scheme via the root dark block — `light-dark()` takes colours only) and `--cui-backdrop-blur` (8px). Each component's `*-backdrop-bg` token mixes them (`color-mix(in oklch, var(--cui-backdrop-color) var(--cui-backdrop-opacity), transparent)`), so either can be retuned alone, globally or per overlay; the drawer sets `--cui-backdrop-color: var(--cui-bg-body)` and `25%` in its map for its translucent look. `--cui-dialog-backdrop-bg` / `--cui-drawer-backdrop-bg` stay as the resulting tokens.
- **Presets** in `helpers/_backdrop.scss` (`@layer helpers`, so they beat the component maps): `.backdrop-scrim`, `.backdrop-translucent`, `.backdrop-none`. `.dialog-no-backdrop` / `.drawer-no-backdrop` keep working.
- **`backdrop-transitions($duration, $timing)`** in `mixins/_backdrop.scss` (upstream's `_dialog-shared` shape) replaces the two duplicated transition lists.
- **Sidebar**: its backdrop tokens were unprefixed `--cui-backdrop-zindex/-bg/-opacity`, which the new root tokens would have shadowed; they are `--cui-sidebar-backdrop-*` now.
- Docs: "Backdrop" section in `customize/components`, a preset example on the dialog and drawer pages; migration entry.
- Bundlewatch: the three root tokens reach every entry point, so `coreui-reboot.min.css` (at its ceiling) and `coreui-utilities.min.css` (+50 B) get their budgets raised to 6 kB / 19 kB, per the v6 rule.

Measured in Chromium after the entry transition, both schemes: dialog and drawer defaults identical before/after; `.drawer.backdrop-scrim` equals the dialog default, `.dialog.backdrop-translucent` equals the drawer default, `.backdrop-none` hides. Step 1 of the backdrop primitive; modal/offcanvas/sidebar move to the same tokens with the legacy decision. From the SCSS audit (D.4).