### PR TITLE
refactor(ChipInput): read the group's tokens instead of a private frame

### DIFF
--- a/docs/src/content/docs/forms/chip-input.mdx
+++ b/docs/src/content/docs/forms/chip-input.mdx
@@ -288,7 +288,7 @@ The Bootstrap Chip Input component follows WAI-ARIA patterns to ensure the chip 
 
 ### CSS variables
 
-Chips inputs use local CSS variables on `.chip-input` for enhanced real-time customization.
+A chip input is a `.form-control-group`, so it reads the group's `--cui-control-*` tokens; `.chip-input` only re-points the ones it sets differently — padding, border colour and radius, and the gap between chips. Override any group token on the element to restyle a single chip input.
 
 <ScssDocs file="scss/forms/_chip-input.scss" capture="chip-input-css-vars" />
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -978,6 +978,19 @@ A chip input has no control to wrap — the element *is* the frame — so it add
 `.form-control-group` to itself rather than asking you to write both. Writing
 both still works; the component only removes on `dispose()` a class it added.
 
+#### Chip Input reads the group's tokens
+
+`.chip-input` no longer keeps a private copy of the frame. `--cui-chip-input-min-height`
+and `--cui-chip-input-gap` are gone: the element reads `--cui-control-min-height`
+and `--cui-control-group-gap` from `.form-control-group` like every other group,
+and `.chip-input-sm`/`-lg` switch those tokens instead of private ones. The Sass
+variables that only re-pointed a `--cui-btn-input-*` token (`$chip-input-min-height`,
+`-font-size`, `-bg`, `-color`, `-border-width`, `-transition-*` and the size
+variants of min-height and font-size) are removed; what remains is what the chip
+input sets differently — padding, border colour and radius, and the gap, per
+size. The disabled chip's opacity reads `--cui-control-group-disabled-opacity`
+instead of a literal `.65`. Rendered values are unchanged.
+
 #### Number Input (new)
 
 - **New component: [Number Input](/forms/number-input/)** (PRO) — a number field

--- a/scss/forms/_chip-input.scss
+++ b/scss/forms/_chip-input.scss
@@ -1,37 +1,24 @@
 @use "sass:map";
 @use "../functions/defaults" as *;
-@use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
 @use "../config" as *;
 
 // scss-docs-start chip-input-variables
