### PR TITLE
feat(toast, badge): placement classes replace the utility stacks

### DIFF
--- a/docs/src/content/docs/components/badge.mdx
+++ b/docs/src/content/docs/components/badge.mdx
@@ -44,21 +44,21 @@ Unless the context is clear — as in the Notifications example above, where the
 
 ### Positioned
 
-Use utilities to modify a `.badge` and position it in the corner of a link or button.
+<AddedIn version="6.0.0" /> `.badge-position-{block}-{inline}` pins a badge to a corner of its positioned parent, centred on that corner: `block` is `top` or `bottom`, `inline` is `start` or `end`, and the classes follow the writing direction.
 
 <Example code={`<button type="button" class="btn-solid theme-primary position-relative">
     Inbox
-    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill border border-bg theme-danger">
+    <span class="badge badge-position-top-end rounded-pill border border-bg theme-danger">
       99+
       <span class="visually-hidden">unread messages</span>
     </span>
   </button>`} />
 
-You can also replace the `.badge` class with a few more utilities without a count for a more generic indicator.
+Without a count, a `.badge-position-*` on any element makes a generic indicator — here a padded, rounded dot:
 
 <Example code={`<button type="button" class="btn-solid theme-primary position-relative">
     Profile
-    <span class="position-absolute top-0 start-100 translate-middle p-2 bg-danger border border-bg rounded-circle">
+    <span class="badge-position-top-end p-2 bg-danger border border-bg rounded-circle">
       <span class="visually-hidden">New alerts</span>
     </span>
   </button>`} />

--- a/docs/src/content/docs/components/toasts.mdx
+++ b/docs/src/content/docs/components/toasts.mdx
@@ -215,27 +215,27 @@ By default, toasts fade in and out. To disable the animation, add `.toast-instan
 
 ## Placement
 
-Place toasts with custom CSS where needed. The top right and top middle are common positions for notifications. If you're only ever going to display one toast at a time, apply the positioning styles directly to the `.toast`.
+<AddedIn version="6.0.0" /> Nine `.toast-container-{block}-{inline}` classes pin the container to the viewport: `block` is `top`, `middle` or `bottom`, `inline` is `start`, `center` or `end`. They set `position: fixed` and read the distance from the edge from `--cui-toast-container-inset` (`--cui-spacer-4` by default). Inside a positioned box — like the example below — add `.position-absolute` to pin the container to that box instead of the viewport.
 
 <Example code={`<form>
     <div class="mb-3">
       <label for="selectToastPlacement">Toast placement</label>
       <select class="form-control mt-2" id="selectToastPlacement">
         <option value="" selected>Select a position...</option>
-        <option value="top-0 start-0">Top left</option>
-        <option value="top-0 start-50 translate-middle-x">Top center</option>
-        <option value="top-0 end-0">Top right</option>
-        <option value="top-50 start-0 translate-middle-y">Middle left</option>
-        <option value="top-50 start-50 translate-middle">Middle center</option>
-        <option value="top-50 end-0 translate-middle-y">Middle right</option>
-        <option value="bottom-0 start-0">Bottom left</option>
-        <option value="bottom-0 start-50 translate-middle-x">Bottom center</option>
-        <option value="bottom-0 end-0">Bottom right</option>
+        <option value="toast-container-top-start">Top start</option>
+        <option value="toast-container-top-center">Top center</option>
+        <option value="toast-container-top-end">Top end</option>
+        <option value="toast-container-middle-start">Middle start</option>
+        <option value="toast-container-middle-center">Middle center</option>
+        <option value="toast-container-middle-end">Middle end</option>
+        <option value="toast-container-bottom-start">Bottom start</option>
+        <option value="toast-container-bottom-center">Bottom center</option>
+        <option value="toast-container-bottom-end">Bottom end</option>
       </select>
     </div>
   </form>
   <div aria-live="polite" aria-atomic="true" class="bg-black position-relative docs-example-toasts">
-    <div class="toast-container position-absolute p-3" id="toastPlacement">
+    <div class="toast-container position-absolute" id="toastPlacement">
       <div class="toast show">
         <div class="toast-header">
           <svg class="docs-placeholder-img rounded me-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"></rect><text x="50%" y="50%" fill="#dee2e6" dy=".3em"></text></svg>
