### PR TITLE
feat(RangeSlider): a bare number in labels is a tick without text

### DIFF
--- a/docs/src/content/docs/forms/range-slider.mdx
+++ b/docs/src/content/docs/forms/range-slider.mdx
@@ -99,11 +99,15 @@ Add labels to specific points on the slider for better context. If you provide a
 
 ### Labels customization
 
-Labels can be configured as an array of strings or objects. When using objects, you can specify additional properties like `value`, `label`, `class`, and `style`.
+Labels can be configured as an array of strings, numbers or objects. A number is a bare tick at that value, with no text; with objects you can specify additional properties like `value`, `label`, `class`, and `style`. Every entry draws a tick, taller when it has text, and all of them are laid out on one grid, so unevenly spaced values stay aligned.
 
 <Example pro code={`<div id="myRangeSliderCustomLabels"></div>`} sandboxJs={rangeSliderCustomLabels} />
 
 <Code code={rangeSliderCustomLabels} lang="js" />
+
+Numbers and labelled points mix in one array; passed through a data attribute, the array is JSON.
+
+<Example pro code={`<div data-coreui-toggle="range-slider" data-coreui-value="25,75" data-coreui-labels='[{"value": 0, "label": "Cold"}, 25, {"value": 50, "label": "Mild"}, 75, {"value": 100, "label": "Hot"}]'></div>`} />
 
 ### Tick marks from a datalist
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -1178,8 +1178,9 @@ adornment in the library — so the button needs no icon markup at all:
   values, so labels are in normal flow: the container sizes itself, and the
   resize listener plus the measured container height are gone. Every label
   draws a tick from `--cui-range-tick-*` — taller when it has text — and the
-  labels are sorted by value. The new `list` option reads a `<datalist>`
-  like the range does and merges its options with `labels`. Custom CSS that
+  labels are sorted by value. A bare number in `labels` is a tick without
+  text at that value. The new `list` option reads a `<datalist>` like the
+  range does and merges its options with `labels`. Custom CSS that
   positioned `.range-slider-label` through `left`/`bottom` no longer applies.
 - **Range slider tooltips follow the range's modes.** `tooltips: true` shows a
   handle's tooltip on hover, drag and visible focus; `"always"` keeps them on.

--- a/js/src/range-slider.ts
+++ b/js/src/range-slider.ts
@@ -52,7 +52,7 @@ const SELECTOR_RANGE_SLIDER_INPUT = '.range-slider-input'
 const SELECTOR_RANGE_SLIDER_INPUTS_CONTAINER = '.range-slider-inputs-container'
 const SELECTOR_RANGE_SLIDER_LABEL = '.range-slider-label'
 
-type RangeSliderLabel = string | { class?: string | string[], label?: string, style?: Record<string, string>, value?: number }
+type RangeSliderLabel = number | string | { class?: string | string[], label?: string, style?: Record<string, string>, value?: number }
 
 type RangeSliderConfig = {
   allowList: SanitizerAllowList
@@ -385,13 +385,16 @@ class RangeSlider extends BaseComponent {
 
     if (Array.isArray(labels) && labels.length > 0) {
       for (const [index, label] of labels.entries()) {
-        const value = typeof label === 'object' && label.value !== undefined ?
-          label.value :
-          min + (labels.length === 1 ? 0 : (index / (labels.length - 1)) * span)
+        // A bare number is a tick without text at that value
+        const value = typeof label === 'number' ?
+          label :
+          (typeof label === 'object' && label.value !== undefined ?
+            label.value :
+            min + (labels.length === 1 ? 0 : (index / (labels.length - 1)) * span))
 
         points.push({
           class: typeof label === 'object' ? label.class : undefined,
-          label: typeof label === 'object' ? (label.label ?? '') : label,
+          label: typeof label === 'number' ? '' : (typeof label === 'object' ? (label.label ?? '') : label),
           ratio: ratio(value),
           style: typeof label === 'object' ? label.style : undefined,
           value

--- a/js/tests/unit/range-slider.spec.js
+++ b/js/tests/unit/range-slider.spec.js
@@ -147,6 +147,20 @@ describe('RangeSlider', () => {
       expect(inputs[1].value).toBe('30')
     })
 
+    it('should draw a bare number in labels as a tick without text', () => {
+      fixtureEl.innerHTML = '<div id="slider"></div>'
+
+      const element = fixtureEl.querySelector('#slider')
+      // eslint-disable-next-line no-new
+      new RangeSlider(element, { labels: [{ value: 0, label: 'Cold' }, 25, { value: 50, label: 'Mild' }] })
+
+      const labels = element.querySelectorAll('.range-slider-label')
+      expect(labels.length).toBe(3)
+      expect(labels[1].textContent).toBe('')
+      expect(labels[1].dataset.coreuiValue).toBe('25')
+      expect(labels[1].style.gridColumnStart).toBe('3')
+    })
+
     it('should initialize with custom configuration via JavaScript', () => {
       fixtureEl.innerHTML = '<div id="slider"></div>'
 


### PR DESCRIPTION
`labels` takes numbers next to strings and objects: a number is a tick at that value with no text, drawn at the minor height like a datalist option without a label. One array then carries labelled and unlabelled points, and the React and Vue editions share the same shape instead of a separate `ticks` prop on the slider. `list` stays as the HTML-only path. Docs: Labels customization mentions numbers and shows a mixed array through the JSON form of the data attribute; migration updated. Spec covers the bare tick (empty text, data value, grid column). Full pre-push gate incl. docs build.