### PR TITLE
fix(RangeSlider): keep the bubble body inside the <output>

### DIFF
--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -243,6 +243,10 @@ $range-slider-vertical-tokens: defaults(
     inset-inline-start: calc(var(--#{$prefix}range-slider-thumb-width) * .5 + var(--cui-range-slider-tooltip-position, 0) * (100% - var(--#{$prefix}range-slider-thumb-width)));
     pointer-events: none;
     @include ltr-rtl("transform", translateX(-50%), null, translateX(50%));
+
+    .tooltip-inner {
+      display: block;
+    }
   }
 
   .range-slider:not(.range-slider-vertical) {


### PR DESCRIPTION
Follow-up to #1133. The bubble's `.tooltip-inner` is a `<span>` (an `<output>` holds phrasing content), so it laid out inline: the output's line box was 21 px tall while the padded span was 29 px, and the 4 px of overflow at the bottom covered the arrow anchored to the output's edge. The span is a block now, the output wraps it exactly and the arrow hangs below the body again.

Measured on the built docs with the real plugin: output and inner share the same 33 px box, the arrow starts on the bubble's bottom edge (horizontal) and on its end edge (vertical). CSS-only, so the React/Vue ports need nothing.