### PR TITLE
refactor(scss): compute the radius scale from one --cui-radius token in the browser

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -290,7 +290,7 @@ finished, not whether the state changed.
   `--cui-breadcrumb-border-radius` and `--cui-breadcrumb-font-size` were `null`
   in Sass, so the first two were emitted empty (`--cui-breadcrumb-bg: ;`) and
   the third was not emitted at all. They are `transparent`,
-  `var(--cui-border-radius)` and `inherit` now. Nothing renders differently on
+  `var(--cui-radius-5)` and `inherit` now. Nothing renders differently on
   a default breadcrumb, and a font size set on an ancestor still reaches it —
   the one visible change is that a breadcrumb **given a background** now has
   rounded corners like every other surface. Set
@@ -2350,9 +2350,10 @@ as such.
 
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
   **Components read stops of a radius scale, and most got rounder.** `:root`
-  emits `--cui-radius-0` through `--cui-radius-9` (multiples of `$radius`,
-  `.5rem` by default) plus `--cui-radius-pill`, and component tokens read
-  stops instead of the one global `--cui-border-radius`: buttons, inputs,
+  emits `--cui-radius` (`$radius`, `.5rem` by default) and the stops
+  `--cui-radius-0` through `--cui-radius-9` as `calc()` multiples of it, plus
+  `--cui-radius-pill`, and component tokens read stops instead of the one
+  global `--cui-border-radius`: buttons, inputs,
   alerts, list groups, tabs, nav links, progress, tooltips, thumbnails,
   callouts, combobox options and the range slider's tooltip sit on
   `--cui-radius-5` (`.5rem`), badges, popovers, dialogs, drawers, menus,
@@ -2360,17 +2361,18 @@ as such.
   cards on `--cui-radius-8` (`1rem`), pills on `--cui-radius-9` (`1.5rem`).
   Everything that used the `.375rem` default is visibly rounder. To keep a
   component on its old radius, set its own token
-  (`--cui-card-border-radius: .375rem`); to retune the whole page, override
-  the stops or `$radius`. The `$border-radius(-sm/-lg/-xl/-xxl/-pill)`
+  (`--cui-card-border-radius: .375rem`); to retune the whole page, set
+  `--cui-radius` (every stop follows) or override single stops. The `$border-radius(-sm/-lg/-xl/-xxl/-pill)`
   variables and their `--cui-border-radius-*` tokens are gone with it: no
   component read them any more (the modal, the chip, the switch, the chip
   input, the search button's key, the sidebar nav, the header toggler, the
   password-strength segments and the validation tooltip moved to the stop
   with the same value: `--cui-border-radius` → `--cui-radius-4`, `-sm` →
   `-3`, `-lg` → `-5`, `-pill` → `--cui-radius-pill`), and the `.rounded-*`
-  utilities now read the scale too (see the utilities section). Only
-  `--cui-border-radius` survives on `:root`, as a deprecated alias of
-  `--cui-radius-4` for stylesheets written against v5.
+  utilities now read the scale too (see the utilities section).
+  `--cui-border-radius` is gone from `:root` as well: nothing in the library
+  read it, so a stylesheet setting it changed nothing — set `--cui-radius` or
+  a stop instead.
 
 #### Interaction surfaces sit two rungs lighter on the ladder
 
@@ -4110,8 +4112,8 @@ no output at all.
 **CSS custom properties** — `--cui-high-emphasis`,
 `--cui-medium-emphasis`, `--cui-disabled`, and the three
 `-inverse` counterparts, plus `--cui-border-radius-sm`, `-lg`, `-xl`, `-xxl`,
-`-2xl` and `-pill` (use `--cui-radius-0` … `-9` and `--cui-radius-pill`;
-`--cui-border-radius` itself stays as a deprecated alias of `--cui-radius-4`),
+`-2xl`, `-pill` and `--cui-border-radius` itself (use `--cui-radius`,
+`--cui-radius-0` … `-9` and `--cui-radius-pill`),
 `--cui-dropdown-inner-border-radius` and
 `--cui-calendar-cell-range-hover-bg` (declared and never read),
 `--cui-font-monospace` (renamed `--cui-font-mono`), `--cui-highlight-color` and
