### PR TITLE
refactor(root)!: name the shared tokens the way the rest of the family reads

### DIFF
--- a/docs/src/content/docs/content/typography.mdx
+++ b/docs/src/content/docs/content/typography.mdx
@@ -33,7 +33,7 @@ Then override the tokens, in a `<style>` tag or your own stylesheet:
 ```css
 :root {
   --cui-font-sans-serif: "Inter", system-ui, sans-serif;
-  --cui-font-monospace: "JetBrains Mono", ui-monospace, monospace;
+  --cui-font-mono: "JetBrains Mono", ui-monospace, monospace;
 }
 ```
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -4027,6 +4027,11 @@ no output at all.
 `--cui-border-radius` itself stays as a deprecated alias of `--cui-radius-4`),
 `--cui-dropdown-inner-border-radius` and
 `--cui-calendar-cell-range-hover-bg` (declared and never read),
+`--cui-font-monospace` (renamed `--cui-font-mono`), `--cui-highlight-color` and
+`--cui-highlight-bg` (renamed `--cui-mark-color` / `--cui-mark-bg`),
+`--cui-btn-input-color` (renamed `--cui-btn-input-fg`) and `--cui-control-color`
+(renamed `--cui-control-fg`, on `.form-control` and everything sharing its
+frame),
 `--cui-body-text-align`, `--cui-btn-input-font-family`, `--cui-btn-font-family`,
 `--cui-control-font-family` and `--cui-search-button-font-family` (never emitted,
 see the Sass variables above). Optional knobs that stay `null` by default —
@@ -4207,6 +4212,14 @@ Prefer the `.d-sidebar-narrow*` names in new markup.
   classes set logical corners (`border-start-start-radius`, …), so
   `.rounded-top` flips with the writing direction like `.rounded-start`
   already did.
