### PR TITLE
refactor(DateInput): read the control frame instead of restating it

### DIFF
--- a/scss/forms/_form-date-time.scss
+++ b/scss/forms/_form-date-time.scss
@@ -1,8 +1,8 @@
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
-@use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
 @use "../config" as *;
+@use "form-control-group" as *;
 
 // scss-docs-start form-date-time-variables
 $form-date-time-placeholder-color:       var(--#{$prefix}fg-2) !default;
@@ -38,22 +38,11 @@ $form-date-time-tokens: defaults(
 
     display: flex;
     align-items: center;
-    min-height: var(--#{$prefix}btn-input-min-height);
+    min-height: var(--#{$prefix}control-min-height);
     cursor: text;
 
-    &.form-control-sm {
-      min-height: var(--#{$prefix}btn-input-sm-min-height);
-    }
-
-    &.form-control-lg {
-      min-height: var(--#{$prefix}btn-input-lg-min-height);
-    }
-
     &:focus-within {
-      color: var(--#{$prefix}control-focus-color);
-      background-color: var(--#{$prefix}control-focus-bg);
-      border-color: var(--#{$prefix}control-focus-border-color);
-      @include focus-ring(true, $color: var(--#{$prefix}control-focus-ring));
+      @include form-control-group-focus();
     }
 
     &.disabled {


### PR DESCRIPTION
`.form-date-time` is `.form-control` on a `<div>`, so its focus and disabled states have to be restated for `:focus-within` and `.disabled` — its sizing did not. The element carries `--cui-control-min-height` from `.form-control` and the `.form-control-sm/-lg` loop already switches it, so the three `min-height` declarations collapse into one read of that token; a size added to `$form-control-sizes` now reaches the date field too. The focus block is the `form-control-group-focus()` mixin (same four declarations).

Compiled diff: the two `.form-date-time.form-control-sm/-lg` rules disappear, everything else byte-identical; layer order unchanged. Computed `min-height` measured identical in Chromium for default/sm/lg (38/31/48 px).