### PR TITLE
refactor(functions): drop three unused Sass functions

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -2316,8 +2316,9 @@ assembles maps of CSS expressions and the browser resolves them.
 
 - **Every `--cui-{name}-rgb` custom property is gone**, along with the
   `$theme-colors-rgb` and `$theme-colors-rgb-dark` maps, the `to-rgb()`
-  function's role in `:root`, and the `rgba-css-var()` helper (now
-  `translucent-css-var()`). They existed only so
+  function's role in `:root`, and the `rgba-css-var()` and
+  `translucent-css-var()` helpers (`color-var-ref()` is the function that
+  stays — see the utilities section). They existed only so
   `rgba(var(--cui-primary-rgb), .5)` could apply an alpha to a token; that is
   what `color-mix()` does directly:
 
@@ -3241,8 +3242,10 @@ and still compose. What changes is where the translucency expression lives:
   (`var(--cui-primary)`, `var(--cui-primary-fg)`) instead of a `color-mix()`
   expression per entry. The
   expression is written once, in the utility's `property` map. If you built a
-  map of your own by calling `translucent-css-var()`, call the new
-  `color-var-ref()` instead — same arguments, without the wrapper.
+  map of your own by calling `translucent-css-var()`, call
+  `color-var-ref()` instead — same arguments, without the wrapper;
+  `translucent-css-var()` is removed, along with the unused `map-loop()` and
+  `color-contrast-variables()`.
 - **`.text-muted`, `.text-black-50`, `.text-white-50` and `.text-body-secondary`
   now respond to `.text-opacity-*`.** They rendered the same colour before and
   render the same colour now; they simply went through the plain value and so

--- a/scss/functions/_maps.scss
+++ b/scss/functions/_maps.scss
@@ -1,36 +1,6 @@
 @use "sass:list";
 @use "sass:map";
 @use "sass:meta";
-@use "color" as *;
-@use "color-var-ref" as *;
-@use "translucent-css-var" as *;
-@use "to-rgb" as *;
-@use "../config" as *;
-
-// stylelint-disable scss/dollar-variable-pattern
-@function map-loop($map, $func, $args...) {
-  $_map: ();
-
-  @each $key, $value in $map {
-    // allow to pass the $key and $value of the map as an function argument
-    $_args: ();
-    @each $arg in $args {
-      @if $arg == "$prefix" {
-        $_args: list.append($_args, $prefix);
-      } @else if $arg == "$key" {
-        $_args: list.append($_args, $key);
-      } @else if $arg == "$value" {
-        $_args: list.append($_args, $value);
-      } @else {
-        $_args: list.append($_args, $arg);
-      }
-    }
-
-    $_map: map.merge($_map, ($key: meta.call(meta.get-function($func), $_args...)));
-  }
-  @return $_map;
-}
-// stylelint-enable scss/dollar-variable-pattern
 
 // Internal Bootstrap function to turn maps into its negative variant.
 // It prefixes the keys with `n` and makes the value negative.

--- a/scss/functions/index.scss
+++ b/scss/functions/index.scss
@@ -2,7 +2,6 @@
 @forward "assert-starts-at-zero";
 @forward "color";
 @forward "color-contrast";
-@forward "color-contrast-variables";
 @forward "color-scheme";
 @forward "color-translucent";
 @forward "color-var-ref";
@@ -13,4 +12,3 @@
 @forward "math";
 @forward "str-replace";
 @forward "to-rgb";
-@forward "translucent-css-var";


### PR DESCRIPTION
`color-contrast-variables()`, `map-loop()` and `translucent-css-var()` had no caller in the library, the docs or the tests; `translucent-css-var()` only existed for the `--cui-*-rgb` triplets v6 removed, and `map-loop()` pulled three modules into `_maps.scss` just to be able to call them.

Kept on purpose: `to-rgb()` — the docs engine (`@coreui/astro-docs`, shared with v5) imports it for its own `-rgb` triplets, which the pre-push docs build caught; `color-var-ref()` (the migration guide sends users to it); `color-contrast()` (upstream parity, documented); `divide()` (grid).

Compiled stylesheet byte-identical (sorted diff empty), sass-true suite 62/0, docs build green. Migration: the utilities entry notes `translucent-css-var()` is gone.