+- **Buttons and controls carry a line height per size.** `:root` emits
+  `--cui-btn-input-xs-line-height` (`1.125`), `-sm-line-height`
+  (`--cui-line-height-sm`) and `-lg-line-height` (`--cui-line-height-md`), the
+  size classes hand them to `--cui-btn-line-height` / `--cui-control-line-height`,
+  and each size's `min-height` is computed from its own line height. `.btn-xs`
+  and `.form-control-xs` get tighter (their line height was the body's `1.5`);
+  `sm` and `lg` keep the body value. `--cui-border-width-keyline` (`.5px`) is
+  a root token now and `.border-keyline` reads it.
 - **New `.rounded-size-*`.** It writes the radius into `--cui-rounded-size`
   without setting `border-radius` itself, and the unprefixed side classes
   (`.rounded-top`, `.rounded-end`, `.rounded-bottom`, `.rounded-start`) read

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -93,16 +93,19 @@ $input-btn-gap-xs:            .25rem !default;
 $input-btn-padding-y-xs:      .125rem !default;
 $input-btn-padding-x-xs:      .5rem !default;
 $input-btn-font-size-xs:      var(--#{$prefix}font-size-xs) !default;
+$input-btn-line-height-xs:    1.125 !default;
 
 $input-btn-gap-sm:            .375rem !default;
 $input-btn-padding-y-sm:      .25rem !default;
 $input-btn-padding-x-sm:      .5rem !default;
 $input-btn-font-size-sm:      var(--#{$prefix}font-size-sm) !default;
+$input-btn-line-height-sm:    var(--#{$prefix}line-height-sm) !default;
 
 $input-btn-gap-lg:            .375rem !default;
 $input-btn-padding-y-lg:      .5rem !default;
 $input-btn-padding-x-lg:      1rem !default;
 $input-btn-font-size-lg:      var(--#{$prefix}font-size-lg) !default;
+$input-btn-line-height-lg:    var(--#{$prefix}line-height-md) !default;
 // scss-docs-end input-btn-variables
 
 $code-color: light-dark(var(--#{$prefix}pink), var(--#{$prefix}pink-300)) !default;
@@ -183,7 +186,7 @@ $root-token-defaults: map.merge(
     --#{$prefix}black: $black,
     --#{$prefix}white: $white,
     --#{$prefix}font-sans-serif: meta.inspect($font-family-sans-serif),
-    --#{$prefix}font-monospace: meta.inspect($font-family-monospace),
+    --#{$prefix}font-mono: meta.inspect($font-family-monospace),
     --#{$prefix}gradient: $gradient,
     // scss-docs-start root-body-variables
     --#{$prefix}root-font-size: $font-size-root,
@@ -209,10 +212,11 @@ $root-token-defaults: map.merge(
     --#{$prefix}link-underline-offset: .2em,
     --#{$prefix}link-hover-color: $link-hover-color,
     --#{$prefix}code-color: $code-color,
-    --#{$prefix}highlight-color: $mark-color,
-    --#{$prefix}highlight-bg: $mark-bg,
+    --#{$prefix}mark-color: $mark-color,
+    --#{$prefix}mark-bg: $mark-bg,
     // scss-docs-start root-border-var
     --#{$prefix}border-width: $border-width,
+    --#{$prefix}border-width-keyline: #{map.get($border-widths, keyline)},
     --#{$prefix}border-style: $border-style,
     --#{$prefix}border-color: $border-color,
     --#{$prefix}border-color-translucent: $border-color-translucent,
@@ -257,13 +261,13 @@ $root-token-defaults: map.merge(
     --#{$prefix}btn-input-transition-property: $input-btn-transition-property,
     --#{$prefix}btn-input-action-transition-property: $input-btn-action-transition-property,
     --#{$prefix}btn-input-disabled-opacity: $input-btn-disabled-opacity,
-    --#{$prefix}btn-input-color: var(--#{$prefix}fg-body),
+    --#{$prefix}btn-input-fg: var(--#{$prefix}fg-body),
     --#{$prefix}btn-input-bg: var(--#{$prefix}bg-body),
     --#{$prefix}btn-input-font-weight: var(--#{$prefix}body-font-weight),
     --#{$prefix}btn-input-border-color: var(--#{$prefix}border-color),
     --#{$prefix}btn-input-border-radius: var(--#{$prefix}radius-5),
     --#{$prefix}btn-input-box-shadow: var(--#{$prefix}box-shadow-inset),
-    --#{$prefix}btn-input-focus-color: var(--#{$prefix}btn-input-color),
+    --#{$prefix}btn-input-focus-color: var(--#{$prefix}btn-input-fg),
     --#{$prefix}btn-input-focus-bg: var(--#{$prefix}btn-input-bg),
     --#{$prefix}btn-input-focus-border-color: color-mix(in srgb, var(--#{$prefix}primary-base) 50%, var(--#{$prefix}bg-body)),
     --#{$prefix}btn-input-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2),
@@ -271,20 +275,23 @@ $root-token-defaults: map.merge(
     --#{$prefix}btn-input-xs-padding-y: $input-btn-padding-y-xs,
     --#{$prefix}btn-input-xs-padding-x: $input-btn-padding-x-xs,
     --#{$prefix}btn-input-xs-font-size: $input-btn-font-size-xs,
+    --#{$prefix}btn-input-xs-line-height: $input-btn-line-height-xs,
     --#{$prefix}btn-input-xs-border-radius: var(--#{$prefix}radius-5),
-    --#{$prefix}btn-input-xs-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-xs-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2),
+    --#{$prefix}btn-input-xs-min-height: calc(var(--#{$prefix}btn-input-xs-line-height) * 1em + var(--#{$prefix}btn-input-xs-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2),
     --#{$prefix}btn-input-sm-gap: $input-btn-gap-sm,
     --#{$prefix}btn-input-sm-padding-y: $input-btn-padding-y-sm,
     --#{$prefix}btn-input-sm-padding-x: $input-btn-padding-x-sm,
     --#{$prefix}btn-input-sm-font-size: $input-btn-font-size-sm,
+    --#{$prefix}btn-input-sm-line-height: $input-btn-line-height-sm,
     --#{$prefix}btn-input-sm-border-radius: var(--#{$prefix}radius-5),
-    --#{$prefix}btn-input-sm-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-sm-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2),
+    --#{$prefix}btn-input-sm-min-height: calc(var(--#{$prefix}btn-input-sm-line-height) * 1em + var(--#{$prefix}btn-input-sm-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2),
     --#{$prefix}btn-input-lg-gap: $input-btn-gap-lg,
     --#{$prefix}btn-input-lg-padding-y: $input-btn-padding-y-lg,
     --#{$prefix}btn-input-lg-padding-x: $input-btn-padding-x-lg,
     --#{$prefix}btn-input-lg-font-size: $input-btn-font-size-lg,
+    --#{$prefix}btn-input-lg-line-height: $input-btn-line-height-lg,
     --#{$prefix}btn-input-lg-border-radius: var(--#{$prefix}radius-7),
-    --#{$prefix}btn-input-lg-min-height: calc(var(--#{$prefix}btn-input-line-height) * 1em + var(--#{$prefix}btn-input-lg-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2),
+    --#{$prefix}btn-input-lg-min-height: calc(var(--#{$prefix}btn-input-lg-line-height) * 1em + var(--#{$prefix}btn-input-lg-padding-y) * 2 + var(--#{$prefix}btn-input-border-width) * 2),
     // scss-docs-end root-btn-input-variables
     // scss-docs-start root-control-variables
     // State colors shared by every control that can be checked or selected —

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -24,7 +24,7 @@ $time-picker-roll-cell-selected-hover-color:  var(--#{$prefix}primary-contrast) 
 $time-picker-roll-cell-selected-hover-bg:     oklch(from var(--#{$prefix}primary-base) calc(l * .85) c h) !default;
 
 $time-picker-inline-select-font-size:       var(--#{$prefix}btn-input-sm-font-size) !default;
-$time-picker-inline-select-color:           var(--#{$prefix}btn-input-color) !default;
+$time-picker-inline-select-color:           var(--#{$prefix}btn-input-fg) !default;
 $time-picker-inline-select-padding-y:       var(--#{$prefix}btn-input-sm-padding-y) !default;
 $time-picker-inline-select-padding-x:       var(--#{$prefix}btn-input-sm-padding-x) !default;
 $time-picker-inline-select-disabled-color:  var(--#{$prefix}fg-body) !default;

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -331,7 +331,7 @@ $utilities: map.merge(
     "border-width": (
       property: border-width,
       class: border,
-      values: $border-widths
+      values: map.merge($border-widths, (keyline: var(--#{$prefix}border-width-keyline)))
     ),
     "border-top-width": (
       property: border-top-width,
@@ -814,7 +814,7 @@ $utilities: map.merge(
       property: font-family,
       class: font,
       values: (
-        monospace: var(--#{$prefix}font-monospace),
+        monospace: var(--#{$prefix}font-mono),
         body: var(--#{$prefix}body-font-family)
       )
     ),

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -468,6 +468,7 @@ $btn-check-deprecated: ".btn-check:not(#{$btn-variant-selectors})" !default;
       --#{$prefix}btn-padding-y: var(--#{$prefix}btn-input-#{$size}-padding-y);
       --#{$prefix}btn-padding-x: var(--#{$prefix}btn-input-#{$size}-padding-x);
       --#{$prefix}btn-font-size: var(--#{$prefix}btn-input-#{$size}-font-size);
+      --#{$prefix}btn-line-height: var(--#{$prefix}btn-input-#{$size}-line-height);
       --#{$prefix}btn-border-radius: var(--#{$prefix}btn-input-#{$size}-border-radius);
     }
   }

--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -5,7 +5,7 @@
 
 // scss-docs-start reboot-type-variables
 $paragraph-margin-bottom:     var(--#{$prefix}spacer) !default;
-$font-family-code:            var(--#{$prefix}font-monospace) !default;
+$font-family-code:            var(--#{$prefix}font-mono) !default;
 $headings-margin-bottom:      var(--#{$prefix}spacer-2) !default;
 $headings-font-family:        inherit !default;
 $headings-font-style:         inherit !default;
@@ -331,8 +331,8 @@ $th-font-weight:       null !default;
   mark,
   .mark {
     padding: var(--#{$prefix}mark-padding);
-    color: var(--#{$prefix}highlight-color);
-    background-color: var(--#{$prefix}highlight-bg);
+    color: var(--#{$prefix}mark-color);
+    background-color: var(--#{$prefix}mark-bg);
   }
 
 

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -17,7 +17,7 @@ $form-color-width:                3rem !default;
 // scss-docs-end form-color-variables
 
 // scss-docs-start form-file-variables
-$form-file-button-color:          var(--#{$prefix}btn-input-color) !default;
+$form-file-button-color:          var(--#{$prefix}btn-input-fg) !default;
 $form-file-button-bg:             var(--#{$prefix}bg-1) !default;
 $form-file-button-hover-bg:       var(--#{$prefix}bg-2) !default;
 // scss-docs-end form-file-variables
@@ -43,7 +43,7 @@ $form-control-tokens: defaults(
     --#{$prefix}control-font-size: var(--#{$prefix}btn-input-font-size),
     --#{$prefix}control-font-weight: var(--#{$prefix}btn-input-font-weight),
     --#{$prefix}control-line-height: var(--#{$prefix}btn-input-line-height),
-    --#{$prefix}control-color: var(--#{$prefix}btn-input-color),
+    --#{$prefix}control-fg: var(--#{$prefix}btn-input-fg),
     --#{$prefix}control-bg: var(--#{$prefix}btn-input-bg),
     --#{$prefix}control-border-width: var(--#{$prefix}btn-input-border-width),
     --#{$prefix}control-border-color: var(--#{$prefix}btn-input-border-color),
@@ -57,7 +57,7 @@ $form-control-tokens: defaults(
     --#{$prefix}control-focus-bg: var(--#{$prefix}btn-input-focus-bg),
     --#{$prefix}control-focus-border-color: var(--#{$prefix}btn-input-focus-border-color),
     --#{$prefix}control-focus-ring: var(--#{$prefix}theme-focus-ring, var(--#{$prefix}focus-ring-color)),
-    --#{$prefix}control-disabled-color: var(--#{$prefix}control-color),
+    --#{$prefix}control-disabled-color: var(--#{$prefix}control-fg),
     --#{$prefix}control-disabled-bg: var(--#{$prefix}bg-2),
     --#{$prefix}control-disabled-border-color: var(--#{$prefix}control-border-color),
     --#{$prefix}control-action-color: #{$form-file-button-color},
@@ -252,6 +252,7 @@ $form-control-select-tokens: defaults(
       --#{$prefix}control-padding-y: var(--#{$prefix}btn-input-#{$size}-padding-y);
       --#{$prefix}control-padding-x: var(--#{$prefix}btn-input-#{$size}-padding-x);
       --#{$prefix}control-font-size: var(--#{$prefix}btn-input-#{$size}-font-size);
+      --#{$prefix}control-line-height: var(--#{$prefix}btn-input-#{$size}-line-height);
       --#{$prefix}control-border-radius: var(--#{$prefix}btn-input-#{$size}-border-radius);
 
       min-height: var(--#{$prefix}control-min-height);
@@ -294,7 +295,7 @@ $form-control-select-tokens: defaults(
     // Remove the dotted focus outline Firefox draws inside a select
     &:-moz-focusring {
       color: transparent;
-      text-shadow: 0 0 0 var(--#{$prefix}control-color);
+      text-shadow: 0 0 0 var(--#{$prefix}control-fg);
     }
   }
 

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -10,7 +10,7 @@
 $input-group-addon-padding-y:           var(--#{$prefix}btn-input-padding-y) !default;
 $input-group-addon-padding-x:           var(--#{$prefix}btn-input-padding-x) !default;
 $input-group-addon-font-weight:         var(--#{$prefix}btn-input-font-weight) !default;
-$input-group-addon-color:               var(--#{$prefix}btn-input-color) !default;
+$input-group-addon-color:               var(--#{$prefix}btn-input-fg) !default;
 $input-group-addon-bg:                  var(--#{$prefix}bg-2) !default;
 $input-group-addon-border-color:        var(--#{$prefix}btn-input-border-color) !default;
 // scss-docs-end input-group-variables
@@ -127,6 +127,7 @@ $input-group-tokens: defaults(
       --#{$prefix}control-padding-y: var(--#{$prefix}btn-input-#{$size}-padding-y);
       --#{$prefix}control-padding-x: var(--#{$prefix}btn-input-#{$size}-padding-x);
       --#{$prefix}control-font-size: var(--#{$prefix}btn-input-#{$size}-font-size);
+      --#{$prefix}control-line-height: var(--#{$prefix}btn-input-#{$size}-line-height);
       --#{$prefix}control-border-radius: var(--#{$prefix}btn-input-#{$size}-border-radius);
 
       padding: var(--#{$prefix}control-padding-y) var(--#{$prefix}control-padding-x);

--- a/scss/mixins/_form-control.scss
+++ b/scss/mixins/_form-control.scss
@@ -10,7 +10,7 @@
   font-size: var(--#{$prefix}control-font-size);
   font-weight: var(--#{$prefix}control-font-weight);
   line-height: var(--#{$prefix}control-line-height);
-  color: var(--#{$prefix}control-color);
+  color: var(--#{$prefix}control-fg);
   background-color: var(--#{$prefix}control-bg);
   background-clip: padding-box;
   border: var(--#{$prefix}control-border-width) solid var(--#{$prefix}control-border-color);


### PR DESCRIPTION
## Renames

| before | after |
| --- | --- |
| `--cui-btn-input-color` | `--cui-btn-input-fg` |
| `--cui-control-color` | `--cui-control-fg` |
| `--cui-font-monospace` | `--cui-font-mono` |
| `--cui-highlight-color` / `--cui-highlight-bg` | `--cui-mark-color` / `--cui-mark-bg` |

Every reader follows (form control frame, input group addon, file button, time picker, utilities, reboot).

## New tokens

- `--cui-border-width-keyline` (`.5px`) on `:root`; `.border-keyline` reads it instead of a compiled value.
- `--cui-btn-input-{xs,sm,lg}-line-height` (`1.125`, `--cui-line-height-sm`, `--cui-line-height-md`); the button, control and input-group size classes hand them to `--cui-btn-line-height` / `--cui-control-line-height`, and each size's `min-height` is computed from its own line height. `.btn-xs` and `.form-control-xs` tighten; `sm` and `lg` keep the body value.

**BREAKING:** the four renamed tokens. Migration guide updated.

## Verification

- Sorted-CSS diff: only the renamed declarations and reads, the keyline token and read, the six line-height declarations and reads.
- `css-test` 110 specs, `fusv` 0 unused, `stylelint`, pre-push gate: green.
