### PR TITLE
refactor(utilities): move the API loop into generate-utilities-loop()

### DIFF
--- a/docs/src/content/docs/utilities/api.mdx
+++ b/docs/src/content/docs/utilities/api.mdx
@@ -466,6 +466,10 @@ Sass cannot read a module and configure the same module in one file, which is th
 
 Your map is merged over the defaults, and the merge is shallow: a group you supply replaces the whole default group under that key. Include `property` and `values` in every group that emits CSS.
 
+The API module hands the map to the `generate-utilities-loop()` mixin, which walks it once per breakpoint and once more for print. Call it yourself to emit a map of your own outside `$utilities` — in a component partial, or against a different set of breakpoints:
+
+<ScssDocs file="scss/mixins/_utilities.scss" capture="generate-utilities-loop" />
+
 For a utilities-only build, load the utilities module and then the API module, which emits the classes and nothing else:
 
 ```scss

--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -3,6 +3,7 @@
 @use "sass:meta";
 @use "sass:string";
 @use "../config" as *;
+@use "../layout/breakpoints" as *;
 
 // Registers every custom property a utility assigns to as non-inheriting.
 //
@@ -220,3 +221,33 @@
     }
   }
 }
+
+// scss-docs-start generate-utilities-loop
+@mixin generate-utilities-loop($utilities, $breakpoints) {
+  @each $breakpoint in map.keys($breakpoints) {
+    @include media-breakpoint-up($breakpoint, $breakpoints) {
+      $infix: breakpoint-infix($breakpoint, $breakpoints);
+
+      @each $key, $utility in $utilities {
+        // The utility can be disabled by replacing it with `false` or by setting
+        // `enabled: false`, thus check if the utility is a map first.
+        // Only proceed if responsive media queries are enabled or if it's the base media query
+        @if meta.type-of($utility) == "map" and map.get($utility, enabled) != false and (map.get($utility, responsive) or $infix == "") {
+          @include generate-utility($utility, $infix);
+        }
+      }
+    }
+  }
+
+  // Print utilities
+  @media print {
+    @each $key, $utility in $utilities {
+      // The utility can be disabled with `false`, thus check if the utility is a map first
+      // Then check if the utility needs print styles
+      @if meta.type-of($utility) == "map" and map.get($utility, enabled) != false and map.get($utility, print) == true {
+        @include generate-utility($utility, "-print");
+      }
+    }
+  }
+}
+// scss-docs-end generate-utilities-loop

--- a/scss/tests/utilities/_api.test.scss
+++ b/scss/tests/utilities/_api.test.scss
@@ -1,57 +1,87 @@
-@use "sass:map";
+@use "../../mixins/utilities" as *;
 
-@use "../../config" with (
-  // Stated rather than inherited: this spec is about breakpoints, so it should
-  // not change meaning when the importance default does.
-  $enable-important-utilities: false,
-  $grid-breakpoints: (
-    xs: 0,
-    sm: 333px,
-    md: 666px
-  )
+$test-breakpoints: (
+  xs: 0,
+  sm: 333px,
+  md: 666px
 );
 
-@use "../../utilities" as *;
+@include describe("utilities/api loop") {
+  @include describe("enabled") {
+    @include it("skips utilities with enabled: false") {
+      $test-utilities: (
+        opacity: (
+          property: opacity,
+          values: (50: .5)
+        ),
+        float: (
+          property: float,
+          enabled: false,
+          values: (start: inline-start, end: inline-end)
+        )
+      );
 
-$utilities: (
-  margin: (
-    property: margin,
-    values: auto
-  ),
-  padding: (
-    property: padding,
-    responsive: true,
-    values: 1rem
-  ),
-  font-size: (
-    property: font-size,
-    values: (large: 1.25rem),
-    print: true
-  )
-);
+      @include assert() {
+        @include output() {
+          @include generate-utilities-loop($test-utilities, $test-breakpoints);
+        }
 
-@include describe("utilities/api") {
-  @include it("generates utilities for each breakpoints") {
-    @include assert() {
-      @include output() {
-        @import "../../utilities/api";
+        @include expect() {
+          .opacity-50 {
+            opacity: .5;
+          }
+        }
       }
+    }
 
-      @include expect() {
-        // The API emits into the utilities cascade layer.
-        @layer utilities {
-          // margin is not set to responsive
+    @include it("outputs utilities without an explicit enabled key") {
+      $test-utilities: (
+        opacity: (
+          property: opacity,
+          values: (25: .25)
+        )
+      );
+
+      @include assert() {
+        @include output() {
+          @include generate-utilities-loop($test-utilities, $test-breakpoints);
+        }
+
+        @include expect() {
+          .opacity-25 {
+            opacity: .25;
+          }
+        }
+      }
+    }
+  }
+
+  @include describe("responsive") {
+    @include it("generates responsive classes only for utilities with responsive: true") {
+      $test-utilities: (
+        margin: (
+          property: margin,
+          values: auto
+        ),
+        padding: (
+          property: padding,
+          responsive: true,
+          values: 1rem
+        )
+      );
+
+      @include assert() {
+        @include output() {
+          @include generate-utilities-loop($test-utilities, $test-breakpoints);
+        }
+
+        @include expect() {
           .margin-auto {
             margin: auto;
           }
 
-          // padding is, though
           .padding-1rem {
             padding: 1rem;
-          }
-
-          .font-size-large {
-            font-size: 1.25rem;
           }
 
           @media (width >= 333px) {
@@ -65,6 +95,38 @@ $utilities: (
               padding: 1rem;
             }
           }
+        }
+      }
+    }
+  }
+
+  @include describe("print") {
+    @include it("generates print classes only for utilities with print: true") {
+      $test-utilities: (
+        font-size: (
+          property: font-size,
+          values: (large: 1.25rem),
+          print: true
+        ),
+        opacity: (
+          property: opacity,
+          values: (50: .5)
+        )
+      );
+
+      @include assert() {
+        @include output() {
+          @include generate-utilities-loop($test-utilities, $test-breakpoints);
+        }
+
+        @include expect() {
+          .font-size-large {
+            font-size: 1.25rem;
+          }
+
+          .opacity-50 {
+            opacity: .5;
+          }
 
           @media print {
             .font-size-print-large {
@@ -73,7 +135,6 @@ $utilities: (
           }
         }
       }
-
     }
   }
 }

--- a/scss/utilities/_api.scss
+++ b/scss/utilities/_api.scss
@@ -1,7 +1,6 @@
 @use "sass:map";
 @use "sass:meta";
 @use "../utilities" as *;
-@use "../layout/breakpoints" as *;
 @use "../mixins/ltr-rtl" as *;
 @use "../mixins/utilities" as *;
 @use "../config" as *;
@@ -11,24 +10,7 @@
 @include generate-utility-at-properties($utilities);
 
 @layer utilities {
-  // Loop over each breakpoint
-  @each $breakpoint in map.keys($grid-breakpoints) {
-
-    // Generate media query if needed
-    @include media-breakpoint-up($breakpoint) {
-      $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
-
-      // Loop over each utility property
-      @each $key, $utility in $utilities {
-        // The utility can be disabled by replacing it with `false` or by setting
-        // `enabled: false`, thus check if the utility is a map first.
-        // Only proceed if responsive media queries are enabled or if it's the base media query
-        @if meta.type-of($utility) == "map" and map.get($utility, enabled) != false and (map.get($utility, responsive) or $infix == "") {
-          @include generate-utility($utility, $infix);
-        }
-      }
-    }
-  }
+  @include generate-utilities-loop($utilities, $grid-breakpoints);
 
   // `transform` is not direction-aware, so the one utility that centres an
   // element on a logical inset has to be flipped by hand: in an RTL document
@@ -58,17 +40,6 @@
       .animation-shake,
       .animation-pop {
         animation: none;
-      }
-    }
-  }
-
-  // Print utilities
-  @media print {
-    @each $key, $utility in $utilities {
-      // The utility can be disabled with `false`, thus check if the utility is a map first
-      // Then check if the utility needs print styles
-      @if meta.type-of($utility) == "map" and map.get($utility, enabled) != false and map.get($utility, print) == true {
-        @include generate-utility($utility, "-print");
       }
     }
   }


### PR DESCRIPTION
The breakpoint and print loops lived inline in `utilities/_api.scss`, so the only way to test them was to `@import` the partial with a global `$utilities` map — the last `@import` in the repo, a deprecation on every `css-test` run and a hard error on Dart Sass 3.

The loops are a mixin now, `generate-utilities-loop($utilities, $breakpoints)` in `mixins/_utilities.scss` (the shape upstream uses, without its `dark:` pass); the API partial calls it with `$grid-breakpoints`, and the spec calls it with its own map and breakpoints — enabled, responsive and print cases, 65 specs green, no deprecation. Compiled `coreui.css` and `coreui-utilities.css` are identical line-for-line apart from the print block moving ahead of the RTL and reduced-motion rules inside the utilities layer (sorted diff empty). The mixin is documented on the utilities API page under Using the API.