@@ -4323,7 +4325,9 @@ Prefer the `.d-sidebar-narrow*` names in new markup.
 
   The same numbering applies to `.rounded-size-*` and the side classes
   (`.rounded-top-*`, `.rounded-end-*`, `.rounded-bottom-*`, `.rounded-start-*`);
-  `.rounded-0`, `.rounded-circle` and `.rounded-pill` are unchanged. The side
+  `.rounded-0`, `.rounded-circle` and `.rounded-pill` are unchanged. Each class
+  writes `var(--cui-radius-{n})` rather than the stop's value, so a stop
+  overridden on `:root` re-rounds the utilities along with the components. The side
   classes set logical corners (`border-start-start-radius`, …), so
   `.rounded-top` flips with the writing direction like `.rounded-start`
   already did.

--- a/docs/src/content/docs/utilities/border-radius.mdx
+++ b/docs/src/content/docs/utilities/border-radius.mdx
@@ -54,13 +54,13 @@ Without a `.rounded-size-*` in scope the corner classes fall back to `--cui-radi
 
 ### CSS variables
 
-The radius scale is emitted on `:root` as `--cui-radius-0` through `--cui-radius-9`, plus `--cui-radius-pill`. Components read stops of the scale (`--cui-radius-5`, `--cui-radius-7`), so overriding a stop re-rounds everything that uses it without recompiling.
+The radius scale is emitted on `:root` as `--cui-radius`, the base, and `--cui-radius-0` through `--cui-radius-9`, each a `calc()` multiple of the base, plus `--cui-radius-pill`. Components and the `.rounded-*` utilities read stops of the scale (`--cui-radius-5`, `--cui-radius-7`), so setting `--cui-radius` re-rounds the whole page and overriding one stop re-rounds everything that uses it, without recompiling.
 
 <ScssDocs file="scss/_root.scss" capture="root-radius-loop" />
 
 ### Sass variables
 
-`$radius` is the base of the scale — every stop is a multiple of it.
+`$radius` sets the default of `--cui-radius`; the stops are computed from that token in the browser, not from `$radius` at build time.
 
 <ScssDocs file="scss/_config.scss" capture="radius-variables" />
 
@@ -68,7 +68,7 @@ The radius scale is emitted on `:root` as `--cui-radius-0` through `--cui-radius
 
 ### Sass maps
 
