### PR TITLE
fix(Range): no fill stub on a bare range input

### DIFF
--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -102,9 +102,10 @@ $form-range-tokens: defaults(
 }
 
 @mixin form-range-track() {
-  // Fill (progress) up to the thumb. The Range plugin keeps `--cui-range-fill` (0–1) in sync.
-  // The thumb travels between half its width from either end, so the edge follows the same path.
-  --#{$prefix}range-fill-edge: calc(var(--#{$prefix}range-thumb-width) * .5 + var(--#{$prefix}range-fill, 0) * (100% - var(--#{$prefix}range-thumb-width)));
+  // Fill (progress) up to the thumb. The Range plugin keeps `--cui-range-fill` (0–1) in sync; without it
+  // the edge is invalid and the gradient falls back to an empty track. The thumb travels between half
+  // its width from either end, so the edge follows the same path.
+  --#{$prefix}range-fill-edge: calc(var(--#{$prefix}range-thumb-width) * .5 + var(--#{$prefix}range-fill) * (100% - var(--#{$prefix}range-thumb-width)));
 
   width: var(--#{$prefix}range-track-width);
   height: var(--#{$prefix}range-track-height);
@@ -114,8 +115,8 @@ $form-range-tokens: defaults(
   background-image:
     linear-gradient(
       var(--#{$prefix}range-track-direction, to right),
-      color-mix(in oklch, var(--#{$prefix}theme-bg, var(--#{$prefix}range-track-fill-bg)) 50%, transparent) var(--#{$prefix}range-fill-edge),
-      transparent var(--#{$prefix}range-fill-edge)
+      color-mix(in oklch, var(--#{$prefix}theme-bg, var(--#{$prefix}range-track-fill-bg)) 50%, transparent) var(--#{$prefix}range-fill-edge, 0),
+      transparent var(--#{$prefix}range-fill-edge, 0)
     );
   border-color: transparent;
   @include border-radius(var(--#{$prefix}range-track-border-radius));

--- a/scss/tests/forms/_form-range.test.scss
+++ b/scss/tests/forms/_form-range.test.scss
@@ -22,13 +22,13 @@
       }
       @include expect() {
         .test {
-          --cui-range-fill-edge: calc(var(--cui-range-thumb-width) * .5 + var(--cui-range-fill, 0) * (100% - var(--cui-range-thumb-width)));
+          --cui-range-fill-edge: calc(var(--cui-range-thumb-width) * .5 + var(--cui-range-fill) * (100% - var(--cui-range-thumb-width)));
           width: var(--cui-range-track-width);
           height: var(--cui-range-track-height);
           color: transparent;
           cursor: var(--cui-range-track-cursor);
           background-color: var(--cui-range-track-bg);
-          background-image: linear-gradient(var(--cui-range-track-direction, to right), color-mix(in oklch, var(--cui-theme-bg, var(--cui-range-track-fill-bg)) 50%, transparent) var(--cui-range-fill-edge), transparent var(--cui-range-fill-edge));
+          background-image: linear-gradient(var(--cui-range-track-direction, to right), color-mix(in oklch, var(--cui-theme-bg, var(--cui-range-track-fill-bg)) 50%, transparent) var(--cui-range-fill-edge, 0), transparent var(--cui-range-fill-edge, 0));
           border-color: transparent;
           border-radius: var(--cui-range-track-border-radius);
         }


### PR DESCRIPTION
A bare `<input class="form-range">` without the plugin drew half a thumb's width of fill at the start of the track, because `--cui-range-fill` fell back to 0 inside the fill edge. The edge now has no fallback (invalid without a fill) and the gradient reads it with a fallback of 0, so the track stays empty until the plugin or a static `--cui-range-fill` sets it. sass-true updated; rendered bare inputs at 0 and 50, a static fill and two plugin wrappers in Chromium.