### PR TITLE
fix(colors): keep the v5 gray hue and the v5 shade curve

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -2954,11 +2954,13 @@ pair, and `[data#{$data-infix}theme="dark"]` only declares `color-scheme: dark`.
   `$color-tints` and `$color-shades` gained `025`, `050`, `950` and `975`, so
   **every** colour now carries the full thirteen stops. The curve is
   `94 / 90 / 80 / 60 / 40 / 20 %` of white for `025` … `400` and
-  `16 / 32 / 48 / 64 / 70 / 76 %` of black for `600` … `975`, and `$gray` is
-  `oklch(60% 0.02 245)`. The light band is far more spread out than the v5
-  ramp it replaces: against white, `gray-100` reads 1.27:1 (was 1.10),
-  `gray-200` 1.63 (was 1.21), `gray-300` 2.14 (was 1.34), `gray-400` 2.87
-  (was 1.49); `gray-600` and below are within a step of where they were.
+  `21.9 / 33.4 / 48.8 / 60.4 / 69.2 / 74 %` of black for `600` … `975`, and
+  `$gray` keeps the v5 hue and chroma at a lower lightness,
+  `oklch(64% 0.03948 265.02)`. The light band is far more spread out than the
+  v5 ramp it replaces: against white, `gray-100` reads 1.24:1 (was 1.10),
+  `gray-200` 1.55 (was 1.21), `gray-300` 1.97 (was 1.34), `gray-400` 2.56
+  (was 1.49); `gray-600` and below stay within a step of the v5 grays
+  (`gray-900` `#1f222a`, was `#22262e`).
   Everything that reads a light stop moves with it — the neutral surfaces
   `bg-1` … `bg-4`, `border-color`, `theme-secondary`, every `-bg-subtle` and
   `-border` slot — which is what makes a plain badge or a secondary button

--- a/scss/_colors.scss
+++ b/scss/_colors.scss
@@ -23,7 +23,7 @@ $yellow:  oklch(84.417% 0.17216 84.93) !default;
 $green:   oklch(55.203% 0.1234 157.01) !default;
 $teal:    oklch(74.409% 0.14802 166.36) !default;
 $cyan:    oklch(77.493% 0.13797 218.05) !default;
-$gray:    oklch(60% 0.02 245) !default;
+$gray:    oklch(64% 0.03948 265.02) !default;
 // scss-docs-end color-variables
 
 // scss-docs-start colors-map
@@ -81,12 +81,12 @@ $color-shades: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $color-shades: defaults(
   (
-    "600": 16%,
-    "700": 32%,
-    "800": 48%,
-    "900": 64%,
-    "950": 70%,
-    "975": 76%
+    "600": 21.9%,
+    "700": 33.4%,
+    "800": 48.8%,
+    "900": 60.4%,
+    "950": 69.2%,
+    "975": 74%
   ),
   $color-shades
 );


### PR DESCRIPTION
#1149 took upstream's gray base and shade curve along with its tint curve. Two things went with it: the v5 hue and chroma of the grays (`0.03948 265.02`, a cool gray) and the dark side of the ramp — mixing black in `oklch` with upstream's percentages pulled `gray-900` to `#161a20` and `gray-975` to `#080a0c`, darker than v5 and darker than the `lab`-mixed build upstream currently ships.

**After**: `$gray` is `oklch(64% 0.03948 265.02)` — the v5 hue and chroma at a lightness that keeps the light band spread — and `$color-shades` returns to `21.9 / 33.4 / 48.8 / 60.4 / 69.2 / 74 %`. The tint curve from #1149 stays.

| stop | v5 | #1149 | now |
| --- | --- | --- | --- |
| gray-100 vs white | 1.10 | 1.27 | 1.24 |
| gray-300 vs white | 1.34 | 2.14 | 1.97 |
| gray-400 vs white | 1.49 | 2.87 | 2.56 |
| gray-600 | `#636c7e` | `#5d666e` | `#5b6375` |
| gray-900 | `#22262e` | `#171a1d` | `#1f222a` |
| gray-975 | `#0f1115` | `#080a0c` | `#0c0f13` |

Sass suite 98 specs, class-api, docs build green; visual suite passes on the current baselines within tolerance.