-Each entry is one `--cui-radius-{step}` token as a multiple of `$radius` — override the map to add or retune a step:
+Each entry is one `--cui-radius-{step}` token as a `calc()` multiple of `--cui-radius` — override the map to add or retune a step:
 
 <ScssDocs file="scss/_config.scss" capture="radii-map" />
 

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -212,15 +212,15 @@ $radii: () !default;
 $radii: defaults(
   (
     0: 0,
-    1: $radius * .25,
-    2: $radius * .375,
-    3: $radius * .5,
-    4: $radius * .75,
-    5: $radius,
-    6: $radius * 1.25,
-    7: $radius * 1.5,
-    8: $radius * 2,
-    9: $radius * 3,
+    1: calc(var(--#{$prefix}radius) * .25),
+    2: calc(var(--#{$prefix}radius) * .375),
+    3: calc(var(--#{$prefix}radius) * .5),
+    4: calc(var(--#{$prefix}radius) * .75),
+    5: var(--#{$prefix}radius),
+    6: calc(var(--#{$prefix}radius) * 1.25),
+    7: calc(var(--#{$prefix}radius) * 1.5),
+    8: calc(var(--#{$prefix}radius) * 2),
+    9: calc(var(--#{$prefix}radius) * 3),
   ),
   $radii
 );

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -149,6 +149,7 @@ $root-token-defaults: theme-color-tokens();
 // scss-docs-start root-radius-loop
 // One token per stop of the radius scale, so a page can re-round the library
 // at runtime; components read stops instead of the one global radius.
+$root-token-defaults: map.set($root-token-defaults, --#{$prefix}radius, $radius);
 @each $key, $value in $radii {
   $root-token-defaults: map.set($root-token-defaults, --#{$prefix}radius-#{$key}, $value);
 }
@@ -220,7 +221,6 @@ $root-token-defaults: map.merge(
     --#{$prefix}border-style: $border-style,
     --#{$prefix}border-color: $border-color,
     --#{$prefix}border-color-translucent: $border-color-translucent,
-    --#{$prefix}border-radius: var(--#{$prefix}radius-4),
     // scss-docs-end root-border-var
     --#{$prefix}shadow-color: $shadow-color,
     --#{$prefix}shadow-strength: $shadow-strength,

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -46,6 +46,7 @@ $utilities-border-subtle: theme-color-refs("border", "-subtle") !default;
 // scss-docs-end utilities-border-colors
 
 $utilities-links-underline: theme-color-refs("fg") !default;
+$utilities-radii: theme-token-refs($radii, "radius") !default;
 
 // scss-docs-start font-sizes-legacy
 // The numeric keys v5 shipped, kept so `.fs-1` … `.fs-6` keep rendering. They
@@ -1162,9 +1163,9 @@ $utilities: map.merge(
       ),
       class: rounded,
       values: map.merge(
-        $radii,
+        $utilities-radii,
         (
-          null: map.get($radii, 5),
+          null: var(--#{$prefix}radius-5),
           circle: 50%,
           pill: var(--#{$prefix}radius-pill)
         )
@@ -1174,9 +1175,9 @@ $utilities: map.merge(
       property: --#{$prefix}rounded-size,
       class: rounded-size,
       values: map.merge(
-        $radii,
+        $utilities-radii,
         (
-          null: map.get($radii, 5),
+          null: var(--#{$prefix}radius-5),
           circle: 50%,
           pill: var(--#{$prefix}radius-pill)
         )
@@ -1186,7 +1187,7 @@ $utilities: map.merge(
       property: border-start-start-radius border-start-end-radius,
       class: rounded-top,
       values: map.merge(
-        $radii,
+        $utilities-radii,
         (
           null: var(--#{$prefix}rounded-size, var(--#{$prefix}radius-5)),
           circle: 50%,
@@ -1198,7 +1199,7 @@ $utilities: map.merge(
       property: border-start-end-radius border-end-end-radius,
       class: rounded-end,
       values: map.merge(
-        $radii,
+        $utilities-radii,
         (
           null: var(--#{$prefix}rounded-size, var(--#{$prefix}radius-5)),
           circle: 50%,
@@ -1210,7 +1211,7 @@ $utilities: map.merge(
       property: border-end-start-radius border-end-end-radius,
       class: rounded-bottom,
       values: map.merge(
-        $radii,
+        $utilities-radii,
         (
           null: var(--#{$prefix}rounded-size, var(--#{$prefix}radius-5)),
           circle: 50%,
@@ -1222,7 +1223,7 @@ $utilities: map.merge(
       property: border-start-start-radius border-end-start-radius,
       class: rounded-start,
       values: map.merge(
-        $radii,
+        $utilities-radii,
         (
           null: var(--#{$prefix}rounded-size, var(--#{$prefix}radius-5)),
           circle: 50%,


### PR DESCRIPTION
## What changes

- `:root` emits `--cui-radius` (from `$radius`, `.5rem`) and the stops `--cui-radius-1` … `-9` as `calc()` multiples of it. Before, the stops were multiplied in Sass and emitted as literals, so there was one knob at build time and none at runtime. Now `:root { --cui-radius: .25rem }` re-rounds every component.
- `.rounded-*`, `.rounded-size-*` and the side classes write `var(--cui-radius-N)` instead of the stop's value, so a stop overridden on `:root` re-rounds the utilities along with the components. The docs already said this; it was not true.
- `--cui-border-radius` is removed from `:root`. Nothing in the compiled CSS read it, so setting it never changed anything.

Sass API unchanged: `$radius`, `$radii` and the `scss-docs` markers keep their shape, so `@use … with ($radius: …)` and every `<ScssDocs>` capture still work.

## Verification

- Compiled diff is limited to the `:root` radius block, the removed alias and the `.rounded-*` values.
- Chromium probe on the built stylesheet (button / `.rounded-3` / card, `border-radius` in px):

  | override | button | `.rounded-3` | card |
  | --- | --- | --- | --- |
  | none | 8 | 4 | 16 |
  | `--cui-radius: .25rem` | 4 | 2 | 8 |
  | `--cui-radius-3: 1px` | 8 | 1 | 16 |

- stylelint, `npm run css`, bundlewatch (`coreui.css` 73.22 kB < 74 kB), `docs-build` (180 pages), pre-push gate: all green.

## Docs

Migration guide (radius scale entry, removed-tokens list, `.rounded-*` entry, breadcrumb default) and `utilities/border-radius` updated.
