### PR TITLE
chore(stylelint): reject non-zero logical radius longhands outside the mixins

### DIFF
--- a/scss/mixins/_border-radius.scss
+++ b/scss/mixins/_border-radius.scss
@@ -1,4 +1,4 @@
-// stylelint-disable property-disallowed-list
+// stylelint-disable property-disallowed-list, declaration-property-value-disallowed-list
 @use "sass:list";
 @use "sass:math";
 @use "sass:meta";

--- a/scss/tests/mixins/_border-radius.test.scss
+++ b/scss/tests/mixins/_border-radius.test.scss
@@ -1,4 +1,4 @@
-// stylelint-disable property-disallowed-list
+// stylelint-disable property-disallowed-list, declaration-property-value-disallowed-list
 @use "../../config" as *;
 @use "../../mixins/border-radius" as *;
 

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -34,7 +34,8 @@ export default {
       rules: {
         'declaration-property-value-disallowed-list': {
           border: 'none',
-          outline: 'none'
+          outline: 'none',
+          '/^border-(start|end)-(start|end)-radius$/': ['/^(?!0$).+/']
         },
         'function-disallowed-list': [
           'lighten',


### PR DESCRIPTION
`property-disallowed-list` forbids `border-radius` and the four physical corners so every radius goes through the mixins that honour `$enable-rounded`, but the logical longhands (`border-start-start-radius` and friends) were not on the list — the same gap upstream's config has.

They are covered now by `declaration-property-value-disallowed-list` with a pattern that accepts only `0`: zeroing a corner directly (the drawer's bottom sheet, which matches upstream line for line) stays legal, while `border-start-end-radius: 1rem` or `var(--cui-radius-5)` written directly is rejected and has to go through the mixins. Verified with a probe file (0 passes, `1rem` and `var()` fail); the library lints clean. The mixin partial and its spec, which emit the longhands on purpose, opt out on their existing disable line. No stylesheet change.