### PR TITLE
feat(layout): breakpoints lg 1024, xl 1280, 2xl 1536

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",
-      "maxSize": "19 kB"
+      "maxSize": "19.25 kB"
     },
     {
       "path": "./dist/css/coreui.css",
@@ -30,7 +30,7 @@
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "66.5 kB"
+      "maxSize": "67 kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/build/class-api-removals.json
+++ b/build/class-api-removals.json
@@ -1,4 +1,6 @@
 {
+  "*-xxl": "Renamed in v6: the largest breakpoint is `2xl` (1536px) — .container-xxl becomes .container-2xl, .hstack-xxl .hstack-2xl. Size variants that happen to spell xxl (.drawer-xxl, .offcanvas-xxl, .icon-xxl) are not breakpoints and keep their name.",
+  "*-xxl-*": "Renamed in v6: the largest breakpoint is `2xl` (1536px), so every responsive class reads -2xl- where it read -xxl- (.col-xxl-6 becomes .col-2xl-6). The lg and xl breakpoints also move, to 1024px and 1280px.",
   "accordion-button": "The accordion is built on <details>/<summary> now, so the trigger is the summary itself. Put .accordion-header on the <summary> element and drop the nested button.",
   "accordion-collapse": "The panel is the <details> element's own content now, revealed by the browser and styled through ::details-content. Nothing wraps the .accordion-body any more.",
   "alert-dark": "Removed in v6 with the `dark` theme colour. Rename it to the `-inverse` variant: `inverse` resolves to gray-900 in light mode and gray-100 in dark, so it stands against the page in both schemes instead of staying near-black on a near-black one.",

--- a/docs/src/content/docs/components/dialog.mdx
+++ b/docs/src/content/docs/components/dialog.mdx
@@ -241,9 +241,9 @@ Pop up a dialog that covers the user viewport, via modifier classes placed on th
 | `.dialog-fullscreen` | Always |
 | `.dialog-fullscreen-sm-down` | `576px` |
 | `.dialog-fullscreen-md-down` | `768px` |
-| `.dialog-fullscreen-lg-down` | `992px` |
-| `.dialog-fullscreen-xl-down` | `1200px` |
-| `.dialog-fullscreen-xxl-down` | `1400px` |
+| `.dialog-fullscreen-lg-down` | `1024px` |
+| `.dialog-fullscreen-xl-down` | `1280px` |
+| `.dialog-fullscreen-2xl-down` | `1536px` |
 
 ```html
 <dialog class="dialog dialog-fullscreen-sm-down">

--- a/docs/src/content/docs/components/dropdowns.mdx
+++ b/docs/src/content/docs/components/dropdowns.mdx
@@ -395,7 +395,7 @@ By default, a dropdown menu is automatically positioned 100% from the top and al
 
 If you want to use responsive alignment, disable dynamic positioning by adding the `data-coreui-display="static"` attribute and use the responsive variation classes.
 
-To align **right** the dropdown menu with the given breakpoint or larger, add `.dropdown-menu{-sm|-md|-lg|-xl|-xxl}-end`.
+To align **right** the dropdown menu with the given breakpoint or larger, add `.dropdown-menu{-sm|-md|-lg|-xl|-2xl}-end`.
 
 <Example code={`<div class="btn-group">
     <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" aria-expanded="false">
@@ -408,7 +408,7 @@ To align **right** the dropdown menu with the given breakpoint or larger, add `.
     </ul>
   </div>`} />
 
-To align **left** the dropdown menu with the given breakpoint or larger, add `.dropdown-menu-end` and `.dropdown-menu{-sm|-md|-lg|-xl|-xxl}-start`.
+To align **left** the dropdown menu with the given breakpoint or larger, add `.dropdown-menu-end` and `.dropdown-menu{-sm|-md|-lg|-xl|-2xl}-start`.
 
 <Example code={`<div class="btn-group">
     <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" aria-expanded="false">

--- a/docs/src/content/docs/components/list-group.mdx
+++ b/docs/src/content/docs/components/list-group.mdx
@@ -124,7 +124,7 @@ These work great with custom content as well.
 
 ## Horizontal
 
-Add `.list-group-horizontal` to change the layout of list group items from vertical to horizontal across all breakpoints. Alternatively, choose a responsive variant `.list-group-horizontal-{sm|md|lg|xl|xxl}` to turn horizontal from that breakpoint up. Currently **horizontal list groups cannot be combined with flush list groups.**
+Add `.list-group-horizontal` to change the layout of list group items from vertical to horizontal across all breakpoints. Alternatively, choose a responsive variant `.list-group-horizontal-{sm|md|lg|xl|2xl}` to turn horizontal from that breakpoint up. Currently **horizontal list groups cannot be combined with flush list groups.**
 
 The responsive variants measure the nearest [query container](/utilities/container-queries/), not the viewport, so a list group in a narrow column stays stacked while the same class in a wide one goes horizontal. Mark an ancestor with `.contains-inline` — without one the query has nothing to read and the direction never switches. Plain `.list-group-horizontal` needs no container.
 

--- a/docs/src/content/docs/components/menu.mdx
+++ b/docs/src/content/docs/components/menu.mdx
@@ -137,7 +137,7 @@ All placements support `-start` and `-end` alignment modifiers (e.g., `bottom-st
 
 ### Responsive
 
-Change placement at different breakpoints using responsive prefixes. The syntax is `breakpoint:placement`, where breakpoint is one of `sm`, `md`, `lg`, `xl`, or `xxl`. Multiple breakpoints can be combined in a single attribute, space-separated.
+Change placement at different breakpoints using responsive prefixes. The syntax is `breakpoint:placement`, where breakpoint is one of `sm`, `md`, `lg`, `xl`, or `2xl`. Multiple breakpoints can be combined in a single attribute, space-separated.
 
 For example, `data-coreui-placement="bottom-start md:bottom-end lg:end-start"` will:
 

--- a/docs/src/content/docs/components/modal.mdx
+++ b/docs/src/content/docs/components/modal.mdx
@@ -449,11 +449,11 @@ Another override is the option to pop up a modal that covers the user viewport, 
 | `.modal-fullscreen` | Always |
 | `.modal-fullscreen-sm-down` | `576px` |
 | `.modal-fullscreen-md-down` | `768px` |
-| `.modal-fullscreen-lg-down` | `992px` |
-| `.modal-fullscreen-xl-down` | `1200px` |
-| `.modal-fullscreen-xxl-down` | `1400px` |
+| `.modal-fullscreen-lg-down` | `1024px` |
+| `.modal-fullscreen-xl-down` | `1280px` |
+| `.modal-fullscreen-2xl-down` | `1536px` |
 
-<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreen">Full screen</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenSm">Full screen below sm</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenMd">Full screen below md</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenLg">Full screen below lg</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenXl">Full screen below xl</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenXxl">Full screen below xxl</button>`]} />
+<Example html={[`<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreen">Full screen</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenSm">Full screen below sm</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenMd">Full screen below md</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenLg">Full screen below lg</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenXl">Full screen below xl</button>`, `<button type="button" class="btn-solid theme-primary" data-coreui-toggle="modal" data-coreui-target="#exampleModalFullscreenXxl">Full screen below 2xl</button>`]} />
 
 ```html
 <!-- Full screen modal -->
@@ -527,9 +527,9 @@ Another override is the option to pop up a modal that covers the user viewport, 
   </div>
 </dialog>
 
-<dialog class="modal modal-fullscreen-xxl-down" id="exampleModalFullscreenXxl" aria-labelledby="exampleModalFullscreenXxlLabel">
+<dialog class="modal modal-fullscreen-2xl-down" id="exampleModalFullscreenXxl" aria-labelledby="exampleModalFullscreenXxlLabel">
   <div class="modal-header">
-    <h5 class="modal-title h4" id="exampleModalFullscreenXxlLabel">Full screen below xxl</h5>
+    <h5 class="modal-title h4" id="exampleModalFullscreenXxlLabel">Full screen below 2xl</h5>
     <button type="button" class="btn-close" data-coreui-dismiss="modal" aria-label="Close"></button>
   </div>
   <div class="modal-body">

--- a/docs/src/content/docs/components/navbar.mdx
+++ b/docs/src/content/docs/components/navbar.mdx
@@ -10,7 +10,7 @@ otherFrameworks:
 
 Here's what you need to know before getting started with the navbar:
 
-- Navbars require a wrapping `.navbar` with `.navbar-expand{-sm|-md|-lg|-xl|-xxl}` for responsive collapsing and [color scheme](#color-schemes) classes.
+- Navbars require a wrapping `.navbar` with `.navbar-expand{-sm|-md|-lg|-xl|-2xl}` for responsive collapsing and [color scheme](#color-schemes) classes.
 - Navbars and their contents are fluid by default. Change the [container](#containers) to limit their horizontal width in different ways.
 - Use our [spacing](/utilities/margin/) and [flex](/utilities/flex/) utility classes for controlling spacing and alignment within navbars.
 - Navbars are responsive by default, but you can easily modify them to change that. Responsive behavior depends on our Collapse JavaScript plugin.
@@ -438,7 +438,7 @@ Here's an example navbar using `.navbar-nav-scroll` with `style="--cui-scroll-he
 
 ## Responsive behaviors
 
-Navbars can use `.navbar-toggler`, `.navbar-collapse`, and `.navbar-expand{-sm|-md|-lg|-xl|-xxl}` classes to determine when their content collapses behind a button. In combination with other utilities, you can easily choose when to show or hide particular elements.
+Navbars can use `.navbar-toggler`, `.navbar-collapse`, and `.navbar-expand{-sm|-md|-lg|-xl|-2xl}` classes to determine when their content collapses behind a button. In combination with other utilities, you can easily choose when to show or hide particular elements.
 
 For navbars that never collapse, add the `.navbar-expand` class on the navbar. For navbars that always collapse, don't add any `.navbar-expand` class.
 

--- a/docs/src/content/docs/components/popovers.mdx
+++ b/docs/src/content/docs/components/popovers.mdx
@@ -81,7 +81,7 @@ Four options are available: top, right, bottom, and left aligned. Directions are
 
 ### Responsive placement
 
-Change placement at different breakpoints using responsive prefixes. The syntax is `breakpoint:placement`, where breakpoint is one of `sm`, `md`, `lg`, `xl`, or `xxl`. Multiple breakpoints can be combined in a single attribute, space-separated — a bare placement with no prefix is the one below the smallest listed breakpoint.
+Change placement at different breakpoints using responsive prefixes. The syntax is `breakpoint:placement`, where breakpoint is one of `sm`, `md`, `lg`, `xl`, or `2xl`. Multiple breakpoints can be combined in a single attribute, space-separated — a bare placement with no prefix is the one below the smallest listed breakpoint.
 
 <Example code={`<button type="button" class="btn-solid theme-secondary" data-coreui-container="body" data-coreui-toggle="popover" data-coreui-placement="top md:right lg:bottom" data-coreui-content="Responsive popover">
     Top, then right, then bottom

--- a/docs/src/content/docs/components/tooltips.mdx
+++ b/docs/src/content/docs/components/tooltips.mdx
@@ -87,7 +87,7 @@ Bootstrap Tooltips support multiple placements: top, right, bottom, and left. Th
 
 ### Responsive placement
 
-Change placement at different breakpoints using responsive prefixes. The syntax is `breakpoint:placement`, where breakpoint is one of `sm`, `md`, `lg`, `xl`, or `xxl`. Multiple breakpoints can be combined in a single attribute, space-separated — a bare placement with no prefix is the one below the smallest listed breakpoint.
+Change placement at different breakpoints using responsive prefixes. The syntax is `breakpoint:placement`, where breakpoint is one of `sm`, `md`, `lg`, `xl`, or `2xl`. Multiple breakpoints can be combined in a single attribute, space-separated — a bare placement with no prefix is the one below the smallest listed breakpoint.
 
 <Example code={`<button type="button" class="btn-solid theme-secondary" data-coreui-toggle="tooltip" data-coreui-placement="top md:right lg:bottom" data-coreui-title="Responsive tooltip">
     Top, then right, then bottom

--- a/docs/src/content/docs/content/tables.mdx
+++ b/docs/src/content/docs/content/tables.mdx
@@ -436,7 +436,7 @@ You can also put the `<caption>` on the top of the table with `.caption-top`.
 
 ## Responsive tables
 
-Responsive tables allow tables to be scrolled horizontally with ease. Make any table responsive across all viewports by wrapping a `.table` with `.table-responsive`. Or, pick a maximum breakpoint with which to have a responsive table up to by using `.table-responsive{-sm|-md|-lg|-xl|-xxl}`.
+Responsive tables allow tables to be scrolled horizontally with ease. Make any table responsive across all viewports by wrapping a `.table` with `.table-responsive`. Or, pick a maximum breakpoint with which to have a responsive table up to by using `.table-responsive{-sm|-md|-lg|-xl|-2xl}`.
 
 Every `.table-responsive*` is also a [query container](/utilities/container-queries/), which is what [stacked tables](#stacked-tables) below query to decide when to break rows into blocks.
 
@@ -462,7 +462,7 @@ Across every breakpoint, use `.table-responsive` for horizontally scrolling tabl
 
 ### Breakpoint specific
 
-Use `.table-responsive{-sm|-md|-lg|-xl|-xxl}` as needed to create responsive tables up to a particular breakpoint. From that breakpoint and up, the table will behave normally and not scroll horizontally.
+Use `.table-responsive{-sm|-md|-lg|-xl|-2xl}` as needed to create responsive tables up to a particular breakpoint. From that breakpoint and up, the table will behave normally and not scroll horizontally.
 
 **These tables may appear broken until their responsive styles apply at specific viewport widths.**
 
@@ -525,7 +525,7 @@ Use `.table-responsive{-sm|-md|-lg|-xl|-xxl}` as needed to create responsive tab
   </table>
 </div>
 
-<div class="table-responsive-xxl">
+<div class="table-responsive-2xl">
   <table class="table">
     ...
   </table>
@@ -534,7 +534,7 @@ Use `.table-responsive{-sm|-md|-lg|-xl|-xxl}` as needed to create responsive tab
 
 ## Stacked tables
 
-A table that scrolls sideways is still a table; on a narrow screen it is often easier to read one record at a time. Add `.table-stacked{-sm|-md|-lg|-xl|-xxl}` next to `.table` to turn each row into a block below that breakpoint — the header is hidden from sight (it stays in the accessibility tree) and every cell carries its own label.
+A table that scrolls sideways is still a table; on a narrow screen it is often easier to read one record at a time. Add `.table-stacked{-sm|-md|-lg|-xl|-2xl}` next to `.table` to turn each row into a block below that breakpoint — the header is hidden from sight (it stays in the accessibility tree) and every cell carries its own label.
 
 Two things are required: a `.table-responsive*` ancestor, because that is the query container the class measures, and a `data-cell` attribute on every `<td>` after the first, which supplies the label the hidden header would have given. The first cell is treated as the record's title and needs no label.
 

--- a/docs/src/content/docs/customize/components.mdx
+++ b/docs/src/content/docs/customize/components.mdx
@@ -119,7 +119,7 @@ These Sass loops aren't limited to color maps, either. You can also generate res
 
 Should you modify your `$grid-breakpoints`, your changes will apply to all the loops iterating over that map.
 
-<ScssDocs file="scss/_config.scss" capture="grid-breakpoints" />
+<ScssDocs file="scss/_config.scss" capture="breakpoints" />
 
 For more information and examples on how to modify our Sass maps and variables, please refer to [the Sass section of the Grid documentation](/layout/grid/#customizing).
 

--- a/docs/src/content/docs/helpers/position.mdx
+++ b/docs/src/content/docs/helpers/position.mdx
@@ -37,7 +37,7 @@ Responsive variations also exist for `.sticky-top` utility.
 <div class="sticky-md-top">Stick to the top on viewports sized MD (medium) or wider</div>
 <div class="sticky-lg-top">Stick to the top on viewports sized LG (large) or wider</div>
 <div class="sticky-xl-top">Stick to the top on viewports sized XL (extra-large) or wider</div>
-<div class="sticky-xxl-top">Stick to the top on viewports sized XXL (extra-extra-large) or wider</div>
+<div class="sticky-2xl-top">Stick to the top on viewports sized XXL (extra-extra-large) or wider</div>
 ```
 
 ## Sticky bottom
@@ -57,5 +57,5 @@ Responsive variations also exist for `.sticky-bottom` utility.
 <div class="sticky-md-bottom">Stick to the bottom on viewports sized MD (medium) or wider</div>
 <div class="sticky-lg-bottom">Stick to the bottom on viewports sized LG (large) or wider</div>
 <div class="sticky-xl-bottom">Stick to the bottom on viewports sized XL (extra-large) or wider</div>
-<div class="sticky-xxl-bottom">Stick to the bottom on viewports sized XXL (extra-extra-large) or wider</div>
+<div class="sticky-2xl-bottom">Stick to the bottom on viewports sized XXL (extra-extra-large) or wider</div>
 ```

--- a/docs/src/content/docs/helpers/stacks.mdx
+++ b/docs/src/content/docs/helpers/stacks.mdx
@@ -45,7 +45,7 @@ And with [vertical rules](/helpers/vertical-rule/):
 
 ## Responsive
 
-`.hstack{-sm|-md|-lg|-xl|-xxl}` and `.vstack{-sm|-md|-lg|-xl|-xxl}` switch direction at a breakpoint — a stack that reads as a row on a wide layout and as a column on a narrow one, without writing the flex utilities twice.
+`.hstack{-sm|-md|-lg|-xl|-2xl}` and `.vstack{-sm|-md|-lg|-xl|-2xl}` switch direction at a breakpoint — a stack that reads as a row on a wide layout and as a column on a narrow one, without writing the flex utilities twice.
 
 The breakpoint is measured on the **container**, not the viewport, so mark an ancestor with `.stack-container` (or the [`.contains-inline`](/utilities/container-queries/) utility) for the query to have something to read. Without it the direction never switches.
 

--- a/docs/src/content/docs/layout/breakpoints.mdx
+++ b/docs/src/content/docs/layout/breakpoints.mdx
@@ -21,15 +21,15 @@ CoreUI for Bootstrap includes six default breakpoints, sometimes referred to as 
 | Extra small | <em>None</em>  |&lt;576px |
 | Small | `sm` | &ge;576px |
 | Medium | `md` | &ge;768px |
-| Large | `lg` | &ge;992px |
-| Extra large | `xl` | &ge;1200px |
-| Extra extra large | `xxl` | &ge;1400px |
+| Large | `lg` | &ge;1024px |
+| Extra large | `xl` | &ge;1280px |
+| Extra extra large | `2xl` | &ge;1536px |
 
 Each breakpoint was chosen to comfortably hold containers whose widths are multiples of 12. Breakpoints are also representative of a subset of common device sizes and viewport dimensions—they don't specifically target every use case or device. Instead, the ranges provide a strong and consistent foundation to build on for nearly any device.
 
 These breakpoints are customizable via Sass—you'll find them in a Sass map in our `_config.scss` stylesheet.
 
-<ScssDocs file="scss/_config.scss" capture="grid-breakpoints" />
+<ScssDocs file="scss/_config.scss" capture="breakpoints" />
 
 For more information and examples on how to modify our Sass maps and variables, please refer to [the Sass section of the Grid documentation](/layout/grid/#customizing).
 
@@ -49,7 +49,7 @@ CoreUI for Bootstrap primarily uses the following media query ranges—or breakp
 @include media-breakpoint-up(md) { ... }
 @include media-breakpoint-up(lg) { ... }
 @include media-breakpoint-up(xl) { ... }
-@include media-breakpoint-up(xxl) { ... }
+@include media-breakpoint-up(2xl) { ... }
 
 // Usage
 
@@ -76,14 +76,14 @@ These Sass mixins translate in our compiled CSS using the values declared in our
 // Medium devices (tablets, 768px and up)
 @media (width >= 768px) { ... }
 
-// Large devices (desktops, 992px and up)
-@media (width >= 992px) { ... }
+// Large devices (desktops, 1024px and up)
+@media (width >= 1024px) { ... }
 
-// X-Large devices (large desktops, 1200px and up)
-@media (width >= 1200px) { ... }
+// X-Large devices (large desktops, 1280px and up)
+@media (width >= 1280px) { ... }
 
-// XX-Large devices (larger desktops, 1400px and up)
-@media (width >= 1400px) { ... }
+// XX-Large devices (larger desktops, 1536px and up)
+@media (width >= 1536px) { ... }
 ```
 
 ### Max-width
@@ -96,7 +96,7 @@ We occasionally use media queries that go in the other direction (the given scre
 @include media-breakpoint-down(md) { ... }
 @include media-breakpoint-down(lg) { ... }
 @include media-breakpoint-down(xl) { ... }
-@include media-breakpoint-down(xxl) { ... }
+@include media-breakpoint-down(2xl) { ... }
 
 // Example: Style from medium breakpoint and down
 @include media-breakpoint-down(md) {
@@ -118,14 +118,14 @@ These mixins use the declared breakpoint as an exclusive upper bound. For exampl
 // `md` applies to small devices (landscape phones, less than 768px)
 @media (width < 768px) { ... }
 
-// `lg` applies to medium devices (tablets, less than 992px)
-@media (width < 992px) { ... }
+// `lg` applies to medium devices (tablets, less than 1024px)
+@media (width < 1024px) { ... }
 
-// `xl` applies to large devices (desktops, less than 1200px)
-@media (width < 1200px) { ... }
+// `xl` applies to large devices (desktops, less than 1280px)
+@media (width < 1280px) { ... }
 
-// `xxl` applies to x-large devices (large desktops, less than 1400px)
-@media (width < 1400px) { ... }
+// `2xl` applies to x-large devices (large desktops, less than 1536px)
+@media (width < 1536px) { ... }
 ```
 
 <Callout color="info">
@@ -142,13 +142,13 @@ There are also media queries and mixins for targeting a single segment of screen
 @include media-breakpoint-only(md) { ... }
 @include media-breakpoint-only(lg) { ... }
 @include media-breakpoint-only(xl) { ... }
-@include media-breakpoint-only(xxl) { ... }
+@include media-breakpoint-only(2xl) { ... }
 ```
 
 For example the `@include media-breakpoint-only(md) { ... }` will result in :
 
 ```scss
-@media (width >= 768px) and (width < 992px) { ... }
+@media (width >= 768px) and (width < 1024px) { ... }
 ```
 
 ### Between breakpoints
@@ -164,7 +164,7 @@ Which results in:
 ```scss
 // Example
 // Apply styles starting from medium devices and up to extra large devices
-@media (width >= 768px) and (width < 1200px) { ... }
+@media (width >= 768px) and (width < 1280px) { ... }
 ```
 
 ## Container queries

--- a/docs/src/content/docs/layout/containers.mdx
+++ b/docs/src/content/docs/layout/containers.mdx
@@ -16,14 +16,14 @@ CoreUI for Bootstrap comes with three different containers:
 
 The table below illustrates how each container's `max-width` compares to the original `.container` and `.container-fluid` across each breakpoint.
 
-|  | Extra small<div class="fw-normal">&lt;576px</div> | Small<div class="fw-normal">&ge;576px</div> | Medium<div class="fw-normal">&ge;768px</div> | Large<div class="fw-normal">&ge;992px</div> | X-Large<div class="fw-normal">&ge;1200px</div> | XX-Large<div class="fw-normal">&ge;1400px</div> |
+|  | Extra small<div class="fw-normal">&lt;576px</div> | Small<div class="fw-normal">&ge;576px</div> | Medium<div class="fw-normal">&ge;768px</div> | Large<div class="fw-normal">&ge;1024px</div> | X-Large<div class="fw-normal">&ge;1280px</div> | XX-Large<div class="fw-normal">&ge;1536px</div> |
 | --- | --- | --- | --- | --- | --- | --- |
-| `.container` | <span class="text-muted">100%</span> | 540px | 720px | 960px | 1140px | 1320px |
-| `.container-sm` | <span class="text-muted">100%</span> | 540px | 720px | 960px | 1140px | 1320px |
-| `.container-md` | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | 720px | 960px | 1140px | 1320px |
-| `.container-lg` | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | 960px | 1140px | 1320px |
-| `.container-xl` | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | 1140px | 1320px |
-| `.container-xxl` | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | 1320px |
+| `.container` | <span class="text-muted">100%</span> | 540px | 720px | 960px | 1200px | 1440px |
+| `.container-sm` | <span class="text-muted">100%</span> | 540px | 720px | 960px | 1200px | 1440px |
+| `.container-md` | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | 720px | 960px | 1200px | 1440px |
+| `.container-lg` | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | 960px | 1200px | 1440px |
+| `.container-xl` | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | 1200px | 1440px |
+| `.container-2xl` | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | 1440px |
 | `.container-fluid` | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> | <span class="text-muted">100%</span> |
 
 ## Default container
@@ -38,14 +38,14 @@ Our default `.container` class is a responsive, fixed-width container, meaning i
 
 ## Responsive containers
 
-Responsive containers allow you to specify a class that is 100% wide until the specified breakpoint is reached, after which we apply `max-width`s for each of the higher breakpoints. For example, `.container-sm` is 100% wide to start until the `sm` breakpoint is reached, where it will scale up with `md`, `lg`, `xl`, and `xxl`.
+Responsive containers allow you to specify a class that is 100% wide until the specified breakpoint is reached, after which we apply `max-width`s for each of the higher breakpoints. For example, `.container-sm` is 100% wide to start until the `sm` breakpoint is reached, where it will scale up with `md`, `lg`, `xl`, and `2xl`.
 
 ```html
 <div class="container-sm">100% wide until small breakpoint</div>
 <div class="container-md">100% wide until medium breakpoint</div>
 <div class="container-lg">100% wide until large breakpoint</div>
 <div class="container-xl">100% wide until extra large breakpoint</div>
-<div class="container-xxl">100% wide until extra extra large breakpoint</div>
+<div class="container-2xl">100% wide until extra extra large breakpoint</div>
 ```
 
 ## Fluid containers

--- a/docs/src/content/docs/layout/grid.mdx
+++ b/docs/src/content/docs/layout/grid.mdx
@@ -32,7 +32,7 @@ The above example creates three equal-width columns across all devices and viewp
 
 Breaking it down, here's how the grid system comes together:
 
-- **Our grid supports [six responsive breakpoints](/layout/breakpoints/).**  Breakpoints are based on `min-width` media queries, meaning they affect that breakpoint and all those above it (e.g., `.col-sm-4` applies to `sm`, `md`, `lg`, `xl`, and `xxl`). This means you can control container and column sizing and behavior by each breakpoint.
+- **Our grid supports [six responsive breakpoints](/layout/breakpoints/).**  Breakpoints are based on `min-width` media queries, meaning they affect that breakpoint and all those above it (e.g., `.col-sm-4` applies to `sm`, `md`, `lg`, `xl`, and `2xl`). This means you can control container and column sizing and behavior by each breakpoint.
 
 - **Containers center and horizontally pad your content.** Use `.container` for a responsive pixel width, `.container-fluid` for `width: 100%` across all viewports and devices, or a responsive container (e.g., `.container-md`) for a combination of fluid and pixel widths.
 
@@ -55,7 +55,7 @@ CoreUI for Bootstrap's grid system can adapt across all six default breakpoints,
 - Medium (md)
 - Large (lg)
 - Extra large (xl)
-- Extra extra large (xxl)
+- Extra extra large (2xl)
 
 As noted above, each of these breakpoints have their own container, unique class prefix, and modifiers. Here's how the grid changes across these breakpoints:
 
@@ -78,15 +78,15 @@ As noted above, each of these breakpoints have their own container, unique class
         </th>
         <th scope="col">
           lg<br />
-          <span class="fw-normal">&ge;992px</span>
+          <span class="fw-normal">&ge;1024px</span>
         </th>
         <th scope="col">
           xl<br />
-          <span class="fw-normal">&ge;1200px</span>
+          <span class="fw-normal">&ge;1280px</span>
         </th>
         <th scope="col">
-          xxl<br />
-          <span class="fw-normal">&ge;1400px</span>
+          2xl<br />
+          <span class="fw-normal">&ge;1536px</span>
         </th>
       </tr>
     </thead>
@@ -97,8 +97,8 @@ As noted above, each of these breakpoints have their own container, unique class
         <td>540px</td>
         <td>720px</td>
         <td>960px</td>
-        <td>1140px</td>
-        <td>1320px</td>
+        <td>1200px</td>
+        <td>1440px</td>
       </tr>
       <tr>
         <th class="text-nowrap" scope="row">Class prefix</th>
@@ -107,7 +107,7 @@ As noted above, each of these breakpoints have their own container, unique class
         <td><code>.col-md-</code></td>
         <td><code>.col-lg-</code></td>
         <td><code>.col-xl-</code></td>
-        <td><code>.col-xxl-</code></td>
+        <td><code>.col-2xl-</code></td>
       </tr>
       <tr>
         <th class="text-nowrap" scope="row"># of columns</th>
@@ -139,7 +139,7 @@ Utilize breakpoint-specific column classes for easy column sizing without an exp
 
 ### Equal-width
 
-For example, here are two grid layouts that apply to every device and viewport, from `xs` to `xxl`. Add any number of unit-less classes for each breakpoint you need and every column will be the same width.
+For example, here are two grid layouts that apply to every device and viewport, from `xs` to `2xl`. Add any number of unit-less classes for each breakpoint you need and every column will be the same width.
 
 <Example class="docs-example-row" code={`<div class="container text-center">
     <div class="row">
@@ -426,7 +426,7 @@ $grid-columns:      12;
 $grid-gutter-width: 1.5rem;
 ```
 
-<ScssDocs file="scss/_config.scss" capture="grid-breakpoints" />
+<ScssDocs file="scss/_config.scss" capture="breakpoints" />
 
 <ScssDocs file="scss/_config.scss" capture="container-max-widths" />
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1699,7 +1699,7 @@ Multi Select's option indicators moved with it — they render as a decorative
 
 #### Stacks
 
-- **New: `.hstack{-sm|-md|-lg|-xl|-xxl}` and `.vstack{-sm|-md|-lg|-xl|-xxl}`** switch
+- **New: `.hstack{-sm|-md|-lg|-xl|-2xl}` and `.vstack{-sm|-md|-lg|-xl|-2xl}`** switch
   direction at a breakpoint. The breakpoint is the width of the nearest query
   container, so mark an ancestor with the new `.stack-container` (or the
   [`.contains-inline`](/utilities/container-queries/) utility) — without one the
@@ -1793,7 +1793,7 @@ Multi Select's option indicators moved with it — they render as a decorative
 - **`.table-responsive*` is a query container.** It still scrolls horizontally
   below its breakpoint; the addition is that things inside it can now respond to
   its width.
-- **New: `.table-stacked{-sm|-md|-lg|-xl|-xxl}`** turns rows into stacked blocks
+- **New: `.table-stacked{-sm|-md|-lg|-xl|-2xl}`** turns rows into stacked blocks
   below the breakpoint, reading the width from the `.table-responsive*` wrapper.
   Give every `<td>` past the first a `data-cell` attribute for its label; the
   header is hidden visually and kept in the accessibility tree. See
@@ -1930,7 +1930,7 @@ Multi Select's option indicators moved with it — they render as a decorative
 #### List group
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
-  **`.list-group-horizontal-{sm|md|lg|xl|xxl}` turns horizontal from a
+  **`.list-group-horizontal-{sm|md|lg|xl|2xl}` turns horizontal from a
   container query.** Same change and same fix as `.card-group`: put
   [`.contains-inline`](/utilities/container-queries/) on an ancestor, or the
   list stays vertical. Plain `.list-group-horizontal` is unconditional and
@@ -2268,7 +2268,7 @@ as such.
   Everything that used the `.375rem` default is visibly rounder. To keep a
   component on its old radius, set its own token
   (`--cui-card-border-radius: .375rem`); to retune the whole page, override
-  the stops or `$radius`. The `$border-radius(-sm/-lg/-xl/-xxl/-pill)`
+  the stops or `$radius`. The `$border-radius(-sm/-lg/-xl/-2xl/-pill)`
   variables and their tokens are unchanged and keep driving the `rounded-*`
   utilities — but no component reads them any more: the modal, the chip,
   the switch, the chip input, the search button's key, the sidebar nav, the
@@ -2396,6 +2396,25 @@ as such.
 
   Components that filled with the bare colour read `-base` now; the derived
   hover and active states of a `.theme-*` class are computed from `-bg`.
+
+#### Breakpoints: `lg` 1024, `xl` 1280, `2xl` 1536
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The three largest breakpoints move and the largest is renamed.** `lg` is
+  `1024px` (was 992), `xl` `1280px` (was 1200) and the top tier is `2xl` at
+  `1536px` (was `xxl` at 1400); `sm` and `md` stay. Every responsive class
+  spells the tier the new way — `.col-xxl-6` is `.col-2xl-6`, `.container-xxl`
+  `.container-2xl`, `.modal-fullscreen-xxl-down` `.modal-fullscreen-2xl-down`,
+  `.hstack-xxl` `.hstack-2xl` — and the containers grow with them: `.container`
+  is `1200px` at `xl` (was 1140) and `1440px` at `2xl` (was 1320). Size
+  variants that happen to spell `xxl` (`.drawer-xxl`, `.offcanvas-xxl`,
+  `.icon-xxl`, `--cui-border-radius-xxl`) are not breakpoints and keep their
+  name. The Sass map is `$breakpoints` (was `$grid-breakpoints`) and the mixins
+  take it under that name; `$container-max-widths` keeps its name. The
+  responsive placement of menus, tooltips and popovers
+  (`data-coreui-placement="lg:end"`) reads the same values, and the sidebar's
+  mobile mode, `$mobile-breakpoint: lg`, now starts below `1024px` — a tablet
+  in landscape gets the mobile layout.
 
 #### Every theme colour gets an action-background slot
 

--- a/docs/src/content/docs/utilities/align-content.mdx
+++ b/docs/src/content/docs/utilities/align-content.mdx
@@ -76,11 +76,11 @@ Responsive variations also exist for `align-content`.
 - `.align-content-xl-center`
 - `.align-content-xl-around`
 - `.align-content-xl-stretch`
-- `.align-content-xxl-start`
-- `.align-content-xxl-end`
-- `.align-content-xxl-center`
-- `.align-content-xxl-around`
-- `.align-content-xxl-stretch`
+- `.align-content-2xl-start`
+- `.align-content-2xl-end`
+- `.align-content-2xl-center`
+- `.align-content-2xl-around`
+- `.align-content-2xl-stretch`
 
 
 ## Customizing

--- a/docs/src/content/docs/utilities/align-items.mdx
+++ b/docs/src/content/docs/utilities/align-items.mdx
@@ -46,11 +46,11 @@ Responsive variations also exist for `align-items`.
 - `.align-items-xl-center`
 - `.align-items-xl-baseline`
 - `.align-items-xl-stretch`
-- `.align-items-xxl-start`
-- `.align-items-xxl-end`
-- `.align-items-xxl-center`
-- `.align-items-xxl-baseline`
-- `.align-items-xxl-stretch`
+- `.align-items-2xl-start`
+- `.align-items-2xl-end`
+- `.align-items-2xl-center`
+- `.align-items-2xl-baseline`
+- `.align-items-2xl-stretch`
 
 
 ## Customizing

--- a/docs/src/content/docs/utilities/align-self.mdx
+++ b/docs/src/content/docs/utilities/align-self.mdx
@@ -46,11 +46,11 @@ Responsive variations also exist for `align-self`.
 - `.align-self-xl-center`
 - `.align-self-xl-baseline`
 - `.align-self-xl-stretch`
-- `.align-self-xxl-start`
-- `.align-self-xxl-end`
-- `.align-self-xxl-center`
-- `.align-self-xxl-baseline`
-- `.align-self-xxl-stretch`
+- `.align-self-2xl-start`
+- `.align-self-2xl-end`
+- `.align-self-2xl-center`
+- `.align-self-2xl-baseline`
+- `.align-self-2xl-stretch`
 
 
 ## Customizing

--- a/docs/src/content/docs/utilities/api.mdx
+++ b/docs/src/content/docs/utilities/api.mdx
@@ -362,7 +362,7 @@ Output:
   .opacity-md-100 { opacity: 1; }
 }
 
-@media (min-width: 992px) {
+@media (min-width: 1024px) {
   .opacity-lg-0 { opacity: 0; }
   .opacity-lg-25 { opacity: .25; }
   .opacity-lg-50 { opacity: .5; }
@@ -370,7 +370,7 @@ Output:
   .opacity-lg-100 { opacity: 1; }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1280px) {
   .opacity-xl-0 { opacity: 0; }
   .opacity-xl-25 { opacity: .25; }
   .opacity-xl-50 { opacity: .5; }
@@ -378,12 +378,12 @@ Output:
   .opacity-xl-100 { opacity: 1; }
 }
 
-@media (min-width: 1400px) {
-  .opacity-xxl-0 { opacity: 0; }
-  .opacity-xxl-25 { opacity: .25; }
-  .opacity-xxl-50 { opacity: .5; }
-  .opacity-xxl-75 { opacity: .75; }
-  .opacity-xxl-100 { opacity: 1; }
+@media (min-width: 1536px) {
+  .opacity-2xl-0 { opacity: 0; }
+  .opacity-2xl-25 { opacity: .25; }
+  .opacity-2xl-50 { opacity: .5; }
+  .opacity-2xl-75 { opacity: .75; }
+  .opacity-2xl-100 { opacity: 1; }
 }
 ```
 
@@ -582,19 +582,19 @@ This will now generate responsive variations of `.border` and `.border-0` for ea
   .border-md-0 { ... }
 }
 
-@media (min-width: 992px) {
+@media (min-width: 1024px) {
   .border-lg { ... }
   .border-lg-0 { ... }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1280px) {
   .border-xl { ... }
   .border-xl-0 { ... }
 }
 
-@media (min-width: 1400px) {
-  .border-xxl { ... }
-  .border-xxl-0 { ... }
+@media (min-width: 1536px) {
+  .border-2xl { ... }
+  .border-2xl-0 { ... }
 }
 ```
 

--- a/docs/src/content/docs/utilities/display.mdx
+++ b/docs/src/content/docs/utilities/display.mdx
@@ -11,12 +11,12 @@ Change the value of the [`display` property](https://developer.mozilla.org/en-US
 
 ## Notation
 
-Display utility classes that apply to all [breakpoints](/layout/breakpoints/), from `xs` to `xxl`, have no breakpoint abbreviation in them. This is because those classes are applied from `min-width: 0;` and up, and thus are not bound by a media query. The remaining breakpoints, however, do include a breakpoint abbreviation.
+Display utility classes that apply to all [breakpoints](/layout/breakpoints/), from `xs` to `2xl`, have no breakpoint abbreviation in them. This is because those classes are applied from `min-width: 0;` and up, and thus are not bound by a media query. The remaining breakpoints, however, do include a breakpoint abbreviation.
 
 As such, the classes are named using the format:
 
 - `.d-{value}` for `xs`
-- `.d-{breakpoint}-{value}` for `sm`, `md`, `lg`, `xl`, and `xxl`.
+- `.d-{breakpoint}-{value}` for `sm`, `md`, `lg`, `xl`, and `2xl`.
 
 Where *value* is one of:
 
@@ -36,7 +36,7 @@ Where *value* is one of:
 
 The display values can be altered by changing the `$displays` variable and recompiling the SCSS.
 
-The media queries affect screen widths with the given breakpoint *or larger*. For example, `.d-lg-none` sets `display: none;` on `lg`, `xl`, and `xxl` screens.
+The media queries affect screen widths with the given breakpoint *or larger*. For example, `.d-lg-none` sets `display: none;` on `lg`, `xl`, and `2xl` screens.
 
 ## Examples
 
@@ -50,7 +50,7 @@ The media queries affect screen widths with the given breakpoint *or larger*. Fo
 
 For faster mobile-friendly development, use responsive display classes for showing and hiding elements by device. Avoid creating entirely different versions of the same site, instead hide elements responsively for each screen size.
 
-To hide elements simply use the `.d-none` class or one of the `.d-{sm,md,lg,xl,xxl}-none` classes for any responsive screen variation.
+To hide elements simply use the `.d-none` class or one of the `.d-{sm,md,lg,xl,2xl}-none` classes for any responsive screen variation.
 
 To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-*` class, for example `.d-none .d-md-block .d-xl-none` will hide the element for all screen sizes except on medium and large devices.
 
@@ -61,15 +61,15 @@ To show an element only on a given interval of screen sizes you can combine one 
 | Hidden only on sm | `.d-sm-none .d-md-block` |
 | Hidden only on md | `.d-md-none .d-lg-block` |
 | Hidden only on lg | `.d-lg-none .d-xl-block` |
-| Hidden only on xl | `.d-xl-none .d-xxl-block` |
-| Hidden only on xxl | `.d-xxl-none` |
+| Hidden only on xl | `.d-xl-none .d-2xl-block` |
+| Hidden only on 2xl | `.d-2xl-none` |
 | Visible on all | `.d-block` |
 | Visible only on xs | `.d-block .d-sm-none` |
 | Visible only on sm | `.d-none .d-sm-block .d-md-none` |
 | Visible only on md | `.d-none .d-md-block .d-lg-none` |
 | Visible only on lg | `.d-none .d-lg-block .d-xl-none` |
-| Visible only on xl | `.d-none .d-xl-block .d-xxl-none` |
-| Visible only on xxl | `.d-none .d-xxl-block` |
+| Visible only on xl | `.d-none .d-xl-block .d-2xl-none` |
+| Visible only on 2xl | `.d-none .d-2xl-block` |
 
 <Example code={`<div class="d-lg-none">hide on lg and wider screens</div>
   <div class="d-none d-lg-block">hide on screens smaller than lg</div>`} />

--- a/docs/src/content/docs/utilities/flex.mdx
+++ b/docs/src/content/docs/utilities/flex.mdx
@@ -25,8 +25,8 @@ Responsive variations also exist for `.d-flex` and `.d-inline-flex`.
 - `.d-lg-inline-flex`
 - `.d-xl-flex`
 - `.d-xl-inline-flex`
-- `.d-xxl-flex`
-- `.d-xxl-inline-flex`
+- `.d-2xl-flex`
+- `.d-2xl-inline-flex`
 
 ## Direction
 
@@ -80,10 +80,10 @@ Responsive variations also exist for `flex-direction`.
 - `.flex-xl-row-reverse`
 - `.flex-xl-column`
 - `.flex-xl-column-reverse`
-- `.flex-xxl-row`
-- `.flex-xxl-row-reverse`
-- `.flex-xxl-column`
-- `.flex-xxl-column-reverse`
+- `.flex-2xl-row`
+- `.flex-2xl-row-reverse`
+- `.flex-2xl-column`
+- `.flex-2xl-column-reverse`
 
 ## Alignment
 
@@ -106,7 +106,7 @@ Responsive variations also exist for `flex-fill`.
 - `.flex-md-fill`
 - `.flex-lg-fill`
 - `.flex-xl-fill`
-- `.flex-xxl-fill`
+- `.flex-2xl-fill`
 
 ## Grow and shrink
 
@@ -137,8 +137,8 @@ Responsive variations also exist for `flex-grow` and `flex-shrink`.
 - `.flex-lg-{grow|shrink}-1`
 - `.flex-xl-{grow|shrink}-0`
 - `.flex-xl-{grow|shrink}-1`
-- `.flex-xxl-{grow|shrink}-0`
-- `.flex-xxl-{grow|shrink}-1`
+- `.flex-2xl-{grow|shrink}-0`
+- `.flex-2xl-{grow|shrink}-1`
 
 ## Auto margins
 
@@ -223,9 +223,9 @@ Responsive variations also exist for `flex-wrap`.
 - `.flex-xl-nowrap`
 - `.flex-xl-wrap`
 - `.flex-xl-wrap-reverse`
-- `.flex-xxl-nowrap`
-- `.flex-xxl-wrap`
-- `.flex-xxl-wrap-reverse`
+- `.flex-2xl-nowrap`
+- `.flex-2xl-wrap`
+- `.flex-2xl-wrap-reverse`
 
 ## Order
 
@@ -269,12 +269,12 @@ Responsive variations also exist for `order`.
 - `.order-xl-3`
 - `.order-xl-4`
 - `.order-xl-5`
-- `.order-xxl-0`
-- `.order-xxl-1`
-- `.order-xxl-2`
-- `.order-xxl-3`
-- `.order-xxl-4`
-- `.order-xxl-5`
+- `.order-2xl-0`
+- `.order-2xl-1`
+- `.order-2xl-2`
+- `.order-2xl-3`
+- `.order-2xl-4`
+- `.order-2xl-5`
 
 Additionally there are also responsive `.order-first` and `.order-last` classes that change the `order` of an element by applying `order: -1` and `order: 6`, respectively.
 
@@ -288,8 +288,8 @@ Additionally there are also responsive `.order-first` and `.order-last` classes 
 - `.order-lg-last`
 - `.order-xl-first`
 - `.order-xl-last`
-- `.order-xxl-first`
-- `.order-xxl-last`
+- `.order-2xl-first`
+- `.order-2xl-last`
 
 ## Media object
 

--- a/docs/src/content/docs/utilities/float.mdx
+++ b/docs/src/content/docs/utilities/float.mdx
@@ -23,7 +23,7 @@ Responsive variations also exist for each `float` value.
   <div class="float-md-end">Float end on viewports sized MD (medium) or wider</div><br>
   <div class="float-lg-end">Float end on viewports sized LG (large) or wider</div><br>
   <div class="float-xl-end">Float end on viewports sized XL (extra large) or wider</div><br>
-  <div class="float-xxl-end">Float end on viewports sized XXL (extra extra large) or wider</div><br>`} />
+  <div class="float-2xl-end">Float end on viewports sized XXL (extra extra large) or wider</div><br>`} />
 
 Here are all the support classes:
 
@@ -42,9 +42,9 @@ Here are all the support classes:
 - `.float-xl-start`
 - `.float-xl-end`
 - `.float-xl-none`
-- `.float-xxl-start`
-- `.float-xxl-end`
-- `.float-xxl-none`
+- `.float-2xl-start`
+- `.float-2xl-end`
+- `.float-2xl-none`
 
 ## Customizing
 

--- a/docs/src/content/docs/utilities/justify-content.mdx
+++ b/docs/src/content/docs/utilities/justify-content.mdx
@@ -52,12 +52,12 @@ Responsive variations also exist for `justify-content`.
 - `.justify-content-xl-between`
 - `.justify-content-xl-around`
 - `.justify-content-xl-evenly`
-- `.justify-content-xxl-start`
-- `.justify-content-xxl-end`
-- `.justify-content-xxl-center`
-- `.justify-content-xxl-between`
-- `.justify-content-xxl-around`
-- `.justify-content-xxl-evenly`
+- `.justify-content-2xl-start`
+- `.justify-content-2xl-end`
+- `.justify-content-2xl-center`
+- `.justify-content-2xl-between`
+- `.justify-content-2xl-around`
+- `.justify-content-2xl-evenly`
 
 
 ## Customizing

--- a/docs/src/content/docs/utilities/margin.mdx
+++ b/docs/src/content/docs/utilities/margin.mdx
@@ -13,9 +13,9 @@ Assign responsive-friendly `margin` values to an element or a subset of its side
 
 ## Notation
 
-Margin utilities that apply to all breakpoints, from `xs` to `xxl`, have no breakpoint abbreviation in them. This is because those classes are applied from `min-width: 0` and up, and thus are not bound by a media query. The remaining breakpoints, however, do include a breakpoint abbreviation.
+Margin utilities that apply to all breakpoints, from `xs` to `2xl`, have no breakpoint abbreviation in them. This is because those classes are applied from `min-width: 0` and up, and thus are not bound by a media query. The remaining breakpoints, however, do include a breakpoint abbreviation.
 
-The classes are named using the format `m{sides}-{size}` for `xs` and `m{sides}-{breakpoint}-{size}` for `sm`, `md`, `lg`, `xl`, and `xxl`.
+The classes are named using the format `m{sides}-{size}` for `xs` and `m{sides}-{breakpoint}-{size}` for `sm`, `md`, `lg`, `xl`, and `2xl`.
 
 Where *sides* is one of:
 

--- a/docs/src/content/docs/utilities/object-fit.mdx
+++ b/docs/src/content/docs/utilities/object-fit.mdx
@@ -29,13 +29,13 @@ Add the `object-fit-{value}` class to the [replaced element](https://developer.m
 
 ## Responsive
 
-Responsive variations also exist for each `object-fit` value using the format `.object-fit-{breakpoint}-{value}`, for the following breakpoint abbreviations: `sm`, `md`, `lg`, `xl`, and `xxl`. Classes can be combined for various effects as you need.
+Responsive variations also exist for each `object-fit` value using the format `.object-fit-{breakpoint}-{value}`, for the following breakpoint abbreviations: `sm`, `md`, `lg`, `xl`, and `2xl`. Classes can be combined for various effects as you need.
 
 <Example class="d-flex overflow-auto" code={`<svg class="docs-placeholder-img object-fit-sm-contain border rounded" width="140" height="80" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Contain on sm" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Contain on sm</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Contain on sm</text></svg>
   <svg class="docs-placeholder-img object-fit-md-contain border rounded" width="140" height="80" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Contain on md" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Contain on md</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Contain on md</text></svg>
   <svg class="docs-placeholder-img object-fit-lg-contain border rounded" width="140" height="80" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Contain on lg" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Contain on lg</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Contain on lg</text></svg>
   <svg class="docs-placeholder-img object-fit-xl-contain border rounded" width="140" height="80" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Contain on xl" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Contain on xl</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Contain on xl</text></svg>
-  <svg class="docs-placeholder-img object-fit-xxl-contain border rounded" width="140" height="80" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Contain on xxl" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Contain on xxl</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Contain on xxl</text></svg>`} />
+  <svg class="docs-placeholder-img object-fit-2xl-contain border rounded" width="140" height="80" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Contain on 2xl" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Contain on 2xl</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Contain on 2xl</text></svg>`} />
 
 ## Video
 

--- a/docs/src/content/docs/utilities/padding.mdx
+++ b/docs/src/content/docs/utilities/padding.mdx
@@ -13,9 +13,9 @@ Unlike [margin](/utilities/margin/), `padding` takes no negative values and no `
 
 ## Notation
 
-Padding utilities that apply to all breakpoints, from `xs` to `xxl`, have no breakpoint abbreviation in them. This is because those classes are applied from `min-width: 0` and up, and thus are not bound by a media query. The remaining breakpoints, however, do include a breakpoint abbreviation.
+Padding utilities that apply to all breakpoints, from `xs` to `2xl`, have no breakpoint abbreviation in them. This is because those classes are applied from `min-width: 0` and up, and thus are not bound by a media query. The remaining breakpoints, however, do include a breakpoint abbreviation.
 
-The classes are named using the format `p{sides}-{size}` for `xs` and `p{sides}-{breakpoint}-{size}` for `sm`, `md`, `lg`, `xl`, and `xxl`.
+The classes are named using the format `p{sides}-{size}` for `xs` and `p{sides}-{breakpoint}-{size}` for `sm`, `md`, `lg`, `xl`, and `2xl`.
 
 Where *sides* is one of:
 

--- a/docs/src/content/docs/utilities/text-alignment.mdx
+++ b/docs/src/content/docs/utilities/text-alignment.mdx
@@ -17,7 +17,7 @@ Easily realign text to components with text alignment classes. For start, end, a
   <p class="text-md-end">End aligned text on viewports sized MD (medium) or wider.</p>
   <p class="text-lg-end">End aligned text on viewports sized LG (large) or wider.</p>
   <p class="text-xl-end">End aligned text on viewports sized XL (extra large) or wider.</p>
-  <p class="text-xxl-end">End aligned text on viewports sized XXL (extra extra large) or wider.</p>`} />
+  <p class="text-2xl-end">End aligned text on viewports sized XXL (extra extra large) or wider.</p>`} />
 
 <Callout color="info">
 Note that we don't provide utility classes for justified text. While, aesthetically, justified text might look more appealing, it does make word-spacing more random and therefore harder to read.

--- a/js/src/util/floating-ui.ts
+++ b/js/src/util/floating-ui.ts
@@ -25,15 +25,15 @@ interface BreakpointListener {
 }
 
 /**
- * Breakpoints for responsive placement (matches SCSS $grid-breakpoints —
+ * Breakpoints for responsive placement (matches SCSS $breakpoints —
  * CoreUI keeps the classic scale, not upstream's Tailwind-style one)
  */
 export const BREAKPOINTS: Record<string, number> = {
   sm: 576,
   md: 768,
-  lg: 992,
-  xl: 1200,
-  xxl: 1400
+  lg: 1024,
+  xl: 1280,
+  '2xl': 1536
 }
 
 /**
@@ -101,8 +101,8 @@ export const getResponsivePlacement = (responsivePlacements: ResponsivePlacement
   // Find the largest breakpoint that matches
   let activePlacement = responsivePlacements.xs || defaultPlacement
 
-  // Check breakpoints in order (sm, md, lg, xl, xxl)
-  const breakpointOrder = ['sm', 'md', 'lg', 'xl', 'xxl']
+  // Check breakpoints in order (sm, md, lg, xl, 2xl)
+  const breakpointOrder = ['sm', 'md', 'lg', 'xl', '2xl']
 
   for (const breakpoint of breakpointOrder) {
     const minWidth = BREAKPOINTS[breakpoint]

--- a/js/tests/unit/util/floating-ui.spec.js
+++ b/js/tests/unit/util/floating-ui.spec.js
@@ -13,9 +13,9 @@ describe('FloatingUI Util', () => {
       expect(BREAKPOINTS).toEqual(jasmine.any(Object))
       expect(BREAKPOINTS.sm).toBe(576)
       expect(BREAKPOINTS.md).toBe(768)
-      expect(BREAKPOINTS.lg).toBe(992)
-      expect(BREAKPOINTS.xl).toBe(1200)
-      expect(BREAKPOINTS.xxl).toBe(1400)
+      expect(BREAKPOINTS.lg).toBe(1024)
+      expect(BREAKPOINTS.xl).toBe(1280)
+      expect(BREAKPOINTS['2xl']).toBe(1536)
     })
   })
 
@@ -93,14 +93,14 @@ describe('FloatingUI Util', () => {
     })
 
     it('should parse all breakpoints', () => {
-      const result = parseResponsivePlacement('bottom sm:top md:left lg:right xl:bottom-start xxl:top-end')
+      const result = parseResponsivePlacement('bottom sm:top md:left lg:right xl:bottom-start 2xl:top-end')
       expect(result).toEqual({
         xs: 'bottom',
         sm: 'top',
         md: 'left',
         lg: 'right',
         xl: 'bottom-start',
-        xxl: 'top-end'
+        '2xl': 'top-end'
       })
     })
 
@@ -183,17 +183,17 @@ describe('FloatingUI Util', () => {
       expect(getResponsivePlacement(placements)).toBe('left')
     })
 
-    it('should return appropriate placement for xxl viewport', () => {
+    it('should return appropriate placement for 2xl viewport', () => {
       spyOnProperty(window, 'innerWidth').and.returnValue(1600)
 
-      const placements = { xs: 'bottom', xl: 'top', xxl: 'right-start' }
+      const placements = { xs: 'bottom', xl: 'top', '2xl': 'right-start' }
       expect(getResponsivePlacement(placements)).toBe('right-start')
     })
 
     it('should cascade to smaller breakpoints when larger ones are not defined', () => {
       spyOnProperty(window, 'innerWidth').and.returnValue(1600)
 
-      // Only xs and md defined, viewport is xxl
+      // Only xs and md defined, viewport is 2xl
       const placements = { xs: 'bottom', md: 'top' }
       expect(getResponsivePlacement(placements)).toBe('top')
     })

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -97,19 +97,19 @@ $link-hover-decoration:                   null !default;
 // Define the minimum dimensions at which your layout will change,
 // adapting to different screen sizes, for use in media queries.
 
-// scss-docs-start grid-breakpoints
-$grid-breakpoints: (
+// scss-docs-start breakpoints
+$breakpoints: (
   xs: 0,
   sm: 576px,
   md: 768px,
-  lg: 992px,
-  xl: 1200px,
-  xxl: 1400px
+  lg: 1024px,
+  xl: 1280px,
+  2xl: 1536px
 ) !default;
-// scss-docs-end grid-breakpoints
+// scss-docs-end breakpoints
 
-@include assert-ascending($grid-breakpoints, "$grid-breakpoints");
-@include assert-starts-at-zero($grid-breakpoints, "$grid-breakpoints");
+@include assert-ascending($breakpoints, "$breakpoints");
+@include assert-starts-at-zero($breakpoints, "$breakpoints");
 
 // Define the maximum width of `.container` for different screen sizes.
 
@@ -121,8 +121,8 @@ $container-max-widths: defaults(
     sm: 540px,
     md: 720px,
     lg: 960px,
-    xl: 1140px,
-    xxl: 1320px
+    xl: 1200px,
+    2xl: 1440px
   ),
   $container-max-widths
 );

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -209,8 +209,8 @@ $dialog-tokens: defaults(
   }
 
   // scss-docs-start dialog-fullscreen-loop
-  @each $breakpoint in map.keys($grid-breakpoints) {
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+  @each $breakpoint in map.keys($breakpoints) {
+    $infix: breakpoint-infix($breakpoint, $breakpoints);
     // stylelint-disable-next-line scss/at-function-named-arguments
     $postfix: if(sass($infix != ""): $infix + "-down"; else: "");
 

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -75,18 +75,18 @@ $drawer-tokens: defaults(
     @include tokens($drawer-tokens);
   }
 
-  @each $breakpoint in map.keys($grid-breakpoints) {
-    $next: breakpoint-next($breakpoint, $grid-breakpoints);
-    $infix: breakpoint-infix($next, $grid-breakpoints);
+  @each $breakpoint in map.keys($breakpoints) {
+    $next: breakpoint-next($breakpoint, $breakpoints);
+    $infix: breakpoint-infix($next, $breakpoints);
 
     .drawer#{$infix} {
       @extend %drawer-css-vars;
     }
   }
 
-  @each $breakpoint in map.keys($grid-breakpoints) {
-    $next: breakpoint-next($breakpoint, $grid-breakpoints);
-    $infix: breakpoint-infix($next, $grid-breakpoints);
+  @each $breakpoint in map.keys($breakpoints) {
+    $next: breakpoint-next($breakpoint, $breakpoints);
+    $infix: breakpoint-infix($next, $breakpoints);
 
     .drawer#{$infix} {
       @include media-breakpoint-down($next) {
@@ -259,9 +259,9 @@ $drawer-tokens: defaults(
   }
 
   @starting-style {
-    @each $breakpoint in map.keys($grid-breakpoints) {
-      $next: breakpoint-next($breakpoint, $grid-breakpoints);
-      $infix: breakpoint-infix($next, $grid-breakpoints);
+    @each $breakpoint in map.keys($breakpoints) {
+      $next: breakpoint-next($breakpoint, $breakpoints);
+      $infix: breakpoint-infix($next, $breakpoints);
 
       .drawer#{$infix}:not(.drawer-instant)::backdrop {
         background-color: transparent;

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -187,9 +187,9 @@ $dropdown-dark-tokens: defaults(
   // We deliberately hardcode the `cui-` prefix because we check
   // this custom property in JS to determine Popper's positioning
 
-  @each $breakpoint in map.keys($grid-breakpoints) {
+  @each $breakpoint in map.keys($breakpoints) {
     @include media-breakpoint-up($breakpoint) {
-      $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+      $infix: breakpoint-infix($breakpoint, $breakpoints);
 
       .dropdown-menu#{$infix}-start {
         // Read by the plugin, so the name stays outside `$prefix`.

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -167,8 +167,8 @@ $list-group-tokens: defaults(
   // `.contains-inline` on an ancestor, or the query has nothing to measure and
   // the direction never switches.
 
-  @each $breakpoint in map.keys($grid-breakpoints) {
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+  @each $breakpoint in map.keys($breakpoints) {
+    $infix: breakpoint-infix($breakpoint, $breakpoints);
 
     .list-group-horizontal#{$infix} {
       @include container-breakpoint-up($breakpoint) {

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -261,8 +261,8 @@ $modal-tokens: defaults(
   // scss-docs-end modal-sizes-loop
 
   // scss-docs-start modal-fullscreen-loop
-  @each $breakpoint in map.keys($grid-breakpoints) {
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+  @each $breakpoint in map.keys($breakpoints) {
+    $infix: breakpoint-infix($breakpoint, $breakpoints);
     // stylelint-disable-next-line scss/at-function-named-arguments
     $postfix: if(sass($infix != ""): $infix + "-down"; else: "");
 

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -331,9 +331,9 @@ $navbar-dark-tokens: defaults(
   // Generate series of `.navbar-expand-*` responsive classes for configuring
   // where your navbar collapses.
   .navbar-expand {
-    @each $breakpoint in map.keys($grid-breakpoints) {
-      $next: breakpoint-next($breakpoint, $grid-breakpoints);
-      $infix: breakpoint-infix($next, $grid-breakpoints);
+    @each $breakpoint in map.keys($breakpoints) {
+      $next: breakpoint-next($breakpoint, $breakpoints);
+      $infix: breakpoint-infix($next, $breakpoints);
 
       // stylelint-disable-next-line scss/selector-no-union-class-name
       &#{$infix} {

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -60,18 +60,18 @@ $offcanvas-tokens: defaults(
     @include tokens($offcanvas-tokens);
   }
 
-  @each $breakpoint in map.keys($grid-breakpoints) {
-    $next: breakpoint-next($breakpoint, $grid-breakpoints);
-    $infix: breakpoint-infix($next, $grid-breakpoints);
+  @each $breakpoint in map.keys($breakpoints) {
+    $next: breakpoint-next($breakpoint, $breakpoints);
+    $infix: breakpoint-infix($next, $breakpoints);
 
     .offcanvas#{$infix} {
       @extend %offcanvas-css-vars;
     }
   }
 
-  @each $breakpoint in map.keys($grid-breakpoints) {
-    $next: breakpoint-next($breakpoint, $grid-breakpoints);
-    $infix: breakpoint-infix($next, $grid-breakpoints);
+  @each $breakpoint in map.keys($breakpoints) {
+    $next: breakpoint-next($breakpoint, $breakpoints);
+    $infix: breakpoint-infix($next, $breakpoints);
 
     .offcanvas#{$infix} {
       @include media-breakpoint-down($next) {
@@ -219,9 +219,9 @@ $offcanvas-tokens: defaults(
   }
 
   @starting-style {
-    @each $breakpoint in map.keys($grid-breakpoints) {
-      $next: breakpoint-next($breakpoint, $grid-breakpoints);
-      $infix: breakpoint-infix($next, $grid-breakpoints);
+    @each $breakpoint in map.keys($breakpoints) {
+      $next: breakpoint-next($breakpoint, $breakpoints);
+      $infix: breakpoint-infix($next, $breakpoints);
 
       .offcanvas#{$infix}:not(.offcanvas-instant)::backdrop {
         background-color: transparent;

--- a/scss/content/_tables.scss
+++ b/scss/content/_tables.scss
@@ -245,8 +245,8 @@ $table-variants: map.keys($theme-colors) !default;
   // Generate series of `.table-responsive-*` classes that act as query containers
   // and turn on horizontal scrolling below their breakpoint.
 
-  @each $breakpoint in map.keys($grid-breakpoints) {
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+  @each $breakpoint in map.keys($breakpoints) {
+    $infix: breakpoint-infix($breakpoint, $breakpoints);
 
     .table-responsive#{$infix} {
       @include set-container();
@@ -265,8 +265,8 @@ $table-variants: map.keys($theme-colors) !default;
   // `.table-responsive*` ancestor to query, and `data-cell` on every `<td>` past
   // the first to label the value the way the hidden header would.
 
-  @each $breakpoint in map.keys($grid-breakpoints) {
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+  @each $breakpoint in map.keys($breakpoints) {
+    $infix: breakpoint-infix($breakpoint, $breakpoints);
 
     @include container-breakpoint-down($breakpoint) {
       .table-stacked#{$infix} {

--- a/scss/functions/_assert-starts-at-zero.scss
+++ b/scss/functions/_assert-starts-at-zero.scss
@@ -3,7 +3,7 @@
 
 // Starts at zero
 // Used to ensure the min-width of the lowest breakpoint starts at 0.
-@mixin assert-starts-at-zero($map, $map-name: "$grid-breakpoints") {
+@mixin assert-starts-at-zero($map, $map-name: "$breakpoints") {
   @if list.length($map) > 0 {
     $values: map.values($map);
     $first-value: list.nth($values, 1);

--- a/scss/helpers/_position.scss
+++ b/scss/helpers/_position.scss
@@ -16,9 +16,9 @@
   }
 
   // Responsive sticky top and bottom
-  @each $breakpoint in map.keys($grid-breakpoints) {
+  @each $breakpoint in map.keys($breakpoints) {
     @include media-breakpoint-up($breakpoint) {
-      $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+      $infix: breakpoint-infix($breakpoint, $breakpoints);
 
       .sticky#{$infix}-top {
         position: sticky;

--- a/scss/helpers/_stacks.scss
+++ b/scss/helpers/_stacks.scss
@@ -7,8 +7,8 @@
 // Every stack class, so the shared flex base is written once.
 // stylelint-disable-next-line scss/dollar-variable-default
 $stack-selectors: ();
-@each $breakpoint in map.keys($grid-breakpoints) {
-  $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+@each $breakpoint in map.keys($breakpoints) {
+  $infix: breakpoint-infix($breakpoint, $breakpoints);
   $stack-selectors: list.append($stack-selectors, string.unquote(".hstack#{$infix}"), comma);
   $stack-selectors: list.append($stack-selectors, string.unquote(".vstack#{$infix}"), comma);
 }
@@ -27,8 +27,8 @@ $stack-selectors: ();
   // The responsive variants read the width of the nearest query container — put
   // `.stack-container` (or the `.contains-inline` utility) on an ancestor, or the
   // query has nothing to measure and the direction never switches.
-  @each $breakpoint in map.keys($grid-breakpoints) {
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+  @each $breakpoint in map.keys($breakpoints) {
+    $infix: breakpoint-infix($breakpoint, $breakpoints);
 
     .hstack#{$infix} {
       @include container-breakpoint-up($breakpoint) {

--- a/scss/layout/_breakpoints.scss
+++ b/scss/layout/_breakpoints.scss
@@ -6,19 +6,19 @@
 //
 // Breakpoints are defined as a map of (name: minimum width), order from small to large:
 //
-//    (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px, xxl: 1400px)
+//    (xs: 0, sm: 576px, md: 768px, lg: 1024px, xl: 1280px, 2xl: 1536px)
 //
-// The map defined in the `$grid-breakpoints` global variable is used as the `$breakpoints` argument by default.
+// The map defined in the `$breakpoints` global variable is used as the `$breakpoints` argument by default.
 
 // Name of the next breakpoint, or null for the last breakpoint.
 //
 //    >> breakpoint-next(sm)
 //    md
-//    >> breakpoint-next(sm, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px, xxl: 1400px))
+//    >> breakpoint-next(sm, (xs: 0, sm: 576px, md: 768px, lg: 1024px, xl: 1280px, 2xl: 1536px))
 //    md
-//    >> breakpoint-next(sm, $breakpoint-names: (xs sm md lg xl xxl))
+//    >> breakpoint-next(sm, $breakpoint-names: (xs sm md lg xl 2xl))
 //    md
-@function breakpoint-next($name, $breakpoints: $grid-breakpoints, $breakpoint-names: map.keys($breakpoints)) {
+@function breakpoint-next($name, $breakpoints: $breakpoints, $breakpoint-names: map.keys($breakpoints)) {
   $n: list.index($breakpoint-names, $name);
   @if not $n {
     @error "breakpoint `#{$name}` not found in `#{$breakpoint-names}`";
@@ -33,9 +33,9 @@
 
 // Minimum breakpoint width. Null for the smallest (first) breakpoint.
 //
-//    >> breakpoint-min(sm, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px, xxl: 1400px))
+//    >> breakpoint-min(sm, (xs: 0, sm: 576px, md: 768px, lg: 1024px, xl: 1280px, 2xl: 1536px))
 //    576px
-@function breakpoint-min($name, $breakpoints: $grid-breakpoints) {
+@function breakpoint-min($name, $breakpoints: $breakpoints) {
   $min: map.get($breakpoints, $name);
   @return if(sass($min != 0): $min; else: null);
 }
@@ -43,9 +43,9 @@
 // Maximum breakpoint width for range queries.
 // Returns the breakpoint value to use as an upper bound in `width < $max` queries.
 //
-//    >> breakpoint-max(md, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px, xxl: 1400px))
+//    >> breakpoint-max(md, (xs: 0, sm: 576px, md: 768px, lg: 1024px, xl: 1280px, 2xl: 1536px))
 //    768px
-@function breakpoint-max($name, $breakpoints: $grid-breakpoints) {
+@function breakpoint-max($name, $breakpoints: $breakpoints) {
   @if $name == null {
     @return null;
   }
@@ -56,17 +56,17 @@
 // Returns a blank string if smallest breakpoint, otherwise returns the name with a dash in front.
 // Useful for making responsive utilities.
 //
-//    >> breakpoint-infix(xs, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px, xxl: 1400px))
+//    >> breakpoint-infix(xs, (xs: 0, sm: 576px, md: 768px, lg: 1024px, xl: 1280px, 2xl: 1536px))
 //    ""  (Returns a blank string)
-//    >> breakpoint-infix(sm, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px, xxl: 1400px))
+//    >> breakpoint-infix(sm, (xs: 0, sm: 576px, md: 768px, lg: 1024px, xl: 1280px, 2xl: 1536px))
 //    "-sm"
-@function breakpoint-infix($name, $breakpoints: $grid-breakpoints) {
+@function breakpoint-infix($name, $breakpoints: $breakpoints) {
   @return if(sass(breakpoint-min($name, $breakpoints) == null): ""; else: "-#{$name}");
 }
 
 // Media of at least the minimum breakpoint width. No query for the smallest breakpoint.
 // Makes the @content apply to the given breakpoint and wider.
-@mixin media-breakpoint-up($name, $breakpoints: $grid-breakpoints) {
+@mixin media-breakpoint-up($name, $breakpoints: $breakpoints) {
   $min: breakpoint-min($name, $breakpoints);
   @if $min {
     @media (width >= $min) {
@@ -79,7 +79,7 @@
 
 // Media of at most the maximum breakpoint width. No query for the largest breakpoint.
 // Makes the @content apply to the given breakpoint and narrower.
-@mixin media-breakpoint-down($name, $breakpoints: $grid-breakpoints) {
+@mixin media-breakpoint-down($name, $breakpoints: $breakpoints) {
   $max: breakpoint-max($name, $breakpoints);
   @if $max {
     @media (width < $max) {
@@ -92,7 +92,7 @@
 
 // Media that spans multiple breakpoint widths.
 // Makes the @content apply between the min and max breakpoints
-@mixin media-breakpoint-between($lower, $upper, $breakpoints: $grid-breakpoints) {
+@mixin media-breakpoint-between($lower, $upper, $breakpoints: $breakpoints) {
   $min: breakpoint-min($lower, $breakpoints);
   $max: breakpoint-max($upper, $breakpoints);
 
@@ -114,7 +114,7 @@
 // Media between the breakpoint's minimum and maximum widths.
 // No minimum for the smallest breakpoint, and no maximum for the largest one.
 // Makes the @content apply only to the given breakpoint, not viewports any wider or narrower.
-@mixin media-breakpoint-only($name, $breakpoints: $grid-breakpoints) {
+@mixin media-breakpoint-only($name, $breakpoints: $breakpoints) {
   $min:  breakpoint-min($name, $breakpoints);
   $next: breakpoint-next($name, $breakpoints);
   $max:  breakpoint-max($next, $breakpoints);
@@ -154,7 +154,7 @@
 
 // Container of at least the minimum breakpoint width. No query for the smallest breakpoint.
 // Makes the @content apply to the given breakpoint and wider.
-@mixin container-breakpoint-up($name, $container-name: null, $breakpoints: $grid-breakpoints) {
+@mixin container-breakpoint-up($name, $container-name: null, $breakpoints: $breakpoints) {
   $min: breakpoint-min($name, $breakpoints);
   @if $min {
     @if $container-name {
@@ -173,7 +173,7 @@
 
 // Container of at most the maximum breakpoint width. No query for the largest breakpoint.
 // Makes the @content apply to the given breakpoint and narrower.
-@mixin container-breakpoint-down($name, $container-name: null, $breakpoints: $grid-breakpoints) {
+@mixin container-breakpoint-down($name, $container-name: null, $breakpoints: $breakpoints) {
   $max: breakpoint-max($name, $breakpoints);
   @if $max {
     @if $container-name {
@@ -192,7 +192,7 @@
 
 // Container that spans multiple breakpoint widths.
 // Makes the @content apply between the min and max breakpoints.
-@mixin container-breakpoint-between($lower, $upper, $container-name: null, $breakpoints: $grid-breakpoints) {
+@mixin container-breakpoint-between($lower, $upper, $container-name: null, $breakpoints: $breakpoints) {
   $min: breakpoint-min($lower, $breakpoints);
   $max: breakpoint-max($upper, $breakpoints);
 
@@ -219,7 +219,7 @@
 
 // Container between the breakpoint's minimum and maximum widths.
 // No minimum for the smallest breakpoint, and no maximum for the largest one.
-@mixin container-breakpoint-only($name, $container-name: null, $breakpoints: $grid-breakpoints) {
+@mixin container-breakpoint-only($name, $container-name: null, $breakpoints: $breakpoints) {
   $min: breakpoint-min($name, $breakpoints);
   $next: breakpoint-next($name, $breakpoints);
   $max: breakpoint-max($next, $breakpoints);

--- a/scss/layout/_containers.scss
+++ b/scss/layout/_containers.scss
@@ -17,7 +17,7 @@
         @extend .container-fluid;
       }
 
-      @include media-breakpoint-up($breakpoint, $grid-breakpoints) {
+      @include media-breakpoint-up($breakpoint, $breakpoints) {
         // Extend each breakpoint which is smaller or equal to the current breakpoint
         $extend-breakpoint: true;
 
@@ -25,9 +25,9 @@
           max-width: $container-max-width;
         }
 
-        @each $name, $width in $grid-breakpoints {
+        @each $name, $width in $breakpoints {
           @if ($extend-breakpoint) {
-            .container#{breakpoint-infix($name, $grid-breakpoints)} {
+            .container#{breakpoint-infix($name, $breakpoints)} {
               @extend %responsive-container-#{$breakpoint};
             }
 

--- a/scss/layout/_tokens.scss
+++ b/scss/layout/_tokens.scss
@@ -7,7 +7,7 @@
 
 @layer root {
   :root {
-    @each $name, $value in $grid-breakpoints {
+    @each $name, $value in $breakpoints {
       --#{$prefix}breakpoint-#{$name}: #{$value};
     }
   }

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -73,7 +73,7 @@
 // Used only by Bootstrap to generate the correct number of grid classes given
 // any value of `$grid-columns`.
 
-@mixin make-grid-columns($columns: $grid-columns, $gutter: $grid-gutter-width, $breakpoints: $grid-breakpoints) {
+@mixin make-grid-columns($columns: $grid-columns, $gutter: $grid-gutter-width, $breakpoints: $breakpoints) {
   @each $breakpoint in map.keys($breakpoints) {
     $infix: breakpoint-infix($breakpoint, $breakpoints);
 
@@ -134,7 +134,7 @@
   }
 }
 
-@mixin make-cssgrid($columns: $grid-columns, $breakpoints: $grid-breakpoints) {
+@mixin make-cssgrid($columns: $grid-columns, $breakpoints: $breakpoints) {
   @each $breakpoint in map.keys($breakpoints) {
     $infix: breakpoint-infix($breakpoint, $breakpoints);
 

--- a/scss/utilities/_api.scss
+++ b/scss/utilities/_api.scss
@@ -10,7 +10,7 @@
 @include generate-utility-at-properties($utilities);
 
 @layer utilities {
-  @include generate-utilities-loop($utilities, $grid-breakpoints);
+  @include generate-utilities-loop($utilities, $breakpoints);
 
   // `transform` is not direction-aware, so the one utility that centres an
   // element on a logical inset has to be flipped by hand: in an RTL document


### PR DESCRIPTION
The three largest breakpoints move to where most current systems put them (Tailwind, Radix, Foundation, Fluent share `1024`/`1280`; upstream v6 uses this exact set) and the top tier is renamed `2xl`.

| tier | before | after |
| --- | --- | --- |
| sm / md | 576 / 768 | unchanged |
| lg | 992 | 1024 |
| xl | 1200 | 1280 |
| xxl → 2xl | 1400 | 1536 |
| container xl / 2xl | 1140 / 1320 | 1200 / 1440 |

- Every responsive class spells the tier `-2xl-` (`.col-2xl-6`, `.container-2xl`, `.modal-fullscreen-2xl-down`, `.hstack-2xl`); size variants that happen to spell `xxl` (`.drawer-xxl`, `.offcanvas-xxl`, `.icon-xxl`, `--cui-border-radius-xxl`) are not breakpoints and keep their name.
- The Sass map is `$breakpoints` (was `$grid-breakpoints`), matching the mixin signatures; 16 readers renamed.
- Floating UI responsive placement (`data-coreui-placement="lg:end 2xl:top"`) reads the same values under the `2xl` key; spec updated.
- `$mobile-breakpoint: lg` is unchanged, so the sidebar's mobile mode now starts below 1024px — a tablet in landscape gets the mobile layout.
- Class-api gate: two patterns declare the ~390 renamed classes. Docs: breakpoint/grid/container tables, examples and captures; migration entry.
- Bundlewatch: the two minified CSS ceilings go up by a quarter kilobyte (66.5 → 67 kB, 19 → 19.25 kB); headroom had reached zero before this change.

Gates: Sass suite, class-api, Floating UI spec, visual suite, docs build. React/Vue carry `xxl` as prop values (`CCol`, `CContainer`, `CModal fullscreen`, `COffcanvas responsive`, breakpoint utils) — separate PRs follow.