### PR TITLE
refactor(scss): literal values onto tokens, logical spacing utilities, fewer gradient-bg calls

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -3378,6 +3378,15 @@ Nothing existing changes; these are additions. See
   instead of restating declarations, so state styling follows any control
   automatically.
 
+#### Spacing utilities write logical shorthands
+
+`.mx-*`, `.my-*`, `.px-*` and `.py-*` (and their negative-margin variants)
+emit `margin-inline`, `margin-block`, `padding-inline` and `padding-block`
+instead of two physical longhands each. Rendering is identical in both
+directions; the only visible difference is in DevTools, where one shorthand
+replaces the pair, and in a stylesheet of your own that overrode one of the
+longhands after ours — a shorthand still yields to a later longhand.
+
 #### Opacity utilities no longer cascade to descendants
 
 <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -22,6 +22,8 @@ $chip-img-border-radius:     50% !default;
 $chip-remove-size:           1rem !default;
 $chip-remove-opacity:        .65 !default;
 $chip-remove-hover-opacity:  1 !default;
+$chip-disabled-opacity:      .65 !default;
+$chip-active-opacity:        .9 !default;
 $chip-transition:            background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out, color .15s ease-in-out !default;
 
 $chip-color:                 var(--#{$prefix}fg-body) !default;
@@ -73,6 +75,8 @@ $chip-tokens: defaults(
     --#{$prefix}chip-remove-size: #{$chip-remove-size},
     --#{$prefix}chip-remove-opacity: #{$chip-remove-opacity},
     --#{$prefix}chip-remove-hover-opacity: #{$chip-remove-hover-opacity},
+    --#{$prefix}chip-disabled-opacity: #{$chip-disabled-opacity},
+    --#{$prefix}chip-active-opacity: #{$chip-active-opacity},
     --#{$prefix}chip-transition: #{$chip-transition},
     --#{$prefix}chip-color: var(--#{$prefix}theme-fg-emphasis, #{$chip-color}),
     --#{$prefix}chip-bg: var(--#{$prefix}theme-bg-subtle, #{$chip-bg}),
@@ -141,7 +145,7 @@ $chip-outline-tokens: defaults(
     &.disabled,
     &:disabled {
       pointer-events: none;
-      opacity: .65;
+      opacity: var(--#{$prefix}chip-disabled-opacity);
     }
 
     &:focus-visible {
@@ -175,7 +179,7 @@ $chip-outline-tokens: defaults(
     &.active:hover {
       color: var(--#{$prefix}chip-active-color);
       background-color: var(--#{$prefix}chip-active-bg);
-      opacity: .9;
+      opacity: var(--#{$prefix}chip-active-opacity);
     }
   }
 

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -4,7 +4,6 @@
 @use "mixins/box-shadow" as *;
 @use "layout/breakpoints" as *;
 @use "mixins/caret" as *;
-@use "mixins/gradients" as *;
 @use "mixins/tokens" as *;
 @use "config" as *;
 
@@ -278,7 +277,7 @@ $dropdown-dark-tokens: defaults(
     height: 0;
     margin: var(--#{$prefix}dropdown-divider-margin-y) 0;
     overflow: hidden;
-    border-block-start: 1px solid var(--#{$prefix}dropdown-divider-bg);
+    border-block-start: var(--#{$prefix}border-width) solid var(--#{$prefix}dropdown-divider-bg);
     opacity: 1; // Revisit in v6 to de-dupe styles that conflict with <hr> element
   }
 
@@ -304,14 +303,14 @@ $dropdown-dark-tokens: defaults(
       color: var(--#{$prefix}dropdown-link-hover-color);
       // stylelint-disable-next-line scss/at-function-named-arguments
       text-decoration: if(sass($link-hover-decoration == underline): none);
-      @include gradient-bg(var(--#{$prefix}dropdown-link-hover-bg));
+      background-color: var(--#{$prefix}dropdown-link-hover-bg);
     }
 
     &.active,
     &:active {
       color: var(--#{$prefix}dropdown-link-active-color);
       text-decoration: none;
-      @include gradient-bg(var(--#{$prefix}dropdown-link-active-bg));
+      background-color: var(--#{$prefix}dropdown-link-active-bg);
     }
 
     &.disabled,

--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -185,7 +185,7 @@ $menu-tokens: defaults(
     height: 0;
     margin: var(--#{$prefix}menu-divider-margin-y) var(--#{$prefix}menu-divider-margin-x);
     overflow: hidden;
-    border-block-start: 1px solid var(--#{$prefix}menu-divider-bg);
+    border-block-start: var(--#{$prefix}border-width) solid var(--#{$prefix}menu-divider-bg);
     opacity: 1;
   }
 

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -9,7 +9,6 @@
 @use "layout/breakpoints" as *;
 @use "mixins/color-mode" as *;
 @use "mixins/deprecate" as *;
-@use "mixins/gradients" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
 @use "mixins/translucent" as *;
@@ -176,7 +175,6 @@ $navbar-dark-tokens: defaults(
     justify-content: space-between; // space out brand from logo
     min-height: var(--#{$prefix}navbar-min-height);
     padding: var(--#{$prefix}navbar-padding-y) var(--#{$prefix}navbar-padding-x);
-    @include gradient-bg();
     // The navbar answers to the width it is given, not to the window's: a navbar
     // in a narrow column collapses there while a full-width one stays expanded.
     @include set-container();

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -1,7 +1,6 @@
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/focus-ring" as *;
-@use "mixins/gradients" as *;
 @use "mixins/lists" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
@@ -122,7 +121,7 @@ $pagination-sizes: defaults(
     .active > & {
       z-index: 3;
       color: var(--#{$prefix}theme-contrast, var(--#{$prefix}pagination-active-color));
-      @include gradient-bg(var(--#{$prefix}theme-bg, var(--#{$prefix}pagination-active-bg)));
+      background-color: var(--#{$prefix}theme-bg, var(--#{$prefix}pagination-active-bg));
       border-color: var(--#{$prefix}theme-bg, var(--#{$prefix}pagination-active-border-color));
     }
 

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -18,7 +18,7 @@ $range-slider-track-width:                 100% !default;
 $range-slider-track-height:                .5rem !default;
 $range-slider-track-cursor:                pointer !default;
 $range-slider-track-bg:                    var(--#{$prefix}bg-4) !default;
-$range-slider-track-border-radius:         1rem !default;
+$range-slider-track-border-radius:         var(--#{$prefix}radius-pill) !default;
 $range-slider-track-box-shadow:            var(--#{$prefix}box-shadow-inset) !default;
 
 $range-slider-track-in-range-bg:           color-mix(in srgb, var(--#{$prefix}theme-bg, var(--#{$prefix}primary)) 50%, transparent) !default;
@@ -33,7 +33,7 @@ $range-slider-thumb-width:                 1rem !default;
 $range-slider-thumb-height:                $range-slider-thumb-width !default;
 $range-slider-thumb-bg:                    var(--#{$prefix}theme-bg, var(--#{$prefix}primary)) !default;
 $range-slider-thumb-border:                0 !default;
-$range-slider-thumb-border-radius:         1rem !default;
+$range-slider-thumb-border-radius:         var(--#{$prefix}radius-pill) !default;
 $range-slider-thumb-box-shadow:            0 .1rem .25rem color-mix(in srgb, var(--#{$prefix}black) 10%, transparent) !default;
 $range-slider-thumb-active-bg:             color-mix(in srgb, var(--#{$prefix}theme-bg, var(--#{$prefix}primary)) 30%, var(--#{$prefix}bg-body)) !default;
 $range-slider-thumb-disabled-bg:           var(--#{$prefix}fg-3) !default;

--- a/scss/_stepper.scss
+++ b/scss/_stepper.scss
@@ -198,7 +198,7 @@ $stepper-tokens: defaults(
     color: var(--#{$prefix}stepper-step-indicator-color);
     background: var(--#{$prefix}stepper-step-indicator-bg);
     border: var(--#{$prefix}stepper-step-indicator-border-width) solid var(--#{$prefix}stepper-step-indicator-border-color);
-    @include border-radius(50em);
+    @include border-radius(50%);
     @include transition(var(--#{$prefix}stepper-step-indicator-transition));
   }
 

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -697,13 +697,13 @@ $utilities: map.merge(
     ),
     "margin-x": (
       responsive: true,
-      property: margin-right margin-left,
+      property: margin-inline,
       class: mx,
       values: map.merge($spacers, (auto: auto))
     ),
     "margin-y": (
       responsive: true,
-      property: margin-top margin-bottom,
+      property: margin-block,
       class: my,
       values: map.merge($spacers, (auto: auto))
     ),
@@ -740,13 +740,13 @@ $utilities: map.merge(
     ),
     "negative-margin-x": (
       responsive: true,
-      property: margin-right margin-left,
+      property: margin-inline,
       class: mx,
       values: $negative-spacers
     ),
     "negative-margin-y": (
       responsive: true,
-      property: margin-top margin-bottom,
+      property: margin-block,
       class: my,
       values: $negative-spacers
     ),
@@ -785,13 +785,13 @@ $utilities: map.merge(
     ),
     "padding-x": (
       responsive: true,
-      property: padding-right padding-left,
+      property: padding-inline,
       class: px,
       values: $spacers
     ),
     "padding-y": (
       responsive: true,
-      property: padding-top padding-bottom,
+      property: padding-block,
       class: py,
       values: $spacers
     ),

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -4,7 +4,6 @@
 @use "../mixins/box-shadow" as *;
 @use "../mixins/color-mode" as *;
 @use "../mixins/focus-ring" as *;
-@use "../mixins/gradients" as *;
 @use "../mixins/ltr-rtl" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/form-validation" as *;
@@ -210,8 +209,8 @@ $form-control-select-tokens: defaults(
       margin: calc(var(--#{$prefix}control-padding-y) * -1) calc(var(--#{$prefix}control-padding-x) * -1);
       margin-inline-end: var(--#{$prefix}control-padding-x);
       color: var(--#{$prefix}control-action-color);
-      @include gradient-bg(var(--#{$prefix}control-action-bg));
       pointer-events: none;
+      background-color: var(--#{$prefix}control-action-bg);
       border-color: inherit;
       border-style: solid;
       border-width: 0;

--- a/scss/sidebar/_sidebar-nav.scss
+++ b/scss/sidebar/_sidebar-nav.scss
@@ -168,7 +168,7 @@ $sidebar-nav-tree-link-active-icon-bullet-bg:  var(--#{$prefix}border-color) !de
       padding: var(--#{$prefix}sidebar-nav-title-padding-y) var(--#{$prefix}sidebar-nav-title-padding-x);
       margin-top: var(--#{$prefix}sidebar-nav-title-margin-top);
       font-size: 80%;
-      font-weight: 700;
+      font-weight: var(--#{$prefix}font-weight-bold);
       color: var(--#{$prefix}sidebar-nav-title-color);
       text-transform: uppercase;
       @include transition($sidebar-nav-title-transition);
@@ -365,7 +365,7 @@ $sidebar-nav-tree-link-active-icon-bullet-bg:  var(--#{$prefix}border-color) !de
           z-index: -1;
           height: 100%;
           content: "";
-          border-inline-start: 1px solid var(--#{$prefix}sidebar-nav-tree-group-border-color);
+          border-inline-start: var(--#{$prefix}border-width) solid var(--#{$prefix}sidebar-nav-tree-group-border-color);
         }
 
         // stylelint-disable-next-line selector-max-class


### PR DESCRIPTION
Section F, second half:

- dividers in the dropdown, the menu and the sidebar tree read `--cui-border-width` instead of `1px`; the sidebar title reads `--cui-font-weight-bold`
- the chip's disabled and active opacity become `--cui-chip-disabled-opacity` / `--cui-chip-active-opacity` (map, Sass knobs, docs blocks pick them up)
- the range slider's track and thumb radius read `--cui-radius-pill`; the stepper indicator is `border-radius(50%)` (upstream's value; a circle either way)
- `.mx-*`, `.my-*`, `.px-*`, `.py-*` and the negative margins emit `margin-inline`/`-block` and `padding-inline`/`-block` instead of two physical longhands each — 504 declarations become 252, identical rendering in LTR and RTL (measured); migration note
- `gradient-bg()` stays only where upstream keeps it (active nav pill, the range thumbs in `form-range` and `range-slider`); the navbar (a colourless call), pagination, dropdown items and the control action paint a plain `background-color`, so with `$enable-gradients` on they no longer pick up the sheen. Upstream removed or commented out the same calls across #41928, #42250, #42308 and its pagination commit.

Kept raw on purpose: the four `box-shadow:` declarations (toast, enclosed nav, sidebar ×2) — the `box-shadow()` mixin gates on `$enable-shadows`, which is off by default, so routing them through it would drop the overlays' shadows; upstream's toast is raw too. The calendar cell's `padding: 1px 0` is spacing, not a border.

Rendered values unchanged at the defaults: measured in Chromium before/after for utilities in both directions, chip, sidebar title, slider, stepper, pagination, dropdown item and divider. sass-true 100/0, docs build green.