-$chip-input-min-height:          var(--#{$prefix}btn-input-min-height) !default;
 $chip-input-padding-y:           .25rem !default;
 $chip-input-padding-x:           .75rem !default;
-$chip-input-font-size:           var(--#{$prefix}btn-input-font-size) !default;
-$chip-input-bg:                  var(--#{$prefix}btn-input-bg) !default;
-$chip-input-color:               var(--#{$prefix}btn-input-color) !default;
-$chip-input-border-width:        var(--#{$prefix}btn-input-border-width) !default;
 $chip-input-border-color:        var(--#{$prefix}border-color) !default;
 $chip-input-border-radius:       var(--#{$prefix}radius-4) !default;
 $chip-input-gap:                 .375rem !default;
-$chip-input-transition-property: var(--#{$prefix}btn-input-transition-property) !default;
-$chip-input-transition-duration: var(--#{$prefix}btn-input-transition-duration) !default;
-$chip-input-transition-timing:   var(--#{$prefix}btn-input-transition-timing) !default;
 
-$chip-input-min-height-sm:     var(--#{$prefix}btn-input-sm-min-height) !default;
-$chip-input-padding-y-sm:      .125rem !default;
-$chip-input-padding-x-sm:      .5rem !default;
-$chip-input-font-size-sm:      var(--#{$prefix}btn-input-sm-font-size) !default;
-$chip-input-border-radius-sm:  var(--#{$prefix}radius-3) !default;
-$chip-input-gap-sm:            .125rem !default;
+$chip-input-padding-y-sm:        .125rem !default;
+$chip-input-padding-x-sm:        .5rem !default;
+$chip-input-border-radius-sm:    var(--#{$prefix}radius-3) !default;
+$chip-input-gap-sm:              .125rem !default;
 
-$chip-input-min-height-lg:     var(--#{$prefix}btn-input-lg-min-height) !default;
-$chip-input-padding-y-lg:      .375rem !default;
-$chip-input-padding-x-lg:      1rem !default;
-$chip-input-font-size-lg:      var(--#{$prefix}btn-input-lg-font-size) !default;
-$chip-input-border-radius-lg:  var(--#{$prefix}radius-5) !default;
-$chip-input-gap-lg:            .5rem !default;
+$chip-input-padding-y-lg:        .375rem !default;
+$chip-input-padding-x-lg:        1rem !default;
+$chip-input-border-radius-lg:    var(--#{$prefix}radius-5) !default;
+$chip-input-gap-lg:              .5rem !default;
 // scss-docs-end chip-input-variables
 
 $chip-input-sizes: () !default;
@@ -41,18 +28,14 @@ $chip-input-sizes: () !default;
 $chip-input-sizes: defaults(
   (
     "sm": (
-      min-height:    $chip-input-min-height-sm,
       padding-y:     $chip-input-padding-y-sm,
       padding-x:     $chip-input-padding-x-sm,
-      font-size:     $chip-input-font-size-sm,
       border-radius: $chip-input-border-radius-sm,
       gap:           $chip-input-gap-sm,
     ),
     "lg": (
-      min-height:    $chip-input-min-height-lg,
       padding-y:     $chip-input-padding-y-lg,
       padding-x:     $chip-input-padding-x-lg,
-      font-size:     $chip-input-font-size-lg,
       border-radius: $chip-input-border-radius-lg,
       gap:           $chip-input-gap-lg,
     ),
@@ -67,19 +50,11 @@ $chip-input-sizes: defaults(
 $chip-input-tokens: () !default;
 $chip-input-tokens: defaults(
   (
-    --#{$prefix}chip-input-min-height: #{$chip-input-min-height},
     --#{$prefix}control-padding-y: #{$chip-input-padding-y},
     --#{$prefix}control-padding-x: #{$chip-input-padding-x},
-    --#{$prefix}control-font-size: #{$chip-input-font-size},
-    --#{$prefix}control-bg: #{$chip-input-bg},
-    --#{$prefix}control-color: #{$chip-input-color},
-    --#{$prefix}control-border-width: #{$chip-input-border-width},
     --#{$prefix}control-border-color: #{$chip-input-border-color},
     --#{$prefix}control-border-radius: #{$chip-input-border-radius},
-    --#{$prefix}chip-input-gap: #{$chip-input-gap},
-    --#{$prefix}control-transition-property: #{$chip-input-transition-property},
-    --#{$prefix}control-transition-duration: #{$chip-input-transition-duration},
-    --#{$prefix}control-transition-timing: #{$chip-input-transition-timing},
+    --#{$prefix}control-group-gap: #{$chip-input-gap},
   ),
   $chip-input-tokens
 );
@@ -92,11 +67,9 @@ $chip-input-tokens: defaults(
     @include tokens($chip-input-tokens);
 
     flex-wrap: wrap;
-    gap: var(--#{$prefix}chip-input-gap);
-    min-height: var(--#{$prefix}chip-input-min-height);
 
     &.disabled > .chip {
-      opacity: .65;
+      opacity: var(--#{$prefix}control-group-disabled-opacity);
 
       .chip-remove {
         pointer-events: none;
@@ -114,12 +87,12 @@ $chip-input-tokens: defaults(
   // scss-docs-start chip-input-sizes-loop
   @each $size, $values in $chip-input-sizes {
     .chip-input-#{$size} {
-      --#{$prefix}chip-input-min-height: #{map.get($values, min-height)};
+      --#{$prefix}control-min-height: var(--#{$prefix}btn-input-#{$size}-min-height);
       --#{$prefix}control-padding-y: #{map.get($values, padding-y)};
       --#{$prefix}control-padding-x: #{map.get($values, padding-x)};
+      --#{$prefix}control-font-size: var(--#{$prefix}btn-input-#{$size}-font-size);
       --#{$prefix}control-border-radius: #{map.get($values, border-radius)};
-      --#{$prefix}control-font-size: #{map.get($values, font-size)};
-      --#{$prefix}chip-input-gap: #{map.get($values, gap)};
+      --#{$prefix}control-group-gap: #{map.get($values, gap)};
     }
   }
   // scss-docs-end chip-input-sizes-loop


### PR DESCRIPTION
`.chip-input` is a `.form-control-group`, and the group already declares the full `--cui-control-*` map, the frame, `min-height` and `gap` on that element. The chip-input partial declared a second set next to it: a private `--cui-chip-input-min-height` with the group's value, a private gap overriding the group's `gap` declaration, eight control tokens re-pointing the same `--cui-btn-input-*` defaults, and the disabled chip opacity as a literal `.65`.

The map now carries only what the chip input sets differently (padding, border colour and radius, `--cui-control-group-gap`); the size loop switches `--cui-control-min-height` and `-font-size` like the group's loop; the opacity reads `--cui-control-group-disabled-opacity`. Twelve pass-through Sass variables removed (migration entry). `.chip-input-sm/-lg` stay as the public size classes (React/Vue emit them).

Compiled diff: the private tokens and the duplicate defaults disappear, nothing else changes. Computed `min-height`, `gap`, padding, font-size, radius, border colour and chip opacity measured identical in Chromium for default/sm/lg before and after. The `.chip-input` rule still wins over `.form-control-group` by source order (same specificity), as before — recorded in the audit.