### PR TITLE
docs(config): close the spacers-map block after the spacers map

### DIFF
--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -74,6 +74,7 @@ $spacers: defaults(
   ),
   $spacers
 );
+// scss-docs-end spacers-map
 
 // scss-docs-start negative-spacers-map
 $negative-spacers: () !default;
@@ -108,7 +109,6 @@ $sizes: defaults(
   $sizes
 );
 // scss-docs-end sizes-map
-// scss-docs-end spacers-map
 
 // Define the minimum dimensions at which your layout will change,
 // adapting to different screen sizes, for use in media queries.


### PR DESCRIPTION
The `scss-docs-end spacers-map` marker had drifted below the `$negative-spacers` and `$sizes` maps added in #1151/#1155, so the spacing pages quoted all three maps under one heading. Docs build green.