### PR TITLE
refactor(root): link decoration is a token, not a Sass knob

### DIFF
--- a/docs/src/content/docs/content/typography.mdx
+++ b/docs/src/content/docs/content/typography.mdx
@@ -11,7 +11,7 @@ CoreUI for Bootstrap sets basic global display, typography, and link styles. Whe
 - Use a [native font stack](/content/reboot/#native-font-stack) that selects the best `font-family` for each OS and device.
 - For a more inclusive and accessible type scale, we use the browser's default root `font-size` (typically 16px) so visitors can customize their browser defaults as needed.
 - Use the `$font-family-base`, `$font-size-base`, and `$line-height-base` attributes as our typographic base applied to the `<body>`.
-- Set the global link color via `$link-color` and the underline's distance from the text via `$link-underline-offset`.
+- Set the global link color via `$link-color`; the underline and its distance from the text are the `--cui-link-decoration` and `--cui-link-underline-offset` tokens on `:root`.
 - Use `$bg-body` to set a `background-color` on the `<body>` — `light-dark()` picks white or `--cui-gray-975`, so one value covers both color modes.
 
 These styles can be found within `content/_reboot.scss`, and the global variables are defined in `_config.scss`. Make sure to set `$font-size-base` in `rem`.

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -2476,6 +2476,19 @@ as such.
   alerts, modals, drawers, popovers, callouts, list groups, the sidebar and
   the reboot margins keep their size.
 
+#### Link decoration is a token, not a Sass knob
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`$link-decoration`, `$link-underline-offset` and `$link-hover-decoration`
+  are gone.** The underline lives on `:root` as `--cui-link-decoration`
+  (`underline`) and `--cui-link-underline-offset` (`.2em`); set the token
+  instead of recompiling. `--cui-link-hover-decoration` is no longer declared
+  — the hover falls back to `--cui-link-decoration`, so declare it yourself
+  for a different hover. Nav links, list-group actions, page links, the
+  header, the dropdown item and the button write `text-decoration: none`
+  outright (they used to skip it when the knob was already `none`), and
+  `.btn-link` reads the tokens.
+
 #### Every theme colour gets an action-background slot
 
 `:root` emits `--cui-{color}-bg` for every theme colour, pointing at the

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -112,9 +112,6 @@ $sizes: defaults(
 
 // Style anchor elements.
 
-$link-decoration:                         underline !default;
-$link-underline-offset:                   .2em !default;
-$link-hover-decoration:                   null !default;
 
 // Define the minimum dimensions at which your layout will change,
 // adapting to different screen sizes, for use in media queries.

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -292,7 +292,7 @@ $dropdown-dark-tokens: defaults(
     font-weight: var(--#{$prefix}font-weight-normal);
     color: var(--#{$prefix}dropdown-link-color);
     text-align: inherit; // For `<button>`s
-    text-decoration: if(not sass($link-decoration == none): none);
+    text-decoration: none;
     white-space: nowrap; // prevent links from randomly breaking onto new lines
     background-color: transparent; // For `<button>`s
     border: 0; // For `<button>`s
@@ -301,8 +301,6 @@ $dropdown-dark-tokens: defaults(
     &:hover,
     &:focus {
       color: var(--#{$prefix}dropdown-link-hover-color);
-      // stylelint-disable-next-line scss/at-function-named-arguments
-      text-decoration: if(sass($link-hover-decoration == underline): none);
       background-color: var(--#{$prefix}dropdown-link-hover-bg);
     }
 

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -140,14 +140,12 @@ $header-tokens: defaults(
     margin-inline-end: $header-brand-margin-end;
     font-size: $header-brand-font-size;
     color: var(--#{$prefix}header-brand-color);
-    text-decoration: if(not sass($link-decoration == none): none);
+    text-decoration: none;
     white-space: nowrap;
 
     &:hover,
     &:focus {
       color: var(--#{$prefix}header-brand-hover-color);
-      // stylelint-disable-next-line scss/at-function-named-arguments
-      text-decoration: if(sass($link-hover-decoration == underline): none);
     }
   }
 

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -95,7 +95,7 @@ $list-group-tokens: defaults(
     display: block;
     padding: var(--#{$prefix}list-group-item-padding-y) var(--#{$prefix}list-group-item-padding-x);
     color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}list-group-color));
-    text-decoration: if(not sass($link-decoration == none): none);
+    text-decoration: none;
     background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}list-group-bg));
     border: var(--#{$prefix}list-group-border-width) solid var(--#{$prefix}theme-border, var(--#{$prefix}list-group-border-color));
 

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -221,7 +221,7 @@ $tab-pane-tokens: defaults(
     font-size: var(--#{$prefix}nav-link-font-size);
     font-weight: var(--#{$prefix}nav-link-font-weight);
     color: var(--#{$prefix}theme-fg, var(--#{$prefix}nav-link-color));
-    text-decoration: if(not sass($link-decoration == none): none);
+    text-decoration: none;
     background: none;
     border: 0;
     @include border-radius(var(--#{$prefix}nav-link-border-radius));
@@ -234,8 +234,6 @@ $tab-pane-tokens: defaults(
     &:hover,
     &:focus {
       color: var(--#{$prefix}theme-fg, var(--#{$prefix}nav-link-hover-color));
-      // stylelint-disable-next-line scss/at-function-named-arguments
-      text-decoration: if(sass($link-hover-decoration == underline): none);
       background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}nav-link-hover-bg));
     }
 

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -213,14 +213,12 @@ $navbar-dark-tokens: defaults(
     font-size: var(--#{$prefix}navbar-brand-font-size);
     font-weight: var(--#{$prefix}navbar-brand-font-weight);
     color: var(--#{$prefix}theme-fg, var(--#{$prefix}navbar-brand-color));
-    text-decoration: if(not sass($link-decoration == none): none);
+    text-decoration: none;
     white-space: nowrap;
 
     &:hover,
     &:focus {
       color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}navbar-brand-hover-color));
-      // stylelint-disable-next-line scss/at-function-named-arguments
-      text-decoration: if(sass($link-hover-decoration == underline): none);
     }
   }
 

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -96,7 +96,7 @@ $pagination-sizes: defaults(
     padding: var(--#{$prefix}pagination-padding-y) var(--#{$prefix}pagination-padding-x);
     font-size: var(--#{$prefix}pagination-font-size);
     color: var(--#{$prefix}theme-fg, var(--#{$prefix}pagination-color));
-    text-decoration: if(not sass($link-decoration == none): none);
+    text-decoration: none;
     background-color: var(--#{$prefix}pagination-bg);
     border: var(--#{$prefix}pagination-border-width) solid var(--#{$prefix}pagination-border-color);
     @include transition($pagination-transition);
@@ -104,8 +104,6 @@ $pagination-sizes: defaults(
     &:hover {
       z-index: 2;
       color: var(--#{$prefix}theme-fg-emphasis, var(--#{$prefix}pagination-hover-color));
-      // stylelint-disable-next-line scss/at-function-named-arguments
-      text-decoration: if(sass($link-hover-decoration == underline): none);
       background-color: var(--#{$prefix}theme-bg-subtle, var(--#{$prefix}pagination-hover-bg));
       border-color: var(--#{$prefix}theme-border, var(--#{$prefix}pagination-hover-border-color));
     }

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -213,10 +213,9 @@ $root-token-defaults: map.merge(
     // scss-docs-end root-body-variables
     --#{$prefix}heading-color: $headings-color,
     --#{$prefix}link-color: $link-color,
-    --#{$prefix}link-decoration: $link-decoration,
-    --#{$prefix}link-underline-offset: $link-underline-offset,
+    --#{$prefix}link-decoration: underline,
+    --#{$prefix}link-underline-offset: .2em,
     --#{$prefix}link-hover-color: $link-hover-color,
-    --#{$prefix}link-hover-decoration: $link-hover-decoration,
     --#{$prefix}code-color: $code-color,
     --#{$prefix}highlight-color: $mark-color,
     --#{$prefix}highlight-bg: $mark-bg,

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -265,7 +265,7 @@ $btn-check-deprecated: ".btn-check:not(#{$btn-variant-selectors})" !default;
     line-height: var(--#{$prefix}btn-line-height);
     color: var(--#{$prefix}btn-color);
     text-align: center;
-    text-decoration: if(not sass($link-decoration == none): none);
+    text-decoration: none;
     white-space: var(--#{$prefix}btn-white-space);
     vertical-align: middle;
     // stylelint-disable-next-line scss/at-function-named-arguments
@@ -282,8 +282,6 @@ $btn-check-deprecated: ".btn-check:not(#{$btn-variant-selectors})" !default;
 
     &:hover {
       color: var(--#{$prefix}btn-hover-color);
-      // stylelint-disable-next-line scss/at-function-named-arguments
-      text-decoration: if(sass($link-hover-decoration == underline): none);
       background-color: var(--#{$prefix}btn-hover-bg);
       border-color: var(--#{$prefix}btn-hover-border-color);
     }
@@ -440,14 +438,14 @@ $btn-check-deprecated: ".btn-check:not(#{$btn-variant-selectors})" !default;
   .btn-link {
     @include tokens($button-link-tokens);
 
-    text-decoration: $link-decoration;
+    text-decoration: var(--#{$prefix}link-decoration);
     @if $enable-gradients {
       background-image: none;
     }
 
     &:hover,
     &:focus-visible {
-      text-decoration: $link-hover-decoration;
+      text-decoration: var(--#{$prefix}link-hover-decoration, var(--#{$prefix}link-decoration));
     }
 
     &:focus-visible {


### PR DESCRIPTION
`$link-decoration`, `$link-underline-offset` and `$link-hover-decoration` are gone, as in upstream (#42701). `:root` carries `--cui-link-decoration` (`underline`) and `--cui-link-underline-offset` (`.2em`) as literals; `--cui-link-hover-decoration` is no longer declared, the hover falls back to the link decoration in reboot.

Six components wrote `text-decoration: none` only when the Sass knob was not already `none` (a build-time decision the token could never change); they write it outright now, like upstream. `.btn-link` read the Sass values directly, freezing them at build time; it reads the tokens.

Sass suite, class-api, stylelint and docs build green (run in a worktree, the main clone is parked on #1162); typography page and migration updated.