### PR TITLE
refactor(forms): shared mixins in mixins/, radio gets its own size map

### DIFF
--- a/docs/src/content/docs/forms/radio.mdx
+++ b/docs/src/content/docs/forms/radio.mdx
@@ -211,6 +211,12 @@ Sass variables set these defaults at build time and are removed in v7. The CSS v
 
 <ScssDocs file="scss/forms/_radio.scss" capture="radio-variables" />
 
+### Sass maps
+
+Each size is one entry, and the map merges with your overrides — add a key to define a size, or set one to `null` to drop it:
+
+<ScssDocs file="scss/forms/_radio.scss" capture="radio-sizes" />
+
 ### Shared variables
 
 The checkbox, the radio and the switch share their size and their focus, active and disabled states. Those live on `:root` as `--cui-control-*`, so one declaration retunes all three at runtime; the Sass variables behind them set the defaults:

--- a/scss/_autocomplete.scss
+++ b/scss/_autocomplete.scss
@@ -1,5 +1,5 @@
 @use "config" as *;
-@use "forms/form-control-group" as *;
+@use "mixins/form-control" as *;
 
 @layer components {
   .autocomplete {

--- a/scss/_date-picker.scss
+++ b/scss/_date-picker.scss
@@ -3,7 +3,7 @@
 @use "functions/defaults" as *;
 @use "mixins/tokens" as *;
 @use "config" as *;
-@use "forms/form-control-group" as *;
+@use "mixins/form-control" as *;
 
 // scss-docs-start date-picker-variables
 $date-picker-footer-padding:           .5rem !default;

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -3,7 +3,7 @@
 @use "mixins/tokens" as *;
 @use "theme" as *;
 @use "config" as *;
-@use "forms/form-control-group" as *;
+@use "mixins/form-control" as *;
 
 // scss-docs-start time-picker-variables
 $time-picker-body-padding:                  var(--#{$prefix}spacer-2) !default;

--- a/scss/forms/_check.scss
+++ b/scss/forms/_check.scss
@@ -18,11 +18,17 @@ $check-mark-checked:         url("data:image/svg+xml,<svg xmlns='http://www.w3.o
 $check-mark-indeterminate:   url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/></svg>") !default;
 // scss-docs-end check-variables
 
+$check-sizes: () !default;
+
 // scss-docs-start check-sizes
-$check-sizes: (
-  sm: (size: .875rem, margin-top: .21875rem, font-size: var(--#{$prefix}font-size-sm)),
-  lg: (size: 1.25rem, margin-top: .3125rem, font-size: var(--#{$prefix}font-size-lg))
-) !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$check-sizes: defaults(
+  (
+    sm: (size: .875rem, margin-top: .21875rem, font-size: var(--#{$prefix}font-size-sm)),
+    lg: (size: 1.25rem, margin-top: .3125rem, font-size: var(--#{$prefix}font-size-lg))
+  ),
+  $check-sizes
+);
 // scss-docs-end check-sizes
 
 $check-tokens: () !default;

--- a/scss/forms/_form-control-group.scss
+++ b/scss/forms/_form-control-group.scss
@@ -2,6 +2,7 @@
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/focus-ring" as *;
+@use "../mixins/form-control" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
 @use "../config" as *;
@@ -62,23 +63,6 @@ $form-control-group-tokens: defaults(
 // scss-docs-end form-control-group-tokens
 
 // stylelint-enable scss/dollar-variable-default, custom-property-no-missing-var-function
-
-// scss-docs-start form-control-group-active-mixin
-@mixin form-control-group-active() {
-  color: var(--#{$prefix}control-focus-color);
-  background-color: var(--#{$prefix}control-focus-bg);
-  border-color: var(--#{$prefix}control-focus-border-color);
-}
-// scss-docs-end form-control-group-active-mixin
-
-// scss-docs-start form-control-group-focus-mixin
-// Only where focus actually is: a ring on a field while the user arrows around
-// its popup gives a keyboard user two focus indicators (WCAG 2.4.7).
-@mixin form-control-group-focus() {
-  @include form-control-group-active();
-  @include focus-ring(true, $color: var(--#{$prefix}control-focus-ring));
-}
-// scss-docs-end form-control-group-focus-mixin
 
 @layer forms {
   .form-control-group {

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -4,6 +4,7 @@
 @use "../mixins/box-shadow" as *;
 @use "../mixins/color-mode" as *;
 @use "../mixins/focus-ring" as *;
+@use "../mixins/form-control" as *;
 @use "../mixins/ltr-rtl" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/form-validation" as *;
@@ -72,30 +73,6 @@ $form-control-tokens: defaults(
 // scss-docs-end form-control-tokens
 
 // stylelint-enable scss/dollar-variable-default, custom-property-no-missing-var-function
-
-// scss-docs-start form-control-frame-mixin
-@mixin form-control-frame() {
-  padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
-  font-family: var(--#{$prefix}control-font-family);
-  font-size: var(--#{$prefix}control-font-size);
-  font-weight: var(--#{$prefix}control-font-weight);
-  line-height: var(--#{$prefix}control-line-height);
-  color: var(--#{$prefix}control-color);
-  background-color: var(--#{$prefix}control-bg);
-  background-clip: padding-box;
-  border: var(--#{$prefix}control-border-width) solid var(--#{$prefix}control-border-color);
-
-  // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
-  @include border-radius(var(--#{$prefix}control-border-radius), 0);
-
-  @include box-shadow(var(--#{$prefix}control-box-shadow));
-  @include transition-props(
-    var(--#{$prefix}control-transition-property),
-    var(--#{$prefix}control-transition-duration),
-    var(--#{$prefix}control-transition-timing)
-  );
-}
-// scss-docs-end form-control-frame-mixin
 
 // scss-docs-start form-control-select-variables
 $form-control-select-indicator-color:           $gray-800 !default;

--- a/scss/forms/_form-date-time.scss
+++ b/scss/forms/_form-date-time.scss
@@ -2,7 +2,7 @@
 @use "../mixins/border-radius" as *;
 @use "../mixins/tokens" as *;
 @use "../config" as *;
-@use "form-control-group" as *;
+@use "../mixins/form-control" as *;
 
 // scss-docs-start form-date-time-variables
 $form-date-time-placeholder-color:       var(--#{$prefix}fg-2) !default;

--- a/scss/forms/_form-multi-select.scss
+++ b/scss/forms/_form-multi-select.scss
@@ -1,7 +1,7 @@
 @use "../functions/defaults" as *;
 @use "../mixins/tokens" as *;
 @use "../config" as *;
-@use "form-control-group" as *;
+@use "../mixins/form-control" as *;
 
 // scss-docs-start form-multi-select-variables
 

--- a/scss/forms/_otp-input.scss
+++ b/scss/forms/_otp-input.scss
@@ -2,6 +2,7 @@
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/focus-ring" as *;
+@use "../mixins/form-control" as *;
 @use "../mixins/tokens" as *;
 @use "../config" as *;
 @use "form-control" as *;

--- a/scss/forms/_radio.scss
+++ b/scss/forms/_radio.scss
@@ -1,7 +1,6 @@
 @use "sass:map";
 @use "../functions/defaults" as *;
 @use "../functions/escape-svg" as *;
-@use "check" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/mask-icon" as *;
 @use "../mixins/tokens" as *;
@@ -17,6 +16,19 @@ $radio-border-radius:     50% !default;
 $radio-mark-color:        var(--#{$prefix}primary-contrast) !default;
 $radio-mark:              url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='black'/></svg>") !default;
 // scss-docs-end radio-variables
+
+$radio-sizes: () !default;
+
+// scss-docs-start radio-sizes
+// stylelint-disable-next-line scss/dollar-variable-default
+$radio-sizes: defaults(
+  (
+    sm: (size: .875rem, margin-top: .21875rem, font-size: var(--#{$prefix}font-size-sm)),
+    lg: (size: 1.25rem, margin-top: .3125rem, font-size: var(--#{$prefix}font-size-lg))
+  ),
+  $radio-sizes
+);
+// scss-docs-end radio-sizes
 
 $radio-tokens: () !default;
 
@@ -107,7 +119,7 @@ $radio-selector: if(sass($enable-deprecated-form-check): ".radio, .form-check-in
     }
   }
 
-  @each $size, $map in $check-sizes {
+  @each $size, $map in $radio-sizes {
     .radio-#{$size} {
       --#{$prefix}radio-size: #{map.get($map, "size")};
       --#{$prefix}radio-margin-top: #{map.get($map, "margin-top")};

--- a/scss/mixins/_form-control.scss
+++ b/scss/mixins/_form-control.scss
@@ -1,0 +1,46 @@
+@use "../config" as *;
+@use "border-radius" as *;
+@use "box-shadow" as *;
+@use "focus-ring" as *;
+@use "transition" as *;
+
+// scss-docs-start form-control-frame-mixin
+@mixin form-control-frame() {
+  padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);
+  font-family: var(--#{$prefix}control-font-family);
+  font-size: var(--#{$prefix}control-font-size);
+  font-weight: var(--#{$prefix}control-font-weight);
+  line-height: var(--#{$prefix}control-line-height);
+  color: var(--#{$prefix}control-color);
+  background-color: var(--#{$prefix}control-bg);
+  background-clip: padding-box;
+  border: var(--#{$prefix}control-border-width) solid var(--#{$prefix}control-border-color);
+
+  // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
+  @include border-radius(var(--#{$prefix}control-border-radius), 0);
+
+  @include box-shadow(var(--#{$prefix}control-box-shadow));
+  @include transition-props(
+    var(--#{$prefix}control-transition-property),
+    var(--#{$prefix}control-transition-duration),
+    var(--#{$prefix}control-transition-timing)
+  );
+}
+// scss-docs-end form-control-frame-mixin
+
+// scss-docs-start form-control-group-active-mixin
+@mixin form-control-group-active() {
+  color: var(--#{$prefix}control-focus-color);
+  background-color: var(--#{$prefix}control-focus-bg);
+  border-color: var(--#{$prefix}control-focus-border-color);
+}
+// scss-docs-end form-control-group-active-mixin
+
+// scss-docs-start form-control-group-focus-mixin
+// Only where focus actually is: a ring on a field while the user arrows around
+// its popup gives a keyboard user two focus indicators (WCAG 2.4.7).
+@mixin form-control-group-focus() {
+  @include form-control-group-active();
+  @include focus-ring(true, $color: var(--#{$prefix}control-focus-ring));
+}
+// scss-docs-end form-control-group-focus-mixin

--- a/scss/mixins/index.scss
+++ b/scss/mixins/index.scss
@@ -23,6 +23,7 @@
 @forward "backdrop";
 @forward "caret";
 @forward "chip";
+@forward "form-control";
 @forward "form-validation";
 @forward "icon";
 @forward "lists";


### PR DESCRIPTION
`form-control-frame()`, `form-control-group-active()` and `form-control-group-focus()` read only `--cui-control-*` tokens, so they were mixins living in rule-emitting partials; five components pulled `forms/_form-control-group` in just to reach them (the #776 shape). They live in `mixins/_form-control.scss` now, forwarded from `mixins/index`, and the only partials still importing a rule file are the two that read the `$form-control-tokens` map (group, OTP).

Radio looped over `$check-sizes` and imported `_check` for it; it has `$radio-sizes` now, in the `defaults()` shape `$switch-sizes` already uses, and `$check-sizes` takes that shape too, so the three size maps extend the same way through `@use … with`. The radio page gains the **Sass maps** section with the new block.

Compiled `coreui.css` byte-identical, sass-true 100/0, docs build green. No new variables partial (the shape v6 moves away from) — maps stay with their rules, as upstream keeps them.