### PR TITLE
fix(scss): derive inner border radius from the component tokens

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -16,7 +16,7 @@ $card-border-width:                 var(--#{$prefix}border-width) !default;
 $card-border-color:                 var(--#{$prefix}border-color-translucent) !default;
 $card-border-radius:                var(--#{$prefix}radius-7) !default;
 $card-box-shadow:                   none !default;
-$card-inner-border-radius:          calc(#{$card-border-radius} - #{$card-border-width}) !default;
+$card-inner-border-radius:          calc(var(--#{$prefix}card-border-radius) - var(--#{$prefix}card-border-width)) !default;
 $card-cap-padding-y:                calc(#{$card-spacer-y} * .5) !default;
 $card-cap-padding-x:                $card-spacer-x !default;
 $card-cap-bg:                       var(--#{$prefix}bg-1) !default;

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -18,7 +18,7 @@ $dropdown-bg:                       var(--#{$prefix}bg-body) !default;
 $dropdown-border-color:             var(--#{$prefix}border-color-translucent) !default;
 $dropdown-border-radius:            var(--#{$prefix}radius-7) !default;
 $dropdown-border-width:             var(--#{$prefix}border-width) !default;
-$dropdown-inner-border-radius:      calc(#{$dropdown-border-radius} - #{$dropdown-border-width}) !default;
+$dropdown-inner-border-radius:      calc(var(--#{$prefix}dropdown-border-radius) - var(--#{$prefix}dropdown-border-width)) !default;
 $dropdown-divider-bg:               $dropdown-border-color !default;
 $dropdown-divider-margin-y:         var(--#{$prefix}spacer-2) !default;
 $dropdown-box-shadow:               var(--#{$prefix}box-shadow) !default;

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -24,7 +24,7 @@ $modal-content-bg:                  var(--#{$prefix}bg-body) !default;
 $modal-content-border-color:        var(--#{$prefix}border-color-translucent) !default;
 $modal-content-border-width:        var(--#{$prefix}border-width) !default;
 $modal-content-border-radius:       var(--#{$prefix}radius-5) !default;
-$modal-content-inner-border-radius: calc(#{$modal-content-border-radius} - #{$modal-content-border-width}) !default;
+$modal-content-inner-border-radius: calc(var(--#{$prefix}modal-border-radius) - var(--#{$prefix}modal-border-width)) !default;
 $modal-content-box-shadow-xs:       var(--#{$prefix}box-shadow-sm) !default;
 $modal-content-box-shadow-sm-up:    var(--#{$prefix}box-shadow) !default;
 

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -13,7 +13,7 @@ $popover-max-width:                 276px !default;
 $popover-border-width:              var(--#{$prefix}border-width) !default;
 $popover-border-color:              var(--#{$prefix}border-color-translucent) !default;
 $popover-border-radius:             var(--#{$prefix}radius-7) !default;
-$popover-inner-border-radius:       calc(#{$popover-border-radius} - #{$popover-border-width}) !default;
+$popover-inner-border-radius:       calc(var(--#{$prefix}popover-border-radius) - var(--#{$prefix}popover-border-width)) !default;
 $popover-box-shadow:                var(--#{$prefix}box-shadow) !default;
 
 $popover-header-font-size:          var(--#{$prefix}body-font-size) !default;


### PR DESCRIPTION
## Problem

`$card-inner-border-radius`, `$popover-inner-border-radius`, `$modal-content-inner-border-radius` and `$dropdown-inner-border-radius` interpolated the Sass value of the outer radius, so the emitted token was `calc(var(--cui-radius-7) - var(--cui-border-width))`. Overriding `--cui-card-border-radius` (or `--cui-card-border-width`) at runtime left the header, footer and image corners on the compiled value.

## Change

The inner radius reads the component's own tokens:

```css
--cui-card-inner-border-radius: calc(var(--cui-card-border-radius) - var(--cui-card-border-width));
```

Same shape for popover, modal and dropdown. Accordion and toast already compute theirs this way.

## Verification

- `npm run css-compile`, sorted-CSS diff before/after: exactly the four token declarations change.
- `stylelint` on the four files: clean.
- Pre-push gate (lint, build, bundlewatch, tests): green.

v5 shares the defect (plus accordion); recorded in the workspace backport register.
