### PR TITLE
refactor: translucent surfaces share two root tokens

### DIFF
--- a/docs/src/content/docs/components/card.mdx
+++ b/docs/src/content/docs/components/card.mdx
@@ -751,6 +751,6 @@ Sass variables set these defaults at build time and are removed in v7. The CSS v
 
 <ScssDocs file="scss/_card.scss" capture="card-variables" />
 
-The `.card-translucent` mix amounts and backdrop filter are build-time only — they are not tokens, so a card does not carry three custom properties it will never read.
+`.card-translucent` mixes and blurs through the shared [`--cui-translucent-*` tokens](/customize/components/#translucent); the caps' own mix amount is `--cui-card-translucent-cap-bg-opacity` on the element, set from:
 
 <ScssDocs file="scss/_card.scss" capture="card-translucent-variables" />

--- a/docs/src/content/docs/components/navbar.mdx
+++ b/docs/src/content/docs/components/navbar.mdx
@@ -720,10 +720,6 @@ Variables for the [dark navbar](#color-schemes):
 
 <ScssDocs file="scss/_navbar.scss" capture="navbar-dark-variables" />
 
-The `.navbar-translucent` mix amount and backdrop filter are build-time only — they are not tokens, so a navbar does not carry two custom properties it will never read.
-
-<ScssDocs file="scss/_navbar.scss" capture="navbar-translucent-variables" />
-
 ### Sass loops
 
 [Responsive navbar expand/collapse classes](#responsive-behaviors) (e.g., `.navbar-expand-sm`) are combined with the `$breakpoints` map and generated through a loop in `scss/_navbar.scss`.

--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -415,7 +415,3 @@ Toasts use local CSS variables on `.toast` for enhanced real-time customization.
 Sass variables set these defaults at build time and are removed in v7. The CSS variables above reach the same values without recompiling, and can be set on a single element.
 
 <ScssDocs file="scss/_toasts.scss" capture="toast-variables" />
-
-The `.toast-translucent` mix amount and backdrop filter are build-time only — they are not tokens, so a toast does not carry two custom properties it will never read.
-
-<ScssDocs file="scss/_toasts.scss" capture="toast-translucent-variables" />

--- a/docs/src/content/docs/customize/components.mdx
+++ b/docs/src/content/docs/customize/components.mdx
@@ -101,6 +101,16 @@ Every overlay that dims the page — the dialog and the drawer through their nat
 
 The colour and the opacity are mixed on the element (`color-mix(in oklch, var(--cui-backdrop-color) var(--cui-backdrop-opacity), transparent)`), so either can be changed alone, globally on `:root` or on one overlay. The dialog keeps the defaults, a dark scrim that deepens in the dark scheme; the drawer sets its own tint of the page (`--cui-bg-body` at 25%). The [backdrop helper](/helpers/backdrop/) picks either look — or no backdrop at all — from the markup.
 
+## Translucent
+
+The `*-translucent` variants — `.navbar-translucent`, `.toast-translucent`, `.card-translucent`, `.drawer-translucent` and `.menu-translucent` — let the page show through a blurred, saturated surface. All five mix the component's own background with one opacity and apply one filter, both tokens on `:root`:
+
+<ScssDocs file="scss/_root.scss" capture="root-translucent-variables" />
+
+Set them on `:root` to retune every translucent surface at once, or on one element to change just that one — `style="--cui-translucent-opacity: 60%"` on a card leaves the navbar alone. Their build-time defaults:
+
+<ScssDocs file="scss/_root.scss" capture="translucent-variables" />
+
 ## Responsive
 
 These Sass loops aren't limited to color maps, either. You can also generate responsive variations of your components. Take for example our responsive alignment of the dropdowns where we mix an `@each` loop for the `$grid-breakpoints` Sass map with a media query include.

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -663,6 +663,24 @@ check, radio, carousel and toggler icons already work:
   reach for Dialog and Drawer in new work. See the
   [Dialog docs](/components/dialog/) and [Drawer docs](/components/drawer/).
 
+
+#### Translucent surfaces share two tokens
+
+`.navbar-translucent`, `.toast-translucent`, `.card-translucent`,
+`.drawer-translucent` and `.menu-translucent` used to carry their own mix
+amount and filter — two as Sass variables, three as literals — at 85% or 80%
+depending on the component. All five now read `--cui-translucent-opacity`
+(80%) and `--cui-translucent-backdrop-filter` (`blur(5px) saturate(180%)`)
+from `:root`, so one override retunes every translucent surface and one on an
+element retunes that surface alone. Consequences: the navbar, the toast and
+the card become slightly more see-through (85% → 80%; set
+`--cui-translucent-opacity: 85%` on them to keep the old look), and
+`$navbar-translucent-bg-opacity`, `$navbar-translucent-backdrop-filter`,
+`$toast-translucent-bg-opacity`, `$toast-translucent-backdrop-filter`,
+`$card-translucent-bg-opacity` and `$card-translucent-backdrop-filter` are
+removed in favour of `$translucent-opacity` and
+`$translucent-backdrop-filter`. The card's caps keep their own amount as the
+`--cui-card-translucent-cap-bg-opacity` token on `.card-translucent`.
 #### Calendar
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
@@ -1467,7 +1485,7 @@ adornment in the library — so the button needs no icon markup at all:
   keep the previous rendering.
 - **`.navbar-translucent` is new.** It tints and blurs the navbar the way
   `.toast-translucent` does for a toast, mixing `--cui-navbar-bg` — a new token,
-  defaulting to the body background — at 85%.
+  defaulting to the body background — at `--cui-translucent-opacity`.
 - **A theme beats a navbar token, as everywhere else.** `--cui-navbar-brand-color`,
   `-brand-hover-color` and `-active-color` carried the `--cui-theme-*` slot inside
   their own default, so setting one of them inside a `.theme-{color}` navbar
@@ -1840,9 +1858,10 @@ Multi Select's option indicators moved with it — they render as a decorative
 - **New: `.card-subtle`** swaps the theme's solid fill for its subtle
   background, border and emphasis text.
 - **New: `.card-translucent`** blurs and saturates whatever is behind the card
-  and thins out the caps to match. Tuned at build time through
-  `$card-translucent-bg-opacity`, `$card-translucent-cap-bg-opacity` and
-  `$card-translucent-backdrop-filter`.
+  and thins out the caps to match. The mix and the filter are the shared
+  `--cui-translucent-*` tokens; the caps read
+  `--cui-card-translucent-cap-bg-opacity` (Sass default
+  `$card-translucent-cap-bg-opacity`).
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
   **`.card-group` attaches its cards from a container query, not a media
   query.** The `sm` breakpoint is now the width of the nearest query container,

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -3,6 +3,7 @@
 @use "mixins/box-shadow" as *;
 @use "layout/breakpoints" as *;
 @use "mixins/tokens" as *;
+@use "mixins/translucent" as *;
 @use "config" as *;
 
 // scss-docs-start card-variables
@@ -28,9 +29,7 @@ $card-group-margin:                 $grid-gutter-width * .5 !default;
 // scss-docs-end card-variables
 
 // scss-docs-start card-translucent-variables
-$card-translucent-bg-opacity:       80% !default;
 $card-translucent-cap-bg-opacity:   60% !default;
-$card-translucent-backdrop-filter:  blur(5px) saturate(180%) !default;
 // scss-docs-end card-translucent-variables
 
 $card-tokens: () !default;
@@ -182,12 +181,12 @@ $card-tokens: defaults(
   }
 
   .card-translucent {
-    background-color: color-mix(in oklch, var(--#{$prefix}card-bg) #{$card-translucent-bg-opacity}, transparent);
-    backdrop-filter: $card-translucent-backdrop-filter;
+    --#{$prefix}card-translucent-cap-bg-opacity: #{$card-translucent-cap-bg-opacity};
+    @include translucent(var(--#{$prefix}card-bg));
 
     .card-header,
     .card-footer {
-      background-color: color-mix(in oklch, var(--#{$prefix}card-cap-bg) #{$card-translucent-cap-bg-opacity}, transparent);
+      background-color: color-mix(in oklch, var(--#{$prefix}card-cap-bg) var(--#{$prefix}card-translucent-cap-bg-opacity), transparent);
     }
   }
 

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -7,6 +7,7 @@
 @use "mixins/ltr-rtl" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
+@use "mixins/translucent" as *;
 @use "config" as *;
 
 // stylelint-disable custom-property-no-missing-var-function
@@ -270,8 +271,7 @@ $drawer-tokens: defaults(
   }
 
   .drawer-translucent {
-    background-color: color-mix(in oklch, var(--#{$prefix}drawer-bg) 80%, transparent);
-    backdrop-filter: blur(5px) saturate(180%);
+    @include translucent(var(--#{$prefix}drawer-bg));
   }
 
   .drawer-sheet {

--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -5,6 +5,7 @@
 @use "mixins/box-shadow" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
+@use "mixins/translucent" as *;
 
 // The Menu component, ported from Bootstrap v6. Dropdown keeps its own partial
 // and classes — Menu is the new-generation surface the JS implementation is
@@ -177,8 +178,7 @@ $menu-tokens: defaults(
     --#{$prefix}menu-item-hover-bg: color-mix(in oklch, var(--#{$prefix}bg-1) 85%, transparent);
     --#{$prefix}menu-item-active-bg: color-mix(in oklch, var(--#{$prefix}primary) 75%, transparent);
 
-    background-color: color-mix(in oklch, var(--#{$prefix}menu-bg) 80%, transparent);
-    backdrop-filter: blur(5px) saturate(180%);
+    @include translucent(var(--#{$prefix}menu-bg));
   }
 
   .menu-divider {

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -12,6 +12,7 @@
 @use "mixins/gradients" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
+@use "mixins/translucent" as *;
 @use "nav" as *;
 @use "colors" as *;
 @use "config" as *;
@@ -51,11 +52,6 @@ $navbar-light-toggler-border-color: color-mix(in srgb, var(--#{$prefix}emphasis-
 $navbar-light-brand-color:          $navbar-light-active-color !default;
 $navbar-light-brand-hover-color:    $navbar-light-active-color !default;
 // scss-docs-end navbar-variables
-
-// scss-docs-start navbar-translucent-variables
-$navbar-translucent-bg-opacity:      85% !default;
-$navbar-translucent-backdrop-filter: blur(5px) saturate(180%) !default;
-// scss-docs-end navbar-translucent-variables
 
 // scss-docs-start navbar-dark-variables
 $navbar-dark-color:                 rgba($white, .55) !default;
@@ -420,8 +416,7 @@ $navbar-dark-tokens: defaults(
   // `.navbar` itself stays transparent, so the tint reads the token rather than
   // the painted background.
   .navbar-translucent {
-    background-color: color-mix(in oklch, var(--#{$prefix}navbar-bg) #{$navbar-translucent-bg-opacity}, transparent);
-    backdrop-filter: $navbar-translucent-backdrop-filter;
+    @include translucent(var(--#{$prefix}navbar-bg));
   }
 
   .navbar-dark,

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -78,6 +78,11 @@ $backdrop-opacity:            50% !default;
 $backdrop-opacity-dark:       65% !default;
 $backdrop-blur:               8px !default;
 // scss-docs-end backdrop-variables
+
+// scss-docs-start translucent-variables
+$translucent-opacity:         80% !default;
+$translucent-backdrop-filter: blur(5px) saturate(180%) !default;
+// scss-docs-end translucent-variables
 // scss-docs-start focus-ring-variables
 // scss-docs-end focus-ring-variables
 
@@ -289,6 +294,10 @@ $root-token-defaults: map.merge(
     --#{$prefix}backdrop-opacity: $backdrop-opacity,
     --#{$prefix}backdrop-blur: $backdrop-blur,
     // scss-docs-end root-backdrop-variables
+    // scss-docs-start root-translucent-variables
+    --#{$prefix}translucent-opacity: $translucent-opacity,
+    --#{$prefix}translucent-backdrop-filter: $translucent-backdrop-filter,
+    // scss-docs-end root-translucent-variables
     // scss-docs-start root-btn-input-variables
     // Sizing shared by buttons and form controls, so neither has to reach for
     // the other's Sass variables to line up.

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -2,6 +2,7 @@
 @use "mixins/border-radius" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
+@use "mixins/translucent" as *;
 @use "config" as *;
 
 // stylelint-disable custom-property-no-missing-var-function
@@ -26,11 +27,6 @@ $toast-header-color:                var(--#{$prefix}fg-3) !default;
 $toast-header-background-color:     $toast-background-color !default;
 $toast-header-border-color:         $toast-border-color !default;
 // scss-docs-end toast-variables
-
-// scss-docs-start toast-translucent-variables
-$toast-translucent-bg-opacity:      85% !default;
-$toast-translucent-backdrop-filter: blur(5px) saturate(180%) !default;
-// scss-docs-end toast-translucent-variables
 
 $toast-tokens: () !default;
 
@@ -141,11 +137,10 @@ $toast-tokens: defaults(
   }
 
   .toast-translucent {
-    background-color: color-mix(in oklch, var(--#{$prefix}toast-bg) #{$toast-translucent-bg-opacity}, transparent);
-    backdrop-filter: $toast-translucent-backdrop-filter;
+    @include translucent(var(--#{$prefix}toast-bg));
 
     .toast-header {
-      background-color: color-mix(in oklch, var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}toast-header-bg)) #{$toast-translucent-bg-opacity}, transparent);
+      background-color: color-mix(in oklch, var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}toast-header-bg)) var(--#{$prefix}translucent-opacity), transparent);
     }
   }
 }

--- a/scss/mixins/_translucent.scss
+++ b/scss/mixins/_translucent.scss
@@ -1,0 +1,6 @@
+@use "../config" as *;
+
+@mixin translucent($bg) {
+  background-color: color-mix(in oklch, #{$bg} var(--#{$prefix}translucent-opacity), transparent);
+  backdrop-filter: var(--#{$prefix}translucent-backdrop-filter);
+}

--- a/scss/mixins/index.scss
+++ b/scss/mixins/index.scss
@@ -33,6 +33,7 @@
 @forward "box-shadow";
 @forward "gradients";
 @forward "transition";
+@forward "translucent";
 
 // Layout
 @forward "clearfix";


### PR DESCRIPTION
The five `*-translucent` variants (navbar, toast, card, drawer, menu) mixed their background and applied `backdrop-filter` each in its own way: two through Sass knobs compiled into the rule, three as literals, at 85% or 80% depending on the component, and none of it reachable from the browser.

They now go through a `translucent($bg)` mixin that reads `--cui-translucent-opacity` (80%) and `--cui-translucent-backdrop-filter` (`blur(5px) saturate(180%)`) from `:root`, so one override retunes every surface and one on an element retunes that surface alone. The card's caps keep their own amount as `--cui-card-translucent-cap-bg-opacity` on `.card-translucent`.

Visible change: navbar, toast and card move from 85% to 80% (set `--cui-translucent-opacity: 85%` on them to keep the old look). Six component Sass knobs are replaced by `$translucent-opacity` and `$translucent-backdrop-filter` — migration entry. Docs: **Translucent** section on customize/components with both blocks; the three per-component Sass blocks that only held the knobs are gone.

Measured in Chromium before/after: navbar, toast and toast header 0.85 → 0.8 alpha, card/drawer/menu unchanged, card caps unchanged, and an element-level `--cui-translucent-opacity: 40%` now yields 0.4 where it was ignored before. Layer order unchanged, docs build green.