### PR TITLE
docs(shadows): five sizes, not three

### DIFF
--- a/docs/src/content/docs/utilities/shadows.mdx
+++ b/docs/src/content/docs/utilities/shadows.mdx
@@ -6,7 +6,7 @@ description: "Add or remove shadows to elements with box-shadow utilities."
 
 ## Examples
 
-While shadows on components are disabled by default in CoreUI for Bootstrap and can be enabled via `$enable-shadows`, you can also quickly add or remove a shadow with our `box-shadow` utility classes. Includes support for `.shadow-none` and three default sizes (which have associated variables to match).
+While shadows on components are disabled by default in CoreUI for Bootstrap and can be enabled via `$enable-shadows`, you can also quickly add or remove a shadow with our `box-shadow` utility classes. Includes support for `.shadow-none` and five sizes, `.shadow-xs` to `.shadow-xl` (each with a matching `--cui-box-shadow-*` token).
 
 <Example code={`<div class="shadow-none p-3 mb-5 bg-4 rounded">No shadow</div>
   <div class="shadow-xs p-3 mb-5 bg-body rounded">Extra small shadow</div>


### PR DESCRIPTION
The intro still counted three shadow sizes; `.shadow-xs` to `.shadow-xl` are five, each with a `--cui-box-shadow-*` token. Docs build green.