### PR TITLE
fix(Dropdown): read data-coreui-popper literally, scope $data-infix to authored attributes

### DIFF
--- a/docs/src/content/docs/customize/css-variables.mdx
+++ b/docs/src/content/docs/customize/css-variables.mdx
@@ -47,6 +47,8 @@ Most CSS variables use a prefix to avoid collisions with your own codebase. This
 
 Customize the prefix via the `$prefix` Sass variable. By default, it's set to `cui-` (note the trailing dash).
 
+The `data-*` attributes you write in your markup — `data-coreui-theme`, `data-coreui-target` — carry a second knob, `$data-infix` (`-coreui-` by default), so a theme can rename them: the Bootstrap theme sets it to `-bs-` and reads `data-bs-theme`. Attributes the JavaScript sets on elements while it runs (`data-coreui-popper`, `data-coreui-placement`, `data-coreui-validate`) are always `data-coreui-*` and do not follow it.
+
 ## Examples
 
 CSS variables offer similar flexibility to Sass's variables, but without the need for compilation before being served to the browser. For example, here we're resetting our page's font and link styles with CSS variables.

--- a/docs/src/content/docs/customize/options.mdx
+++ b/docs/src/content/docs/customize/options.mdx
@@ -10,6 +10,7 @@ You can find and customize these variables for key global options in CoreUI for 
 | Variable                       | Values                             | Description                                                                            |
 | ------------------------------ | ---------------------------------- | -------------------------------------------------------------------------------------- |
 | `$spacer`                      | `1rem` (default), or any value > 0 | Specifies the default spacer value to programmatically generate our [margin](/utilities/margin/), [padding](/utilities/padding/) and [gap](/utilities/gap/) utilities. |
+| `$data-infix`                  | `-coreui-` (default)               | Renames the `data-*` attributes you write in your markup (`data-coreui-theme`, `data-coreui-target`); attributes the JavaScript sets are always `data-coreui-*`. See [CSS variables](/customize/css-variables/#prefix). |
 | `$enable-dark-mode`            | `true` (default) or `false`        | Enables built-in [dark mode support](/customize/color-modes/#dark-mode) across the project and its components. |
 | `$enable-rounded`              | `true` (default) or `false`        | Enables predefined `border-radius` styles on various components. |
 | `$enable-shadows`              | `true` or `false` (default)        | Enables predefined decorative `box-shadow` styles on various components. The `--cui-*-box-shadow` component tokens are always declared, but they render only with this option on. Does not affect `box-shadow`s used for focus states. |

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -165,7 +165,7 @@ $dropdown-dark-tokens: defaults(
       display: block;
     }
 
-    &[data#{$data-infix}popper] {
+    &[data-coreui-popper] {
       inset-inline-start: 0;
       top: 100%;
       margin-top: var(--#{$prefix}dropdown-spacer);
@@ -196,7 +196,7 @@ $dropdown-dark-tokens: defaults(
         // Read by the plugin, so the name stays outside `$prefix`.
         --cui-position: start;
 
-        &[data#{$data-infix}popper] {
+        &[data-coreui-popper] {
           inset-inline-start: 0;
           inset-inline-end: auto;
         }
@@ -205,7 +205,7 @@ $dropdown-dark-tokens: defaults(
       .dropdown-menu#{$infix}-end {
         --cui-position: end;
 
-        &[data#{$data-infix}popper] {
+        &[data-coreui-popper] {
           inset-inline-start: auto;
           inset-inline-end: 0;
         }
@@ -217,7 +217,7 @@ $dropdown-dark-tokens: defaults(
   // Allow for dropdowns to go bottom up (aka, dropup-menu)
   // Just add .dropup after the standard .dropdown class and you're set.
   .dropup {
-    .dropdown-menu[data#{$data-infix}popper] {
+    .dropdown-menu[data-coreui-popper] {
       top: auto;
       bottom: 100%;
       margin-top: 0;
@@ -230,7 +230,7 @@ $dropdown-dark-tokens: defaults(
   }
 
   .dropend {
-    .dropdown-menu[data#{$data-infix}popper] {
+    .dropdown-menu[data-coreui-popper] {
       inset-inline-start: 100%;
       inset-inline-end: auto;
       top: 0;
@@ -247,7 +247,7 @@ $dropdown-dark-tokens: defaults(
   }
 
   .dropstart {
-    .dropdown-menu[data#{$data-infix}popper] {
+    .dropdown-menu[data-coreui-popper] {
       inset-inline-start: auto;
       inset-inline-end: 100%;
       top: 0;


### PR DESCRIPTION
`$data-infix` renames the `data-*` attributes an author writes (`theme`, `target`) so the Bootstrap theme can read `data-bs-theme`. The dropdown's six `[data#{$data-infix}popper]` selectors read it too, but that attribute is set by the JavaScript (`Manipulator.setDataAttribute`), which always writes `data-coreui-popper` — so in the Bootstrap theme those selectors looked for `data-bs-popper` and the static-positioned menu lost its rules. They read `data-coreui-popper` now.

Default stylesheet byte-identical; the Bootstrap theme changes exactly the sixteen selector lines carrying the attribute. The knob was undocumented outside the migration guide: it is described on the CSS variables page next to `$prefix` and in the options table as covering authored attributes only (`theme`, `target`), with the JS-written ones (`popper`, `placement`, `validate`) always `data-coreui-*`.