### PR TITLE
feat(scss)!: drop the breadcrumb bottom margin, round cards to radius-8

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -273,6 +273,12 @@ finished, not whether the state changed.
 
 #### Breadcrumb
 
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The breadcrumb has no bottom margin.** `.breadcrumb` sat on
+  `margin-bottom: 1rem` through `$breadcrumb-margin-bottom` and
+  `--cui-breadcrumb-margin-bottom`; both are gone and the list ends where its
+  content ends, like every other navigation component. Add `.mb-4` (or set
+  `margin-bottom` on the `<nav>`) where the page relied on that gap.
 - **Three breadcrumb tokens have real defaults.** `--cui-breadcrumb-bg`,
   `--cui-breadcrumb-border-radius` and `--cui-breadcrumb-font-size` were `null`
   in Sass, so the first two were emitted empty (`--cui-breadcrumb-bg: ;`) and
@@ -2262,9 +2268,9 @@ as such.
   stops instead of the one global `--cui-border-radius`: buttons, inputs,
   alerts, list groups, tabs, nav links, progress, tooltips, thumbnails,
   callouts, combobox options and the range slider's tooltip sit on
-  `--cui-radius-5` (`.5rem`), badges, cards, popovers, dialogs, drawers,
-  menus, accordions, toasts, dropdowns and popups on `--cui-radius-7`
-  (`.75rem`), pills on `--cui-radius-9` (`1.5rem`).
+  `--cui-radius-5` (`.5rem`), badges, popovers, dialogs, drawers, menus,
+  accordions, toasts, dropdowns and popups on `--cui-radius-7` (`.75rem`),
+  cards on `--cui-radius-8` (`1rem`), pills on `--cui-radius-9` (`1.5rem`).
   Everything that used the `.375rem` default is visibly rounder. To keep a
   component on its old radius, set its own token
   (`--cui-card-border-radius: .375rem`); to retune the whole page, override

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -12,7 +12,6 @@ $breadcrumb-font-size:              inherit !default;
 $breadcrumb-padding-y:              0 !default;
 $breadcrumb-padding-x:              0 !default;
 $breadcrumb-item-padding-x:         .5rem !default;
-$breadcrumb-margin-bottom:          1rem !default;
 $breadcrumb-bg:                     transparent !default;
 $breadcrumb-divider-color:          var(--#{$prefix}fg-4) !default;
 $breadcrumb-active-color:           var(--#{$prefix}fg-1) !default;
@@ -36,7 +35,6 @@ $breadcrumb-tokens: defaults(
   (
     --#{$prefix}breadcrumb-padding-x: #{$breadcrumb-padding-x},
     --#{$prefix}breadcrumb-padding-y: #{$breadcrumb-padding-y},
-    --#{$prefix}breadcrumb-margin-bottom: #{$breadcrumb-margin-bottom},
     --#{$prefix}breadcrumb-bg: #{$breadcrumb-bg},
     --#{$prefix}breadcrumb-border-radius: #{$breadcrumb-border-radius},
     --#{$prefix}breadcrumb-divider: #{meta.inspect(escape-svg($breadcrumb-divider))},
@@ -64,7 +62,7 @@ $breadcrumb-tokens: defaults(
     display: flex;
     flex-wrap: wrap;
     padding: var(--#{$prefix}breadcrumb-padding-y) var(--#{$prefix}breadcrumb-padding-x);
-    margin-bottom: var(--#{$prefix}breadcrumb-margin-bottom);
+    margin-bottom: 0;
     font-size: var(--#{$prefix}breadcrumb-font-size);
     list-style-type: "";
     background-color: var(--#{$prefix}breadcrumb-bg);

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -14,7 +14,7 @@ $card-title-color:                  inherit !default;
 $card-subtitle-color:               inherit !default;
 $card-border-width:                 var(--#{$prefix}border-width) !default;
 $card-border-color:                 var(--#{$prefix}border-color-translucent) !default;
-$card-border-radius:                var(--#{$prefix}radius-7) !default;
+$card-border-radius:                var(--#{$prefix}radius-8) !default;
 $card-box-shadow:                   none !default;
 $card-inner-border-radius:          calc(var(--#{$prefix}card-border-radius) - var(--#{$prefix}card-border-width)) !default;
 $card-cap-padding-y:                calc(#{$card-spacer-y} * .5) !default;


### PR DESCRIPTION
Two upstream design changes from the 2026-08 round (`#42877`, `ed9529bf`), taken as-is.

- **Breadcrumb**: `.breadcrumb` carried `margin-bottom: 1rem` through `$breadcrumb-margin-bottom` and `--cui-breadcrumb-margin-bottom`; no other navigation component reserves space below itself. Both are removed and the rule sets `margin-bottom: 0`.
- **Card**: `$card-border-radius` moves from `--cui-radius-7` (.75rem) to `--cui-radius-8` (1rem); the inner radius follows through the token chain (#1167). `.card-img` keeps the inner radius on both ends, because for us it is still the full-bleed overlay image, not an image placed inside the body.

**BREAKING:** pages that relied on the breadcrumb gap need `.mb-4` (or `margin-bottom` on the `<nav>`); cards are visibly rounder. Both in the migration guide.

## Verification

- Sorted-CSS diff: the breadcrumb token and rule, the card radius token; nothing else.
- `stylelint`, `fusv scss/` (0 unused), pre-push gate (lint, build, bundlewatch, tests): green.
