### PR TITLE
feat(RangeSlider)!: build on the Range tokens, grid labels with ticks, datalist and tooltip modes

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/coreui.css",
-      "maxSize": "73 kB"
+      "maxSize": "73.5 kB"
     },
     {
       "path": "./dist/css/coreui.min.css",
-      "maxSize": "68.75 kB"
+      "maxSize": "69.25 kB"
     },
     {
       "path": "./dist/js/coreui.bundle.js",

--- a/docs/src/content/docs/forms/range-slider.mdx
+++ b/docs/src/content/docs/forms/range-slider.mdx
@@ -24,8 +24,8 @@ The **Bootstrap 6 Range Slider** component allows users to select a value or ran
 ## Features
 
 - **Multiple Handles:** Select single or multiple values within the range.
-- **Custom Labels:** Display labels at specific points on the slider.
-- **Tooltips:** Show dynamic tooltips displaying current values.
+- **Custom Labels:** Display labels and tick marks at specific points on the slider, or read them from a `<datalist>`.
+- **Tooltips:** Show the current value of each handle while it is hovered, dragged or focused, or all the time.
 - **Vertical Orientation:** Rotate the slider for vertical layouts.
 - **Clickable Labels:** Enable users to click on labels to set slider values.
 - **Disabled State:** Disable the slider to prevent user interaction.
@@ -105,6 +105,19 @@ Labels can be configured as an array of strings or objects. When using objects, 
 
 <Code code={rangeSliderCustomLabels} lang="js" />
 
+### Tick marks from a datalist
+
+Point the `list` option at the `id` of a `<datalist>` and every `<option>` becomes a tick at its value, with the option's `label` shown beneath it. Ticks with a label are drawn taller than bare ones. Datalist ticks and `labels` can be combined; both are laid out on one grid, so unevenly spaced values stay aligned.
+
+<Example pro code={`<div data-coreui-toggle="range-slider" data-coreui-value="25,75" data-coreui-list="rangeSliderStops"></div>
+  <datalist id="rangeSliderStops">
+    <option value="0" label="Cold"></option>
+    <option value="25"></option>
+    <option value="50" label="Mild"></option>
+    <option value="75"></option>
+    <option value="100" label="Hot"></option>
+  </datalist>`} />
+
 ### Clickable labels
 
 By default, users can click on labels to set the slider to specific values. You can disable this feature by setting `clickableLabels` to `false`.
@@ -113,11 +126,12 @@ By default, users can click on labels to set the slider to specific values. You 
 
 ## Tooltips
 
-The value tooltip is the [Tooltip](/components/tooltips/) component's markup: the plugin renders `<output class="range-slider-tooltip tooltip bs-tooltip-top">` with `.tooltip-arrow` and `.tooltip-inner`, so it takes the tooltip's look and its `--cui-tooltip-*` tokens. It does not inherit the slider's theme class; give it its own through `customClass`, as on the Tooltip plugin.
+The value tooltip is the [Tooltip](/components/tooltips/) component's markup: the plugin renders `<output class="range-slider-tooltip tooltip bs-tooltip-top">` with `.tooltip-arrow` and `.tooltip-inner`, so it takes the tooltip's look and its `--cui-tooltip-*` tokens. It does not inherit the slider's theme class; give it its own through `tooltipClass`.
 
-By default, tooltips display the current value of each handle. You can disable tooltips by setting `tooltips` to `false`
+By default, tooltips show the current value of a handle while the pointer is over it, while it is held, and while it has a visible focus. Set `tooltips` to `"always"` to keep them visible at all times, or to `false` to turn them off.
 
-<Example pro code={`<div data-coreui-toggle="range-slider" data-coreui-value="40,60" data-coreui-tooltips="false"></div>`} />
+<Example pro class="d-flex flex-column gap-4 pt-4" code={`<div data-coreui-toggle="range-slider" data-coreui-value="40,60" data-coreui-tooltips="always"></div>
+  <div data-coreui-toggle="range-slider" data-coreui-value="40,60" data-coreui-tooltips="false"></div>`} />
 
 ### Tooltips formatting
 
@@ -145,10 +159,10 @@ Color the filled track and the handles by adding a [`.theme-{color}` class](/cus
 
 <Example pro class="d-flex flex-column gap-3" code={getData('theme-colors').map((c) => `<div class="theme-${c.name}" data-coreui-toggle="range-slider" data-coreui-value="25, 75" data-coreui-aria-labels='["${c.title} minimum", "${c.title} maximum"]'></div>`)} />
 
-The theme class on the slider colours the track and the handles; the tooltip keeps its default look. To theme the tooltip, set `customClass` (`data-coreui-custom-class`), the same option the [Tooltip](/components/tooltips/#custom-tooltips) plugin has — the class lands on the tooltip only. `theme-secondary` gives a grey tooltip on the default slider; `theme-danger` makes the tooltip match a danger slider.
+The theme class on the slider colours the track and the handles; the tooltip keeps its default look. To theme the tooltip, set `tooltipClass` (`data-coreui-tooltip-class`) — the class lands on the tooltip only. `theme-secondary` gives a grey tooltip on the default slider; `theme-danger` makes the tooltip match a danger slider.
 
-<Example pro class="d-flex flex-column gap-3" code={`<div data-coreui-toggle="range-slider" data-coreui-value="40" data-coreui-custom-class="theme-secondary" data-coreui-aria-labels='["Secondary tooltip"]'></div>
-  <div class="theme-danger" data-coreui-toggle="range-slider" data-coreui-value="60" data-coreui-custom-class="theme-danger" data-coreui-aria-labels='["Danger slider, danger tooltip"]'></div>`} />
+<Example pro class="d-flex flex-column gap-3" code={`<div data-coreui-toggle="range-slider" data-coreui-value="40" data-coreui-tooltip-class="theme-secondary" data-coreui-aria-labels='["Secondary tooltip"]'></div>
+  <div class="theme-danger" data-coreui-toggle="range-slider" data-coreui-value="60" data-coreui-tooltip-class="theme-danger" data-coreui-aria-labels='["Danger slider, danger tooltip"]'></div>`} />
 
 ## Usage
 
@@ -186,7 +200,7 @@ const rangeSlider = new RangeSlider(rangeSliderElement, {
 
 ### Options
 
-Options can be passed using data attributes or JavaScript. To do this, append an option name to `data-coreui-`, such as `data-coreui-animation="{value}"`. Remember to convert the case of the option name from "_camelCase_" to "_kebab-case_" when using data attributes. For instance, you should write `data-coreui-custom-class="beautifier"` rather than `data-coreui-customClass="beautifier"`.
+Options can be passed using data attributes or JavaScript. To do this, append an option name to `data-coreui-`, such as `data-coreui-tooltips="always"`. Remember to convert the case of the option name from "_camelCase_" to "_kebab-case_" when using data attributes. For instance, you should write `data-coreui-tooltip-class="beautifier"` rather than `data-coreui-tooltipClass="beautifier"`.
 
 Starting with CoreUI 4.2.6, all components support an **experimental** reserved data attribute named `data-coreui-config`, which can contain simple component configurations as a JSON string. If an element has attributes `data-coreui-config='{"delay":50, "title":689}'` and `data-coreui-title="Custom Title"`, then the final value for `title` will be `Custom Title`, as the standard data attributes will take precedence over values specified in `data-coreui-config`. Moreover, existing data attributes can also hold JSON values like `data-coreui-delay='{"show":50, "hide":250}'`.
 
@@ -199,17 +213,18 @@ Please note that for security reasons, the `sanitize`, `sanitizeFn`, and `allowL
 | `allowList` | object | [Default value](/getting-started/javascript#sanitizer) |  Defines the set of permitted HTML tags and attributes that can safely appear in the tooltip content when HTML content is passedd. This helps maintain control over the output and prevent injection of malicious code. |
 | `ariaLabels` | array, null | `null` | Accessible name of each handle, in order. Handles are otherwise indistinguishable to a screen reader, so a slider with more than one wants this. A shorter array leaves the remaining handles unnamed. |
 | `clickableLabels` | boolean | `true` | Enables or disables the ability to click on labels to set slider values. |
-| `customClass` | string | `''` | Adds one or more classes to the tooltip, as the Tooltip plugin's option does — a `theme-{color}` class themes the tooltip without touching the slider. |
 | `disabled` | boolean | `false` | Disables the slider, making it non-interactive and grayed out. |
 | `distance` | number | `0` | Sets the minimum distance between multiple slider handles. |
 | `labels` | array, boolean, string | `false` | Adds labels to the slider. Can be an array of label objects, a comma-separated string, or false.|
+| `list` | string, null | `null` | `id` of a `<datalist>` whose options become tick marks, with their `label` shown beneath. Combines with `labels`. |
 | `max` | number | `100` | Defines the maximum value of the slider. |
 | `min` | number | `0` | Defines the minimum value of the slider. |
 | `name` | array, string, null | `null` | Sets the name attribute for each slider input. |
 | `sanitize` | boolean | `true` | Controls whether HTML content in the tooltip should be sanitized before rendering. Strongly recommended to leave enabled unless you’re fully managing the content and trust its source. |
 | `sanitizeFn` | null, function | `null` | You can define your own custom sanitization logic by passing a function here. Ideal if you want to use a specialized HTML sanitizer or integrate with existing security tool. |
 | `step` | number, string | `1` | Specifies the increment step for slider values. |
-| `tooltips` | boolean | `true` | Enables or disables tooltips that display current slider values. |
+| `tooltipClass` | string | `''` | Adds one or more classes to the tooltip — a `theme-{color}` class themes the tooltip without touching the slider. |
+| `tooltips` | boolean, `'always'` | `true` | Shows the current value of each handle: `true` on hover, drag and focus, `'always'` at all times, `false` never. |
 | `tooltipsFormat` | function, null | `null` | Provides a custom formatting function for tooltip values. |
 | `track` | boolean, 'fill' | `'fill'` | Controls the visual representation of the slider's track. When set to `'fill'`, the track is dynamically filled based on the slider's value(s). Setting it to `false` disables the filled track. |
 | `value` | array, number | `0` | Sets the initial value(s) of the slider. |
@@ -256,7 +271,11 @@ Additionally, ensure that labels and tooltips are clear and descriptive to provi
 
 ### CSS variables
 
-Bootstap Range Sliders use local CSS variables on `.range-slider` for enhanced real-time customization.
+The track and the handles read the same tokens as the [range](/forms/range/#css-variables), declared on `.range-slider`, so one setting styles both controls; `--cui-range-track-fill-bg` colours the band between the handles and `--cui-range-tick-*` the tick marks under the labels.
+
+<ScssDocs file="scss/forms/_form-range.scss" capture="form-range-tokens" />
+
+The slider adds its own tokens for the labels and the tooltip offsets.
 
 <ScssDocs file="scss/_range-slider.scss" capture="range-slider-css-vars" />
 

--- a/docs/src/content/docs/forms/range.mdx
+++ b/docs/src/content/docs/forms/range.mdx
@@ -17,7 +17,7 @@ Create custom `<input type="range" />` controls with `.form-range`. The track (t
 
 ## Filled track
 
-Only Firefox can fill the track up to the thumb from a stylesheet alone, and CSS cannot read an input's value. So the filled track is a small **JavaScript component**: wrap an `<input class="form-range-input">` in `.form-range` and the plugin keeps a `--cui-range-fill` custom property (`0`–`1`) in sync on the wrapper, which the CSS uses to draw the fill, the value tooltip and the tick marks.
+Only Firefox can fill the track up to the thumb from a stylesheet alone, and CSS cannot read an input's value. The fill is drawn a shade lighter than the thumb, at half the strength of `--cui-range-track-fill-bg`. So the filled track is a small **JavaScript component**: wrap an `<input class="form-range-input">` in `.form-range` and the plugin keeps a `--cui-range-fill` custom property (`0`–`1`) in sync on the wrapper, which the CSS uses to draw the fill, the value tooltip and the tick marks.
 
 The `.form-range` wrapper owns the component's tokens, so the input and any decorations inherit them. Every wrapper with a `.form-range-input` inside is initialized automatically.
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1141,7 +1141,8 @@ adornment in the library — so the button needs no icon markup at all:
   value tooltip on hover, drag and focus, or permanently with `"always"` (the
   same `tooltips`/`tooltipsFormat` options as the range slider), and a linked `<datalist>` renders tick
   marks laid out on a grid. Every such wrapper initializes itself. The input
-  fires `changed.coreui.range` with the numeric `value`. **The bare
+  fires `changed.coreui.range` with the numeric `value`. The fill is the
+  theme colour at half strength, a shade lighter than the thumb. **The bare
   `<input class="form-range">` keeps working unchanged** as the CSS-only form of
   the control; it gets no plugin, no fill and no instance. New tokens on
   `.form-range`: `--cui-range-track-fill-bg`, `--cui-range-track-disabled-bg`
@@ -1155,6 +1156,33 @@ adornment in the library — so the button needs no icon markup at all:
 - **Validation reaches the range.** `.is-invalid`/`.is-valid` on the input
   (either form) colour the thumb and its focus ring with the state, and a
   feedback element after the wrapper toggles through `:has()`.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The range slider's handles and track read the range's tokens.** The
+  `--cui-range-slider-thumb-*` and `--cui-range-slider-track-*` families are
+  gone; `.range-slider` declares the `--cui-range-*` family instead, so one
+  setting styles both controls. Rename: `--cui-range-slider-thumb-{width,
+  height,bg,border,border-radius,box-shadow,active-bg,disabled-bg}` →
+  `--cui-range-thumb-*`, `--cui-range-slider-thumb-transition` →
+  `--cui-range-thumb-transition-{property,duration,timing}`,
+  `--cui-range-slider-track-{width,height,cursor,bg,border-radius,box-shadow}`
+  → `--cui-range-track-*`, `--cui-range-slider-track-in-range-bg` →
+  `--cui-range-track-fill-bg`, `--cui-range-slider-disabled-track-in-range-bg`
+  → `--cui-range-track-disabled-bg`. The Sass variables follow
+  (`$range-slider-thumb-*`, `$range-slider-track-*` → `$form-range-*`).
+  `--cui-range-slider-label-*`, `--cui-range-slider-tooltip-margin-*` and
+  `--cui-range-slider-vertical-*` stay. The filled band keeps its half-strength mix of the theme colour, now
+  shared with the range's fill, and a disabled slider greys the band through
+  the theme slot on the track.
+- **Range slider labels sit on a grid, with tick marks.** The plugin builds
+  `grid-template-columns` (rows when vertical) from the gaps between label
+  values, so labels are in normal flow: the container sizes itself, and the
+  resize listener plus the measured container height are gone. Every label
+  draws a tick from `--cui-range-tick-*` — taller when it has text — and the
+  labels are sorted by value. The new `list` option reads a `<datalist>`
+  like the range does and merges its options with `labels`. Custom CSS that
+  positioned `.range-slider-label` through `left`/`bottom` no longer applies.
+- **Range slider tooltips follow the range's modes.** `tooltips: true` shows a
+  handle's tooltip on hover, drag and visible focus; `"always"` keeps them on.
 - **A theme beats `--cui-range-thumb-bg`, as everywhere else.** The token carried
   the `--cui-theme-*` slot inside its own default, so setting it inside a themed
   container dropped the theme. The slot sits on the property now.

--- a/js/src/range-slider.ts
+++ b/js/src/range-slider.ts
@@ -29,7 +29,6 @@ const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_MOUSEDOWN = `mousedown${EVENT_KEY}`
 const EVENT_MOUSEMOVE = `mousemove${EVENT_KEY}`
 const EVENT_MOUSEUP = `mouseup${EVENT_KEY}`
-const EVENT_RESIZE = `resize${EVENT_KEY}`
 
 const CLASS_NAME_CLICKABLE = 'clickable'
 const CLASS_NAME_DISABLED = 'disabled'
@@ -46,12 +45,12 @@ const CLASS_NAME_TOOLTIP_START = 'bs-tooltip-start'
 const CLASS_NAME_TOOLTIP_TOP = 'bs-tooltip-top'
 const CLASS_NAME_RANGE_SLIDER_TRACK = 'range-slider-track'
 const CLASS_NAME_RANGE_SLIDER_VERTICAL = 'range-slider-vertical'
+const CLASS_NAME_SHOW = 'show'
 
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="range-slider"]'
 const SELECTOR_RANGE_SLIDER_INPUT = '.range-slider-input'
 const SELECTOR_RANGE_SLIDER_INPUTS_CONTAINER = '.range-slider-inputs-container'
 const SELECTOR_RANGE_SLIDER_LABEL = '.range-slider-label'
-const SELECTOR_RANGE_SLIDER_LABELS_CONTAINER = '.range-slider-labels-container'
 
 type RangeSliderLabel = string | { class?: string | string[], label?: string, style?: Record<string, string>, value?: number }
 
@@ -62,6 +61,7 @@ type RangeSliderConfig = {
   disabled: boolean
   distance: number
   labels: RangeSliderLabel[] | boolean | string
+  list: string | null
   max: number
   min: number
   name: string[] | string | null
@@ -69,7 +69,7 @@ type RangeSliderConfig = {
   sanitizeFn: ((unsafeHtml: string) => string) | null
   step: number | string
   tooltipClass: string
-  tooltips: boolean
+  tooltips: boolean | 'always'
   tooltipsFormat: ((value: number | string) => string) | null
   track: boolean | string
   value: number[] | number
@@ -83,6 +83,7 @@ const Default: RangeSliderConfig = {
   disabled: false,
   distance: 0,
   labels: false,
+  list: null,
   max: 100,
   min: 0,
   name: null,
@@ -104,6 +105,7 @@ const DefaultType: Record<string, string> = {
   disabled: 'boolean',
   distance: 'number',
   labels: '(array|boolean|string)',
+  list: '(string|null)',
   max: 'number',
   min: 'number',
   name: '(array|string|null)',
@@ -111,7 +113,7 @@ const DefaultType: Record<string, string> = {
   sanitizeFn: '(null|function)',
   step: '(number|string)',
   tooltipClass: 'string',
-  tooltips: 'boolean',
+  tooltips: '(boolean|string)',
   tooltipsFormat: '(function|null)',
   track: '(boolean|string)',
   value: '(array|number)',
@@ -129,7 +131,6 @@ class RangeSlider extends BaseComponent {
   protected declare _isDragging: boolean
   protected declare _onDocumentMouseMove: (event: any) => void
   protected declare _onDocumentMouseUp: () => void
-  protected declare _onWindowResize: () => void
   protected declare _sliderTrack: any
   protected declare _tooltips: HTMLElement[]
 
@@ -157,10 +158,6 @@ class RangeSlider extends BaseComponent {
       this._isDragging = false
     }
 
-    this._onWindowResize = () => {
-      this._updateLabelsContainerSize()
-    }
-
     this._initializeRangeSlider()
   }
 
@@ -186,7 +183,6 @@ class RangeSlider extends BaseComponent {
   }
 
   override dispose(): void {
-    EventHandler.off(window, EVENT_RESIZE, this._onWindowResize)
     EventHandler.off(document.documentElement, EVENT_MOUSEMOVE, this._onDocumentMouseMove)
     EventHandler.off(document.documentElement, EVENT_MOUSEUP, this._onDocumentMouseUp)
 
@@ -241,7 +237,6 @@ class RangeSlider extends BaseComponent {
 
     EventHandler.on(document.documentElement, EVENT_MOUSEUP, this._onDocumentMouseUp)
     EventHandler.on(document.documentElement, EVENT_MOUSEMOVE, this._onDocumentMouseMove)
-    EventHandler.on(window, EVENT_RESIZE, this._onWindowResize)
   }
 
   _initializeRangeSlider(): void {
@@ -258,7 +253,6 @@ class RangeSlider extends BaseComponent {
     this._sliderTrack = this._createSliderTrack()
     this._createInputs()
     this._createLabels()
-    this._updateLabelsContainerSize()
     this._createTooltips()
     this._updateGradient()
     this._addEventListeners()
@@ -335,50 +329,46 @@ class RangeSlider extends BaseComponent {
   }
 
   _createLabels(): void {
-    const { clickableLabels, disabled, labels, min, max, vertical } = this._config
+    const points = this._labelPoints()
 
-    if (!labels || !Array.isArray(labels) || labels.length === 0) {
+    if (points.length === 0) {
       return
     }
 
+    const { clickableLabels, disabled, vertical } = this._config
     const labelsContainer = this._createElement('div', CLASS_NAME_RANGE_SLIDER_LABELS_CONTAINER)
 
-    for (const [index, label] of this._config.labels.entries()) {
+    // Columns (rows when vertical) are the gaps between 0, each point and 1, so every label lands on a grid line
+    const stops = [0, ...points.map(point => point.ratio), 1]
+    const tracks = stops.slice(1).map((stop, index) => `${stop - stops[index]}fr`)
+    if (vertical) {
+      labelsContainer.style.gridTemplateRows = tracks.toReversed().join(' ')
+    } else {
+      labelsContainer.style.gridTemplateColumns = tracks.join(' ')
+    }
+
+    for (const [index, point] of points.entries()) {
       const labelElement = this._createElement('div', CLASS_NAME_RANGE_SLIDER_LABEL)
 
       if (clickableLabels && !disabled) {
         labelElement.classList.add(CLASS_NAME_CLICKABLE)
       }
 
-      if (label.class) {
-        const classNames = Array.isArray(label.class) ? label.class : [label.class]
-        labelElement.classList.add(...classNames)
+      if (point.class) {
+        labelElement.classList.add(...(Array.isArray(point.class) ? point.class : [point.class]))
       }
 
-      if (label.style && typeof label.style === 'object') {
-        Object.assign(labelElement.style, label.style)
+      if (point.style && typeof point.style === 'object') {
+        Object.assign(labelElement.style, point.style)
       }
 
-      // Calculate percentage based on index
-      const percentage = labels.length === 1 ? 0 : (index / (labels.length - 1)) * 100
+      Manipulator.setDataAttribute(labelElement, 'value', point.value)
+      labelElement.textContent = point.label
 
-      // Determine label value
-      const labelValue = typeof label === 'object' ? label.value : min + ((percentage / 100) * (max - min))
-
-      // Set data-coreui-value attribute
-      Manipulator.setDataAttribute(labelElement, 'value', labelValue)
-
-      // Set label content
-      labelElement.textContent = typeof label === 'object' ? label.label : label
-
-      // Calculate and set position
-      // @ts-expect-error -- the call passes an argument the method ignores.
-      // Dropping it is a behaviour change, so it is flagged rather than typed away.
-      const position = this._calculateLabelPosition(label, index, percentage)
       if (vertical) {
-        labelElement.style.bottom = position
+        labelElement.style.gridRowStart = `${points.length - index + 1}`
       } else {
-        labelElement.style[isRTL() ? 'right' : 'left'] = position
+        labelElement.style.gridColumnStart = `${index + 2}`
       }
 
       labelsContainer.append(labelElement)
@@ -387,31 +377,40 @@ class RangeSlider extends BaseComponent {
     this._element.append(labelsContainer)
   }
 
-  _calculateLabelPosition(label: RangeSliderLabel, index: number): string {
-    // Check if label is an object with a specific value
-    if (typeof label === 'object' && label.value !== undefined) {
-      return `${((label.value - this._config.min) / (this._config.max - this._config.min)) * 100}%`
+  _labelPoints(): Array<{ class?: string | string[], label: string, ratio: number, style?: Record<string, string>, value: number }> {
+    const { labels, list, min, max } = this._config
+    const span = max - min || 1
+    const ratio = (value: number) => Math.min(Math.max((value - min) / span, 0), 1)
+    const points = []
+
+    if (Array.isArray(labels) && labels.length > 0) {
+      for (const [index, label] of labels.entries()) {
+        const value = typeof label === 'object' && label.value !== undefined ?
+          label.value :
+          min + (labels.length === 1 ? 0 : (index / (labels.length - 1)) * span)
+
+        points.push({
+          class: typeof label === 'object' ? label.class : undefined,
+          label: typeof label === 'object' ? (label.label ?? '') : label,
+          ratio: ratio(value),
+          style: typeof label === 'object' ? label.style : undefined,
+          value
+        })
+      }
     }
 
-    // Calculate position based on index when label is not an object
-    return `${(index / (this._config.labels.length - 1)) * 100}%`
-  }
+    const datalist = list ? document.getElementById(list) : null
+    if (datalist) {
+      for (const option of SelectorEngine.find<HTMLOptionElement>('option', datalist)) {
+        const value = Number.parseFloat(option.value)
 
-  _updateLabelsContainerSize(): void {
-    const labelsContainer = SelectorEngine.findOne(SELECTOR_RANGE_SLIDER_LABELS_CONTAINER, this._element as ParentNode)
-
-    if (!this._config.labels || !labelsContainer) {
-      return
+        if (!Number.isNaN(value)) {
+          points.push({ label: option.label, ratio: ratio(value), value })
+        }
+      }
     }
 
-    const labels = SelectorEngine.find(SELECTOR_RANGE_SLIDER_LABEL, this._element as ParentNode)
-    if (labels.length === 0) {
-      return
-    }
-
-    const maxSize = Math.max(...labels.map(label => (this._config.vertical ? label.offsetWidth : label.offsetHeight)))
-
-    labelsContainer.style[this._config.vertical ? 'width' : 'height'] = `${maxSize}px`
+    return points.toSorted((a, b) => a.ratio - b.ratio)
   }
 
   _createTooltips(): void {
@@ -425,6 +424,7 @@ class RangeSlider extends BaseComponent {
       // `<output>` is a live region; the input already announces the value.
       const tooltipElement = this._createElement('output', CLASS_NAME_RANGE_SLIDER_TOOLTIP)
       tooltipElement.classList.add(CLASS_NAME_TOOLTIP, this._config.vertical ? CLASS_NAME_TOOLTIP_START : CLASS_NAME_TOOLTIP_TOP)
+      tooltipElement.classList.toggle(CLASS_NAME_SHOW, this._config.tooltips === 'always')
       if (this._config.tooltipClass) {
         tooltipElement.classList.add(...this._config.tooltipClass.split(' ').filter(Boolean))
       }

--- a/js/src/range-slider.ts
+++ b/js/src/range-slider.ts
@@ -553,10 +553,15 @@ class RangeSlider extends BaseComponent {
 
     const [min, max] = [Math.min(...this._currentValue), Math.max(...this._currentValue)]
     const span = this._config.max - this._config.min
-    const edge = (value: number): string => `${((value - this._config.min) / span) * 100}%`
+    const ratio = (value: number): string => `${(value - this._config.min) / span}`
 
-    this._sliderTrack.style.setProperty('--cui-range-slider-track-from', this._currentValue.length === 1 ? '0%' : edge(min))
-    this._sliderTrack.style.setProperty('--cui-range-slider-track-to', edge(max))
+    if (this._currentValue.length === 1) {
+      this._sliderTrack.style.setProperty('--cui-range-slider-track-from-edge', '0')
+    } else {
+      this._sliderTrack.style.setProperty('--cui-range-slider-track-from', ratio(min))
+    }
+
+    this._sliderTrack.style.setProperty('--cui-range-slider-track-to', ratio(max))
   }
 
   _updateNearestValue(value: number): void {

--- a/js/tests/unit/range-slider.spec.js
+++ b/js/tests/unit/range-slider.spec.js
@@ -389,21 +389,26 @@ describe('RangeSlider', () => {
       expect(input.getAttribute('aria-orientation')).toBe('horizontal')
     })
 
-    it('should position labels with bottom for vertical mode', () => {
+    it('should lay labels out on grid rows from max at the top to min at the bottom in vertical mode', () => {
       fixtureEl.innerHTML = '<div id="slider"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, {
         vertical: true,
         value: [25],
-        labels: ['Start', 'End']
+        labels: ['Start', 'Middle', 'End']
       })
 
+      const container = element.querySelector('.range-slider-labels-container')
+      expect(container.style.gridTemplateRows).toBe('0fr 0.5fr 0.5fr 0fr')
+      expect(container.style.gridTemplateColumns).toBe('')
+
       const labels = element.querySelectorAll('.range-slider-label')
-      expect(labels[0].style.bottom).toBe('0%')
-      expect(labels[1].style.bottom).toBe('100%')
+      expect(labels[0].style.gridRowStart).toBe('4')
+      expect(labels[1].style.gridRowStart).toBe('3')
+      expect(labels[2].style.gridRowStart).toBe('2')
     })
 
-    it('should position labels with left for horizontal mode', () => {
+    it('should lay labels out on grid columns in horizontal mode', () => {
       fixtureEl.innerHTML = '<div id="slider"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, {
@@ -412,9 +417,12 @@ describe('RangeSlider', () => {
         labels: ['Start', 'End']
       })
 
+      const container = element.querySelector('.range-slider-labels-container')
+      expect(container.style.gridTemplateColumns).toBe('0fr 1fr 0fr')
+
       const labels = element.querySelectorAll('.range-slider-label')
-      expect(labels[0].style.left).toBe('0%')
-      expect(labels[1].style.left).toBe('100%')
+      expect(labels[0].style.gridColumnStart).toBe('2')
+      expect(labels[1].style.gridColumnStart).toBe('3')
     })
   })
 
@@ -434,7 +442,7 @@ describe('RangeSlider', () => {
       expect(labels[2].textContent).toBe('High')
     })
 
-    it('should position labels correctly', () => {
+    it('should place each label on a grid line built from the gaps between values', () => {
       fixtureEl.innerHTML = '<div id="slider"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, {
@@ -442,10 +450,58 @@ describe('RangeSlider', () => {
         labels: ['Start', 'Middle', 'End']
       })
 
+      expect(element.querySelector('.range-slider-labels-container').style.gridTemplateColumns).toBe('0fr 0.5fr 0.5fr 0fr')
+
       const labels = element.querySelectorAll('.range-slider-label')
-      expect(labels[0].style.left).toBe('0%')
-      expect(labels[1].style.left).toBe('50%')
-      expect(labels[2].style.left).toBe('100%')
+      expect(labels[0].style.gridColumnStart).toBe('2')
+      expect(labels[1].style.gridColumnStart).toBe('3')
+      expect(labels[2].style.gridColumnStart).toBe('4')
+      expect(labels[0].style.left).toBe('')
+    })
+
+    it('should sort labels by value so uneven values still land on grid lines', () => {
+      fixtureEl.innerHTML = '<div id="slider"></div>'
+      const element = fixtureEl.querySelector('#slider')
+      const rangeSlider = new RangeSlider(element, {
+        value: [50],
+        labels: [
+          { label: 'High', value: 100 },
+          { label: 'Low', value: 0 },
+          { label: 'Ten', value: 10 }
+        ]
+      })
+
+      expect(element.querySelector('.range-slider-labels-container').style.gridTemplateColumns).toBe('0fr 0.1fr 0.9fr 0fr')
+      expect([...element.querySelectorAll('.range-slider-label')].map(label => label.textContent)).toEqual(['Low', 'Ten', 'High'])
+    })
+
+    it('should render ticks from a linked datalist through the list option', () => {
+      fixtureEl.innerHTML = `
+        <div id="slider"></div>
+        <datalist id="stops">
+          <option value="0" label="Cold"></option>
+          <option value="50"></option>
+          <option value="100" label="Hot"></option>
+        </datalist>
+      `
+      const element = fixtureEl.querySelector('#slider')
+      const rangeSlider = new RangeSlider(element, { value: [50], list: 'stops' })
+
+      const labels = [...element.querySelectorAll('.range-slider-label')]
+      expect(labels.map(label => label.textContent)).toEqual(['Cold', '', 'Hot'])
+      expect(labels.map(label => label.dataset.coreuiValue)).toEqual(['0', '50', '100'])
+      expect(element.querySelector('.range-slider-labels-container').style.gridTemplateColumns).toBe('0fr 0.5fr 0.5fr 0fr')
+    })
+
+    it('should merge datalist ticks with labels', () => {
+      fixtureEl.innerHTML = `
+        <div id="slider"></div>
+        <datalist id="stops"><option value="75"></option></datalist>
+      `
+      const element = fixtureEl.querySelector('#slider')
+      const rangeSlider = new RangeSlider(element, { value: [50], list: 'stops', labels: ['Low', 'High'] })
+
+      expect([...element.querySelectorAll('.range-slider-label')].map(label => label.dataset.coreuiValue)).toEqual(['0', '75', '100'])
     })
 
     it('should handle labels with specific values (object labels)', () => {
@@ -463,8 +519,7 @@ describe('RangeSlider', () => {
       expect(labels.length).toBe(2)
       expect(labels[0].textContent).toBe('Min')
       expect(labels[1].textContent).toBe('Max')
-      expect(labels[0].style.left).toBe('10%')
-      expect(labels[1].style.left).toBe('90%')
+      expect(element.querySelector('.range-slider-labels-container').style.gridTemplateColumns).toBe('0.1fr 0.8fr 0.1fr')
     })
 
     it('should handle labels with class property as string', () => {
@@ -525,6 +580,7 @@ describe('RangeSlider', () => {
 
       const labels = element.querySelectorAll('.range-slider-label')
       expect(labels[0].textContent).toBe('NoStyle')
+      expect(labels[0].getAttribute('style')).toBe('grid-column-start: 2;')
     })
 
     it('should add clickable class when clickableLabels is true and not disabled', () => {
@@ -632,6 +688,24 @@ describe('RangeSlider', () => {
       const tooltip = element.querySelector('.range-slider-tooltip')
       expect(tooltip).not.toBeNull()
       expect(tooltip.querySelector('.tooltip-inner').textContent).toBe('60')
+    })
+
+    it('should keep the tooltip hidden until interaction by default', () => {
+      fixtureEl.innerHTML = '<div id="slider"></div>'
+      const element = fixtureEl.querySelector('#slider')
+      const rangeSlider = new RangeSlider(element, { value: [50], tooltips: true })
+
+      expect(element.querySelector('.range-slider-tooltip')).not.toHaveClass('show')
+    })
+
+    it('should show the tooltip permanently with tooltips "always"', () => {
+      fixtureEl.innerHTML = '<div data-coreui-toggle="range-slider" data-coreui-tooltips="always" data-coreui-value="20,80"></div>'
+      const element = fixtureEl.querySelector('[data-coreui-toggle="range-slider"]')
+      const rangeSlider = new RangeSlider(element)
+
+      const tooltips = element.querySelectorAll('.range-slider-tooltip')
+      expect(tooltips).toHaveSize(2)
+      expect([...tooltips].every(tooltip => tooltip.classList.contains('show'))).toBeTrue()
     })
 
     it('should not display tooltips when disabled', () => {
@@ -1570,7 +1644,7 @@ describe('RangeSlider', () => {
 
   describe('_getThumbSize', () => {
     it('should handle CSS custom property with unit', () => {
-      fixtureEl.innerHTML = '<div id="slider" style="--cui-range-slider-thumb-width: 16px;"></div>'
+      fixtureEl.innerHTML = '<div id="slider" style="--cui-range-thumb-width: 16px;"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, { value: 50, tooltips: true })
 
@@ -1592,7 +1666,7 @@ describe('RangeSlider', () => {
 
   describe('_positionTooltip', () => {
     it('should write the ratio for horizontal mode', () => {
-      fixtureEl.innerHTML = '<div id="slider" style="--cui-range-slider-thumb-width: 16px;"></div>'
+      fixtureEl.innerHTML = '<div id="slider" style="--cui-range-thumb-width: 16px;"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, {
         value: [75],
@@ -1605,7 +1679,7 @@ describe('RangeSlider', () => {
     })
 
     it('should write the same ratio for vertical mode', () => {
-      fixtureEl.innerHTML = '<div id="slider" style="--cui-range-slider-thumb-height: 16px;"></div>'
+      fixtureEl.innerHTML = '<div id="slider" style="--cui-range-thumb-height: 16px;"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, {
         value: [75],
@@ -1645,7 +1719,7 @@ describe('RangeSlider', () => {
 
     it('should not fall back to a thumb size read from the stylesheet', () => {
       // The old parser only matched a bare number and unit.
-      fixtureEl.innerHTML = '<div id="slider" style="--cui-range-slider-thumb-width: calc(1rem + 2px);"></div>'
+      fixtureEl.innerHTML = '<div id="slider" style="--cui-range-thumb-width: calc(1rem + 2px);"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, {
         value: [100],
@@ -1655,47 +1729,6 @@ describe('RangeSlider', () => {
       const tooltip = element.querySelector('.range-slider-tooltip')
       expect(tooltip.style.getPropertyValue('--cui-range-slider-tooltip-position')).toBe('1')
       expect(tooltip.style.marginInlineStart).toBe('')
-    })
-  })
-
-  describe('_updateLabelsContainerSize', () => {
-    it('should set height on labels container for horizontal mode', () => {
-      fixtureEl.innerHTML = '<div id="slider"></div>'
-      const element = fixtureEl.querySelector('#slider')
-      const rangeSlider = new RangeSlider(element, {
-        value: [50],
-        labels: ['A', 'B', 'C'],
-        vertical: false
-      })
-
-      const labelsContainer = element.querySelector('.range-slider-labels-container')
-      // In jsdom, offsetHeight is 0 so it will be "0px"
-      expect(labelsContainer.style.height).toBeDefined()
-    })
-
-    it('should set width on labels container for vertical mode', () => {
-      fixtureEl.innerHTML = '<div id="slider"></div>'
-      const element = fixtureEl.querySelector('#slider')
-      const rangeSlider = new RangeSlider(element, {
-        value: [50],
-        labels: ['A', 'B', 'C'],
-        vertical: true
-      })
-
-      const labelsContainer = element.querySelector('.range-slider-labels-container')
-      expect(labelsContainer.style.width).toBeDefined()
-    })
-
-    it('should do nothing when labels is false', () => {
-      fixtureEl.innerHTML = '<div id="slider"></div>'
-      const element = fixtureEl.querySelector('#slider')
-      const rangeSlider = new RangeSlider(element, {
-        value: [50],
-        labels: false
-      })
-
-      const labelsContainer = element.querySelector('.range-slider-labels-container')
-      expect(labelsContainer).toBeNull()
     })
   })
 
@@ -2061,16 +2094,13 @@ describe('RangeSlider', () => {
 
       const first = new RangeSlider(fixtureEl.querySelector('#first'), { value: [10, 40] })
       const second = new RangeSlider(fixtureEl.querySelector('#second'), { value: [10, 40] })
-      const resizeSpy = spyOn(second, '_updateLabelsContainerSize')
 
       first.dispose()
 
       second._isDragging = true
       document.documentElement.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
-      window.dispatchEvent(new Event('resize'))
 
       expect(second._isDragging).toBeFalse()
-      expect(resizeSpy).toHaveBeenCalledTimes(1)
 
       second.dispose()
     })

--- a/js/tests/unit/range-slider.spec.js
+++ b/js/tests/unit/range-slider.spec.js
@@ -837,7 +837,7 @@ describe('RangeSlider', () => {
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, { track: 'fill', value: 50 })
 
-      expect(edges(element.querySelector('.range-slider-track'))).toEqual(['0%', '50%'])
+      expect(edges(element.querySelector('.range-slider-track'))).toEqual(['', '0.5'])
     })
 
     it('should leave the band unset when track is false', () => {
@@ -848,14 +848,17 @@ describe('RangeSlider', () => {
       // Unset rather than zero-width: the stylesheet has no fallback for these,
       // so the whole `background-image` falls back to `none`.
       expect(edges(element.querySelector('.range-slider-track'))).toEqual(['', ''])
+      expect(element.querySelector('.range-slider-track').style.getPropertyValue('--cui-range-slider-track-from-edge')).toBe('')
     })
 
-    it('should start a single-thumb band at zero', () => {
+    it('should start a single-thumb band at the track edge, not at the thumb centre', () => {
       fixtureEl.innerHTML = '<div id="slider"></div>'
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, { track: 'fill', value: [50] })
 
-      expect(edges(element.querySelector('.range-slider-track'))).toEqual(['0%', '50%'])
+      const track = element.querySelector('.range-slider-track')
+      expect(track.style.getPropertyValue('--cui-range-slider-track-from-edge')).toBe('0')
+      expect(edges(track)).toEqual(['', '0.5'])
     })
 
     it('should span a multi-thumb band between the outermost handles', () => {
@@ -863,7 +866,7 @@ describe('RangeSlider', () => {
       const element = fixtureEl.querySelector('#slider')
       const rangeSlider = new RangeSlider(element, { track: 'fill', value: [25, 75] })
 
-      expect(edges(element.querySelector('.range-slider-track'))).toEqual(['25%', '75%'])
+      expect(edges(element.querySelector('.range-slider-track'))).toEqual(['0.25', '0.75'])
     })
 
     it('should write the same band whatever the orientation', () => {
@@ -872,7 +875,7 @@ describe('RangeSlider', () => {
       const rangeSlider = new RangeSlider(element, { track: 'fill', value: [50], vertical: true })
 
       // Direction is the stylesheet's business now.
-      expect(edges(element.querySelector('.range-slider-track'))).toEqual(['0%', '50%'])
+      expect(edges(element.querySelector('.range-slider-track'))).toEqual(['', '0.5'])
       expect(element.querySelector('.range-slider-track').style.backgroundImage).toBe('')
     })
   })

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -85,19 +85,25 @@ $range-slider-vertical-tokens: defaults(
   }
 
   .range-slider-track {
+    // Outside `$prefix` on purpose: the plugin writes these names. No fallback for the ratios
+    // either: with `track: false` nothing is written and the whole declaration must drop to `none`.
+    // A single thumb gets `--cui-range-slider-track-from-edge: 0` inline, so its band starts at the track's end.
+    --#{$prefix}range-slider-track-thumb: var(--#{$prefix}range-thumb-width);
+    --cui-range-slider-track-from-edge: calc(var(--#{$prefix}range-slider-track-thumb) * .5 + var(--cui-range-slider-track-from) * (100% - var(--#{$prefix}range-slider-track-thumb)));
+    --cui-range-slider-track-to-edge: calc(var(--#{$prefix}range-slider-track-thumb) * .5 + var(--cui-range-slider-track-to) * (100% - var(--#{$prefix}range-slider-track-thumb)));
+
     width: var(--#{$prefix}range-track-width);
     height: var(--#{$prefix}range-track-height);
     cursor: var(--#{$prefix}range-track-cursor);
     background-color: var(--#{$prefix}range-track-bg);
-    // No fallback on purpose: with `track: false` the plugin never writes the edges and the whole declaration must drop to `none`.
     background-image:
       linear-gradient(
         var(--#{$prefix}range-track-direction, to right),
         transparent 0%,
-        transparent var(--cui-range-slider-track-from),
-        color-mix(in oklch, var(--#{$prefix}theme-bg, var(--#{$prefix}range-track-fill-bg)) 50%, transparent) var(--cui-range-slider-track-from),
-        color-mix(in oklch, var(--#{$prefix}theme-bg, var(--#{$prefix}range-track-fill-bg)) 50%, transparent) var(--cui-range-slider-track-to),
-        transparent var(--cui-range-slider-track-to),
+        transparent var(--cui-range-slider-track-from-edge),
+        color-mix(in oklch, var(--#{$prefix}theme-bg, var(--#{$prefix}range-track-fill-bg)) 50%, transparent) var(--cui-range-slider-track-from-edge),
+        color-mix(in oklch, var(--#{$prefix}theme-bg, var(--#{$prefix}range-track-fill-bg)) 50%, transparent) var(--cui-range-slider-track-to-edge),
+        transparent var(--cui-range-slider-track-to-edge),
         transparent 100%
       );
     border-color: transparent;
@@ -248,6 +254,8 @@ $range-slider-vertical-tokens: defaults(
     }
 
     .range-slider-track {
+      --#{$prefix}range-slider-track-thumb: var(--#{$prefix}range-thumb-height);
+
       width: var(--#{$prefix}range-slider-vertical-track-width);
       height: 100%;
     }

--- a/scss/_range-slider.scss
+++ b/scss/_range-slider.scss
@@ -1,43 +1,20 @@
 @use "sass:string";
 @use "functions/defaults" as *;
+@use "forms/form-range" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/box-shadow" as *;
 @use "mixins/focus-ring" as *;
-@use "mixins/gradients" as *;
 @use "mixins/ltr-rtl" as *;
 @use "mixins/tokens" as *;
-@use "mixins/transition" as *;
 @use "config" as *;
 @use "theme" as *;
 
-// stylelint-disable custom-property-no-missing-var-function
-
 // Range Slider
 // scss-docs-start range-slider-variables
-$range-slider-track-width:                 100% !default;
-$range-slider-track-height:                .5rem !default;
-$range-slider-track-cursor:                pointer !default;
-$range-slider-track-bg:                    color-mix(in oklch, var(--#{$prefix}bg-2), var(--#{$prefix}bg-3)) !default;
-$range-slider-track-border-radius:         var(--#{$prefix}radius-pill) !default;
-$range-slider-track-box-shadow:            var(--#{$prefix}box-shadow-inset) !default;
-
-$range-slider-track-in-range-bg:           color-mix(in oklch, var(--#{$prefix}theme-bg, var(--#{$prefix}primary-base)) 50%, transparent) !default;
-$range-slider-disabled-track-in-range-bg:  var(--#{$prefix}fg-4) !default;
-
 $range-slider-label-padding-y:             0 !default;
 $range-slider-label-padding-x:             0 !default;
 $range-slider-label-font-size:             var(--#{$prefix}font-size-sm) !default;
 $range-slider-label-color:                 var(--#{$prefix}fg-body) !default;
-
-$range-slider-thumb-width:                 1rem !default;
-$range-slider-thumb-height:                $range-slider-thumb-width !default;
-$range-slider-thumb-bg:                    var(--#{$prefix}theme-bg, var(--#{$prefix}primary-base)) !default;
-$range-slider-thumb-border:                0 !default;
-$range-slider-thumb-border-radius:         var(--#{$prefix}radius-pill) !default;
-$range-slider-thumb-box-shadow:            0 .1rem .25rem color-mix(in oklch, var(--#{$prefix}black) 10%, transparent) !default;
-$range-slider-thumb-active-bg:             color-mix(in oklch, var(--#{$prefix}theme-bg, var(--#{$prefix}primary-base)) 30%, var(--#{$prefix}bg-body)) !default;
-$range-slider-thumb-disabled-bg:           var(--#{$prefix}fg-3) !default;
-$range-slider-thumb-transition:            background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 
 $range-slider-tooltip-margin-end:          .25rem !default;
 $range-slider-tooltip-margin-bottom:       .25rem !default;
@@ -53,27 +30,10 @@ $range-slider-tokens: () !default;
 // scss-docs-start range-slider-css-vars
 $range-slider-tokens: defaults(
   (
-    --#{$prefix}range-slider-track-width: #{$range-slider-track-width},
-    --#{$prefix}range-slider-track-height: #{$range-slider-track-height},
-    --#{$prefix}range-slider-track-cursor: #{$range-slider-track-cursor},
-    --#{$prefix}range-slider-track-bg: #{$range-slider-track-bg},
-    --#{$prefix}range-slider-track-border-radius: #{$range-slider-track-border-radius},
-    --#{$prefix}range-slider-track-box-shadow: #{$range-slider-track-box-shadow},
-    --#{$prefix}range-slider-track-in-range-bg: #{$range-slider-track-in-range-bg},
-    --#{$prefix}range-slider-disabled-track-in-range-bg: #{$range-slider-disabled-track-in-range-bg},
     --#{$prefix}range-slider-label-padding-y: #{$range-slider-label-padding-y},
     --#{$prefix}range-slider-label-padding-x: #{$range-slider-label-padding-x},
     --#{$prefix}range-slider-label-font-size: #{$range-slider-label-font-size},
     --#{$prefix}range-slider-label-color: #{$range-slider-label-color},
-    --#{$prefix}range-slider-thumb-width: #{$range-slider-thumb-width},
-    --#{$prefix}range-slider-thumb-height: #{$range-slider-thumb-height},
-    --#{$prefix}range-slider-thumb-bg: #{$range-slider-thumb-bg},
-    --#{$prefix}range-slider-thumb-border: #{$range-slider-thumb-border},
-    --#{$prefix}range-slider-thumb-border-radius: #{$range-slider-thumb-border-radius},
-    --#{$prefix}range-slider-thumb-box-shadow: #{$range-slider-thumb-box-shadow},
-    --#{$prefix}range-slider-thumb-active-bg: #{$range-slider-thumb-active-bg},
-    --#{$prefix}range-slider-thumb-disabled-bg: #{$range-slider-thumb-disabled-bg},
-    --#{$prefix}range-slider-thumb-transition: #{$range-slider-thumb-transition},
     --#{$prefix}range-slider-tooltip-margin-end: #{$range-slider-tooltip-margin-end},
     --#{$prefix}range-slider-tooltip-margin-bottom: #{$range-slider-tooltip-margin-bottom},
   ),
@@ -100,6 +60,7 @@ $range-slider-vertical-tokens: defaults(
 // stylelint-enable scss/dollar-variable-default
 @layer components {
   .range-slider {
+    @include tokens($form-range-tokens);
     @include tokens($range-slider-tokens);
 
     position: relative;
@@ -108,9 +69,9 @@ $range-slider-vertical-tokens: defaults(
     align-items: center;
 
     &.disabled {
-      --#{$prefix}range-slider-track-in-range-bg: var(--#{$prefix}range-slider-disabled-track-in-range-bg);
-
       .range-slider-track {
+        --#{$prefix}theme-bg: var(--#{$prefix}range-track-disabled-bg);
+
         cursor: initial;
       }
     }
@@ -120,28 +81,28 @@ $range-slider-vertical-tokens: defaults(
     position: relative;
     display: flex;
     align-items: center;
-    height: string.unquote("max(var(--#{$prefix}range-slider-thumb-height), var(--#{$prefix}range-slider-track-height))");
+    height: string.unquote("max(var(--#{$prefix}range-thumb-height), var(--#{$prefix}range-track-height))");
   }
 
   .range-slider-track {
-    width: var(--#{$prefix}range-slider-track-width);
-    height: var(--#{$prefix}range-slider-track-height);
-    cursor: var(--#{$prefix}range-slider-track-cursor);
-    background-color: var(--#{$prefix}range-slider-track-bg);
+    width: var(--#{$prefix}range-track-width);
+    height: var(--#{$prefix}range-track-height);
+    cursor: var(--#{$prefix}range-track-cursor);
+    background-color: var(--#{$prefix}range-track-bg);
     // No fallback on purpose: with `track: false` the plugin never writes the edges and the whole declaration must drop to `none`.
     background-image:
       linear-gradient(
-        var(--#{$prefix}range-slider-track-direction, to right),
+        var(--#{$prefix}range-track-direction, to right),
         transparent 0%,
         transparent var(--cui-range-slider-track-from),
-        var(--#{$prefix}range-slider-track-in-range-bg) var(--cui-range-slider-track-from),
-        var(--#{$prefix}range-slider-track-in-range-bg) var(--cui-range-slider-track-to),
+        color-mix(in oklch, var(--#{$prefix}theme-bg, var(--#{$prefix}range-track-fill-bg)) 50%, transparent) var(--cui-range-slider-track-from),
+        color-mix(in oklch, var(--#{$prefix}theme-bg, var(--#{$prefix}range-track-fill-bg)) 50%, transparent) var(--cui-range-slider-track-to),
         transparent var(--cui-range-slider-track-to),
         transparent 100%
       );
     border-color: transparent;
-    @include border-radius(var(--#{$prefix}range-slider-track-border-radius));
-    @include box-shadow(var(--#{$prefix}range-slider-track-box-shadow));
+    @include border-radius(var(--#{$prefix}range-track-border-radius));
+    @include box-shadow(var(--#{$prefix}range-track-box-shadow));
   }
 
   .range-slider-input {
@@ -152,8 +113,7 @@ $range-slider-vertical-tokens: defaults(
     pointer-events: none;
     background-color: transparent;
 
-    &:hover + .range-slider-tooltip,
-    &:focus + .range-slider-tooltip {
+    &:is(:hover, :active, :focus-visible) + .range-slider-tooltip {
       opacity: 1;
     }
 
@@ -171,37 +131,15 @@ $range-slider-vertical-tokens: defaults(
     }
 
     &::-webkit-slider-thumb {
-      width: var(--#{$prefix}range-slider-thumb-width);
-      height: var(--#{$prefix}range-slider-thumb-height);
-      appearance: none;
       pointer-events: all;
       cursor: pointer;
-      @include gradient-bg(var(--#{$prefix}range-slider-thumb-bg));
-      border: var(--#{$prefix}range-slider-thumb-border);
-      @include border-radius(var(--#{$prefix}range-slider-thumb-border-radius));
-      @include box-shadow(var(--#{$prefix}range-slider-thumb-box-shadow));
-      @include transition(var(--#{$prefix}range-slider-thumb-transition));
-
-      &:active {
-        @include gradient-bg(var(--#{$prefix}range-slider-thumb-active-bg));
-      }
+      @include form-range-thumb();
     }
 
     &::-moz-range-thumb {
-      width: var(--#{$prefix}range-slider-thumb-width);
-      height: var(--#{$prefix}range-slider-thumb-height);
-      appearance: none;
       pointer-events: all;
       cursor: pointer;
-      @include gradient-bg(var(--#{$prefix}range-slider-thumb-bg));
-      border: var(--#{$prefix}range-slider-thumb-border);
-      @include border-radius(var(--#{$prefix}range-slider-thumb-border-radius));
-      @include box-shadow(var(--#{$prefix}range-slider-thumb-box-shadow));
-      @include transition(var(--#{$prefix}range-slider-thumb-transition));
-
-      &:active {
-        @include gradient-bg(var(--#{$prefix}range-slider-thumb-active-bg));
-      }
+      @include form-range-thumb();
     }
 
     &:disabled {
@@ -210,28 +148,46 @@ $range-slider-vertical-tokens: defaults(
 
       &::-webkit-slider-thumb {
         pointer-events: none;
-        background-color: var(--#{$prefix}range-slider-thumb-disabled-bg);
+        background-color: var(--#{$prefix}range-thumb-disabled-bg);
         opacity: 1;
       }
 
       &::-moz-range-thumb {
         pointer-events: none;
-        background-color: var(--#{$prefix}range-slider-thumb-disabled-bg);
+        background-color: var(--#{$prefix}range-thumb-disabled-bg);
         opacity: 1;
       }
     }
   }
 
+  // The plugin builds the grid template from the gaps between label values, so every label
+  // sits on a grid line and a labelled stop draws a taller tick than a bare one.
   .range-slider-labels-container {
-    position: relative;
+    display: grid;
   }
 
   .range-slider-label {
-    position: absolute;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-self: start;
+    width: 0;
     padding: var(--#{$prefix}range-slider-label-padding-y) var(--#{$prefix}range-slider-label-padding-x);
     font-size: var(--#{$prefix}range-slider-label-font-size);
     color: var(--#{$prefix}range-slider-label-color);
-    @include ltr-rtl("transform", translateX(-50%), null, translateX(50%));
+    white-space: nowrap;
+
+    &::before {
+      width: var(--#{$prefix}range-tick-width);
+      height: var(--#{$prefix}range-tick-minor-height);
+      margin-bottom: var(--#{$prefix}range-tick-label-margin-top);
+      content: "";
+      background-color: var(--#{$prefix}range-tick-bg);
+    }
+
+    &:not(:empty)::before {
+      height: var(--#{$prefix}range-tick-height);
+    }
 
     &.clickable {
       cursor: pointer;
@@ -243,7 +199,7 @@ $range-slider-vertical-tokens: defaults(
 
     // Outside `$prefix` on purpose: the plugin writes this name.
     position: absolute;
-    inset-inline-start: calc(var(--#{$prefix}range-slider-thumb-width) * .5 + var(--cui-range-slider-tooltip-position, 0) * (100% - var(--#{$prefix}range-slider-thumb-width)));
+    inset-inline-start: calc(var(--#{$prefix}range-thumb-width) * .5 + var(--cui-range-slider-tooltip-position, 0) * (100% - var(--#{$prefix}range-thumb-width)));
     pointer-events: none;
     @include ltr-rtl("transform", translateX(-50%), null, translateX(50%));
 
@@ -254,20 +210,20 @@ $range-slider-vertical-tokens: defaults(
 
   .range-slider:not(.range-slider-vertical) {
     @include rtl() {
-      --#{$prefix}range-slider-track-direction: to left;
+      --#{$prefix}range-track-direction: to left;
     }
-
 
     .range-slider-inputs-container {
       width: 100%;
     }
 
     .range-slider-labels-container {
-      width: calc(var(--#{$prefix}range-slider-track-width) - var(--#{$prefix}range-slider-thumb-width));
+      width: 100%;
+      padding-inline: calc(var(--#{$prefix}range-thumb-width) * .5);
     }
 
     .range-slider-tooltip {
-      bottom: calc(var(--#{$prefix}range-slider-tooltip-margin-bottom) + var(--#{$prefix}range-slider-thumb-height));
+      bottom: calc(var(--#{$prefix}range-slider-tooltip-margin-bottom) + var(--#{$prefix}tooltip-arrow-height) + var(--#{$prefix}range-thumb-height));
 
       .tooltip-arrow {
         position: absolute;
@@ -280,14 +236,14 @@ $range-slider-vertical-tokens: defaults(
   .range-slider-vertical {
     @include tokens($range-slider-vertical-tokens);
 
-    --#{$prefix}range-slider-track-direction: to top;
+    --#{$prefix}range-track-direction: to top;
 
     flex-direction: row;
     height: var(--#{$prefix}range-slider-vertical-track-height);
 
     .range-slider-inputs-container {
       justify-content: center;
-      width: string.unquote("max(var(--#{$prefix}range-slider-thumb-width), var(--#{$prefix}range-slider-vertical-track-width))");
+      width: string.unquote("max(var(--#{$prefix}range-thumb-width), var(--#{$prefix}range-slider-vertical-track-width))");
       height: 100%;
     }
 
@@ -304,8 +260,8 @@ $range-slider-vertical-tokens: defaults(
 
     .range-slider-tooltip {
       inset-inline-start: auto;
-      inset-inline-end: calc(var(--#{$prefix}range-slider-tooltip-margin-end) + var(--#{$prefix}range-slider-thumb-width));
-      bottom: calc(var(--#{$prefix}range-slider-thumb-height) * .5 + var(--cui-range-slider-tooltip-position, 0) * (100% - var(--#{$prefix}range-slider-thumb-height)));
+      inset-inline-end: calc(var(--#{$prefix}range-slider-tooltip-margin-end) + var(--#{$prefix}tooltip-arrow-height) + var(--#{$prefix}range-thumb-width));
+      bottom: calc(var(--#{$prefix}range-thumb-height) * .5 + var(--cui-range-slider-tooltip-position, 0) * (100% - var(--#{$prefix}range-thumb-height)));
       transform: translateY(50%);
 
       .tooltip-arrow {
@@ -317,11 +273,28 @@ $range-slider-vertical-tokens: defaults(
 
     .range-slider-labels-container {
       flex-shrink: 0;
-      height: calc(var(--#{$prefix}range-slider-vertical-track-height) - var(--#{$prefix}range-slider-thumb-height));
+      height: 100%;
+      padding-block: calc(var(--#{$prefix}range-thumb-height) * .5);
     }
 
     .range-slider-label {
-      transform: translateY(50%);
+      flex-direction: row;
+      align-self: start;
+      justify-self: auto;
+      width: auto;
+      height: 0;
+
+      &::before {
+        width: var(--#{$prefix}range-tick-minor-height);
+        height: var(--#{$prefix}range-tick-width);
+        margin-inline-end: var(--#{$prefix}range-tick-label-margin-top);
+        margin-bottom: 0;
+      }
+
+      &:not(:empty)::before {
+        width: var(--#{$prefix}range-tick-height);
+        height: var(--#{$prefix}range-tick-width);
+      }
     }
   }
 }

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -102,17 +102,20 @@ $form-range-tokens: defaults(
 }
 
 @mixin form-range-track() {
+  // Fill (progress) up to the thumb. The Range plugin keeps `--cui-range-fill` (0–1) in sync.
+  // The thumb travels between half its width from either end, so the edge follows the same path.
+  --#{$prefix}range-fill-edge: calc(var(--#{$prefix}range-thumb-width) * .5 + var(--#{$prefix}range-fill, 0) * (100% - var(--#{$prefix}range-thumb-width)));
+
   width: var(--#{$prefix}range-track-width);
   height: var(--#{$prefix}range-track-height);
   color: transparent;
   cursor: var(--#{$prefix}range-track-cursor);
-  // Fill (progress) up to the thumb. The Range plugin keeps `--cui-range-fill` (0–1) in sync.
   background-color: var(--#{$prefix}range-track-bg);
   background-image:
     linear-gradient(
       var(--#{$prefix}range-track-direction, to right),
-      color-mix(in oklch, var(--#{$prefix}theme-bg, var(--#{$prefix}range-track-fill-bg)) 50%, transparent) calc(var(--#{$prefix}range-fill, 0) * 100%),
-      transparent calc(var(--#{$prefix}range-fill, 0) * 100%)
+      color-mix(in oklch, var(--#{$prefix}theme-bg, var(--#{$prefix}range-track-fill-bg)) 50%, transparent) var(--#{$prefix}range-fill-edge),
+      transparent var(--#{$prefix}range-fill-edge)
     );
   border-color: transparent;
   @include border-radius(var(--#{$prefix}range-track-border-radius));

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -111,7 +111,7 @@ $form-range-tokens: defaults(
   background-image:
     linear-gradient(
       var(--#{$prefix}range-track-direction, to right),
-      var(--#{$prefix}theme-bg, var(--#{$prefix}range-track-fill-bg)) calc(var(--#{$prefix}range-fill, 0) * 100%),
+      color-mix(in oklch, var(--#{$prefix}theme-bg, var(--#{$prefix}range-track-fill-bg)) 50%, transparent) calc(var(--#{$prefix}range-fill, 0) * 100%),
       transparent calc(var(--#{$prefix}range-fill, 0) * 100%)
     );
   border-color: transparent;

--- a/scss/tests/_range-slider.test.scss
+++ b/scss/tests/_range-slider.test.scss
@@ -1,0 +1,16 @@
+@use "sass:map";
+@use "../forms/form-range" as *;
+@use "../range-slider" as *;
+
+@include describe("range-slider") {
+  @include it("keeps only the label, tooltip offset and vertical tokens as its own; thumb and track come from the range") {
+    @include assert-true(map.has-key($range-slider-tokens, --cui-range-slider-label-color));
+    @include assert-true(map.has-key($range-slider-tokens, --cui-range-slider-tooltip-margin-bottom));
+    @include assert-true(map.has-key($range-slider-vertical-tokens, --cui-range-slider-vertical-track-height));
+    @include assert-false(map.has-key($range-slider-tokens, --cui-range-slider-thumb-bg));
+    @include assert-false(map.has-key($range-slider-tokens, --cui-range-slider-track-bg));
+    @include assert-false(map.has-key($range-slider-tokens, --cui-range-slider-track-in-range-bg));
+    @include assert-true(map.has-key($form-range-tokens, --cui-range-thumb-bg));
+    @include assert-true(map.has-key($form-range-tokens, --cui-range-track-fill-bg));
+  }
+}

--- a/scss/tests/forms/_form-range.test.scss
+++ b/scss/tests/forms/_form-range.test.scss
@@ -22,12 +22,13 @@
       }
       @include expect() {
         .test {
+          --cui-range-fill-edge: calc(var(--cui-range-thumb-width) * .5 + var(--cui-range-fill, 0) * (100% - var(--cui-range-thumb-width)));
           width: var(--cui-range-track-width);
           height: var(--cui-range-track-height);
           color: transparent;
           cursor: var(--cui-range-track-cursor);
           background-color: var(--cui-range-track-bg);
-          background-image: linear-gradient(var(--cui-range-track-direction, to right), color-mix(in oklch, var(--cui-theme-bg, var(--cui-range-track-fill-bg)) 50%, transparent) calc(var(--cui-range-fill, 0) * 100%), transparent calc(var(--cui-range-fill, 0) * 100%));
+          background-image: linear-gradient(var(--cui-range-track-direction, to right), color-mix(in oklch, var(--cui-theme-bg, var(--cui-range-track-fill-bg)) 50%, transparent) var(--cui-range-fill-edge), transparent var(--cui-range-fill-edge));
           border-color: transparent;
           border-radius: var(--cui-range-track-border-radius);
         }

--- a/scss/tests/forms/_form-range.test.scss
+++ b/scss/tests/forms/_form-range.test.scss
@@ -13,7 +13,7 @@
     @include assert-true(map.has-key($form-range-tokens, --cui-range-tick-label-font-size));
   }
 
-  @include it("track: paints the fill from --cui-range-fill and falls back to an empty track without the plugin") {
+  @include it("track: paints the fill at half strength from --cui-range-fill and falls back to an empty track without the plugin") {
     @include assert() {
       @include output() {
         .test {
@@ -27,7 +27,7 @@
           color: transparent;
           cursor: var(--cui-range-track-cursor);
           background-color: var(--cui-range-track-bg);
-          background-image: linear-gradient(var(--cui-range-track-direction, to right), var(--cui-theme-bg, var(--cui-range-track-fill-bg)) calc(var(--cui-range-fill, 0) * 100%), transparent calc(var(--cui-range-fill, 0) * 100%));
+          background-image: linear-gradient(var(--cui-range-track-direction, to right), color-mix(in oklch, var(--cui-theme-bg, var(--cui-range-track-fill-bg)) 50%, transparent) calc(var(--cui-range-fill, 0) * 100%), transparent calc(var(--cui-range-fill, 0) * 100%));
           border-color: transparent;
           border-radius: var(--cui-range-track-border-radius);
         }


### PR DESCRIPTION
## What changes

Follow-up to #1179: the range slider now sits on the same foundations as the range.

**One token family.** `.range-slider` declares the `--cui-range-*` family and the thumb comes from the `form-range-thumb()` mixin, so one setting styles both controls. Removed: `--cui-range-slider-thumb-*`, `--cui-range-slider-track-*`, `-track-in-range-bg`, `-disabled-track-in-range-bg` (and their Sass variables). Kept: `--cui-range-slider-label-*`, `-tooltip-margin-*`, `-vertical-*`. The filled band keeps its half-strength mix of the theme colour and the range's fill takes the same mix, so the fill sits a shade lighter than the thumb in both controls; a disabled slider greys it through the theme slot on the track. Full rename map is in the migration guide.

**Labels on a grid, with ticks.** The plugin builds `grid-template-columns` (rows when vertical, max at the top) from the gaps between label values. Labels are in normal flow, so the container sizes itself; the resize listener, the measured container size and the inline `left`/`bottom` offsets are gone. Labels are sorted by value and each draws a tick from `--cui-range-tick-*`, taller when it has text.

**`list` option.** Reads a `<datalist>` by id like the range does and merges its options with `labels`.

**Tooltip modes.** `tooltips: true` shows a handle's tooltip on hover, drag and visible focus; `'always'` keeps them on. The offset now includes the arrow height, so the arrow tip sits 4 px from the thumb like the range's, instead of 2.4 px inside it.

**Fill edge under the thumb.** Both tracks used the ratio of the whole width for the fill edge while the thumb travels between half its width from either end, so the band lagged near the minimum and overtook the thumb from about 94 %. The edge now follows the thumb's path (the same formula the tooltip uses); the slider plugin writes plain ratios and a single thumb pins the start edge to 0 so its band still begins at the track's end.

**Docs.** Datalist example, tooltip modes, the shared tokens block on the Customizing section, and the option table names `tooltipClass` (`data-coreui-tooltip-class`), which is what the plugin reads; the page said `customClass`.

## Verification

- `css-test` 114 specs (new: the slider keeps only its own tokens, thumb/track keys live in the range map), stylelint, `css-test-class-api` passed.
- `js-test` full suite green with coverage; 140 specs for `RangeSlider` (grid columns/rows, sorting by value, `list` alone and merged with `labels`, `always`, non-object `style`).
- `docs-build` 179 pages.
- Chromium probe on the built `dist`: label centres equal thumb centres at min/mid/max horizontally (24/380/736 px) and vertically (max at the top); RTL mirrors labels and the fill direction; ticks 8/6 px for labelled/bare stops; disabled band grey under `theme-danger`; arrow-tip gap 4 px in range, horizontal and vertical slider.
- Bundlewatch: coreui.css 73.5 kB (min 69.25 kB), the shared track and label rules landed exactly on the previous ceiling.

## Follow-up (workspace TODO)

`CRangeSlider` in React/Vue PRO reads the old token names in its `utils.ts` and its `styling.mdx` shows `--cui-range-slider-track-bg`; both ports move to the new names together with the grid labels, `list` and tooltip modes.