### PR TITLE
fix(layout): drawer and offcanvas responsive variants are breakpoints too

### DIFF
--- a/build/class-api-removals.json
+++ b/build/class-api-removals.json
@@ -1,5 +1,5 @@
 {
-  "*-xxl": "Renamed in v6: the largest breakpoint is `2xl` (1536px) — .container-xxl becomes .container-2xl, .hstack-xxl .hstack-2xl. Size variants that happen to spell xxl (.drawer-xxl, .offcanvas-xxl, .icon-xxl) are not breakpoints and keep their name.",
+  "*-xxl": "Renamed in v6: the largest breakpoint is `2xl` (1536px) — .container-xxl becomes .container-2xl, .hstack-xxl .hstack-2xl, .drawer-xxl .drawer-2xl, .offcanvas-xxl .offcanvas-2xl. Only .icon-xxl is a size, not a breakpoint, and keeps its name.",
   "*-xxl-*": "Renamed in v6: the largest breakpoint is `2xl` (1536px), so every responsive class reads -2xl- where it read -xxl- (.col-xxl-6 becomes .col-2xl-6). The lg and xl breakpoints also move, to 1024px and 1280px.",
   "accordion-button": "The accordion is built on <details>/<summary> now, so the trigger is the summary itself. Put .accordion-header on the <summary> element and drop the nested button.",
   "accordion-collapse": "The panel is the <details> element's own content now, revealed by the browser and styled through ::details-content. Nothing wraps the .accordion-body any more.",

--- a/docs/src/content/docs/components/drawer.mdx
+++ b/docs/src/content/docs/components/drawer.mdx
@@ -249,7 +249,7 @@ Responsive drawer classes are available for each breakpoint.
 - `.drawer-md`
 - `.drawer-lg`
 - `.drawer-xl`
-- `.drawer-xxl`
+- `.drawer-2xl`
 
 ## Accessibility
 

--- a/docs/src/content/docs/components/offcanvas.mdx
+++ b/docs/src/content/docs/components/offcanvas.mdx
@@ -185,7 +185,7 @@ Responsive offcanvas classes are available for each breakpoint.
 - `.offcanvas-md`
 - `.offcanvas-lg`
 - `.offcanvas-xl`
-- `.offcanvas-xxl`
+- `.offcanvas-2xl`
 
 ## Placement
 

--- a/docs/src/content/docs/customize/components.mdx
+++ b/docs/src/content/docs/customize/components.mdx
@@ -113,11 +113,11 @@ Set them on `:root` to retune every translucent surface at once, or on one eleme
 
 ## Responsive
 
-These Sass loops aren't limited to color maps, either. You can also generate responsive variations of your components. Take for example our responsive alignment of the dropdowns where we mix an `@each` loop for the `$grid-breakpoints` Sass map with a media query include.
+These Sass loops aren't limited to color maps, either. You can also generate responsive variations of your components. Take for example our responsive alignment of the dropdowns where we mix an `@each` loop for the `$breakpoints` Sass map with a media query include.
 
 <ScssDocs file="scss/_dropdown.scss" capture="responsive-breakpoints" />
 
-Should you modify your `$grid-breakpoints`, your changes will apply to all the loops iterating over that map.
+Should you modify your `$breakpoints`, your changes will apply to all the loops iterating over that map.
 
 <ScssDocs file="scss/_config.scss" capture="breakpoints" />
 

--- a/docs/src/content/docs/helpers/stacks.mdx
+++ b/docs/src/content/docs/helpers/stacks.mdx
@@ -91,6 +91,6 @@ Create an inline form with `.hstack`:
 
 ### Sass loops
 
-`.hstack` and `.vstack` are one rule each; the responsive variants come from a loop over `$grid-breakpoints`, so a breakpoint you add to that map gets its own `.hstack-{breakpoint}` and `.vstack-{breakpoint}` classes. The variants measure the nearest query container, not the viewport — `.stack-container` is what gives them something to measure.
+`.hstack` and `.vstack` are one rule each; the responsive variants come from a loop over `$breakpoints`, so a breakpoint you add to that map gets its own `.hstack-{breakpoint}` and `.vstack-{breakpoint}` classes. The variants measure the nearest query container, not the viewport — `.stack-container` is what gives them something to measure.
 
 <ScssDocs file="scss/helpers/_stacks.scss" capture="stacks" />

--- a/docs/src/content/docs/layout/grid.mdx
+++ b/docs/src/content/docs/layout/grid.mdx
@@ -394,10 +394,10 @@ $grid-gutter-width: 1.5rem !default;
 
 ### Grid tiers
 
-Moving beyond the columns themselves, you may also customize the number of grid tiers. If you wanted just four grid tiers, you'd update the `$grid-breakpoints` and `$container-max-widths` to something like this:
+Moving beyond the columns themselves, you may also customize the number of grid tiers. If you wanted just four grid tiers, you'd update the `$breakpoints` and `$container-max-widths` to something like this:
 
 ```scss
-$grid-breakpoints: (
+$breakpoints: (
   xs: 0,
   sm: 480px,
   md: 768px,

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -657,7 +657,7 @@ check, radio, carousel and toggler icons already work:
   Dialog is a centered floating panel over a blurred backdrop with optional
   slide entry variants; Drawer is a floating, inset, rounded panel with
   translucent/sheet/fullscreen/fit-content variants and responsive classes
-  (`.drawer-sm`…`.drawer-xxl`). Both share the DialogBase behavior with
+  (`.drawer-sm`…`.drawer-2xl`). Both share the DialogBase behavior with
   Modal/Offcanvas, which keep the classic look and the v5 vocabulary as
   **compatibility layers over it — deprecated in v6 and removable in v7**, so
   reach for Dialog and Drawer in new work. See the
@@ -2405,12 +2405,13 @@ as such.
   `1536px` (was `xxl` at 1400); `sm` and `md` stay. Every responsive class
   spells the tier the new way — `.col-xxl-6` is `.col-2xl-6`, `.container-xxl`
   `.container-2xl`, `.modal-fullscreen-xxl-down` `.modal-fullscreen-2xl-down`,
-  `.hstack-xxl` `.hstack-2xl` — and the containers grow with them: `.container`
-  is `1200px` at `xl` (was 1140) and `1440px` at `2xl` (was 1320). Size
-  variants that happen to spell `xxl` (`.drawer-xxl`, `.offcanvas-xxl`,
-  `.icon-xxl`, `--cui-border-radius-xxl`) are not breakpoints and keep their
-  name. The Sass map is `$breakpoints` (was `$grid-breakpoints`) and the mixins
-  take it under that name; `$container-max-widths` keeps its name. The
+  `.hstack-xxl` `.hstack-2xl`, `.drawer-xxl` `.drawer-2xl`, `.offcanvas-xxl`
+  `.offcanvas-2xl` — and the containers grow with them: `.container` is
+  `1200px` at `xl` (was 1140) and `1440px` at `2xl` (was 1320). Only
+  `.icon-xxl` and `--cui-border-radius-xxl` keep the spelling: they are
+  sizes, not breakpoints. The Sass map is `$breakpoints` (was
+  `$grid-breakpoints`) and the mixins take it under that name;
+  `$container-max-widths` keeps its name. The
   responsive placement of menus, tooltips and popovers
   (`data-coreui-placement="lg:end"`) reads the same values, and the sidebar's
   mobile mode, `$mobile-breakpoint: lg`, now starts below `1024px` — a tablet

--- a/js/src/drawer.ts
+++ b/js/src/drawer.ts
@@ -36,7 +36,7 @@ const OPEN_SELECTOR = 'dialog[open][class*="drawer"]'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="drawer"]'
 // Responsive variants replace the base class, so the dismiss fallback must
 // match them too
-const SELECTOR_DISMISS_SCOPE = '.drawer, .drawer-sm, .drawer-md, .drawer-lg, .drawer-xl, .drawer-xxl'
+const SELECTOR_DISMISS_SCOPE = '.drawer, .drawer-sm, .drawer-md, .drawer-lg, .drawer-xl, .drawer-2xl'
 
 const Default = {
   backdrop: true,

--- a/js/src/offcanvas.ts
+++ b/js/src/offcanvas.ts
@@ -38,7 +38,7 @@ const OPEN_SELECTOR = 'dialog[open][class*="offcanvas"]'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="offcanvas"]'
 // Responsive variants replace the base class, so the dismiss fallback must
 // match them too
-const SELECTOR_DISMISS_SCOPE = '.offcanvas, .offcanvas-sm, .offcanvas-md, .offcanvas-lg, .offcanvas-xl, .offcanvas-xxl'
+const SELECTOR_DISMISS_SCOPE = '.offcanvas, .offcanvas-sm, .offcanvas-md, .offcanvas-lg, .offcanvas-xl, .offcanvas-2xl'
 
 const Default = {
   backdrop: true,

--- a/js/src/util/floating-ui.ts
+++ b/js/src/util/floating-ui.ts
@@ -25,8 +25,7 @@ interface BreakpointListener {
 }
 
 /**
- * Breakpoints for responsive placement (matches SCSS $breakpoints —
- * CoreUI keeps the classic scale, not upstream's Tailwind-style one)
+ * Breakpoints for responsive placement (matches SCSS $breakpoints)
  */
 export const BREAKPOINTS: Record<string, number> = {
   sm: 576,


### PR DESCRIPTION
Follow-up to #1153. `.drawer-xxl` and `.offcanvas-xxl` come from a loop over `$breakpoints`, so the CSS already ships `.drawer-2xl` and `.offcanvas-2xl` — but the dismiss-scope selectors in `drawer.ts` and `offcanvas.ts` still listed the old names, and the migration entry and the class-api note called them size variants. Only `.icon-xxl` and `--cui-border-radius-xxl` keep the spelling. Also: three docs pages still named `$grid-breakpoints`, and the Floating UI comment claimed CoreUI keeps the classic scale. Drawer/offcanvas specs, eslint and docs build green.