### PR TITLE
test(scss): specs for the untested functions and mixins

### DIFF
--- a/scss/tests/functions/_color-translucent.test.scss
+++ b/scss/tests/functions/_color-translucent.test.scss
@@ -1,0 +1,15 @@
+@use "../../functions/color-translucent" as *;
+
+@include describe("color-translucent function") {
+  @include it("un-blends a colour so it renders the same at the given alpha over the background") {
+    @include assert-equal(color-translucent(#808080, .5, #fff), rgba(1, 1, 1, .5));
+  }
+
+  @include it("defaults to a 10% alpha over white") {
+    @include assert-equal(color-translucent(#f2f2f2), rgba(125, 125, 125, .1));
+  }
+
+  @include it("returns a colour that already has alpha untouched") {
+    @include assert-equal(color-translucent(rgba(0, 0, 0, .3), .5), rgba(0, 0, 0, .3));
+  }
+}

--- a/scss/tests/functions/_defaults.test.scss
+++ b/scss/tests/functions/_defaults.test.scss
@@ -1,0 +1,23 @@
+@use "../../functions/defaults" as *;
+
+@include describe("defaults function") {
+  @include it("merges overrides on top of defaults") {
+    @include assert-equal(defaults(("a": 1, "b": 2), ("b": 3, "c": 4)), ("a": 1, "b": 3, "c": 4));
+  }
+
+  @include it("drops keys set to null so @use ... with () can remove an entry") {
+    @include assert-equal(defaults(("a": 1, "b": 2), ("a": null)), ("b": 2));
+  }
+
+  @include it("drops keys set to an empty string, the value an interpolated null leaves behind") {
+    @include assert-equal(defaults(("a": 1, "b": 2), ("b": "")), ("a": 1));
+  }
+
+  @include it("turns a list of defaults into a map of true") {
+    @include assert-equal(defaults(("sm", "lg"), ()), ("sm": true, "lg": true));
+  }
+
+  @include it("lets an override remove a list entry") {
+    @include assert-equal(defaults(("sm", "lg"), ("sm": null)), ("lg": true));
+  }
+}

--- a/scss/tests/functions/_maps.test.scss
+++ b/scss/tests/functions/_maps.test.scss
@@ -1,0 +1,28 @@
+@use "../../functions/maps" as *;
+
+$sizes: (
+  "sm": ("font-size": .875rem, "padding": .25rem),
+  "lg": ("font-size": 1.25rem, "padding": .5rem)
+);
+
+@include describe("maps functions") {
+  @include it("map-slot pulls one slot out of every entry") {
+    @include assert-equal(map-slot($sizes, "font-size"), ("sm": .875rem, "lg": 1.25rem));
+  }
+
+  @include it("map-get-nested skips entries without the key") {
+    @include assert-equal(map-get-nested(("sm": ("padding": .25rem), "lg": ("font-size": 1.25rem)), "font-size"), ("lg": 1.25rem));
+  }
+
+  @include it("map-get-multiple keeps only the requested keys, in map order") {
+    @include assert-equal(map-get-multiple(("a": 1, "b": 2, "c": 3), ("c", "a")), ("a": 1, "c": 3));
+  }
+
+  @include it("negativify-map prefixes keys with n and negates values, skipping 0") {
+    @include assert-equal(negativify-map((0: 0, 1: .25rem, 2: .5rem)), ("n1": -.25rem, "n2": -.5rem));
+  }
+
+  @include it("map-merge-multiple merges left to right") {
+    @include assert-equal(map-merge-multiple(("a": 1), ("a": 2, "b": 2), ("c": 3)), ("a": 2, "b": 2, "c": 3));
+  }
+}

--- a/scss/tests/functions/_strings.test.scss
+++ b/scss/tests/functions/_strings.test.scss
@@ -1,0 +1,30 @@
+@use "../../functions/escape-svg" as *;
+@use "../../functions/str-replace" as *;
+
+@include describe("str-replace function") {
+  @include it("replaces every occurrence") {
+    @include assert-equal(str-replace("a-b-c", "-", "+"), "a+b+c");
+  }
+
+  @include it("removes the search string when no replacement is given") {
+    @include assert-equal(str-replace("a-b-c", "-"), "abc");
+  }
+
+  @include it("returns the string untouched when the search is absent") {
+    @include assert-equal(str-replace("abc", "x", "y"), "abc");
+  }
+}
+
+@include describe("escape-svg function") {
+  @include it("percent-encodes the characters a data URI cannot carry") {
+    @include assert-equal(escape-svg("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><path fill='#fff' d='M0 0'/></svg>"), "data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg'%3e%3cpath fill='%23fff' d='M0 0'/%3e%3c/svg%3e");
+  }
+
+  @include it("keeps the url() wrapper and its quotes") {
+    @include assert-equal(escape-svg(url("data:image/svg+xml,<svg></svg>")), url("data:image/svg+xml,%3csvg%3e%3c/svg%3e"));
+  }
+
+  @include it("leaves a string without a data URI alone") {
+    @include assert-equal(escape-svg("<b>(x)</b>"), "<b>(x)</b>");
+  }
+}

--- a/scss/tests/mixins/_border-radius.test.scss
+++ b/scss/tests/mixins/_border-radius.test.scss
@@ -1,0 +1,72 @@
+// stylelint-disable property-disallowed-list
+@use "../../config" as *;
+@use "../../mixins/border-radius" as *;
+
+$original-enable-rounded: $enable-rounded;
+
+@include describe("border-radius mixins") {
+  @include it("emits the radius when rounding is enabled") {
+    $enable-rounded: true !global;
+
+    @include assert() {
+      @include output() {
+        .test {
+          @include border-radius(.5rem);
+          @include border-end-radius(.25rem);
+        }
+      }
+
+      @include expect() {
+        .test {
+          border-radius: .5rem;
+          border-start-end-radius: .25rem;
+          border-end-end-radius: .25rem;
+        }
+      }
+    }
+
+    $enable-rounded: $original-enable-rounded !global;
+  }
+
+  @include it("clamps a negative radius to 0") {
+    $enable-rounded: true !global;
+
+    @include assert() {
+      @include output() {
+        .test {
+          @include border-radius(-1px);
+        }
+      }
+
+      @include expect() {
+        .test {
+          border-radius: 0;
+        }
+      }
+    }
+
+    $enable-rounded: $original-enable-rounded !global;
+  }
+
+  @include it("emits nothing but the fallback when rounding is disabled") {
+    $enable-rounded: false !global;
+
+    @include assert() {
+      @include output() {
+        .test {
+          @include border-radius(.5rem);
+          @include border-top-radius(.5rem);
+          @include border-radius(.5rem, 0);
+        }
+      }
+
+      @include expect() {
+        .test {
+          border-radius: 0;
+        }
+      }
+    }
+
+    $enable-rounded: $original-enable-rounded !global;
+  }
+}

--- a/scss/tests/mixins/_color-scheme.test.scss
+++ b/scss/tests/mixins/_color-scheme.test.scss
@@ -1,0 +1,23 @@
+@use "../../mixins/color-scheme" as *;
+
+@include describe("color-scheme mixin") {
+  @include it("wraps the content in a prefers-color-scheme query") {
+    @include assert() {
+      @include output() {
+        @include color-scheme(dark) {
+          .test {
+            color: #fff;
+          }
+        }
+      }
+
+      @include expect() {
+        @media (prefers-color-scheme: dark) {
+          .test {
+            color: #fff;
+          }
+        }
+      }
+    }
+  }
+}

--- a/scss/tests/mixins/_ltr-rtl.test.scss
+++ b/scss/tests/mixins/_ltr-rtl.test.scss
@@ -1,0 +1,70 @@
+@use "../../config" as *;
+@use "../../mixins/ltr-rtl" as *;
+
+@include describe("ltr-rtl mixins") {
+  @include it("reflect swaps left and right") {
+    @include assert-equal(reflect(margin-left), margin-right);
+    @include assert-equal(reflect(right), left);
+    @include assert-equal(reflect(center), center);
+  }
+
+  @include it("ltr-rtl writes the base value and the mirrored one under [dir=rtl]") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include ltr-rtl("margin-left", 1rem);
+        }
+      }
+
+      @include expect() {
+        .test {
+          margin-left: 1rem;
+        }
+
+        *[dir="rtl"] & .test {
+          margin-right: 1rem;
+        }
+      }
+    }
+  }
+
+  @include it("ltr-rtl takes an explicit rtl property and value") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include ltr-rtl("transform", translateX(-50%), null, translateX(50%));
+        }
+      }
+
+      @include expect() {
+        .test {
+          transform: translateX(-50%);
+        }
+
+        *[dir="rtl"] & .test {
+          transform: translateX(50%);
+        }
+      }
+    }
+  }
+
+  @include it("ltr-rtl-value-only keeps the property and mirrors the value") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include ltr-rtl-value-only("float", left);
+        }
+      }
+
+      @include expect() {
+        .test {
+          float: left;
+        }
+
+        *[dir="rtl"] & .test {
+          float: right;
+        }
+      }
+    }
+  }
+}

