### PR TITLE
feat(Tooltip): theme slots, roomier padding, .95 opacity

### DIFF
--- a/docs/src/content/docs/components/tooltips.mdx
+++ b/docs/src/content/docs/components/tooltips.mdx
@@ -67,6 +67,15 @@ Feel free to personalize the look of your tooltips with [CSS variables](#css-var
     Custom tooltip
   </button>`} />
 
+### Theme variants
+
+A tooltip reads the `.theme-{color}` slots, so a theme class on the tip colours its surface and picks the contrasting text. The class lands on the tip through `data-coreui-custom-class`; without one the tip keeps its default look, the page's foreground colour.
+
+<Example class="tooltip-demo" sandboxJsId="enable-tooltips" code={`<button type="button" class="btn-outline" data-coreui-toggle="tooltip" data-coreui-custom-class="theme-primary" data-coreui-title="Primary tooltip">Primary</button>
+  <button type="button" class="btn-outline" data-coreui-toggle="tooltip" data-coreui-custom-class="theme-secondary" data-coreui-title="Secondary tooltip">Secondary</button>
+  <button type="button" class="btn-outline" data-coreui-toggle="tooltip" data-coreui-custom-class="theme-success" data-coreui-title="Success tooltip">Success</button>
+  <button type="button" class="btn-outline" data-coreui-toggle="tooltip" data-coreui-custom-class="theme-danger" data-coreui-title="Danger tooltip">Danger</button>`} />
+
 ### Positioning
 
 Bootstrap Tooltips support multiple placements: top, right, bottom, and left. The default is top. Directions are mirrored when using CoreUI in RTL. To change placement, use the `data-coreui-placement` attribute:

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1232,6 +1232,15 @@ adornment in the library — so the button needs no icon markup at all:
   had been `null` and deprecated since v4; the token compiled to an empty
   value and the `margin` declaration reading it never took effect. Position
   a tooltip with the JS `offset` option instead.
+- **Roomier tip, less see-through.** `--cui-tooltip-padding-y` is
+  `calc(var(--cui-spacer) * .375)` (was `--cui-spacer-1`),
+  `--cui-tooltip-padding-x` is `--cui-spacer-3` (was `--cui-spacer-2`) and
+  `--cui-tooltip-opacity` is `.95` (was `.9`). Set the three tokens on
+  `.tooltip` to keep the old proportions.
+- **Tooltips take theme classes.** `--cui-tooltip-bg` and `--cui-tooltip-color`
+  carry the `--cui-theme-bg`/`--cui-theme-contrast` slots, so a
+  `.theme-{color}` class on the tip (via `customClass`) colours it; the
+  default look is unchanged.
 
 #### OTP input
 

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -11,9 +11,9 @@ $tooltip-max-width:                 200px !default;
 $tooltip-color:                     var(--#{$prefix}bg-body) !default;
 $tooltip-bg:                        var(--#{$prefix}fg-body) !default;
 $tooltip-border-radius:             var(--#{$prefix}radius-5) !default;
-$tooltip-opacity:                   .9 !default;
-$tooltip-padding-y:                 var(--#{$prefix}spacer-1) !default;
-$tooltip-padding-x:                 var(--#{$prefix}spacer-2) !default;
+$tooltip-opacity:                   .95 !default;
+$tooltip-padding-y:                 calc(var(--#{$prefix}spacer) * .375) !default;
+$tooltip-padding-x:                 var(--#{$prefix}spacer-3) !default;
 
 $tooltip-arrow-width:               .8rem !default;
 $tooltip-arrow-height:              .4rem !default;
@@ -35,8 +35,8 @@ $tooltip-tokens: defaults(
     --#{$prefix}tooltip-padding-x: #{$tooltip-padding-x},
     --#{$prefix}tooltip-padding-y: #{$tooltip-padding-y},
     --#{$prefix}tooltip-font-size: #{$tooltip-font-size},
-    --#{$prefix}tooltip-color: #{$tooltip-color},
-    --#{$prefix}tooltip-bg: #{$tooltip-bg},
+    --#{$prefix}tooltip-color: var(--#{$prefix}theme-contrast, #{$tooltip-color}),
+    --#{$prefix}tooltip-bg: var(--#{$prefix}theme-bg, #{$tooltip-bg}),
     --#{$prefix}tooltip-border-radius: #{$tooltip-border-radius},
     --#{$prefix}tooltip-opacity: #{$tooltip-opacity},
     --#{$prefix}tooltip-arrow-width: #{$tooltip-arrow-width},


### PR DESCRIPTION
`--cui-tooltip-bg` and `--cui-tooltip-color` carry the `--cui-theme-bg`/`--cui-theme-contrast` slots, so a `.theme-<color>` class on the tip (via `customClass`) colours it. Both tokens are declared and read on `.tooltip`, so the slot sits inside the token (the #910 rule). Padding moves to `calc(var(--cui-spacer) * .375)` / `var(--cui-spacer-3)` (6/16 px, was 4/8) and the surface opacity to `.95` (was `.9`); `--cui-tooltip-surface-bg` (opacity folded into the colour for contrast) stays.

Measured in Chromium: default tip unchanged apart from padding and alpha; `.theme-danger` now paints the danger colour with black text where it did nothing before. Docs: **Theme variants** example under Examples, two migration entries. React/Vue docs sections follow; the range slider bubble moves onto the tooltip markup in a separate PR.