### PR TITLE
refactor(scss): share the dialog header, title, body and footer rules

### DIFF
--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -3,6 +3,7 @@
 @use "mixins/backdrop" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/box-shadow" as *;
+@use "mixins/dialog-shared" as *;
 @use "layout/breakpoints" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
@@ -241,10 +242,7 @@ $dialog-tokens: defaults(
 
   // Dialog header
   .dialog-header {
-    display: flex;
-    flex-shrink: 0;
-    align-items: center;
-    padding: var(--#{$prefix}dialog-header-padding);
+    @include dialog-header(var(--#{$prefix}dialog-header-padding));
     border-block-end: var(--#{$prefix}dialog-header-border-width) solid var(--#{$prefix}dialog-header-border-color);
 
     .btn-close {
@@ -254,26 +252,17 @@ $dialog-tokens: defaults(
 
   // Dialog title
   .dialog-title {
-    margin-bottom: 0;
-    line-height: var(--#{$prefix}dialog-title-line-height);
+    @include dialog-title(var(--#{$prefix}dialog-title-line-height));
   }
 
   // Dialog body
   .dialog-body {
     position: relative;
-    flex: 1 1 auto;
-    padding: var(--#{$prefix}dialog-padding);
+    @include dialog-body(var(--#{$prefix}dialog-padding));
   }
 
   // Dialog footer
   .dialog-footer {
-    display: flex;
-    flex-shrink: 0;
-    flex-wrap: wrap;
-    gap: var(--#{$prefix}dialog-footer-gap);
-    align-items: center;
-    justify-content: flex-end;
-    padding: var(--#{$prefix}dialog-footer-padding);
-    border-block-start: var(--#{$prefix}dialog-footer-border-width) solid var(--#{$prefix}dialog-footer-border-color);
+    @include dialog-footer(var(--#{$prefix}dialog-footer-padding), var(--#{$prefix}dialog-footer-gap), var(--#{$prefix}dialog-footer-border-width), var(--#{$prefix}dialog-footer-border-color));
   }
 }

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -3,6 +3,7 @@
 @use "mixins/backdrop" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/box-shadow" as *;
+@use "mixins/dialog-shared" as *;
 @use "layout/breakpoints" as *;
 @use "mixins/ltr-rtl" as *;
 @use "mixins/tokens" as *;
@@ -293,10 +294,7 @@ $drawer-tokens: defaults(
   }
 
   .drawer-header {
-    display: flex;
-    flex-shrink: 0;
-    align-items: center;
-    padding: var(--#{$prefix}drawer-padding-y) var(--#{$prefix}drawer-padding-x);
+    @include dialog-header(var(--#{$prefix}drawer-padding-y) var(--#{$prefix}drawer-padding-x));
 
     .btn-close {
       margin-block: calc(-.5 * var(--#{$prefix}drawer-padding-y));
@@ -305,8 +303,7 @@ $drawer-tokens: defaults(
   }
 
   .drawer-title {
-    margin-bottom: 0;
-    line-height: var(--#{$prefix}drawer-title-line-height);
+    @include dialog-title(var(--#{$prefix}drawer-title-line-height));
   }
 
   .drawer-body {
@@ -314,22 +311,14 @@ $drawer-tokens: defaults(
     // the body instead of being clipped by the drawer's overflow.
     position: relative;
     display: flex;
-    flex: 1 1 auto;
     flex-direction: column;
     gap: var(--#{$prefix}drawer-padding-y);
+    @include dialog-body(var(--#{$prefix}drawer-padding-y) var(--#{$prefix}drawer-padding-x));
     min-height: 0; // allow the body to shrink for inner scrolling
-    padding: var(--#{$prefix}drawer-padding-y) var(--#{$prefix}drawer-padding-x);
     overflow-y: auto;
   }
 
   .drawer-footer {
-    display: flex;
-    flex-shrink: 0;
-    flex-wrap: wrap;
-    gap: .5rem;
-    align-items: center;
-    justify-content: flex-end;
-    padding: var(--#{$prefix}drawer-padding-y) var(--#{$prefix}drawer-padding-x);
-    border-block-start: var(--#{$prefix}drawer-border-width) solid var(--#{$prefix}drawer-border-color);
+    @include dialog-footer(var(--#{$prefix}drawer-padding-y) var(--#{$prefix}drawer-padding-x), .5rem, var(--#{$prefix}drawer-border-width), var(--#{$prefix}drawer-border-color));
   }
 }

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -2,6 +2,7 @@
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/box-shadow" as *;
+@use "mixins/dialog-shared" as *;
 @use "layout/breakpoints" as *;
 @use "mixins/tokens" as *;
 @use "mixins/transition" as *;
@@ -204,10 +205,7 @@ $modal-tokens: defaults(
   }
 
   .modal-header {
-    display: flex;
-    flex-shrink: 0;
-    align-items: center;
-    padding: var(--#{$prefix}modal-header-padding);
+    @include dialog-header(var(--#{$prefix}modal-header-padding));
     border-block-end: var(--#{$prefix}modal-header-border-width) solid var(--#{$prefix}modal-header-border-color);
     @include border-top-radius(var(--#{$prefix}modal-inner-border-radius));
 
@@ -221,26 +219,17 @@ $modal-tokens: defaults(
   }
 
   .modal-title {
-    margin-bottom: 0;
-    line-height: var(--#{$prefix}modal-title-line-height);
+    @include dialog-title(var(--#{$prefix}modal-title-line-height));
   }
 
   .modal-body {
     position: relative;
-    flex: 1 1 auto;
-    padding: var(--#{$prefix}modal-padding);
+    @include dialog-body(var(--#{$prefix}modal-padding));
   }
 
   .modal-footer {
-    display: flex;
-    flex-shrink: 0;
-    flex-wrap: wrap;
-    gap: var(--#{$prefix}modal-footer-gap);
-    align-items: center; // vertically center
-    justify-content: flex-end; // Right align buttons with flex property because text-align doesn't work on flex items
-    padding: var(--#{$prefix}modal-padding);
+    @include dialog-footer(var(--#{$prefix}modal-padding), var(--#{$prefix}modal-footer-gap), var(--#{$prefix}modal-footer-border-width), var(--#{$prefix}modal-footer-border-color));
     background-color: var(--#{$prefix}modal-footer-bg, transparent);
-    border-block-start: var(--#{$prefix}modal-footer-border-width) solid var(--#{$prefix}modal-footer-border-color);
     @include border-bottom-radius(var(--#{$prefix}modal-inner-border-radius));
   }
 

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -1,6 +1,7 @@
 @use "sass:map";
 @use "functions/defaults" as *;
 @use "mixins/box-shadow" as *;
+@use "mixins/dialog-shared" as *;
 @use "layout/breakpoints" as *;
 @use "mixins/ltr-rtl" as *;
 @use "mixins/tokens" as *;
@@ -230,10 +231,7 @@ $offcanvas-tokens: defaults(
   }
 
   .offcanvas-header {
-    display: flex;
-    flex-shrink: 0;
-    align-items: center;
-    padding: var(--#{$prefix}offcanvas-padding-y) var(--#{$prefix}offcanvas-padding-x);
+    @include dialog-header(var(--#{$prefix}offcanvas-padding-y) var(--#{$prefix}offcanvas-padding-x));
 
     .btn-close {
       padding: calc(var(--#{$prefix}offcanvas-padding-y) * .5) calc(var(--#{$prefix}offcanvas-padding-x) * .5);
@@ -245,14 +243,12 @@ $offcanvas-tokens: defaults(
   }
 
   .offcanvas-title {
-    margin-bottom: 0;
-    line-height: var(--#{$prefix}offcanvas-title-line-height);
+    @include dialog-title(var(--#{$prefix}offcanvas-title-line-height));
   }
 
   .offcanvas-body {
     position: relative;
-    flex-grow: 1;
-    padding: var(--#{$prefix}offcanvas-padding-y) var(--#{$prefix}offcanvas-padding-x);
+    @include dialog-body(var(--#{$prefix}offcanvas-padding-y) var(--#{$prefix}offcanvas-padding-x));
     overflow-y: auto;
   }
 }

--- a/scss/mixins/_dialog-shared.scss
+++ b/scss/mixins/_dialog-shared.scss
@@ -1,0 +1,35 @@
+// Shared mixins for Dialog and Drawer sub-components.
+// Both components use identical header/footer/body/title patterns
+// with different token namespaces.
+
+// Header: flex row with close button alignment
+@mixin dialog-header($padding) {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  padding: $padding;
+}
+
+// Footer: flex row with end-aligned actions
+@mixin dialog-footer($padding, $gap, $border-width, $border-color) {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  gap: $gap;
+  align-items: center;
+  justify-content: flex-end;
+  padding: $padding;
+  border-block-start: $border-width solid $border-color;
+}
+
+// Body: flexible scrollable content area
+@mixin dialog-body($padding) {
+  flex: 1 1 auto;
+  padding: $padding;
+}
+
+// Title: reset margin, set line-height
+@mixin dialog-title($line-height: 1.25) {
+  margin-bottom: 0;
+  line-height: $line-height;
+}

--- a/scss/mixins/index.scss
+++ b/scss/mixins/index.scss
@@ -23,6 +23,7 @@
 @forward "backdrop";
 @forward "caret";
 @forward "chip";
+@forward "dialog-shared";
 @forward "form-control";
 @forward "form-validation";
 @forward "icon";


### PR DESCRIPTION
Dialog, drawer, modal and offcanvas each carried the same flex-row header, margin-less title, growing body and end-aligned footer. The four blocks now come from `mixins/_dialog-shared.scss` (`dialog-header`, `dialog-title`, `dialog-body`, `dialog-footer`); each component adds only what is its own (dialog header border, modal footer background and inner radius, drawer column layout and scrolling).

Compiled CSS: `.offcanvas-body` reads `flex: 1 1 auto` instead of the equivalent `flex-grow: 1`; the sorted diff shows nothing else. `stylelint`, `css-test` and the pre-push gate are green.