### PR TITLE
fix(Tooltip): 12 px horizontal padding

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1246,7 +1246,7 @@ adornment in the library — so the button needs no icon markup at all:
   a tooltip with the JS `offset` option instead.
 - **Roomier tip, less see-through.** `--cui-tooltip-padding-y` is
   `calc(var(--cui-spacer) * .375)` (was `--cui-spacer-1`),
-  `--cui-tooltip-padding-x` is `--cui-spacer-3` (was `--cui-spacer-2`) and
+  `--cui-tooltip-padding-x` is `calc(var(--cui-spacer) * .75)` (was `--cui-spacer-2`) and
   `--cui-tooltip-opacity` is `.95` (was `.9`). Set the three tokens on
   `.tooltip` to keep the old proportions.
 - **Tooltips take theme classes.** `--cui-tooltip-bg` and `--cui-tooltip-color`

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -13,7 +13,7 @@ $tooltip-bg:                        var(--#{$prefix}fg-body) !default;
 $tooltip-border-radius:             var(--#{$prefix}radius-5) !default;
 $tooltip-opacity:                   .95 !default;
 $tooltip-padding-y:                 calc(var(--#{$prefix}spacer) * .375) !default;
-$tooltip-padding-x:                 var(--#{$prefix}spacer-3) !default;
+$tooltip-padding-x:                 calc(var(--#{$prefix}spacer) * .75) !default;
 
 $tooltip-arrow-width:               .8rem !default;
 $tooltip-arrow-height:              .4rem !default;


### PR DESCRIPTION
Follow-up to #1132. The horizontal padding was set to `--cui-spacer-3` by token name; on our spacer scale that is 1rem where the intended value is .75rem, so the tip came out 16 px wide at the sides instead of 12 (measured live against the upstream docs: 6/12 px there, 6/16 px here, everything else identical). It now reads `calc(var(--cui-spacer) * .75)`, which keeps the value on the spacer knob without depending on the scale's step names. The range slider bubble follows. Migration entry updated.