### PR TITLE
refactor(root): emit the colors layer right after the layer declaration

### DIFF
--- a/docs/src/content/docs/customize/architecture.mdx
+++ b/docs/src/content/docs/customize/architecture.mdx
@@ -11,7 +11,7 @@ Where each piece lives, from the raw hue up to the component:
 
 | Layer | File | What it defines |
 | --- | --- | --- |
-| Color scales | `scss/_colors.scss` | `$color-tokens`, emitted on `:root, :host` in the `colors` layer: one base token per color, expanded into the `100`–`900` steps with `color-mix()` against `$tint-color` / `$shade-color`. The mix names the base token, not its value, so overriding `--cui-primary` retints the whole scale in the browser. The grays are hand-picked stops rather than a mix, because a neutral ramp has to stay neutral. |
+| Color scales | `scss/_colors.scss` | `$color-tokens`, emitted on `:root, :host` from `scss/_root.scss` in the `colors` layer: one base token per color, expanded into the `100`–`900` steps with `color-mix()` against `$tint-color` / `$shade-color`. The mix names the base token, not its value, so overriding `--cui-primary` retints the whole scale in the browser. The grays are hand-picked stops rather than a mix, because a neutral ramp has to stay neutral. |
 | Theme colors | `scss/_theme.scss` | `$theme-colors`, one nested map per role (`primary`, `danger`, …), each holding `base`, `fg`, `text-emphasis`, `bg`, `bg-subtle`, `bg-muted`, `border-subtle`, `focus-ring` and `contrast` |
 | Global tokens | `scss/_root.scss` | `$root-tokens`, everything else emitted on `:root, :host` — spacing, radii, typography, z-index and the surface ladders |
 | Component tokens | the component's own partial | `$alert-tokens`, `$card-tokens` and the rest, emitted on the component's base class |

--- a/scss/_colors.scss
+++ b/scss/_colors.scss
@@ -4,7 +4,6 @@
 @use "sass:map";
 @use "config" as *;
 @use "functions" as *;
-@use "mixins/tokens" as *;
 
 // Color system
 //
@@ -192,12 +191,3 @@ $-color-defaults: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $color-tokens: defaults($-color-defaults, $color-tokens);
 // scss-docs-end color-tokens
-
-// Registered before the `@layer` declaration in _root.scss, which is safe only
-// because `colors` is the first name that declaration lists.
-@layer colors {
-  :root,
-  :host {
-    @include tokens($color-tokens);
-  }
-}

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -371,6 +371,13 @@ $root-tokens: defaults($root-token-defaults, $root-tokens);
 
 @layer colors, config, root, reboot, layout, content, forms, components, custom, helpers, utilities;
 
+@layer colors {
+  :root,
+  :host {
+    @include tokens($color-tokens);
+  }
+}
+
 @layer root {
   :root,
   :host,


### PR DESCRIPTION
`_colors.scss` emitted `@layer colors {}` before `_root.scss` declared the layer order, which only worked because `colors` happens to be the first name in that declaration. The palette block moves into `_root.scss`, between the declaration and `@layer root`, so every bundle that carries the declaration now opens with it (line 7 of `coreui.css`, `coreui-reboot.css` and `coreui-utilities.css`), and `_colors.scss` is a variables-only partial again. The `colors` layer and its documented contract (palette below everything, overridable from your own `@layer colors`) are unchanged.

Sorted diff of `coreui.css` empty; the only ordered change is the declaration moving from line 236 to line 7. `coreui-grid.css` still carries no declaration (it does not load `_root`) — separate question. Docs: architecture table names `_root.scss` as where the palette is emitted.