### PR TITLE
feat(OtpInput): .form-otp-group joins cells into one field

### DIFF
--- a/docs/src/content/docs/forms/otp-input.mdx
+++ b/docs/src/content/docs/forms/otp-input.mdx
@@ -212,6 +212,39 @@ Create custom one-time password layouts with separators and different field coun
     </div>
   </div>`} />
 
+## Grouped cells
+
+Wrap cells in `.form-otp-group` to join them into one field: the cells share their borders and only the outer corners keep the radius. One group joins the whole code; several groups split it into segments, spaced by the `--cui-form-otp-gap` of the wrapper.
+
+<Example pro code={`<div class="mb-3">
+    <label class="form-label">6-digit OTP, one group</label>
+    <div class="form-otp" data-coreui-toggle="otp">
+      <div class="form-otp-group">
+        <input class="form-otp-control">
+        <input class="form-otp-control">
+        <input class="form-otp-control">
+        <input class="form-otp-control">
+        <input class="form-otp-control">
+        <input class="form-otp-control">
+      </div>
+    </div>
+  </div>
+  <div>
+    <label class="form-label">6-digit OTP, two groups</label>
+    <div class="form-otp" data-coreui-toggle="otp">
+      <div class="form-otp-group">
+        <input class="form-otp-control">
+        <input class="form-otp-control">
+        <input class="form-otp-control">
+      </div>
+      <div class="form-otp-group">
+        <input class="form-otp-control">
+        <input class="form-otp-control">
+        <input class="form-otp-control">
+      </div>
+    </div>
+  </div>`} />
+
 ## Sizing variants
 
 One-time password input supports different sizes. You may choose from small, normal (default), and large inputs to match our similarly sized text inputs.  To adjust the size of a component, use `.form-otp-lg` or `.form-otp-sm`.

--- a/scss/forms/_otp-input.scss
+++ b/scss/forms/_otp-input.scss
@@ -103,6 +103,26 @@ $form-otp-control-tokens: defaults(
     }
   }
 
+  .form-otp-group {
+    display: flex;
+
+    > .form-otp-control {
+      &:not(:first-child) {
+        margin-inline-start: calc(var(--#{$prefix}control-border-width) * -1);
+        @include border-start-radius(0);
+      }
+
+      &:not(:last-child) {
+        @include border-end-radius(0);
+      }
+
+      &:focus {
+        position: relative;
+        z-index: 1;
+      }
+    }
+  }
+
   // scss-docs-start form-otp-sizes-loop
   @each $size, $values in $form-otp-sizes {
     .form-otp-#{$size} .form-otp-control {


### PR DESCRIPTION
Cells wrapped in `.form-otp-group` share their borders: every cell after the first pulls back by `--cui-control-border-width` and drops its start radius, every cell before the last drops its end radius, and the focused cell is raised (`position: relative; z-index: 1`) so its ring and border sit above the neighbours. One group joins the whole code; several groups split it into segments spaced by the wrapper's `--cui-form-otp-gap`.

The JS finds cells by descendant selector, so the wrapper needs no option and no port of the vanilla script. Measured in Chromium on a 3-cell lg group: radii 12/0, 0/0, 0/12 px; cells overlap by 1 px; focused cell `position: relative`, `z-index: 1`.

Docs: new **Grouped cells** section (one group, and 3 + 3). React/Vue ports follow in their own PRs (the components clone direct children, so they need a group component and a recursive walk).