### PR TITLE
fix(Menu): keep submenu triggers in the keyboard walk of their level

### DIFF
--- a/js/src/menu.ts
+++ b/js/src/menu.ts
@@ -855,16 +855,40 @@ class Menu extends BaseComponent {
   // Keyboard navigation
   // -------------------------------------------------------------------------
 
+  // Items sit either directly in `.menu`, or as a submenu trigger one level deeper
+  // (`.menu > .submenu > .menu-item`). Both are navigable at the same level.
+  protected _getItemsInMenu(menu: Element): HTMLElement[] {
+    return SelectorEngine.find(
+      `:scope > ${this.constructor.SELECTOR_VISIBLE_ITEMS}, :scope > ${this.constructor.SELECTOR_SUBMENU} > ${this.constructor.SELECTOR_VISIBLE_ITEMS}`,
+      menu
+    ).filter(element => isVisible(element))
+  }
+
   protected _selectMenuItem({ key, target }: CoreUIEvent): void {
     const currentMenu = (target as Element).closest(this.constructor.SELECTOR_MENU) || this._menu
-    const items = SelectorEngine.find(`:scope > ${this.constructor.SELECTOR_VISIBLE_ITEMS}`, currentMenu)
-      .filter(element => isVisible(element))
+    const items = this._getItemsInMenu(currentMenu)
 
     if (!items.length) {
       return
     }
 
-    getNextActiveElement(items, target as HTMLElement, key === ARROW_DOWN_KEY, !items.includes(target as HTMLElement)).focus()
+    const nextItem = getNextActiveElement(items, target as HTMLElement, key === ARROW_DOWN_KEY, !items.includes(target as HTMLElement))
+    nextItem.focus()
+    this._closeUnrelatedSubmenus(currentMenu, nextItem)
+  }
+
+  // Moving focus along one level closes the submenus focus left behind, matching
+  // what hover and click already do through `_closeSiblingSubmenus`.
+  protected _closeUnrelatedSubmenus(currentMenu: Element, focusedElement: HTMLElement): void {
+    for (const [submenu] of this._openSubmenus) {
+      const submenuWrapper = submenu.closest(this.constructor.SELECTOR_SUBMENU)
+
+      if (!submenuWrapper || submenuWrapper.parentElement !== currentMenu || submenuWrapper.contains(focusedElement)) {
+        continue
+      }
+
+      this._closeSubmenu(submenu, submenuWrapper)
+    }
   }
 
   protected _handleSubmenuKeydown(event: CoreUIEvent): boolean {
@@ -938,12 +962,12 @@ class Menu extends BaseComponent {
       event.stopPropagation()
 
       const currentMenu = (target as Element).closest(this.constructor.SELECTOR_MENU)!
-      const items = SelectorEngine.find(`:scope > ${this.constructor.SELECTOR_VISIBLE_ITEMS}`, currentMenu)
-        .filter(element => isVisible(element))
+      const items = this._getItemsInMenu(currentMenu)
 
       if (items.length) {
-        const targetItem = key === HOME_KEY ? items[0] : items[items.length - 1]
+        const targetItem = key === HOME_KEY ? items[0] : items.at(-1)!
         targetItem.focus()
+        this._closeUnrelatedSubmenus(currentMenu, targetItem)
       }
 
       return true

--- a/js/tests/unit/menu.spec.js
+++ b/js/tests/unit/menu.spec.js
@@ -4394,6 +4394,110 @@ describe('Menu', () => {
   })
 
   describe('scoped keyboard navigation', () => {
+    it('should walk submenu triggers, items past a divider, Home and End at one level', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-coreui-toggle="menu">Menu</button>',
+          '  <div class="menu">',
+          '    <div class="submenu">',
+          '      <button id="trigger-1" class="menu-item" type="button">File</button>',
+          '      <div class="menu">',
+          '        <a id="sub-item-1" class="menu-item" href="#">New</a>',
+          '      </div>',
+          '    </div>',
+          '    <div class="submenu">',
+          '      <button id="trigger-2" class="menu-item" type="button">Edit</button>',
+          '      <div class="menu">',
+          '        <a class="menu-item" href="#">Cut</a>',
+          '      </div>',
+          '    </div>',
+          '    <hr class="menu-divider">',
+          '    <a id="top-item" class="menu-item" href="#">Preferences</a>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-coreui-toggle="menu"]')
+        const trigger1 = fixtureEl.querySelector('#trigger-1')
+        const trigger2 = fixtureEl.querySelector('#trigger-2')
+        const topItem = fixtureEl.querySelector('#top-item')
+        const menu = new Menu(btnMenu)
+        const press = (element, key) => {
+          const keydown = createEvent('keydown', { bubbles: true })
+          keydown.key = key
+          element.dispatchEvent(keydown)
+        }
+
+        btnMenu.addEventListener('shown.coreui.menu', () => {
+          press(btnMenu, 'ArrowDown')
+          expect(document.activeElement).toEqual(trigger1)
+
+          press(trigger1, 'ArrowDown')
+          expect(document.activeElement).toEqual(trigger2)
+
+          press(trigger2, 'ArrowDown')
+          expect(document.activeElement).toEqual(topItem)
+
+          press(topItem, 'ArrowUp')
+          expect(document.activeElement).toEqual(trigger2)
+
+          press(trigger2, 'End')
+          expect(document.activeElement).toEqual(topItem)
+
+          press(topItem, 'Home')
+          expect(document.activeElement).toEqual(trigger1)
+
+          resolve()
+        })
+
+        menu.show()
+      })
+    })
+
+    it('should close the submenu focus leaves when arrowing along the parent level', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-coreui-toggle="menu">Menu</button>',
+          '  <div class="menu">',
+          '    <div class="submenu">',
+          '      <button id="trigger-1" class="menu-item" type="button">File</button>',
+          '      <div id="submenu-1" class="menu">',
+          '        <a class="menu-item" href="#">New</a>',
+          '      </div>',
+          '    </div>',
+          '    <a id="top-item" class="menu-item" href="#">Preferences</a>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-coreui-toggle="menu"]')
+        const trigger1 = fixtureEl.querySelector('#trigger-1')
+        const submenu1 = fixtureEl.querySelector('#submenu-1')
+        const topItem = fixtureEl.querySelector('#top-item')
+        const menu = new Menu(btnMenu)
+
+        btnMenu.addEventListener('shown.coreui.menu', () => {
+          trigger1.focus()
+          const enter = createEvent('keydown', { bubbles: true })
+          enter.key = 'Enter'
+          trigger1.dispatchEvent(enter)
+          expect(submenu1).toHaveClass('show')
+
+          const arrowDown = createEvent('keydown', { bubbles: true })
+          arrowDown.key = 'ArrowDown'
+          trigger1.dispatchEvent(arrowDown)
+
+          expect(document.activeElement).toEqual(topItem)
+          expect(submenu1).not.toHaveClass('show')
+          resolve()
+        })
+
+        menu.show()
+      })
+    })
+
     it('should scope ArrowDown/ArrowUp to direct children of the current menu level', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [


### PR DESCRIPTION
## Summary

Arrow keys, Home and End in a Menu collected only the direct children of the current `.menu`, so a submenu trigger (`.menu > .submenu > .menu-item`) was invisible to keyboard navigation:

- ArrowDown from a submenu trigger skipped straight to the first plain item.
- ArrowUp from an item below a divider could not climb back over it to the triggers.
- Home/End never landed on a trigger.

Items are now gathered from both places in document order (`_getItemsInMenu`), and moving focus along one level closes the submenu focus left behind (`_closeUnrelatedSubmenus`), as hover and click already do through `_closeSiblingSubmenus`. Dropdown keeps its own descendant-based lookup and is unaffected.

## Verification

- `npm run lint`, `tsc --noEmit`
- `js-test-unit` with coverage: 62 files, 3384 tests (2 new in `menu.spec.js`)
- `js-test-a11y`: 33 passed, 0 failed
- `npm run js` + bundlewatch PASS