### PR TITLE
fix(theme): merge $theme-colors through defaults() and test the @use with() surface

### DIFF
--- a/docs/src/content/docs/customize/color-modes.mdx
+++ b/docs/src/content/docs/customize/color-modes.mdx
@@ -237,23 +237,20 @@ A theme color is one entry in the `$theme-colors` map — a map of slots coverin
 <Callout color="info"><Fragment set:html={`<p> <strong>Heads up!</strong> Reach our Sass with <code>@use</code>. The <code>*.import.scss</code> files that let <code>@import</code> resolve our modules are gone, so the snippet below will not compile behind an <code>@import</code>. </p>`} /></Callout>
 
 ```scss
-@use "sass:map";
-@use "@coreui/coreui/scss/theme" as *;
-
-$theme-colors: map.merge($theme-colors, (
-  "custom-color": (
-    "base":          #712cf9,
-    "contrast":      #fff,
-    "fg":            light-dark(var(--cui-custom-color-600), var(--cui-custom-color-400)),
-    "fg-emphasis": light-dark(var(--cui-custom-color-800), var(--cui-custom-color-200)),
-    "bg-subtle":     light-dark(var(--cui-custom-color-100), var(--cui-custom-color-900)),
-    "bg-muted":      light-dark(var(--cui-custom-color-200), var(--cui-custom-color-800)),
-    "border-subtle": light-dark(var(--cui-custom-color-300), var(--cui-custom-color-600)),
-    "focus-ring":    color-mix(in srgb, var(--cui-custom-color) calc(var(--cui-focus-ring-opacity) * 100%), transparent),
-  ),
-));
-
-@use "@coreui/coreui/scss/coreui";
+@use "@coreui/coreui/scss/coreui" with (
+  $theme-colors: (
+    "custom-color": (
+      "base":        #712cf9,
+      "contrast":    #fff,
+      "fg":          light-dark(var(--cui-custom-color-600), var(--cui-custom-color-400)),
+      "fg-emphasis": light-dark(var(--cui-custom-color-800), var(--cui-custom-color-200)),
+      "bg-subtle":   light-dark(var(--cui-custom-color-100), var(--cui-custom-color-900)),
+      "bg-muted":    light-dark(var(--cui-custom-color-200), var(--cui-custom-color-800)),
+      "border":      light-dark(var(--cui-custom-color-300), var(--cui-custom-color-600)),
+      "focus-ring":  color-mix(in srgb, var(--cui-custom-color-base) calc(var(--cui-focus-ring-opacity) * 100%), transparent),
+    ),
+  )
+);
 ```
 
 The slots are `light-dark()` pairs of the runtime scale, so both color modes are covered by the one entry — there is no second, dark set of maps to fill in.