@@ -254,9 +254,9 @@ For systems that generate more notifications, consider using a wrapping element 
 <Example class="bg-black docs-example-toasts p-0" code={`<div aria-live="polite" aria-atomic="true" class="position-relative">
     <!-- Position it: -->
     <!-- - \`.toast-container\` for spacing between toasts -->
-    <!-- - \`top-0\` & \`end-0\` to position the toasts in the upper right corner -->
-    <!-- - \`.p-3\` to prevent the toasts from sticking to the edge of the container  -->
-    <div class="toast-container top-0 end-0 p-3">
+    <!-- - \`.toast-container-top-end\` to pin the toasts to the upper end corner, inset by the container's inset token -->
+    <!-- - \`.position-absolute\` to pin them to this box rather than the viewport -->
+    <div class="toast-container toast-container-top-end position-absolute">
 
       <!-- Then put toasts within -->
       <div class="toast show" role="alert" aria-live="assertive" aria-atomic="true">
@@ -407,6 +407,10 @@ myToastEl.addEventListener('hidden.coreui.toast', () => {
 Toasts use local CSS variables on `.toast` for enhanced real-time customization.
 
 <ScssDocs file="scss/_toasts.scss" capture="toast-css-vars" />
+
+The container declares its own two, on `.toast-container`:
+
+<ScssDocs file="scss/_toasts.scss" capture="toast-container-css-vars" />
 
 ### Sass variables
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -518,6 +518,14 @@ check, radio, carousel and toggler icons already work:
 - **The font size has a legibility floor.** `--cui-badge-font-size` is
   `clamp(12px, .75em, .75em)`, so a badge inside small text stops shrinking at
   12px while still scaling up with a larger parent.
+- **New: `.badge-position-{top|bottom}-{start|end}`.** One class pins a badge to
+  a corner of its positioned parent, centred on the corner, and flips with the
+  writing direction. It replaces the `position-absolute top-0 start-100
+  translate-middle` utility stack the docs used to recommend; that stack still
+  works. The `.btn .badge` nudge (`position: relative; top: -1px`) is written as
+  `.btn :where(.badge)` so a position class on a badge inside a button wins;
+  a stylesheet that relied on beating `.btn .badge` with two classes now beats
+  it with one.
 
 - **New: `--cui-badge-border-width` / `--cui-badge-border-color` (transparent),
   `.badge-lg`, and a link reset.** The border tokens are what `.badge-outline`
@@ -1931,6 +1939,14 @@ Multi Select's option indicators moved with it — they render as a decorative
   `var(--cui-body-bg)`. Add `.toast-translucent` for the see-through look, which
   puts `blur(5px) saturate(180%)` behind the toast and thins the header to match,
   the same way `.card-translucent` and `.menu-translucent` work.
+- **New: `.toast-container-{top|middle|bottom}-{start|center|end}`.** Nine
+  classes pin a `.toast-container` to the viewport (`position: fixed`), inset
+  from the edge by `--cui-toast-container-inset` (`--cui-spacer-4`, 1rem, by
+  default) and centred with logical insets and auto margins rather than
+  transforms, so they hold in RTL. They replace the `position-fixed top-0 end-0
+  p-3` utility stack; inside a positioned box add `.position-absolute` to pin
+  the container to the box. `--cui-toast-container-inset` is declared on
+  `.toast-container` next to `--cui-toast-zindex`.
 
 #### Card
 

--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -1,6 +1,7 @@
 @use "sass:map";
 @use "functions/defaults" as *;
 @use "mixins/border-radius" as *;
+@use "mixins/ltr-rtl" as *;
 @use "mixins/tokens" as *;
 @use "config" as *;
 
@@ -116,10 +117,27 @@ $badge-variants: defaults(
   }
 
   // Quick fix for badges in buttons
-  .btn .badge {
+  .btn :where(.badge) {
     position: relative;
     top: -1px;
   }
+
+  // scss-docs-start badge-positions
+  @each $block, $inset-block in (top: 0, bottom: 100%) {
+    @each $inline, $inset-inline in (start: 0, end: 100%) {
+      .badge-position-#{$block}-#{$inline} {
+        position: absolute;
+        inset-block-start: $inset-block;
+        inset-inline-start: $inset-inline;
+        translate: -50% -50%;
+
+        @include rtl() {
+          translate: 50% -50%;
+        }
+      }
+    }
+  }
+  // scss-docs-end badge-positions
 
   // scss-docs-start badge-modifiers
   @each $variant, $properties in $badge-variants {

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -19,6 +19,7 @@ $toast-border-color:                var(--#{$prefix}border-color-translucent) !d
 $toast-border-radius:               var(--#{$prefix}radius-7) !default;
 $toast-box-shadow:                  var(--#{$prefix}box-shadow) !default;
 $toast-spacing:                     $container-padding-x !default;
+$toast-container-inset:             var(--#{$prefix}spacer-4) !default;
 $toast-transition-property:         "opacity, display" !default;
 $toast-transition-duration:         .15s !default;
 $toast-transition-timing:           linear !default;
@@ -103,7 +104,10 @@ $toast-tokens: defaults(
   }
 
   .toast-container {
+    // scss-docs-start toast-container-css-vars
     --#{$prefix}toast-zindex: var(--#{$prefix}z-toast);
+    --#{$prefix}toast-container-inset: #{$toast-container-inset};
+    // scss-docs-end toast-container-css-vars
 
     position: absolute;
     z-index: var(--#{$prefix}toast-zindex);
@@ -115,6 +119,51 @@ $toast-tokens: defaults(
       margin-bottom: var(--#{$prefix}toast-spacing);
     }
   }
+
+  // scss-docs-start toast-container-placements
+  .toast-container-top-start,
+  .toast-container-top-center,
+  .toast-container-top-end,
+  .toast-container-middle-start,
+  .toast-container-middle-center,
+  .toast-container-middle-end,
+  .toast-container-bottom-start,
+  .toast-container-bottom-center,
+  .toast-container-bottom-end {
+    position: fixed;
+  }
+
+  @each $block, $property in (top: inset-block-start, bottom: inset-block-end) {
+    .toast-container-#{$block}-start,
+    .toast-container-#{$block}-center,
+    .toast-container-#{$block}-end {
+      #{$property}: var(--#{$prefix}toast-container-inset);
+    }
+  }
+
+  .toast-container-middle-start,
+  .toast-container-middle-center,
+  .toast-container-middle-end {
+    inset-block: var(--#{$prefix}toast-container-inset);
+    height: fit-content;
+    margin-block: auto;
+  }
+
+  @each $inline, $property in (start: inset-inline-start, end: inset-inline-end) {
+    .toast-container-top-#{$inline},
+    .toast-container-middle-#{$inline},
+    .toast-container-bottom-#{$inline} {
+      #{$property}: var(--#{$prefix}toast-container-inset);
+    }
+  }
+
+  .toast-container-top-center,
+  .toast-container-middle-center,
+  .toast-container-bottom-center {
+    inset-inline: var(--#{$prefix}toast-container-inset);
+    margin-inline: auto;
+  }
+  // scss-docs-end toast-container-placements
 
   .toast-header {
     display: flex;


### PR DESCRIPTION
Part of the token layer on `v6-dev-tokens`. Components stop composing utilities for placement; the classes live in the stylesheet with tokens.

## What changes

- **`.toast-container-{top|middle|bottom}-{start|center|end}`** pins a `.toast-container` to the viewport: `position: fixed`, inset from the edge by `--cui-toast-container-inset` (`--cui-spacer-4`, declared on `.toast-container` next to `--cui-toast-zindex`), centred with logical insets and auto margins rather than transforms, so it holds in RTL. Inside a positioned box add `.position-absolute`.
- **`.badge-position-{top|bottom}-{start|end}`** pins a badge to a corner of its positioned parent, centred on the corner, flipped under `[dir=rtl]`. The `.btn .badge` nudge becomes `.btn :where(.badge)` so a position class on a badge inside a button wins.
- Docs: toasts placement section and select demo, badge positioned examples, migration entries (Toast, Badge), `toast-container-css-vars` capture.

## Verification

Chromium probe against the utility stacks the docs recommended (`position-fixed top-50 start-50 translate-middle`, `position-absolute top-0 start-100 translate-middle`), LTR and RTL:

| element | new class | utility stack |
| --- | --- | --- |
| toaster middle-center | 300, 289 | 300, 289 |
| badge top-end, LTR (button right edge 140, top 40) | centre 138.5, 41 | centre 243.5, 41 on its own button |
| badge top-end, RTL (button left edge 1140) | centre 1140.5, 41 | mirror |

The first probe caught `.btn .badge { position: relative }` beating the position class — hence `:where()`. Plain badges in buttons keep `relative` / `top: -1px`.

stylelint, `npm run css`, bundlewatch (73.46 kB < 74 kB), `docs-build`, vnu, pre-push gate: green.

## Next

React: coreui-react-pro `feat/placement-classes-v6` switches `CToaster` and `CBadge` to these classes. The six `CWidgetStats*` components are the remaining utility users and need a vanilla SCSS family first — tracked in the workspace TODO.
