### PR TITLE
feat(utilities): --config reads the utilities section of a config module

### DIFF
--- a/build/lib/utilities.mjs
+++ b/build/lib/utilities.mjs
@@ -18,11 +18,26 @@ export const LAYERS = ['colors', 'config', 'root', 'reboot', 'layout', 'content'
 // The package map with user files merged over it the way `$utilities` merges:
 // an existing key replaces the whole group, `null` removes it, a new key is
 // appended. `only` keeps just the keys the user files name.
-export const loadUtilities = ({ files = [], only = false } = {}) => {
+// A plain object (a config file's `utilities.extend`) in the Map shape the
+// generator reads; arrays and scalars pass through.
+const toMap = value => {
+  if (Array.isArray(value)) {
+    return value.map(item => toMap(item))
+  }
+
+  if (value && typeof value === 'object') {
+    return new Map(Object.entries(value).map(([key, item]) => [key, toMap(item)]))
+  }
+
+  return value
+}
+
+export const loadUtilities = ({ files = [], extend = {}, only = false } = {}) => {
   const utilities = parseOrdered(readFileSync(path.join(root, 'utilities.json'), 'utf8'))
   const userKeys = new Set()
-  for (const file of files) {
-    for (const [key, utility] of parseOrdered(readFileSync(path.resolve(file), 'utf8'))) {
+  const overrides = [...files.map(file => parseOrdered(readFileSync(path.resolve(file), 'utf8'))), toMap(extend)]
+  for (const override of overrides) {
+    for (const [key, utility] of override) {
       userKeys.add(key)
       if (utility === null || utility === false) {
         utilities.delete(key)

--- a/build/lib/utilities.test.mjs
+++ b/build/lib/utilities.test.mjs
@@ -47,3 +47,19 @@ test('the class index covers the full stylesheet', () => {
     assert.ok(full.includes(`.${name.replace('-hover', '-hover:hover')} {`), name)
   }
 })
+
+test('extend merges a plain object the way a user file does', () => {
+  const extended = loadUtilities({
+    extend: {
+      rotate: {
+        responsive: true, property: 'transform', class: 'rotate', values: { 45: 'rotate(45deg)' }
+      },
+      width: null
+    }
+  })
+  assert.ok(extended.has('rotate'))
+  assert.ok(!extended.has('width'))
+  const css = stylesheet(extended)
+  assert.match(css, /\.rotate-md-45 \{\n {6}transform: rotate\(45deg\);/)
+  assert.doesNotMatch(css, /\.w-25 \{/)
+})

--- a/build/utilities.mjs
+++ b/build/utilities.mjs
@@ -10,13 +10,15 @@
  * file merged over utilities.json (a key replaces the whole entry, `null`
  * removes it, a new key is appended); `--only` keeps just the keys those
  * files name. `--scan <glob>` (repeatable) keeps just the classes found in
- * the matching source files, plus `--safelist a,b`. A `.css` argument is the
- * output path, otherwise stdout.
+ * the matching source files, plus `--safelist a,b`. `--config <file>` reads
+ * the `utilities` section (`extend`, `safelist`, `scan`) of a config module —
+ * its default export, or the object itself. A `.css` argument is the output
+ * path, otherwise stdout.
  */
 
 import { globSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import {
   LAYERS, loadUtilities, scanFiles, stylesheet
 } from './lib/utilities.mjs'
@@ -27,10 +29,13 @@ const only = process.argv.includes('--only')
 const output = process.argv.find(argument => !argument.startsWith('-') && argument.endsWith('.css'))
 const files = process.argv.slice(2).filter(argument => argument.endsWith('.json'))
 const option = name => process.argv.flatMap((argument, index) => (argument === name ? [process.argv[index + 1]] : []))
-const patterns = option('--scan')
-const safelist = option('--safelist').flatMap(list => list.split(','))
+const configFile = option('--config')[0]
+const config = configFile ? await import(pathToFileURL(path.resolve(configFile)).href) : null
+const configured = config?.default?.utilities ?? config?.utilities ?? {}
+const patterns = [...(configured.scan ?? []), ...option('--scan')]
+const safelist = [...(configured.safelist ?? []), ...option('--safelist').flatMap(list => list.split(','))]
 
-const utilities = loadUtilities({ files, only })
+const utilities = loadUtilities({ files, extend: configured.extend ?? {}, only })
 let used = null
 if (patterns.length > 0) {
   const sources = patterns.flatMap(pattern => globSync(pattern))
@@ -44,7 +49,7 @@ if (patterns.length > 0) {
   }
 }
 
-const css = stylesheet(utilities, { layer: files.length > 0 || used !== null, only: used })
+const css = stylesheet(utilities, { layer: files.length > 0 || configFile !== undefined || used !== null, only: used })
 
 if (check) {
   const rootScss = readFileSync(path.join(root, 'scss/_root.scss'), 'utf8')

--- a/docs/src/content/docs/utilities/api.mdx
+++ b/docs/src/content/docs/utilities/api.mdx
@@ -739,4 +739,23 @@ Either way the file starts with the cascade layer order, so your classes land in
 npx coreui-utilities --scan "src/**/*.{html,tsx,vue}" css/utilities.css
 ```
 
+The same three settings can live in a config module instead of on the command line — `extend` with the JSON shape above, `safelist` and `scan` — which is what `defineConfig()` in the React binding produces:
+
+```js
+// coreui.config.mjs
+export default {
+  utilities: {
+    extend: { rotate: { responsive: true, property: 'transform', class: 'rotate', values: { 45: 'rotate(45deg)' } } },
+    safelist: ['mt-1'],
+    scan: ['src/**/*.{html,tsx}'],
+  },
+}
+```
+
+```sh
+npx coreui-utilities --config coreui.config.mjs css/utilities.css
+```
+
+A `.ts` config works on a Node that strips types (22.6 and later). Flags on the command line add to what the config says.
+
 The rules come out in the order of the map, not the order of use, so two utilities on one element resolve exactly as they do in the full stylesheet, and only the `@property` registrations and keyframes those rules need are written. A name built at runtime (`` `mt-${n}` ``) cannot be found this way — pass it with `--safelist mt-1,mt-2`, or keep the set of names static. During development generate the full stylesheet instead and scan for the production build.


### PR DESCRIPTION
On `v6-dev-tokens`. Pairs with coreui/coreui-react-pro#320 (`defineConfig()`).

## What changes

- `coreui-utilities --config coreui.config.{mjs,ts} out.css` imports the module and reads `utilities.extend`, `utilities.safelist` and `utilities.scan` from its default export (or the object itself) — the section `defineConfig()` returns. A `.ts` config loads on a Node that strips types (22.6+). Flags on the command line add to the config.
- `loadUtilities({ extend })` takes the extension as a plain object and merges it the way a user JSON file is merged (replace / `null` removes / append).
- One more `node:test`; Sass parity unchanged. Docs: `utilities/api` § Only what you use.

## Smoke

`.mjs` config with `extend` (rotate responsive, width removed), `safelist: ['mt-1']` and `scan` over one HTML file → exactly `.d-flex`, `.mt-1`, `.rotate-md-45`. A `.ts` config loads and applies its safelist.

eslint, `utilities-test`, `utilities-check`, docs-build, vnu, pre-push gate: green.