### PR TITLE
chore(scss): mechanical cleanups from the quality audit

### DIFF
--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -110,8 +110,6 @@ $avatar-variants: defaults(
     justify-content: center;
     width: var(--#{$prefix}avatar-size);
     height: var(--#{$prefix}avatar-size);
-    // Declared as a fallback rather than a token, so the derived size is the
-    // default and an explicit one still wins.
     font-size: var(--#{$prefix}avatar-font-size);
     color: var(--#{$prefix}avatar-color);
     vertical-align: middle;

--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -197,7 +197,7 @@ $chip-outline-tokens: defaults(
     margin-inline-start: calc(var(--#{$prefix}chip-gap) * -.25);
 
     > svg {
-      display: block; // Prevents baseline alignment issues
+      display: block;
       width: var(--#{$prefix}chip-icon-size);
       height: var(--#{$prefix}chip-icon-size);
     }
@@ -218,7 +218,7 @@ $chip-outline-tokens: defaults(
     margin-inline-start: calc(var(--#{$prefix}chip-gap) * -.25);
 
     > svg {
-      display: block; // Prevents baseline alignment issues
+      display: block;
       width: var(--#{$prefix}chip-icon-size);
       height: var(--#{$prefix}chip-icon-size);
     }
@@ -250,7 +250,7 @@ $chip-outline-tokens: defaults(
     }
 
     > svg {
-      display: block; // Prevents baseline alignment issues
+      display: block;
       width: var(--#{$prefix}chip-remove-size);
       height: var(--#{$prefix}chip-remove-size);
     }

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -5,10 +5,6 @@
 
 $prefix:                      cui- !default;
 
-// Gradients
-
-// Characters which are escaped by the escape-svg function
-
 // Quickly modify global styling by enabling or disabling optional features.
 
 $enable-caret:                true !default;
@@ -54,8 +50,6 @@ $data-infix:                  -coreui- !default;
 
 $mobile-breakpoint:           lg !default;
 
-// This gradient is also added to elements with `.bg-gradient`
-
 // You can add more entries to the $spacers map, should you need more variation.
 
 // scss-docs-start spacer-variables
@@ -76,10 +70,6 @@ $spacers: (
   9: $spacer * 8,
 ) !default;
 // scss-docs-end spacers-map
-
-// Define the edge positioning anchors of the position utilities.
-
-// Define common box shadows
 
 // Style anchor elements.
 
@@ -256,18 +246,6 @@ $font-sizes: (
   "6xl": ("font-size": $font-size-6xl,        "line-height": $headings-line-height)
 ) !default;
 // scss-docs-end font-sizes
-
-// Icons
-
-// Customizes the `.table` component with basic values, each used across all table variations.
-
-// Shared variables that are reassigned to `$input-` and `$btn-` specific variables.
-
-// For each of Bootstrap's buttons, define text, background, and border color.
-
-// Forms
-
-// Form validation
 
 // Warning: Avoid customizing these values. They're used for a bird's eye view
 // of components dependent on the z-axis and are designed to all work together.

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -90,7 +90,7 @@ $modal-tokens: defaults(
     --#{$prefix}modal-backdrop-opacity: #{$modal-backdrop-opacity},
     --#{$prefix}modal-header-padding-x: #{$modal-header-padding-x},
     --#{$prefix}modal-header-padding-y: #{$modal-header-padding-y},
-    --#{$prefix}modal-header-padding: #{$modal-header-padding}, // Todo in v6: Split this padding into x and y
+    --#{$prefix}modal-header-padding: #{$modal-header-padding},
     --#{$prefix}modal-header-border-color: #{$modal-header-border-color},
     --#{$prefix}modal-header-border-width: #{$modal-header-border-width},
     --#{$prefix}modal-title-line-height: #{$modal-title-line-height},

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -260,7 +260,7 @@ $navbar-dark-tokens: defaults(
 
   // Navbar text
   //
-  //
+  // For adding text or inline elements to the navbar
 
   .navbar-text {
     padding-top: var(--#{$prefix}navbar-text-padding-y);

--- a/scss/_popup.scss
+++ b/scss/_popup.scss
@@ -51,7 +51,6 @@ $popup-tokens: defaults(
     opacity: 0;
     @include box-shadow(var(--#{$prefix}popup-box-shadow));
 
-    //
     @include transition(
       opacity var(--#{$prefix}popup-transition-duration) var(--#{$prefix}popup-transition-timing),
       display var(--#{$prefix}popup-transition-duration) allow-discrete

--- a/scss/_rating.scss
+++ b/scss/_rating.scss
@@ -103,11 +103,6 @@ $rating-tokens: defaults(
 
     svg {
       height: var(--#{$prefix}rating-item-height);
-      pointer-events: none;
-
-      * {
-        pointer-events: none;
-      }
     }
 
     &.active {

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -1,9 +1,7 @@
-@use "sass:color";
 @use "sass:map";
 @use "sass:meta";
 @use "functions/defaults" as *;
 @use "mixins/tokens" as *;
-@use "functions/color" as *;
 @use "functions/color-translucent" as *;
 @use "mixins/color-mode" as *;
 @use "theme" as *;

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -97,8 +97,6 @@ $position-values: (
 // scss-docs-end position-map
 
 
-// The opacity utilities scale a runtime var, so calc() is unavoidable here.
-
 // Utilities
 
 $utilities: () !default;

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -1,4 +1,3 @@
-@use "sass:math";
 @use "../functions/defaults" as *;
 @use "../functions/escape-svg" as *;
 @use "../mixins/border-radius" as *;

--- a/scss/functions/_escape-svg.scss
+++ b/scss/functions/_escape-svg.scss
@@ -1,5 +1,4 @@
 @use "sass:string";
-@use "../config" as *;
 @use "str-replace" as *;
 
 $escaped-characters: (

--- a/scss/helpers/_color-bg.scss
+++ b/scss/helpers/_color-bg.scss
@@ -2,8 +2,6 @@
 @use "../theme" as *;
 @use "../config" as *;
 
-// The opacity utilities scale a runtime var, so calc() is unavoidable here.
-
 @layer helpers {
   @each $color in map.keys($theme-colors) {
     .text-bg-#{$color} {

--- a/scss/helpers/index.scss
+++ b/scss/helpers/index.scss
@@ -6,8 +6,8 @@
 @forward "icon-link";
 @forward "position";
 @forward "stacks";
-@forward "theme-colors";
-@forward "visually-hidden";
 @forward "stretched-link";
 @forward "text-truncation";
+@forward "theme-colors";
+@forward "visually-hidden";
 @forward "vr";

--- a/scss/mixins/_form-validation.scss
+++ b/scss/mixins/_form-validation.scss
@@ -16,7 +16,6 @@ $form-feedback-icon-invalid-color:  $danger !default;
 $form-feedback-icon-invalid:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='#{$form-feedback-icon-invalid-color}'><circle cx='6' cy='6' r='4.5'/><path stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/><circle cx='6' cy='8.2' r='.6' fill='#{$form-feedback-icon-invalid-color}' stroke='none'/></svg>") !default;
 // scss-docs-end form-feedback-variables
 
-// `icon` stays a Sass value because the SVG bakes its fill in at build time.
 // scss-docs-start form-validation-states
 // `icon` stays a Sass value because the SVG bakes its fill in at build time.
 $form-validation-states: (

--- a/scss/sidebar/_sidebar-nav.scss
+++ b/scss/sidebar/_sidebar-nav.scss
@@ -3,7 +3,6 @@
 @use "../mixins/transition" as *;
 @use "sidebar" as *;
 @use "../config" as *;
-@use "sidebar" as *;
 // Sidebar navigation
 
 // scss-docs-start sidebar-nav-variables

--- a/scss/themes/bootstrap/bootstrap.scss
+++ b/scss/themes/bootstrap/bootstrap.scss
@@ -1,4 +1,3 @@
-@use "sass:color";
 @use "../../banner" with (
   $file: "Bootstrap Theme"
 );


### PR DESCRIPTION
Section F, first half — nothing that changes a rendered value:

- unused `@use` in `_root`, `forms/_form-control`, `functions/_escape-svg` and `themes/bootstrap`; a doubled `@use "sidebar"` in `sidebar/_sidebar-nav`
- eleven section headers in `_config.scss` whose variables moved to their partials (`// Gradients`, `// Icons`, `// Forms`, …)
- a repeated comment in `mixins/_form-validation`, a stray `//` in `_popup`, the empty description under `// Navbar text` restored to upstream's line, comments in `_avatar`, `_modal`, `_chip`, `_utilities` and `helpers/_color-bg` that described removed code or a stylelint rule that no longer exists
- `helpers/index.scss` in alphabetical order
- the rating item's `svg` and `svg *` `pointer-events: none`, already covered by the item's `*` rule

Compiled output: only the two redundant `pointer-events` rules disappear and the helper blocks reorder within the `helpers` layer (no overlapping selectors there); sorted diff otherwise empty for `coreui.css` and the Bootstrap theme. sass-true 100/0, docs build green.