### PR TITLE
chore(card): drop the narrative comment above the title stretch rule

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -124,8 +124,6 @@ $card-tokens: defaults(
     }
   }
 
-  // The body aligns its children to the start so a button keeps its own width;
-  // text has to opt back into the full column.
   .card-title,
   .card-subtitle,
   .card-text {


### PR DESCRIPTION
The rule stays. `.card-body` aligns children to the start so a button keeps its own width; measured in Chromium, a `.card-title` without `align-self: stretch` shrinks to its text (49 px instead of 326 px in a 400 px card), which breaks `.text-center`, `.text-end` and any background on `.card-title` / `.card-text`. Upstream removed the rule in `ed9529bf`; we keep it and only cut the two-line comment. No CSS output changes.
