### PR TITLE
feat(typography): every type stop carries its own line height

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -2437,6 +2437,18 @@ as such.
   dialog read their own key instead of the legacy component's. The legacy keys
   stay; both spellings of a pair always resolve to one number.
 
+#### Every type stop carries its own line height
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`$font-sizes` sets a line height per stop instead of one value for all
+  headings.** `xs` is 1.25, `sm` … `lg` the body leading (`--cui-body-line-height`, 1.5), `xl` 2.5⁄1.75, `2xl` 3⁄2.25,
+  `3xl` 1.2, `4xl` and `5xl` 1.1, `6xl` 1 — the larger the type, the tighter
+  the leading, and the small stops read at body leading instead of 1.2. The
+  sizes are unchanged. Headings follow their stop through
+  `--cui-line-height-*`: `h5` (`lg`) and `h4` (`xl`) get taller lines, `h1`
+  (`4xl`) a tighter one. `$headings-line-height` still feeds
+  `--cui-heading-line-height` for anything that reads it directly.
+
 #### Every theme colour gets an action-background slot
 
 `:root` emits `--cui-{color}-bg` for every theme colour, pointing at the

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -313,16 +313,16 @@ $font-sizes: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $font-sizes: defaults(
   (
-    "xs":  ("font-size": calc(var(--#{$prefix}body-font-size) * .75),   "line-height": var(--#{$prefix}body-line-height)),
+    "xs":  ("font-size": calc(var(--#{$prefix}body-font-size) * .75),   "line-height": 1.25),
     "sm":  ("font-size": calc(var(--#{$prefix}body-font-size) * .875),  "line-height": var(--#{$prefix}body-line-height)),
     "md":  ("font-size": var(--#{$prefix}body-font-size),               "line-height": var(--#{$prefix}body-line-height)),
-    "lg":  ("font-size": calc(var(--#{$prefix}body-font-size) * 1.25),  "line-height": $headings-line-height),
-    "xl":  ("font-size": clamp(1.275rem, 1.275rem + .3vw, 1.5rem),  "line-height": $headings-line-height),
-    "2xl": ("font-size": clamp(1.3rem, 1.3rem + .6vw, 1.75rem),     "line-height": $headings-line-height),
-    "3xl": ("font-size": clamp(1.325rem, 1.325rem + .9vw, 2rem),    "line-height": $headings-line-height),
-    "4xl": ("font-size": clamp(1.375rem, 1.375rem + 1.5vw, 2.5rem), "line-height": $headings-line-height),
-    "5xl": ("font-size": clamp(1.425rem, 1.425rem + 2.1vw, 3rem),   "line-height": $headings-line-height),
-    "6xl": ("font-size": clamp(1.475rem, 1.475rem + 2.7vw, 3.5rem), "line-height": $headings-line-height)
+    "lg":  ("font-size": calc(var(--#{$prefix}body-font-size) * 1.25),  "line-height": var(--#{$prefix}body-line-height)),
+    "xl":  ("font-size": clamp(1.275rem, 1.275rem + .3vw, 1.5rem),  "line-height": calc(2.5 / 1.75)),
+    "2xl": ("font-size": clamp(1.3rem, 1.3rem + .6vw, 1.75rem),     "line-height": calc(3 / 2.25)),
+    "3xl": ("font-size": clamp(1.325rem, 1.325rem + .9vw, 2rem),    "line-height": 1.2),
+    "4xl": ("font-size": clamp(1.375rem, 1.375rem + 1.5vw, 2.5rem), "line-height": 1.1),
+    "5xl": ("font-size": clamp(1.425rem, 1.425rem + 2.1vw, 3rem),   "line-height": 1.1),
+    "6xl": ("font-size": clamp(1.475rem, 1.475rem + 2.7vw, 3.5rem), "line-height": 1)
   ),
   $font-sizes
 );


### PR DESCRIPTION
`$font-sizes` sets a line height per stop instead of one `1.2` for every heading stop and the body leading for the rest: `xs` 1.25, `sm`–`lg` the body leading (`--cui-body-line-height`, so they keep following a runtime override), `xl` 2.5⁄1.75, `2xl` 3⁄2.25, `3xl` 1.2, `4xl`/`5xl` 1.1, `6xl` 1 — upstream's curve, our sizes.

Visible: `h5` (`lg`) and `h4` (`xl`) get taller lines, `h1` (`4xl`) a tighter one, `.text-xs` tightens. `$headings-line-height` still feeds `--cui-heading-line-height`. Sorted CSS diff: the ten `--cui-line-height-*` tokens and the `.text-*` declarations that read them. Gates green; migration entry.