### PR TITLE
feat(utilities): layered shadows

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "./dist/css/coreui-reboot.css",
-      "maxSize": "6.25 kB"
+      "maxSize": "6.5 kB"
     },
     {
       "path": "./dist/css/coreui-reboot.min.css",
@@ -18,7 +18,7 @@
     },
     {
       "path": "./dist/css/coreui-utilities.css",
-      "maxSize": "20.5 kB"
+      "maxSize": "20.75 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "71 kB"
+      "maxSize": "71.5 kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "67 kB"
+      "maxSize": "67.5 kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -2449,6 +2449,19 @@ as such.
   (`4xl`) a tighter one. `$headings-line-height` still feeds
   `--cui-heading-line-height` for anything that reads it directly.
 
+#### Layered shadows
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **Every shadow is a stack of two to four layers with a negative spread**
+  instead of one wide blur: a tight layer for contact, wider ones for
+  ambient light, each at 4–9 % alpha, so a card reads as lifted rather than
+  smeared. `.shadow-xs` and `--cui-box-shadow-xs` are new (one thin layer).
+  The inset shadow reads 8 % in the light scheme and 26 % in the dark one.
+  `--cui-shadow-strength` in the dark scheme is `2.4` (was 2.5). The knobs are
+  unchanged: `--cui-shadow-color` and `--cui-shadow-strength` on `:root`,
+  `.shadow-{color}` and `.shadow-opacity-*` on the element, `$shadows` in
+  Sass — a custom entry is now a comma-separated list of layers.
+
 #### Every theme colour gets an action-background slot
 
 `:root` emits `--cui-{color}-bg` for every theme colour, pointing at the

--- a/docs/src/content/docs/utilities/shadows.mdx
+++ b/docs/src/content/docs/utilities/shadows.mdx
@@ -9,7 +9,8 @@ description: "Add or remove shadows to elements with box-shadow utilities."
 While shadows on components are disabled by default in CoreUI for Bootstrap and can be enabled via `$enable-shadows`, you can also quickly add or remove a shadow with our `box-shadow` utility classes. Includes support for `.shadow-none` and three default sizes (which have associated variables to match).
 
 <Example code={`<div class="shadow-none p-3 mb-5 bg-4 rounded">No shadow</div>
-  <div class="shadow-sm p-3 mb-5 bg-body rounded">Small shadow</div>
+  <div class="shadow-xs p-3 mb-5 bg-body rounded">Extra small shadow</div>
+<div class="shadow-sm p-3 mb-5 bg-body rounded">Small shadow</div>
   <div class="shadow p-3 mb-5 bg-body rounded">Regular shadow</div>
   <div class="shadow-lg p-3 mb-5 bg-body rounded">Larger shadow</div>
   <div class="shadow-xl p-3 mb-5 bg-body rounded">Extra large shadow</div>`} />

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -248,11 +248,29 @@ $radii: defaults(
 // scss-docs-start box-shadow-variables
 
 $shadows: (
-  null:  0 .5rem 1rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(15% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
-  sm:    0 .125rem .25rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(7.5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
-  lg:    0 1rem 3rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(17.5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
-  xl:    0 1.5rem 4rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(20% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
-  inset: inset 0 1px 2px color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(7.5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
+  null: #{(
+    "0 .125rem .25rem -.0625rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(4% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent)",
+    "0 .375rem .75rem -.125rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent)",
+    "0 .75rem 1.5rem -.25rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(6% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent)"
+  )},
+  xs: 0 .0625rem .125rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(4% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent),
+  sm: #{(
+    "0 .0625rem .125rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(4% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent)",
+    "0 .125rem .375rem -.0625rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent)"
+  )},
+  lg: #{(
+    "0 .125rem .375rem -.0625rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent)",
+    "0 .375rem 1rem -.1875rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(6% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent)",
+    "0 .75rem 2rem -.375rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(7% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent)",
+    "0 1.5rem 3.5rem -.75rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(8% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent)"
+  )},
+  xl: #{(
+    "0 .1875rem .5rem -.0625rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(5% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent)",
+    "0 .5rem 1.25rem -.1875rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(6% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent)",
+    "0 1rem 2.5rem -.375rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(7% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent)",
+    "0 2rem 5rem -.75rem color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(9% * var(--#{$prefix}shadow-strength) * var(--#{$prefix}shadow-opacity, 1)), transparent)"
+  )},
+  inset: inset 0 1px 2px light-dark(color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(8% * var(--#{$prefix}shadow-opacity, 1)), transparent), color-mix(in oklch, var(--#{$prefix}shadow-tint, var(--#{$prefix}shadow-color)) calc(26% * var(--#{$prefix}shadow-opacity, 1)), transparent)),
 ) !default;
 // scss-docs-end box-shadow-variables
 

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -35,7 +35,7 @@ $border-radius-xxl: 2rem !default;
 // scss-docs-start box-shadow-variables
 $shadow-color:         #000 !default;
 $shadow-strength:      1 !default;
-$shadow-strength-dark: 2.5 !default;
+$shadow-strength-dark: 2.4 !default;
 // scss-docs-end box-shadow-variables
 
 // scss-docs-start transition-variables


### PR DESCRIPTION
Every shadow is a stack of two to four layers with a negative spread instead of one wide blur — a tight contact layer and wider ambient ones at 4–9 % alpha each, upstream's geometry on our tokens (`--cui-shadow-tint`/`--cui-shadow-opacity` as the element overrides, `--cui-shadow-color`/`--cui-shadow-strength` on `:root`, mixed with `color-mix()` rather than relative colour syntax). `.shadow-xs` and `--cui-box-shadow-xs` are new; the inset shadow reads 8 % / 26 % per scheme; dark strength 2.4.

Knobs unchanged; a custom `$shadows` entry is a comma-separated list of layers now. Sass suite, class-api, visual suite and docs build green; migration entry. Bundlewatch: four CSS ceilings up by a quarter to half a kilobyte (the tokens live in every bundle that carries `:root`).