### PR TITLE
fix(scss): let $container-max-widths hold a width across breakpoints

### DIFF
--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -144,7 +144,7 @@ $container-max-widths: defaults(
 );
 // scss-docs-end container-max-widths
 
-@include assert-ascending($container-max-widths, "$container-max-widths");
+@include assert-ascending($container-max-widths, "$container-max-widths", $allow-equal: true);
 
 // Set the number of columns and specify the width of the gutters.
 

--- a/scss/functions/_assert-ascending.scss
+++ b/scss/functions/_assert-ascending.scss
@@ -2,7 +2,7 @@
 
 // Ascending
 // Used to evaluate Sass maps like our grid breakpoints.
-@mixin assert-ascending($map, $map-name) {
+@mixin assert-ascending($map, $map-name, $allow-equal: false) {
   $prev-key: null;
   $prev-num: null;
   @each $key, $num in $map {
@@ -10,7 +10,9 @@
       // Do nothing
     } @else if not math.compatible($prev-num, $num) {
       @warn "Potentially invalid value for #{$map-name}: This map must be in ascending order, but key '#{$key}' has value #{$num} whose unit makes it incomparable to #{$prev-num}, the value of the previous key '#{$prev-key}' !";
-    } @else if $prev-num >= $num {
+    } @else if $prev-num > $num {
+      @warn "Invalid value for #{$map-name}: This map must not decrease, but key '#{$key}' has value #{$num} which is less than #{$prev-num}, the value of the previous key '#{$prev-key}' !";
+    } @else if not $allow-equal and $prev-num == $num {
       @warn "Invalid value for #{$map-name}: This map must be in ascending order, but key '#{$key}' has value #{$num} which isn't greater than #{$prev-num}, the value of the previous key '#{$prev-key}' !";
     }
     $prev-key: $key;


### PR DESCRIPTION
A container that stops growing past a breakpoint is a valid configuration —
`md`, `lg` and `xl` all at `720px`. The map feeds `max-width` and nothing
downstream reads the gaps between its entries. `assert-ascending()` warned on it
anyway, because it rejected any value that was not *strictly* greater than its
predecessor:

```
WARNING: Invalid value for $container-max-widths: This map must be in ascending
order, but key 'lg' has value 720px which isn't greater than 720px, the value of
the previous key 'md' !
```

The mixin now takes `$allow-equal` and splits the two failures apart. A
decreasing value is still reported everywhere, with a message that says what
actually went wrong; an equal one is only reported where equality really breaks
something.

`$breakpoints` keeps the strict check — two stops at the same width would
collapse `breakpoint-next()` and every media query built on it.

Reported upstream as twbs/bootstrap#42192 and closed without a fix. It is moot
there: both `_assert-*` calls have been commented out since the Sass modules
migration (twbs/bootstrap#41512), where `_functions.scss` started doing
`@use "config"` and `_config.scss` could no longer load it back without a module
cycle. Our per-function files carry no config dependency, so the calls still run
here — and so did the false warning.

## Behaviour

| configuration | before | after |
| --- | --- | --- |
| containers hold a width (`md: 720px, lg: 720px, xl: 720px`) | 2 warnings | silent |
| containers decrease (`md: 720px, lg: 600px`) | warned | warned |
| breakpoints repeat a width (`sm: 576px, md: 576px`) | warned | warned |
| breakpoints do not start at 0 | warned | warned |
| defaults | silent | silent |

## Verification

- all five compiled stylesheets byte-identical to `v6-dev`
- `css-test` 116 specs, 0 failures
- `stylelint` and `docs-build` clean
