### PR TITLE
feat(RangeSlider): tooltipClass for the value tooltip, tooltip keeps the plain look

### DIFF
--- a/docs/src/content/docs/forms/range-slider.mdx
+++ b/docs/src/content/docs/forms/range-slider.mdx
@@ -113,7 +113,7 @@ By default, users can click on labels to set the slider to specific values. You 
 
 ## Tooltips
 
-The value bubble is a [tooltip](/components/tooltips/): the plugin renders `<output class="range-slider-tooltip tooltip bs-tooltip-top">` with the tooltip's arrow and body, so it takes the tooltip's look, its `--cui-tooltip-*` tokens and its theme slots. A `.theme-{color}` class on the slider colours the thumb and the bubble alike.
+The value bubble is a [tooltip](/components/tooltips/): the plugin renders `<output class="range-slider-tooltip tooltip bs-tooltip-top">` with the tooltip's arrow and body, so it takes the tooltip's look and its `--cui-tooltip-*` tokens. The bubble does not inherit the slider's theme: it stays the plain tooltip inside a `.theme-{color}` slider, and takes its own theme through the `customClass` option.
 
 By default, tooltips display the current value of each handle. You can disable tooltips by setting `tooltips` to `false`
 
@@ -144,6 +144,11 @@ If you set `data-coreui-track` to `false`, the slider's track will not display a
 Color the filled track and the handles by adding a [`.theme-{color}` class](/customize/components/#theme-variants) to the slider element.
 
 <Example pro class="d-flex flex-column gap-3" code={getData('theme-colors').map((c) => `<div class="theme-${c.name}" data-coreui-toggle="range-slider" data-coreui-value="25, 75" data-coreui-aria-labels='["${c.title} minimum", "${c.title} maximum"]'></div>`)} />
+
+The value bubble keeps the default tooltip look inside a themed slider. To theme the bubble alone, or differently, pass a `theme-{color}` class through the `customClass` option — it lands on the bubble only.
+
+<Example pro class="d-flex flex-column gap-3" code={`<div data-coreui-toggle="range-slider" data-coreui-value="40" data-coreui-custom-class="theme-secondary" data-coreui-aria-labels='["Secondary bubble"]'></div>
+  <div class="theme-danger" data-coreui-toggle="range-slider" data-coreui-value="60" data-coreui-custom-class="theme-inverse" data-coreui-aria-labels='["Danger slider, inverse bubble"]'></div>`} />
 
 ## Usage
 
@@ -194,6 +199,7 @@ Please note that for security reasons, the `sanitize`, `sanitizeFn`, and `allowL
 | `allowList` | object | [Default value](/getting-started/javascript#sanitizer) |  Defines the set of permitted HTML tags and attributes that can safely appear in the tooltip content when HTML content is passedd. This helps maintain control over the output and prevent injection of malicious code. |
 | `ariaLabels` | array, null | `null` | Accessible name of each handle, in order. Handles are otherwise indistinguishable to a screen reader, so a slider with more than one wants this. A shorter array leaves the remaining handles unnamed. |
 | `clickableLabels` | boolean | `true` | Enables or disables the ability to click on labels to set slider values. |
+| `customClass` | string | `''` | Adds one or more classes to the value bubble alone — a `theme-{color}` class themes the bubble without touching the slider. |
 | `disabled` | boolean | `false` | Disables the slider, making it non-interactive and grayed out. |
 | `distance` | number | `0` | Sets the minimum distance between multiple slider handles. |
 | `labels` | array, boolean, string | `false` | Adds labels to the slider. Can be an array of label objects, a comma-separated string, or false.|

--- a/docs/src/content/docs/forms/range-slider.mdx
+++ b/docs/src/content/docs/forms/range-slider.mdx
@@ -113,7 +113,7 @@ By default, users can click on labels to set the slider to specific values. You 
 
 ## Tooltips
 
-The value bubble is a [tooltip](/components/tooltips/): the plugin renders `<output class="range-slider-tooltip tooltip bs-tooltip-top">` with the tooltip's arrow and body, so it takes the tooltip's look and its `--cui-tooltip-*` tokens. The bubble does not inherit the slider's theme: it stays the plain tooltip inside a `.theme-{color}` slider, and takes its own theme through the `customClass` option.
+The value tooltip is the [Tooltip](/components/tooltips/) component's markup: the plugin renders `<output class="range-slider-tooltip tooltip bs-tooltip-top">` with `.tooltip-arrow` and `.tooltip-inner`, so it takes the tooltip's look and its `--cui-tooltip-*` tokens. It does not inherit the slider's theme class; give it its own through `customClass`, as on the Tooltip plugin.
 
 By default, tooltips display the current value of each handle. You can disable tooltips by setting `tooltips` to `false`
 
@@ -145,10 +145,10 @@ Color the filled track and the handles by adding a [`.theme-{color}` class](/cus
 
 <Example pro class="d-flex flex-column gap-3" code={getData('theme-colors').map((c) => `<div class="theme-${c.name}" data-coreui-toggle="range-slider" data-coreui-value="25, 75" data-coreui-aria-labels='["${c.title} minimum", "${c.title} maximum"]'></div>`)} />
 
-The value bubble keeps the default tooltip look inside a themed slider. To theme the bubble alone, or differently, pass a `theme-{color}` class through the `customClass` option — it lands on the bubble only.
+The theme class on the slider colours the track and the handles; the tooltip keeps its default look. To theme the tooltip, set `customClass` (`data-coreui-custom-class`), the same option the [Tooltip](/components/tooltips/#custom-tooltips) plugin has — the class lands on the tooltip only. `theme-secondary` gives a grey tooltip on the default slider; `theme-danger` makes the tooltip match a danger slider.
 
-<Example pro class="d-flex flex-column gap-3" code={`<div data-coreui-toggle="range-slider" data-coreui-value="40" data-coreui-custom-class="theme-secondary" data-coreui-aria-labels='["Secondary bubble"]'></div>
-  <div class="theme-danger" data-coreui-toggle="range-slider" data-coreui-value="60" data-coreui-custom-class="theme-inverse" data-coreui-aria-labels='["Danger slider, inverse bubble"]'></div>`} />
+<Example pro class="d-flex flex-column gap-3" code={`<div data-coreui-toggle="range-slider" data-coreui-value="40" data-coreui-custom-class="theme-secondary" data-coreui-aria-labels='["Secondary tooltip"]'></div>
+  <div class="theme-danger" data-coreui-toggle="range-slider" data-coreui-value="60" data-coreui-custom-class="theme-danger" data-coreui-aria-labels='["Danger slider, danger tooltip"]'></div>`} />
 
 ## Usage
 
@@ -199,7 +199,7 @@ Please note that for security reasons, the `sanitize`, `sanitizeFn`, and `allowL
 | `allowList` | object | [Default value](/getting-started/javascript#sanitizer) |  Defines the set of permitted HTML tags and attributes that can safely appear in the tooltip content when HTML content is passedd. This helps maintain control over the output and prevent injection of malicious code. |
 | `ariaLabels` | array, null | `null` | Accessible name of each handle, in order. Handles are otherwise indistinguishable to a screen reader, so a slider with more than one wants this. A shorter array leaves the remaining handles unnamed. |
 | `clickableLabels` | boolean | `true` | Enables or disables the ability to click on labels to set slider values. |
-| `customClass` | string | `''` | Adds one or more classes to the value bubble alone — a `theme-{color}` class themes the bubble without touching the slider. |
+| `customClass` | string | `''` | Adds one or more classes to the tooltip, as the Tooltip plugin's option does — a `theme-{color}` class themes the tooltip without touching the slider. |
 | `disabled` | boolean | `false` | Disables the slider, making it non-interactive and grayed out. |
 | `distance` | number | `0` | Sets the minimum distance between multiple slider handles. |
 | `labels` | array, boolean, string | `false` | Adds labels to the slider. Can be an array of label objects, a comma-separated string, or false.|

--- a/js/src/range-slider.ts
+++ b/js/src/range-slider.ts
@@ -59,6 +59,7 @@ type RangeSliderConfig = {
   allowList: SanitizerAllowList
   ariaLabels: string[] | null
   clickableLabels: boolean
+  customClass: string
   disabled: boolean
   distance: number
   labels: RangeSliderLabel[] | boolean | string
@@ -79,6 +80,7 @@ const Default: RangeSliderConfig = {
   allowList: DefaultAllowlist,
   ariaLabels: null,
   clickableLabels: true,
+  customClass: '',
   disabled: false,
   distance: 0,
   labels: false,
@@ -99,6 +101,7 @@ const DefaultType: Record<string, string> = {
   allowList: 'object',
   ariaLabels: '(array|null)',
   clickableLabels: 'boolean',
+  customClass: 'string',
   disabled: 'boolean',
   distance: 'number',
   labels: '(array|boolean|string)',
@@ -422,6 +425,10 @@ class RangeSlider extends BaseComponent {
       // `<output>` is a live region; the input already announces the value.
       const tooltipElement = this._createElement('output', CLASS_NAME_RANGE_SLIDER_TOOLTIP)
       tooltipElement.classList.add(CLASS_NAME_TOOLTIP, this._config.vertical ? CLASS_NAME_TOOLTIP_START : CLASS_NAME_TOOLTIP_TOP)
+      if (this._config.customClass) {
+        tooltipElement.classList.add(...this._config.customClass.split(' ').filter(Boolean))
+      }
+
       tooltipElement.setAttribute('aria-hidden', 'true')
       const tooltipArrowElement = this._createElement('span', CLASS_NAME_TOOLTIP_ARROW)
       const tooltipInnerElement = this._createElement('span', CLASS_NAME_TOOLTIP_INNER)

--- a/js/src/range-slider.ts
+++ b/js/src/range-slider.ts
@@ -59,7 +59,6 @@ type RangeSliderConfig = {
   allowList: SanitizerAllowList
   ariaLabels: string[] | null
   clickableLabels: boolean
-  customClass: string
   disabled: boolean
   distance: number
   labels: RangeSliderLabel[] | boolean | string
@@ -69,6 +68,7 @@ type RangeSliderConfig = {
   sanitize: boolean
   sanitizeFn: ((unsafeHtml: string) => string) | null
   step: number | string
+  tooltipClass: string
   tooltips: boolean
   tooltipsFormat: ((value: number | string) => string) | null
   track: boolean | string
@@ -80,7 +80,6 @@ const Default: RangeSliderConfig = {
   allowList: DefaultAllowlist,
   ariaLabels: null,
   clickableLabels: true,
-  customClass: '',
   disabled: false,
   distance: 0,
   labels: false,
@@ -90,6 +89,7 @@ const Default: RangeSliderConfig = {
   sanitize: true,
   sanitizeFn: null,
   step: 1,
+  tooltipClass: '',
   tooltips: true,
   tooltipsFormat: null,
   track: 'fill',
@@ -101,7 +101,6 @@ const DefaultType: Record<string, string> = {
   allowList: 'object',
   ariaLabels: '(array|null)',
   clickableLabels: 'boolean',
-  customClass: 'string',
   disabled: 'boolean',
   distance: 'number',
   labels: '(array|boolean|string)',
@@ -111,6 +110,7 @@ const DefaultType: Record<string, string> = {
   sanitize: 'boolean',
   sanitizeFn: '(null|function)',
   step: '(number|string)',
+  tooltipClass: 'string',
   tooltips: 'boolean',
   tooltipsFormat: '(function|null)',
   track: '(boolean|string)',
@@ -425,8 +425,8 @@ class RangeSlider extends BaseComponent {
       // `<output>` is a live region; the input already announces the value.
       const tooltipElement = this._createElement('output', CLASS_NAME_RANGE_SLIDER_TOOLTIP)
       tooltipElement.classList.add(CLASS_NAME_TOOLTIP, this._config.vertical ? CLASS_NAME_TOOLTIP_START : CLASS_NAME_TOOLTIP_TOP)
-      if (this._config.customClass) {
-        tooltipElement.classList.add(...this._config.customClass.split(' ').filter(Boolean))
+      if (this._config.tooltipClass) {
+        tooltipElement.classList.add(...this._config.tooltipClass.split(' ').filter(Boolean))
       }
 
       tooltipElement.setAttribute('aria-hidden', 'true')

--- a/js/tests/unit/range-slider.spec.js
+++ b/js/tests/unit/range-slider.spec.js
@@ -75,6 +75,18 @@ describe('RangeSlider', () => {
       expect([...tooltip.children].map(child => child.tagName)).toEqual(['SPAN', 'SPAN'])
     })
 
+    it('should add customClass to the tooltip only', () => {
+      fixtureEl.innerHTML = '<div data-coreui-toggle="range-slider" data-coreui-custom-class="theme-secondary my-bubble"></div>'
+
+      const element = fixtureEl.querySelector('[data-coreui-toggle="range-slider"]')
+      const rangeSlider = new RangeSlider(element)
+      const tooltip = element.querySelector('.range-slider-tooltip')
+
+      expect(tooltip.classList.contains('theme-secondary')).toBeTrue()
+      expect(tooltip.classList.contains('my-bubble')).toBeTrue()
+      expect(element.classList.contains('theme-secondary')).toBeFalse()
+    })
+
     it('should render the tooltip with the Tooltip markup, placed by orientation', () => {
       fixtureEl.innerHTML = '<div data-coreui-toggle="range-slider" data-coreui-value="40"></div><div data-coreui-toggle="range-slider" data-coreui-vertical="true"></div>'
 

--- a/js/tests/unit/range-slider.spec.js
+++ b/js/tests/unit/range-slider.spec.js
@@ -75,8 +75,8 @@ describe('RangeSlider', () => {
       expect([...tooltip.children].map(child => child.tagName)).toEqual(['SPAN', 'SPAN'])
     })
 
-    it('should add customClass to the tooltip only', () => {
-      fixtureEl.innerHTML = '<div data-coreui-toggle="range-slider" data-coreui-custom-class="theme-secondary my-bubble"></div>'
+    it('should add tooltipClass to the tooltip only', () => {
+      fixtureEl.innerHTML = '<div data-coreui-toggle="range-slider" data-coreui-tooltip-class="theme-secondary my-bubble"></div>'
 
       const element = fixtureEl.querySelector('[data-coreui-toggle="range-slider"]')
       const rangeSlider = new RangeSlider(element)

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -8,6 +8,7 @@
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
 @use "config" as *;
+@use "theme" as *;
 
 // stylelint-disable custom-property-no-missing-var-function
 
@@ -238,6 +239,8 @@ $range-slider-vertical-tokens: defaults(
   }
 
   .range-slider-tooltip {
+    @include theme-reset();
+
     // Outside `$prefix` on purpose: the plugin writes this name.
     position: absolute;
     inset-inline-start: calc(var(--#{$prefix}range-slider-thumb-width) * .5 + var(--cui-range-slider-tooltip-position, 0) * (100% - var(--#{$prefix}range-slider-thumb-width)));

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -207,11 +207,15 @@ $theme-state-colors: (
 // scss-docs-end theme-classes
 
 // scss-docs-start theme-reset
+@mixin theme-reset() {
+  @each $token, $suffix in map.merge($theme-token-refs, ("hover": null, "active": null)) {
+    --#{$prefix}theme-#{$token}: initial;
+  }
+}
+
 @mixin generate-theme-reset() {
   .theme-reset {
-    @each $token, $suffix in map.merge($theme-token-refs, ("hover": null, "active": null)) {
-      --#{$prefix}theme-#{$token}: initial;
-    }
+    @include theme-reset();
   }
 }
 // scss-docs-end theme-reset


### PR DESCRIPTION
Since #1133 the bubble read the slider's theme slots through inheritance, so a `.theme-<color>` slider painted its bubble too and nothing could theme the bubble on its own.

The bubble now resets the `--cui-theme-*` slots — new `theme-reset()` mixin in `_theme.scss`, shared with the `.theme-reset` helper — in the `components` layer, so it stays the plain tooltip inside a themed slider, while a class from the new `customClass` option (the Tooltip's option name: `data-coreui-custom-class`) lands on the bubble alone and wins from the `helpers` layer. A fixed `.theme-reset` class on the bubble would not have worked: it is emitted after the theme classes in the same layer and would have cancelled the custom class too.

Measured in Chromium: bubble in a `.theme-danger` slider keeps the default surface, `customClass="theme-secondary"` paints it secondary, `theme-inverse` on top of a danger slider paints it inverse. Unit suite 138 passing. Docs: options row, Theme variants example. React/Vue ports (`tooltipsClassName`) follow.