--- a/docs/src/content/docs/customize/sass.mdx
+++ b/docs/src/content/docs/customize/sass.mdx
@@ -183,45 +183,38 @@ $theme-colors: (
 
 ### Add to map
 
-Add new colors to `$theme-colors`, or any other map, by creating a new Sass map with your custom values and merging it with the original map. In this case, we'll create a new `$custom-colors` map and merge it with `$theme-colors`. A theme colour entry is a map of slots: give the new colour a `base` and a `contrast`, and point the remaining slots at the 100–900 scale the library mixes from the base at runtime, the same way the built-in colours do.
+Add new colors to `$theme-colors`, or any other map, through `with ()`: `defaults()` merges your entries on top of the built-ins, so you pass only what you add. A theme colour entry is a map of slots: give the new colour a `base` and a `contrast`, and point the remaining slots at the 100–900 scale the library mixes from the base at runtime, the same way the built-in colours do.
 
 ```scss
-@use "sass:map";
-@use "@coreui/coreui/scss/theme" as *;
-
-$custom-colors: (
-  "custom-color": (
-    "base":          #900,
-    "contrast":      #fff,
-    "fg":            light-dark(var(--cui-custom-color-600), var(--cui-custom-color-400)),
-    "fg-emphasis": light-dark(var(--cui-custom-color-800), var(--cui-custom-color-200)),
-    "bg-subtle":     light-dark(var(--cui-custom-color-100), var(--cui-custom-color-900)),
-    "bg-muted":      light-dark(var(--cui-custom-color-200), var(--cui-custom-color-800)),
-    "border-subtle": light-dark(var(--cui-custom-color-300), var(--cui-custom-color-600)),
-    "focus-ring":    color-mix(in srgb, var(--cui-custom-color) calc(var(--cui-focus-ring-opacity) * 100%), transparent),
-  ),
+@use "@coreui/coreui/scss/coreui" with (
+  $theme-colors: (
+    "custom-color": (
+      "base":        #900,
+      "contrast":    #fff,
+      "fg":          light-dark(var(--cui-custom-color-600), var(--cui-custom-color-400)),
+      "fg-emphasis": light-dark(var(--cui-custom-color-800), var(--cui-custom-color-200)),
+      "bg-subtle":   light-dark(var(--cui-custom-color-100), var(--cui-custom-color-900)),
+      "bg-muted":    light-dark(var(--cui-custom-color-200), var(--cui-custom-color-800)),
+      "border":      light-dark(var(--cui-custom-color-300), var(--cui-custom-color-600)),
+      "focus-ring":  color-mix(in srgb, var(--cui-custom-color-base) calc(var(--cui-focus-ring-opacity) * 100%), transparent),
+    ),
+  )
 );
-
-$theme-colors: map.merge($theme-colors, $custom-colors);
-
-@use "@coreui/coreui/scss/coreui";
 ```
+
+The merge is one level deep: to change one slot of a built-in colour, pass that colour's whole sub-map.
 
 ### Remove from map
 
-To remove colors from `$theme-colors`, or any other map, use `map-remove`. Be aware you must insert it between our requirements and options:
+To remove colors from `$theme-colors`, or any other map, set the key to `null` — `defaults()` drops it from the output, and the derived `$theme-colors-*` families follow, because they are read from the merged map:
 
 ```scss
-@use "sass:map";
-@use "@coreui/coreui/scss/theme" as *;
-
-$theme-colors: map-remove($theme-colors, "info", "light", "dark");
-$theme-colors-border: map.remove($theme-colors-border, "info", "light", "dark");
-
-@use "@coreui/coreui/scss/coreui";
+@use "@coreui/coreui/scss/coreui" with (
+  $theme-colors: (
+    "info": null,
+  )
+);
 ```
-
-The `$theme-colors-*` families are derived from `$theme-colors` when the theme module first loads, so a later reassignment of the main map doesn't reach them — remove the keys from each derived map you use, as above.
 
 ### Size maps
 

--- a/docs/src/content/docs/customize/theme.mdx
+++ b/docs/src/content/docs/customize/theme.mdx
@@ -100,24 +100,23 @@ Because the tokens are ordinary custom properties, they inherit: put a `.theme-*
 A new theme color is one entry in the map. Point the slots at the runtime scale and the library generates the tokens, the scale, and the `.theme-*` class for it:
 
 ```scss
-@use "sass:map";
-@use "@coreui/coreui/scss/theme" as *;
-
-$theme-colors: map.merge($theme-colors, (
-  "brand": (
-    "base":        #6f42c1,
-    "contrast":    #fff,
-    "fg":          light-dark(var(--cui-brand-600), var(--cui-brand-400)),
-    "fg-emphasis": light-dark(var(--cui-brand-800), var(--cui-brand-200)),
-    "bg-subtle":   light-dark(var(--cui-brand-100), var(--cui-brand-900)),
-    "bg-muted":    light-dark(var(--cui-brand-200), var(--cui-brand-800)),
-    "border":      light-dark(var(--cui-brand-300), var(--cui-brand-600)),
-    "focus-ring":  color-mix(in srgb, var(--cui-brand) calc(var(--cui-focus-ring-opacity) * 100%), transparent),
-  ),
-));
-
-@use "@coreui/coreui/scss/coreui";
+@use "@coreui/coreui/scss/coreui" with (
+  $theme-colors: (
+    "brand": (
+      "base":        #6f42c1,
+      "contrast":    #fff,
+      "fg":          light-dark(var(--cui-brand-600), var(--cui-brand-400)),
+      "fg-emphasis": light-dark(var(--cui-brand-800), var(--cui-brand-200)),
+      "bg-subtle":   light-dark(var(--cui-brand-100), var(--cui-brand-900)),
+      "bg-muted":    light-dark(var(--cui-brand-200), var(--cui-brand-800)),
+      "border":      light-dark(var(--cui-brand-300), var(--cui-brand-600)),
+      "focus-ring":  color-mix(in srgb, var(--cui-brand-base) calc(var(--cui-focus-ring-opacity) * 100%), transparent),
+    ),
+  )
+);
 ```
+
+Each theme color is a nested map and the merge is one level deep: pass the whole sub-map to change a built-in color, and set a color to `null` to remove it.
 
 For a runtime-only brand — no Sass compilation — set the generic tokens on a container instead, as shown in [the theme variants section](/customize/components/#theme-variants).
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -2717,10 +2717,21 @@ editing four blocks. It is a map of maps now — one name, eight slots.
 
   ```diff
   - $success-bg-subtle: #e8f5ec;
-  + $theme-colors: map.merge($theme-colors, (
-  +   "success": map.merge(map.get($theme-colors, "success"), ("bg-subtle": #e8f5ec))
-  + ));
+  + @use "@coreui/coreui/scss/coreui" with (
+  +   $theme-colors: (
+  +     "success": (
+  +       "base": $success,
+  +       "bg-subtle": #e8f5ec,
+  +       // …the remaining slots of the built-in entry
+  +     ),
+  +   )
+  + );
   ```
+
+  The map merges one level deep, so a built-in colour is replaced as a whole:
+  copy its sub-map from `scss/_theme.scss` and change the slot. `$theme-colors`
+  goes through `defaults()` like every other configuration map, so a new colour
+  is one entry passed through `with ()` and `null` removes one.
 
   Every `--cui-{color}-*` custom property keeps its name and its value, so
   a runtime override is unaffected.

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -23,78 +23,83 @@ $link-color:    light-dark(var(--#{$prefix}primary-base), var(--#{$prefix}primar
 
 
 // scss-docs-start theme-colors-map
-$theme-colors: (
-  "primary": (
-    "base":          $primary,
-    "contrast":      var(--#{$prefix}white),
-    "fg":            light-dark(var(--#{$prefix}primary-600), var(--#{$prefix}primary-400)),
-    "fg-emphasis":   light-dark(var(--#{$prefix}primary-800), var(--#{$prefix}primary-200)),
-    "bg-subtle":     light-dark(var(--#{$prefix}primary-100), var(--#{$prefix}primary-900)),
-    "bg-muted":      light-dark(var(--#{$prefix}primary-200), var(--#{$prefix}primary-800)),
-    "border":        light-dark(var(--#{$prefix}primary-300), var(--#{$prefix}primary-600)),
-    "focus-ring":    color-mix(in srgb, var(--#{$prefix}primary-base) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+$theme-colors: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$theme-colors: defaults(
+  (
+    "primary": (
+      "base":          $primary,
+      "contrast":      var(--#{$prefix}white),
+      "fg":            light-dark(var(--#{$prefix}primary-600), var(--#{$prefix}primary-400)),
+      "fg-emphasis":   light-dark(var(--#{$prefix}primary-800), var(--#{$prefix}primary-200)),
+      "bg-subtle":     light-dark(var(--#{$prefix}primary-100), var(--#{$prefix}primary-900)),
+      "bg-muted":      light-dark(var(--#{$prefix}primary-200), var(--#{$prefix}primary-800)),
+      "border":        light-dark(var(--#{$prefix}primary-300), var(--#{$prefix}primary-600)),
+      "focus-ring":    color-mix(in srgb, var(--#{$prefix}primary-base) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+    ),
+    "secondary": (
+      "base":          $secondary,
+      "contrast":      light-dark(var(--#{$prefix}gray-900), var(--#{$prefix}white)),
+      "fg":            light-dark(var(--#{$prefix}gray-600), var(--#{$prefix}gray-400)),
+      "fg-emphasis":   light-dark(var(--#{$prefix}gray-800), var(--#{$prefix}gray-200)),
+      "bg-subtle":     light-dark(var(--#{$prefix}gray-025), var(--#{$prefix}gray-800)),
+      "bg-muted":      light-dark(var(--#{$prefix}gray-050), var(--#{$prefix}gray-700)),
+      "border":        light-dark(var(--#{$prefix}gray-300), var(--#{$prefix}gray-600)),
+      "focus-ring":    color-mix(in srgb, light-dark(var(--#{$prefix}gray-500), var(--#{$prefix}gray-300)) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+    ),
+    "success": (
+      "base":          $success,
+      "contrast":      var(--#{$prefix}black),
+      "fg":            light-dark(var(--#{$prefix}success-600), var(--#{$prefix}success-400)),
+      "fg-emphasis":   light-dark(var(--#{$prefix}success-800), var(--#{$prefix}success-200)),
+      "bg-subtle":     light-dark(var(--#{$prefix}success-100), var(--#{$prefix}success-900)),
+      "bg-muted":      light-dark(var(--#{$prefix}success-200), var(--#{$prefix}success-800)),
+      "border":        light-dark(var(--#{$prefix}success-300), var(--#{$prefix}success-600)),
+      "focus-ring":    color-mix(in srgb, var(--#{$prefix}success-base) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+    ),
+    "info": (
+      "base":          $info,
+      "contrast":      var(--#{$prefix}black),
+      "fg":            light-dark(var(--#{$prefix}info-700), var(--#{$prefix}info-300)),
+      "fg-emphasis":   light-dark(var(--#{$prefix}info-800), var(--#{$prefix}info-200)),
+      "bg-subtle":     light-dark(var(--#{$prefix}info-100), var(--#{$prefix}info-900)),
+      "bg-muted":      light-dark(var(--#{$prefix}info-200), var(--#{$prefix}info-800)),
+      "border":        light-dark(var(--#{$prefix}info-300), var(--#{$prefix}info-600)),
+      "focus-ring":    color-mix(in srgb, var(--#{$prefix}info-base) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+    ),
+    "warning": (
+      "base":          $warning,
+      "contrast":      var(--#{$prefix}black),
+      "fg":            light-dark(var(--#{$prefix}warning-700), var(--#{$prefix}warning-300)),
+      "fg-emphasis":   light-dark(var(--#{$prefix}warning-800), var(--#{$prefix}warning-200)),
+      "bg-subtle":     light-dark(var(--#{$prefix}warning-100), var(--#{$prefix}warning-900)),
+      "bg-muted":      light-dark(var(--#{$prefix}warning-200), var(--#{$prefix}warning-800)),
+      "border":        light-dark(var(--#{$prefix}warning-300), var(--#{$prefix}warning-600)),
+      "focus-ring":    color-mix(in srgb, var(--#{$prefix}warning-base) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+    ),
+    "danger": (
+      "base":          $danger,
+      "contrast":      var(--#{$prefix}black),
+      "fg":            light-dark(var(--#{$prefix}danger-600), var(--#{$prefix}danger-400)),
+      "fg-emphasis":   light-dark(var(--#{$prefix}danger-800), var(--#{$prefix}danger-200)),
+      "bg-subtle":     light-dark(var(--#{$prefix}danger-100), var(--#{$prefix}danger-900)),
+      "bg-muted":      light-dark(var(--#{$prefix}danger-200), var(--#{$prefix}danger-800)),
+      "border":        light-dark(var(--#{$prefix}danger-300), var(--#{$prefix}danger-600)),
+      "focus-ring":    color-mix(in srgb, var(--#{$prefix}danger-base) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+    ),
+    "inverse": (
+      "base":          $inverse,
+      "contrast":      light-dark(var(--#{$prefix}white), var(--#{$prefix}gray-900)),
+      "fg":            light-dark(var(--#{$prefix}gray-900), var(--#{$prefix}gray-200)),
+      "fg-emphasis":   light-dark(var(--#{$prefix}black), var(--#{$prefix}white)),
+      "bg-subtle":     light-dark(var(--#{$prefix}gray-100), var(--#{$prefix}gray-900)),
+      "bg-muted":      light-dark(var(--#{$prefix}gray-200), var(--#{$prefix}gray-700)),
+      "border":        light-dark(var(--#{$prefix}gray-400), var(--#{$prefix}gray-600)),
+      "focus-ring":    color-mix(in srgb, light-dark(var(--#{$prefix}gray-900), var(--#{$prefix}gray-100)) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
+    ),
   ),
-  "secondary": (
-    "base":          $secondary,
-    "contrast":      light-dark(var(--#{$prefix}gray-900), var(--#{$prefix}white)),
-    "fg":            light-dark(var(--#{$prefix}gray-600), var(--#{$prefix}gray-400)),
-    "fg-emphasis":   light-dark(var(--#{$prefix}gray-800), var(--#{$prefix}gray-200)),
-    "bg-subtle":     light-dark(var(--#{$prefix}gray-025), var(--#{$prefix}gray-800)),
-    "bg-muted":      light-dark(var(--#{$prefix}gray-050), var(--#{$prefix}gray-700)),
-    "border":        light-dark(var(--#{$prefix}gray-300), var(--#{$prefix}gray-600)),
-    "focus-ring":    color-mix(in srgb, light-dark(var(--#{$prefix}gray-500), var(--#{$prefix}gray-300)) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
-  ),
-  "success": (
-    "base":          $success,
-    "contrast":      var(--#{$prefix}black),
-    "fg":            light-dark(var(--#{$prefix}success-600), var(--#{$prefix}success-400)),
-    "fg-emphasis":   light-dark(var(--#{$prefix}success-800), var(--#{$prefix}success-200)),
-    "bg-subtle":     light-dark(var(--#{$prefix}success-100), var(--#{$prefix}success-900)),
-    "bg-muted":      light-dark(var(--#{$prefix}success-200), var(--#{$prefix}success-800)),
-    "border":        light-dark(var(--#{$prefix}success-300), var(--#{$prefix}success-600)),
-    "focus-ring":    color-mix(in srgb, var(--#{$prefix}success-base) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
-  ),
-  "info": (
-    "base":          $info,
-    "contrast":      var(--#{$prefix}black),
-    "fg":            light-dark(var(--#{$prefix}info-700), var(--#{$prefix}info-300)),
-    "fg-emphasis":   light-dark(var(--#{$prefix}info-800), var(--#{$prefix}info-200)),
-    "bg-subtle":     light-dark(var(--#{$prefix}info-100), var(--#{$prefix}info-900)),
-    "bg-muted":      light-dark(var(--#{$prefix}info-200), var(--#{$prefix}info-800)),
-    "border":        light-dark(var(--#{$prefix}info-300), var(--#{$prefix}info-600)),
-    "focus-ring":    color-mix(in srgb, var(--#{$prefix}info-base) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
-  ),
-  "warning": (
-    "base":          $warning,
-    "contrast":      var(--#{$prefix}black),
-    "fg":            light-dark(var(--#{$prefix}warning-700), var(--#{$prefix}warning-300)),
-    "fg-emphasis":   light-dark(var(--#{$prefix}warning-800), var(--#{$prefix}warning-200)),
-    "bg-subtle":     light-dark(var(--#{$prefix}warning-100), var(--#{$prefix}warning-900)),
-    "bg-muted":      light-dark(var(--#{$prefix}warning-200), var(--#{$prefix}warning-800)),
-    "border":        light-dark(var(--#{$prefix}warning-300), var(--#{$prefix}warning-600)),
-    "focus-ring":    color-mix(in srgb, var(--#{$prefix}warning-base) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
-  ),
-  "danger": (
-    "base":          $danger,
-    "contrast":      var(--#{$prefix}black),
-    "fg":            light-dark(var(--#{$prefix}danger-600), var(--#{$prefix}danger-400)),
-    "fg-emphasis":   light-dark(var(--#{$prefix}danger-800), var(--#{$prefix}danger-200)),
-    "bg-subtle":     light-dark(var(--#{$prefix}danger-100), var(--#{$prefix}danger-900)),
-    "bg-muted":      light-dark(var(--#{$prefix}danger-200), var(--#{$prefix}danger-800)),
-    "border":        light-dark(var(--#{$prefix}danger-300), var(--#{$prefix}danger-600)),
-    "focus-ring":    color-mix(in srgb, var(--#{$prefix}danger-base) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
-  ),
-  "inverse": (
-    "base":          $inverse,
-    "contrast":      light-dark(var(--#{$prefix}white), var(--#{$prefix}gray-900)),
-    "fg":            light-dark(var(--#{$prefix}gray-900), var(--#{$prefix}gray-200)),
-    "fg-emphasis":   light-dark(var(--#{$prefix}black), var(--#{$prefix}white)),
-    "bg-subtle":     light-dark(var(--#{$prefix}gray-100), var(--#{$prefix}gray-900)),
-    "bg-muted":      light-dark(var(--#{$prefix}gray-200), var(--#{$prefix}gray-700)),
-    "border":        light-dark(var(--#{$prefix}gray-400), var(--#{$prefix}gray-600)),
-    "focus-ring":    color-mix(in srgb, light-dark(var(--#{$prefix}gray-900), var(--#{$prefix}gray-100)) calc(var(--#{$prefix}focus-ring-opacity) * 100%), transparent),
-  ),
-) !default;
+  $theme-colors
+);
 // scss-docs-end theme-colors-map
 
 // scss-docs-start theme-bgs-map
@@ -240,16 +245,21 @@ $theme-active-lightness:  .8 !default;
 // fill swaps ends between schemes, so one multiplier would darken a dark fill in
 // one scheme and wash out a light one in the other.
 // scss-docs-start theme-state-colors
-$theme-state-colors: (
-  "secondary": (
-    "hover":  light-dark(var(--#{$prefix}gray-200), var(--#{$prefix}gray-700)),
-    "active": light-dark(var(--#{$prefix}gray-300), var(--#{$prefix}gray-800))
+$theme-state-colors: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$theme-state-colors: defaults(
+  (
+    "secondary": (
+      "hover":  light-dark(var(--#{$prefix}gray-200), var(--#{$prefix}gray-700)),
+      "active": light-dark(var(--#{$prefix}gray-300), var(--#{$prefix}gray-800))
+    ),
+    "inverse": (
+      "hover":  light-dark(var(--#{$prefix}gray-800), var(--#{$prefix}gray-200)),
+      "active": light-dark(var(--#{$prefix}gray-700), var(--#{$prefix}gray-300))
+    )
   ),
-  "inverse": (
-    "hover":  light-dark(var(--#{$prefix}gray-800), var(--#{$prefix}gray-200)),
-    "active": light-dark(var(--#{$prefix}gray-700), var(--#{$prefix}gray-300))
-  )
-) !default;
+  $theme-state-colors
+);
 // scss-docs-end theme-state-colors
 
 @mixin theme-tokens($state) {

--- a/scss/tests/forms/_validation.test.scss
+++ b/scss/tests/forms/_validation.test.scss
@@ -1,0 +1,77 @@
+@use "../../mixins/form-validation" as *;
+
+@include describe("form-validation-state-selector") {
+
+  @include it("invalid: gates :user-invalid behind [data-coreui-validate] and keeps .is-invalid global") {
+    @include assert() {
+      @include output() {
+        .form-control {
+          @include form-validation-state-selector("invalid") {
+            border-color: #d00;
+          }
+        }
+      }
+      @include expect() {
+        @at-root [data-coreui-validate] #{&} .form-control:user-invalid,
+        #{&} .form-control.is-invalid {
+          border-color: #d00;
+        }
+      }
+    }
+  }
+
+  @include it("valid: gates :user-valid behind [data-coreui-validate~=valid] and keeps .is-valid global") {
+    @include assert() {
+      @include output() {
+        .form-control {
+          @include form-validation-state-selector("valid") {
+            border-color: #0d0;
+          }
+        }
+      }
+      @include expect() {
+        @at-root [data-coreui-validate~="valid"] #{&} .form-control:user-valid,
+        #{&} .form-control.is-valid {
+          border-color: #0d0;
+        }
+      }
+    }
+  }
+
+  @include it("custom state (warning): only .is-warning, no :user-*") {
+    @include assert() {
+      @include output() {
+        .form-control {
+          @include form-validation-state-selector("warning") {
+            border-color: #f80;
+          }
+        }
+      }
+      @include expect() {
+        .form-control.is-warning {
+          border-color: #f80;
+        }
+      }
+    }
+  }
+
+  @include it("sibling combinator works for feedback display") {
+    @include assert() {
+      @include output() {
+        .form-control {
+          @include form-validation-state-selector("invalid") {
+            ~ .invalid-feedback {
+              display: block;
+            }
+          }
+        }
+      }
+      @include expect() {
+        @at-root [data-coreui-validate] #{&} .form-control:user-invalid ~ .invalid-feedback,
+        #{&} .form-control.is-invalid ~ .invalid-feedback {
+          display: block;
+        }
+      }
+    }
+  }
+}

--- a/scss/tests/modules/_config-maps.test.scss
+++ b/scss/tests/modules/_config-maps.test.scss
@@ -1,0 +1,45 @@
+@use "sass:map";
+
+// Configure global config maps through the entrypoint. This checks that
+// `defaults()` merges overrides on top of the built-ins instead of replacing
+// the whole map.
+@use "../../coreui" as * with (
+  $spacers: (
+    "custom": 4rem,
+  ),
+  $badge-variants: (
+    "brand": (
+      "color": "contrast",
+      "bg": "bg",
+      "border-color": "transparent"
+    ),
+  )
+);
+
+$true-terminal-output: false;
+
+@include describe("Config map configuration") {
+  @include describe("@use coreui with config maps") {
+    @include it("should add a custom spacer and keep the built-ins") {
+      @include assert-true(
+        map.has-key($spacers, "custom"),
+        "The custom spacer should be configurable via @use ... with"
+      );
+      @include assert-true(
+        map.has-key($spacers, 3),
+        "Adding a spacer must not drop the built-in spacers"
+      );
+    }
+
+    @include it("should add a custom badge variant and keep the built-ins") {
+      @include assert-true(
+        map.has-key($badge-variants, "brand"),
+        "The custom badge variant should merge on top of the built-ins"
+      );
+      @include assert-true(
+        map.has-key($badge-variants, "subtle"),
+        "Adding a variant must not drop the built-in badge variants"
+      );
+    }
+  }
+}

--- a/scss/tests/modules/_configuration.test.scss
+++ b/scss/tests/modules/_configuration.test.scss
@@ -1,0 +1,56 @@
+@use "sass:map";
+
+// Test @use with token map configuration syntax using a single module instance
+@use "../../alert" as * with (
+  $alert-tokens: (
+    --cui-alert-gap: .75rem,
+    --cui-alert-padding-x: 1rem,
+    --cui-alert-padding-y: 1rem,
+    --cui-alert-border-radius: var(--cui-radius-2),
+    --cui-alert-link-color: #0a58ca,
+  )
+);
+
+$true-terminal-output: false;
+
+@include describe("CoreUI module configuration") {
+  @include describe("@use with configuration syntax") {
+    @include it("should allow configuring alert tokens with @use ... with") {
+      @include assert() {
+        @include output() {
+          .test {
+            color: map.get($alert-tokens, --cui-alert-link-color);
+          }
+        }
+
+        @include expect() {
+          .test {
+            color: #0a58ca;
+          }
+        }
+      }
+    }
+
+    @include it("should maintain other alert tokens with configured values") {
+      @include assert() {
+        @include output() {
+          .test {
+            padding-y: map.get($alert-tokens, --cui-alert-padding-y);
+            padding-x: map.get($alert-tokens, --cui-alert-padding-x);
+            // stylelint-disable-next-line property-disallowed-list
+            border-radius: map.get($alert-tokens, --cui-alert-border-radius);
+          }
+        }
+
+        @include expect() {
+          .test {
+            padding-y: 1rem;
+            padding-x: 1rem;
+            // stylelint-disable-next-line property-disallowed-list
+            border-radius: var(--cui-radius-2);
+          }
+        }
+      }
+    }
+  }
+}

--- a/scss/tests/modules/_root-tokens.test.scss
+++ b/scss/tests/modules/_root-tokens.test.scss
@@ -1,0 +1,73 @@
+@use "sass:map";
+
+// Test customizing root tokens via @use "root" with ($root-tokens: (...))
+@use "../../root" as * with (
+  $root-tokens: (
+    --cui-black: #111,
+    --cui-white: #fefefe,
+    --cui-brand-color: #f60,
+    --cui-custom-spacing: 1.5rem,
+  )
+);
+
+$true-terminal-output: false;
+
+@include describe("Root token customization") {
+  @include describe("@use with $root-tokens overrides") {
+    @include it("should override existing token values") {
+      @include assert() {
+        @include output() {
+          .test {
+            color: map.get($root-tokens, --cui-black);
+            background: map.get($root-tokens, --cui-white);
+          }
+        }
+
+        @include expect() {
+          .test {
+            color: #111;
+            background: #fefefe;
+          }
+        }
+      }
+    }
+
+    @include it("should include custom tokens added via configuration") {
+      @include assert() {
+        @include output() {
+          .test {
+            padding: map.get($root-tokens, --cui-custom-spacing);
+            color: map.get($root-tokens, --cui-brand-color);
+          }
+        }
+
+        @include expect() {
+          .test {
+            padding: 1.5rem;
+            color: #f60;
+          }
+        }
+      }
+    }
+
+    @include it("should still include dynamically generated theme tokens") {
+      @include assert() {
+        @include output() {
+          .test {
+            has-bg-body: #{map.has-key($root-tokens, --cui-bg-body)};
+            has-fg-body: #{map.has-key($root-tokens, --cui-fg-body)};
+            has-primary-bg: #{map.has-key($root-tokens, --cui-primary-bg)};
+          }
+        }
+
+        @include expect() {
+          .test {
+            has-bg-body: true;
+            has-fg-body: true;
+            has-primary-bg: true;
+          }
+        }
+      }
+    }
+  }
+}

--- a/scss/tests/modules/_theme-colors.test.scss
+++ b/scss/tests/modules/_theme-colors.test.scss
@@ -1,0 +1,54 @@
+@use "sass:map";
+
+// Configure a custom theme through the entrypoint. This fails if `coreui.scss`
+// does not forward the `theme` module or `$theme-colors` replaces the map
+// instead of merging into it.
+@use "../../coreui" as * with (
+  $theme-colors: (
+    "custom": (
+      "base": var(--cui-black),
+      "contrast": var(--cui-white),
+    ),
+  )
+);
+
+$true-terminal-output: false;
+
+@include describe("Theme color configuration") {
+  @include describe("@use coreui with $theme-colors") {
+    @include it("should add a custom theme through the entrypoint") {
+      @include assert-equal(
+        map.get(map.get($theme-colors, "custom"), "base"),
+        var(--cui-black),
+        "The custom theme base color should be configurable via @use ... with"
+      );
+    }
+
+    @include it("should merge custom themes on top of the built-ins") {
+      @include assert-true(
+        map.has-key($theme-colors, "primary"),
+        "Adding a theme must not drop the built-in primary theme"
+      );
+    }
+
+    @include it("should emit CSS custom properties for the custom theme") {
+      @include assert() {
+        @include output() {
+          .test {
+            base: map.get(theme-color-scale-tokens(), --cui-custom-base);
+            bg: map.get(theme-color-tokens(), --cui-custom-bg);
+            contrast: map.get(theme-color-tokens(), --cui-custom-contrast);
+          }
+        }
+
+        @include expect() {
+          .test {
+            base: var(--cui-black);
+            bg: var(--cui-custom-base);
+            contrast: var(--cui-white);
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`$theme-colors` and `$theme-state-colors` were plain `!default` maps, so `@use "coreui" with ($theme-colors: ("custom": (…)))` replaced the whole map: the custom colour compiled and `--cui-primary-base` and every other built-in vanished. The docs taught `map.merge($theme-colors, …)` between `@use "theme"` and `@use "coreui"`, which never took effect because `@use` rules are hoisted.

## Change

- Both maps go through `defaults()`: an entry adds, a full sub-map replaces one colour, `null` removes one. Compiled CSS is byte-identical.
- Theme, sass and color-modes pages (vanilla here; React PRO and Vue PRO in their own PRs) configure the map through `with ()`, use the `border` slot the map reads and the `-base` token in the focus ring; the migration snippet follows.
- Five sass-true suites ported from upstream `tests/modules` and `tests/forms`: alert tokens through `with ()`, custom spacer and badge variant on top of the built-ins, root token overrides and additions, a custom theme colour that keeps `primary`, and the validation selector gating `:user-*` behind `[data-coreui-validate]`.

## Verification

- Probe before: `@use "coreui" with ($theme-colors: ("custom": ("base": #000)))` emitted 0 `--cui-primary-base`; after: 1.
- `css-test`: 110 specs, 0 failures (was 96). `stylelint` on tests and `_theme.scss`: clean.
- Sorted-CSS diff: empty.
- Pre-push gate (lint, build, bundlewatch, tests): green.