--- a/scss/tests/mixins/_theme.test.scss
+++ b/scss/tests/mixins/_theme.test.scss
@@ -1,0 +1,82 @@
+@use "../../config" as *;
+@use "../../theme" as *;
+
+@include describe("theme helpers") {
+  @include it("theme-color-refs points every colour at the slot's root token") {
+    $refs: theme-color-refs("bg-subtle");
+
+    @include assert-equal(map-get($refs, "primary"), var(--cui-primary-bg-subtle));
+    @include assert-equal(map-get($refs, "danger"), var(--cui-danger-bg-subtle));
+  }
+
+  @include it("theme-color-refs appends the key suffix") {
+    @include assert-equal(map-get(theme-color-refs("bg", "-hover"), "primary-hover"), var(--cui-primary-bg));
+  }
+
+  @include it("theme-tokens fills every slot from the colour's root tokens and derives the states") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include theme-tokens("primary");
+        }
+      }
+
+      @include expect() {
+        .test {
+          --cui-theme-bg: var(--cui-primary-bg);
+          --cui-theme-contrast: var(--cui-primary-contrast);
+          --cui-theme-fg: var(--cui-primary-fg);
+          --cui-theme-fg-emphasis: var(--cui-primary-fg-emphasis);
+          --cui-theme-bg-subtle: var(--cui-primary-bg-subtle);
+          --cui-theme-bg-muted: var(--cui-primary-bg-muted);
+          --cui-theme-border: var(--cui-primary-border);
+          --cui-theme-focus-ring: var(--cui-primary-focus-ring);
+          --cui-theme-hover: oklch(from var(--cui-primary) calc(l * .85) c h);
+          --cui-theme-active: oklch(from var(--cui-primary) calc(l * .8) c h);
+        }
+      }
+    }
+  }
+
+  @include it("theme-tokens takes the neutral pair's states from the gray scale") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include theme-tokens("secondary");
+        }
+      }
+
+      @include contains() {
+        .test {
+          --cui-theme-hover: light-dark(var(--cui-gray-200), var(--cui-gray-700));
+          --cui-theme-active: light-dark(var(--cui-gray-300), var(--cui-gray-800));
+        }
+      }
+    }
+  }
+
+  @include it("theme-reset sets every slot back to initial") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include theme-reset();
+        }
+      }
+
+      @include expect() {
+        .test {
+          --cui-theme-bg: initial;
+          --cui-theme-contrast: initial;
+          --cui-theme-fg: initial;
+          --cui-theme-fg-emphasis: initial;
+          --cui-theme-bg-subtle: initial;
+          --cui-theme-bg-muted: initial;
+          --cui-theme-border: initial;
+          --cui-theme-focus-ring: initial;
+          --cui-theme-hover: initial;
+          --cui-theme-active: initial;
+        }
+      }
+    }
+  }
+}

--- a/scss/tests/mixins/_tokens.test.scss
+++ b/scss/tests/mixins/_tokens.test.scss
@@ -1,0 +1,20 @@
+@use "../../mixins/tokens" as *;
+
+@include describe("tokens mixin") {
+  @include it("writes every map entry as a custom property") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include tokens((--cui-a: 1rem, --cui-b: var(--cui-a)));
+        }
+      }
+
+      @include expect() {
+        .test {
+          --cui-a: 1rem;
+          --cui-b: var(--cui-a);
+        }
+      }
+    }
+  }
+}

--- a/scss/tests/mixins/_utility-at-properties.test.scss
+++ b/scss/tests/mixins/_utility-at-properties.test.scss
@@ -1,0 +1,72 @@
+// stylelint-disable custom-property-no-missing-var-function, block-no-empty
+@use "../../mixins/utilities" as *;
+
+@include describe("generate-utility-at-properties mixin") {
+  @include it("registers every custom property a utility writes, once, as non-inheriting") {
+    $utilities: (
+      "opacity": (
+        property: --cui-opacity,
+        values: (50: .5)
+      ),
+      "bg": (
+        property: (--cui-bg, --cui-opacity),
+        values: (white: #fff)
+      ),
+      "rounded-size": (
+        property: (--cui-rounded-size: null, border-radius: var(--cui-rounded-size)),
+        values: (4: 1rem)
+      )
+    );
+
+    @include assert() {
+      @include output() {
+        @include generate-utility-at-properties($utilities);
+      }
+
+      @include expect() {
+        @property --cui-opacity {
+          syntax: "*";
+          inherits: false;
+        }
+
+        @property --cui-bg {
+          syntax: "*";
+          inherits: false;
+        }
+
+        @property --cui-rounded-size {
+          syntax: "*";
+          inherits: false;
+        }
+      }
+    }
+  }
+
+  @include it("skips plain properties, disabled utilities and at-property: false") {
+    $utilities: (
+      "float": (
+        property: float,
+        values: (start: inline-start)
+      ),
+      "off": (
+        property: --cui-off,
+        enabled: false,
+        values: (1: 1)
+      ),
+      "focus-ring": (
+        property: --cui-focus-ring-color,
+        at-property: false,
+        values: (primary: red)
+      )
+    );
+
+    @include assert() {
+      @include output() {
+        @include generate-utility-at-properties($utilities);
+      }
+
+      @include expect() {
+      }
+    }
+  }
+}


### PR DESCRIPTION
sass-true specs for what the SCSS audit found untested: `defaults()` (merge, null and empty-string removal, list defaults — the #1077 behaviour), the map helpers (`map-slot`, `map-get-nested`, `map-get-multiple`, `negativify-map`, `map-merge-multiple`), `str-replace()` and `escape-svg()`, `color-translucent()`, `tokens()`, `color-scheme()`, the border-radius mixins with `$enable-rounded` on and off (negative clamp, fallback), `ltr-rtl`/`ltr-rtl-value-only`/`reflect()`, `theme-color-refs()`, `theme-tokens()` (slots, derived and gray-scale states) and `theme-reset()`, and `generate-utility-at-properties()` (map/list/string properties, dedupe, `enabled: false`, `at-property: false`).

Suite: 100 specs, 0 failures (62 before). No library changes.