### PR TITLE
refactor(scss): compute the spacing scale from --cui-spacer in the browser

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -2,11 +2,11 @@
   "files": [
     {
       "path": "./dist/css/coreui-grid.css",
-      "maxSize": "11 kB"
+      "maxSize": "11.5 kB"
     },
     {
       "path": "./dist/css/coreui-grid.min.css",
-      "maxSize": "10 kB"
+      "maxSize": "10.5 kB"
     },
     {
       "path": "./dist/css/coreui-reboot.css",
@@ -14,15 +14,15 @@
     },
     {
       "path": "./dist/css/coreui-reboot.min.css",
-      "maxSize": "6 kB"
+      "maxSize": "6.25 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.css",
-      "maxSize": "21.5 kB"
+      "maxSize": "22 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",
-      "maxSize": "20.25 kB"
+      "maxSize": "20.75 kB"
     },
     {
       "path": "./dist/css/coreui.css",

--- a/build/lib/utilities.mjs
+++ b/build/lib/utilities.mjs
@@ -65,20 +65,10 @@ const pathOf = dotted => dotted.split('.')
 
 const tokenMap = (dotted, mapValue) => new Map(entries(get(tokens, ...pathOf(dotted))).map(([key, token]) => [key, mapValue(token, key)]))
 
-const evaluate = value => {
-  if (typeof value === 'string') {
-    return value.startsWith('{') ? evaluate(valueOf(get(tokens, ...pathOf(value.slice(1, -1))))) : cssValue(value)
-  }
-
-  const [ref, factor] = value.get('multiply')
-  const base = /^(-?[\d.]+)([a-z%]*)$/.exec(valueOf(get(tokens, ...pathOf(ref.slice(1, -1)))))
-  return `${Math.round(Number(base[1]) * factor * 1e6) / 1e6}${base[2]}`
-}
-
 const sources = {
   $theme: (slot, source) => new Map(entries(get(tokens, 'color', 'theme')).map(([color]) => [`${color}${source.get('$suffix') ?? ''}`, `var(--cui-${color}-${slot})`])),
   $family: family => new Map(entries(get(tokens, 'color', family)).filter(([, token]) => valueOf(token) !== 'inherit').map(([key]) => [key, `var(--cui-${family}-${key})`])),
-  $scale: dotted => tokenMap(dotted, token => evaluate(valueOf(token))),
+  $scale: dotted => tokenMap(dotted, token => cssValue(valueOf(token))),
   $refs: dotted => tokenMap(dotted, (token, key) => `var(--cui-${cssName(`{${dotted}.${key}}`)})`),
   $tokens: dotted => tokenMap(dotted, token => cssValue(valueOf(token))),
   $opacity(property, source) {

--- a/build/tokens.mjs
+++ b/build/tokens.mjs
@@ -117,9 +117,9 @@ const BLOCKS = {
   },
   'scss/_config.scss': {
     'spacer-variables': () => scalars(new Map([['spacer', get(tokens, 'space', 'spacer')]]), 0),
-    'spacers-map': () => map({ name: 'spacers', body: rows(scale(['space', 'scale'], 'sass'), 0, '    ', true, false) }),
-    'negative-spacers-map': () => map({ name: 'negative-spacers', body: rows(scale(['space', 'negative'], 'sass'), 0, '    ', true) }),
-    'sizes-map': () => map({ name: 'sizes', body: rows(scale(['space', 'size'], 'sass'), 0, '    ', false, false) }),
+    'spacers-map': () => map({ name: 'spacers', body: rows(scale(['space', 'scale']), 0, '    ', true, false) }),
+    'negative-spacers-map': () => map({ name: 'negative-spacers', body: rows(scale(['space', 'negative']), 0, '    ', true) }),
+    'sizes-map': () => map({ name: 'sizes', body: rows(scale(['space', 'size']), 0, '    ', false, false) }),
     breakpoints: () => map({ name: 'breakpoints', plain: true, body: rows(scale(['breakpoint']), 0, '  ', false, false) }),
     'container-max-widths': () => map({ name: 'container-max-widths', body: rows(scale(['container']), 0, '    ', false, false) }),
     'border-widths-map': () => map({ name: 'border-widths', body: rows(scale(['border', 'width']), 0, '    ', false, false) }),

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -3749,6 +3749,24 @@ Nothing existing changes; these are additions. See
   instead of restating declarations, so state styling follows any control
   automatically.
 
+#### The spacing scale is computed from `--cui-spacer` in the browser
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`--cui-spacer-1` … `-9` are `calc()` multiples of `--cui-spacer`, and the
+  spacing utilities read the stops.** `$spacers` used to multiply `$spacer`
+  when the stylesheet was built and every `.m-*`, `.p-*`, `.gap-*`,
+  `.space-*` and `.g-*` class carried the literal length, so the only way to
+  rescale spacing was to recompile. Now `:root` declares `--cui-spacer`
+  (`$spacer`, 1rem) and the stops as `calc(var(--cui-spacer) * n)`, the
+  utilities write `var(--cui-spacer-n)`, the negative margins and the
+  `.w-*` sizes `calc(var(--cui-spacer) * n)`, and the gutters read the same
+  stops. `:root { --cui-spacer: .75rem }` rescales all of it at run time,
+  and overriding one stop re-spaces every utility on it. The scale moved
+  next to the breakpoints in `scss/layout/_tokens.scss`, so the grid,
+  utilities and reboot bundles each declare it; a `$root-tokens` override of
+  a `--cui-spacer-*` key no longer reaches it — override the custom property
+  instead.
+
 #### Spacing utilities write logical shorthands
 
 `.mx-*`, `.my-*`, `.px-*` and `.py-*` (and their negative-margin variants)

--- a/docs/src/content/docs/utilities/gap.mdx
+++ b/docs/src/content/docs/utilities/gap.mdx
@@ -46,7 +46,7 @@ Support includes responsive options for all of CoreUI's grid breakpoints, as wel
 
 ### Sass variables
 
-`$spacer` is the step the whole scale is built from, so changing it rescales every spacing utility at once.
+`$spacer` sets the default of `--cui-spacer`, the step the whole scale is built from: the stops `--cui-spacer-1` … `-9` are `calc()` multiples of it on `:root`, the utilities read the stops, so `:root { --cui-spacer: .75rem }` rescales every spacing utility at run time, no recompile.
 
 <ScssDocs file="scss/_config.scss" capture="spacer-variables" />
 

--- a/docs/src/content/docs/utilities/margin.mdx
+++ b/docs/src/content/docs/utilities/margin.mdx
@@ -76,7 +76,7 @@ Additionally, CoreUI for Bootstrap also includes an `.mx-auto` class for horizon
 
 ## Negative margin
 
-Two negative steps ship for the inline margins, `.me--1`, `.me--2`, `.ms--1` and `.ms--2`, for pulling an element back over its neighbour's gap. They come from the `$negative-spacers` map; add a key there to extend the set (`"-3": $spacer * -.75`), or set one to `null` to drop it. The block margins have no negative form.
+Two negative steps ship for the inline margins, `.me--1`, `.me--2`, `.ms--1` and `.ms--2`, for pulling an element back over its neighbour's gap. They come from the `$negative-spacers` map; add a key there to extend the set (`"-3": calc(var(--cui-spacer) * -.75)`), or set one to `null` to drop it. The block margins have no negative form.
 
 <ScssDocs file="scss/_config.scss" capture="negative-spacers-map" />
 
@@ -84,7 +84,7 @@ Two negative steps ship for the inline margins, `.me--1`, `.me--2`, `.ms--1` and
 
 ### Sass variables
 
-`$spacer` is the step the whole scale is built from, so changing it rescales every spacing utility at once.
+`$spacer` sets the default of `--cui-spacer`, the step the whole scale is built from: the stops `--cui-spacer-1` … `-9` are `calc()` multiples of it on `:root`, the utilities read the stops, so `:root { --cui-spacer: .75rem }` rescales every spacing utility at run time, no recompile.
 
 <ScssDocs file="scss/_config.scss" capture="spacer-variables" />
 

--- a/docs/src/content/docs/utilities/padding.mdx
+++ b/docs/src/content/docs/utilities/padding.mdx
@@ -30,10 +30,10 @@ Where *sides* is one of:
 Where *size* is one of:
 
 - `0` - for classes that eliminate the `padding` by setting it to `0`
-- `1` - (by default) for classes that set the `padding` to `$spacer * .25`
-- `2` - (by default) for classes that set the `padding` to `$spacer * .5`
-- `3` - (by default) for classes that set the `padding` to `$spacer * .75`
-- `4` - (by default) for classes that set the `padding` to `$spacer`
+- `1` - (by default) for classes that set the `padding` to `--cui-spacer-1` (`calc(var(--cui-spacer) * .25)`)
+- `2` - (by default) for classes that set the `padding` to `--cui-spacer-2` (`calc(var(--cui-spacer) * .5)`)
+- `3` - (by default) for classes that set the `padding` to `--cui-spacer-3` (`calc(var(--cui-spacer) * .75)`)
+- `4` - (by default) for classes that set the `padding` to `--cui-spacer-4` (`var(--cui-spacer)`)
 - `5` - (by default) for classes that set the `padding` to `$spacer * 1.25`
 - `6` - (by default) for classes that set the `padding` to `$spacer * 1.5`
 - `7` - (by default) for classes that set the `padding` to `$spacer * 2`

--- a/docs/src/content/docs/utilities/space.mdx
+++ b/docs/src/content/docs/utilities/space.mdx
@@ -58,7 +58,7 @@ sit in a row, and `space-x-md-3` takes over along the inline axis.
 
 ### Sass variables
 
-`$spacer` is the step the whole scale is built from, so changing it rescales every spacing utility at once.
+`$spacer` sets the default of `--cui-spacer`, the step the whole scale is built from: the stops `--cui-spacer-1` … `-9` are `calc()` multiples of it on `:root`, the utilities read the stops, so `:root { --cui-spacer: .75rem }` rescales every spacing utility at run time, no recompile.
 
 <ScssDocs file="scss/_config.scss" capture="spacer-variables" />
 

--- a/docs/src/content/docs/utilities/width.mdx
+++ b/docs/src/content/docs/utilities/width.mdx
@@ -17,7 +17,7 @@ Width utilities are generated from the utility API in `_utilities.scss`. Include
 
 ## Fixed widths
 
-`.w-1` through `.w-12` set a width from the `$sizes` map, one `$spacer` (1rem) per step, for boxes that should hold their size whatever the parent does — an avatar column, a fixed label, a swatch.
+`.w-1` through `.w-12` set a width from the `$sizes` map, one `--cui-spacer` (1rem) per step, computed in the browser, for boxes that should hold their size whatever the parent does — an avatar column, a fixed label, a swatch.
 
 <Example code={`<div class="w-4 p-2 bg-2">.w-4</div>
 <div class="w-8 p-2 bg-2">.w-8</div>

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 @use "functions/assert-ascending" as *;
 @use "functions/assert-starts-at-zero" as *;
 @use "functions/defaults" as *;
@@ -62,15 +63,15 @@ $spacers: () !default;
 $spacers: defaults(
   (
     0: 0,
-    1: $spacer * .25,
-    2: $spacer * .5,
-    3: $spacer * .75,
-    4: $spacer,
-    5: $spacer * 1.25,
-    6: $spacer * 1.5,
-    7: $spacer * 2,
-    8: $spacer * 2.5,
-    9: $spacer * 3,
+    1: calc(var(--#{$prefix}spacer) * .25),
+    2: calc(var(--#{$prefix}spacer) * .5),
+    3: calc(var(--#{$prefix}spacer) * .75),
+    4: var(--#{$prefix}spacer),
+    5: calc(var(--#{$prefix}spacer) * 1.25),
+    6: calc(var(--#{$prefix}spacer) * 1.5),
+    7: calc(var(--#{$prefix}spacer) * 2),
+    8: calc(var(--#{$prefix}spacer) * 2.5),
+    9: calc(var(--#{$prefix}spacer) * 3),
   ),
   $spacers
 );
@@ -81,8 +82,8 @@ $negative-spacers: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $negative-spacers: defaults(
   (
-    "-1": $spacer * -.25,
-    "-2": $spacer * -.5,
+    "-1": calc(var(--#{$prefix}spacer) * -.25),
+    "-2": calc(var(--#{$prefix}spacer) * -.5),
   ),
   $negative-spacers
 );
@@ -93,18 +94,18 @@ $sizes: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $sizes: defaults(
   (
-    1: $spacer,
-    2: $spacer * 2,
-    3: $spacer * 3,
-    4: $spacer * 4,
-    5: $spacer * 5,
-    6: $spacer * 6,
-    7: $spacer * 7,
-    8: $spacer * 8,
-    9: $spacer * 9,
-    10: $spacer * 10,
-    11: $spacer * 11,
-    12: $spacer * 12
+    1: var(--#{$prefix}spacer),
+    2: calc(var(--#{$prefix}spacer) * 2),
+    3: calc(var(--#{$prefix}spacer) * 3),
+    4: calc(var(--#{$prefix}spacer) * 4),
+    5: calc(var(--#{$prefix}spacer) * 5),
+    6: calc(var(--#{$prefix}spacer) * 6),
+    7: calc(var(--#{$prefix}spacer) * 7),
+    8: calc(var(--#{$prefix}spacer) * 8),
+    9: calc(var(--#{$prefix}spacer) * 9),
+    10: calc(var(--#{$prefix}spacer) * 10),
+    11: calc(var(--#{$prefix}spacer) * 11),
+    12: calc(var(--#{$prefix}spacer) * 12)
   ),
   $sizes
 );
@@ -155,7 +156,13 @@ $grid-gutter-y:               0 !default;
 // fusv-disable
 $grid-gutter-width:           $grid-gutter-x !default; // Deprecated in v6.0.0, removed in v7
 // fusv-enable
-$gutters:                     $spacers !default;
+$gutters:                     null !default;
+@if $gutters == null {
+  $gutters: ();
+  @each $key in map.keys($spacers) {
+    $gutters: map.set($gutters, $key, var(--#{$prefix}spacer-#{$key}));
+  }
+}
 
 // Container padding
 

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -137,15 +137,6 @@ $root-token-defaults: theme-color-tokens();
 }
 // scss-docs-end root-font-size-loop
 
-// scss-docs-start root-spacer-loop
-// One token per stop of the spacing scale, so rescaling the system is a
-// runtime change rather than a recompile. Components read these instead of
-// multiplying `$spacer` when the stylesheet is built.
-@each $key, $value in $spacers {
-  $root-token-defaults: map.set($root-token-defaults, --#{$prefix}spacer-#{$key}, $value);
-}
-// scss-docs-end root-spacer-loop
-
 // scss-docs-start root-radius-loop
 // One token per stop of the radius scale, so a page can re-round the library
 // at runtime; components read stops instead of the one global radius.
@@ -229,7 +220,6 @@ $root-token-defaults: map.merge(
     // drawer, menu and popup. One override restyles all four.
     --#{$prefix}transition-timing-overlay: $transition-timing-overlay,
     // scss-docs-end root-transition-variables
-    --#{$prefix}spacer: $spacer,
     // Focus styles
     // scss-docs-start root-focus-variables
     --#{$prefix}focus-ring-width: $focus-ring-width,

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -47,6 +47,7 @@ $utilities-border-subtle: theme-color-refs("border", "-subtle") !default;
 
 $utilities-links-underline: theme-color-refs("fg") !default;
 $utilities-radii: theme-token-refs($radii, "radius") !default;
+$utilities-spacers: theme-token-refs($spacers, "spacer") !default;
 
 // scss-docs-start font-sizes-legacy
 // The numeric keys v5 shipped, kept so `.fs-1` … `.fs-6` keep rendering. They
@@ -674,43 +675,43 @@ $utilities: map.merge(
       responsive: true,
       property: margin,
       class: m,
-      values: map.merge($spacers, (auto: auto))
+      values: map.merge($utilities-spacers, (auto: auto))
     ),
     "margin-x": (
       responsive: true,
       property: margin-inline,
       class: mx,
-      values: map.merge($spacers, (auto: auto))
+      values: map.merge($utilities-spacers, (auto: auto))
     ),
     "margin-y": (
       responsive: true,
       property: margin-block,
       class: my,
-      values: map.merge($spacers, (auto: auto))
+      values: map.merge($utilities-spacers, (auto: auto))
     ),
     "margin-top": (
       responsive: true,
       property: margin-top,
       class: mt,
-      values: map.merge($spacers, (auto: auto))
+      values: map.merge($utilities-spacers, (auto: auto))
     ),
     "margin-end": (
       responsive: true,
       property: margin-inline-end,
       class: me,
-      values: map-merge-multiple($spacers, $negative-spacers, (auto: auto)),
+      values: map-merge-multiple($utilities-spacers, $negative-spacers, (auto: auto)),
     ),
     "margin-bottom": (
       responsive: true,
       property: margin-bottom,
       class: mb,
-      values: map.merge($spacers, (auto: auto))
+      values: map.merge($utilities-spacers, (auto: auto))
     ),
     "margin-start": (
       responsive: true,
       property: margin-inline-start,
       class: ms,
-      values: map-merge-multiple($spacers, $negative-spacers, (auto: auto)),
+      values: map-merge-multiple($utilities-spacers, $negative-spacers, (auto: auto)),
     ),
     // Padding utilities
     // scss-docs-end utils-margin
@@ -719,43 +720,43 @@ $utilities: map.merge(
       responsive: true,
       property: padding,
       class: p,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "padding-x": (
       responsive: true,
       property: padding-inline,
       class: px,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "padding-y": (
       responsive: true,
       property: padding-block,
       class: py,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "padding-top": (
       responsive: true,
       property: padding-top,
       class: pt,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "padding-end": (
       responsive: true,
       property: padding-inline-end,
       class: pe,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "padding-bottom": (
       responsive: true,
       property: padding-bottom,
       class: pb,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "padding-start": (
       responsive: true,
       property: padding-inline-start,
       class: ps,
-      values: $spacers
+      values: $utilities-spacers
     ),
     // Gap utility
     // scss-docs-end utils-padding
@@ -764,19 +765,19 @@ $utilities: map.merge(
       responsive: true,
       property: gap,
       class: gap,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "row-gap": (
       responsive: true,
       property: row-gap,
       class: row-gap,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "column-gap": (
       responsive: true,
       property: column-gap,
       class: column-gap,
-      values: $spacers
+      values: $utilities-spacers
     ),
     // scss-docs-end utils-gap
     // scss-docs-end utils-spacing
@@ -786,14 +787,14 @@ $utilities: map.merge(
       property: margin-inline-end,
       class: space-x,
       child-selector: "> :not(:last-child)",
-      values: $spacers
+      values: $utilities-spacers
     ),
     "space-y": (
       responsive: true,
       property: margin-block-end,
       class: space-y,
       child-selector: "> :not(:last-child)",
-      values: $spacers
+      values: $utilities-spacers
     ),
     // scss-docs-end utils-space
     // scss-docs-start utils-divide

--- a/scss/coreui-reboot.scss
+++ b/scss/coreui-reboot.scss
@@ -5,4 +5,5 @@
 @forward "config";
 
 @forward "root";
+@forward "layout/tokens";
 @forward "content/reboot";

--- a/scss/coreui-utilities.scss
+++ b/scss/coreui-utilities.scss
@@ -7,6 +7,7 @@
 @forward "utilities";
 
 @forward "root";
+@forward "layout/tokens";
 
 // Helpers
 @forward "helpers";

--- a/scss/layout/_tokens.scss
+++ b/scss/layout/_tokens.scss
@@ -1,14 +1,23 @@
 @use "../config" as *;
 
-// The breakpoint scale as custom properties, for consumers reading it at runtime.
-// It lives with layout rather than in _root.scss because coreui-grid.scss ships
-// layout without root, and it is forwarded ahead of the layout partials so the
-// root layer registers before the layout one in that bundle too.
+// The breakpoint and spacing scales as custom properties, for consumers reading
+// them at runtime. They live with layout rather than in _root.scss because
+// coreui-grid.scss ships layout without root, and the partial is forwarded ahead
+// of the layout partials so the root layer registers before the layout one in
+// that bundle too.
 
 @layer root {
   :root {
     @each $name, $value in $breakpoints {
       --#{$prefix}breakpoint-#{$name}: #{$value};
     }
+
+    // scss-docs-start root-spacer-loop
+    --#{$prefix}spacer: #{$spacer};
+
+    @each $key, $value in $spacers {
+      --#{$prefix}spacer-#{$key}: #{$value};
+    }
+    // scss-docs-end root-spacer-loop
   }
 }

--- a/utilities.json
+++ b/utilities.json
@@ -712,7 +712,7 @@
     "values": {
       "$merge": [
         {
-          "$scale": "space.scale"
+          "$refs": "space.scale"
         },
         {
           "auto": "auto"
@@ -727,7 +727,7 @@
     "values": {
       "$merge": [
         {
-          "$scale": "space.scale"
+          "$refs": "space.scale"
         },
         {
           "auto": "auto"
@@ -742,7 +742,7 @@
     "values": {
       "$merge": [
         {
-          "$scale": "space.scale"
+          "$refs": "space.scale"
         },
         {
           "auto": "auto"
@@ -757,7 +757,7 @@
     "values": {
       "$merge": [
         {
-          "$scale": "space.scale"
+          "$refs": "space.scale"
         },
         {
           "auto": "auto"
@@ -772,7 +772,7 @@
     "values": {
       "$merge": [
         {
-          "$scale": "space.scale"
+          "$refs": "space.scale"
         },
         {
           "$scale": "space.negative"
@@ -790,7 +790,7 @@
     "values": {
       "$merge": [
         {
-          "$scale": "space.scale"
+          "$refs": "space.scale"
         },
         {
           "auto": "auto"
@@ -805,7 +805,7 @@
     "values": {
       "$merge": [
         {
-          "$scale": "space.scale"
+          "$refs": "space.scale"
         },
         {
           "$scale": "space.negative"
@@ -821,7 +821,7 @@
     "property": "padding",
     "class": "p",
     "values": {
-      "$scale": "space.scale"
+      "$refs": "space.scale"
     }
   },
   "padding-x": {
@@ -829,7 +829,7 @@
     "property": "padding-inline",
     "class": "px",
     "values": {
-      "$scale": "space.scale"
+      "$refs": "space.scale"
     }
   },
   "padding-y": {
@@ -837,7 +837,7 @@
     "property": "padding-block",
     "class": "py",
     "values": {
-      "$scale": "space.scale"
+      "$refs": "space.scale"
     }
   },
   "padding-top": {
@@ -845,7 +845,7 @@
     "property": "padding-top",
     "class": "pt",
     "values": {
-      "$scale": "space.scale"
+      "$refs": "space.scale"
     }
   },
   "padding-end": {
@@ -853,7 +853,7 @@
     "property": "padding-inline-end",
     "class": "pe",
     "values": {
-      "$scale": "space.scale"
+      "$refs": "space.scale"
     }
   },
   "padding-bottom": {
@@ -861,7 +861,7 @@
     "property": "padding-bottom",
     "class": "pb",
     "values": {
-      "$scale": "space.scale"
+      "$refs": "space.scale"
     }
   },
   "padding-start": {
@@ -869,7 +869,7 @@
     "property": "padding-inline-start",
     "class": "ps",
     "values": {
-      "$scale": "space.scale"
+      "$refs": "space.scale"
     }
   },
   "gap": {
@@ -877,7 +877,7 @@
     "property": "gap",
     "class": "gap",
     "values": {
-      "$scale": "space.scale"
+      "$refs": "space.scale"
     }
   },
   "row-gap": {
@@ -885,7 +885,7 @@
     "property": "row-gap",
     "class": "row-gap",
     "values": {
-      "$scale": "space.scale"
+      "$refs": "space.scale"
     }
   },
   "column-gap": {
@@ -893,7 +893,7 @@
     "property": "column-gap",
     "class": "column-gap",
     "values": {
-      "$scale": "space.scale"
+      "$refs": "space.scale"
     }
   },
   "space-x": {
@@ -902,7 +902,7 @@
     "class": "space-x",
     "child-selector": "> :not(:last-child)",
     "values": {
-      "$scale": "space.scale"
+      "$refs": "space.scale"
     }
   },
   "space-y": {
@@ -911,7 +911,7 @@
     "class": "space-y",
     "child-selector": "> :not(:last-child)",
     "values": {
-      "$scale": "space.scale"
+      "$refs": "space.scale"
     }
   },
   "divide-x": {


### PR DESCRIPTION
On `v6-dev-tokens`. The same fix `--cui-radius` got in #1188, for spacing.

## What changes

- `:root` declares `--cui-spacer` (`$spacer`, 1rem) and the stops `--cui-spacer-1` … `-9` as `calc()` multiples of it. Before, `$spacers`/`$negative-spacers`/`$sizes` multiplied at build time and every spacing utility carried the literal length.
- Margin, padding, gap and space utilities write `var(--cui-spacer-n)`; negative margins and `.w-*` write `calc(var(--cui-spacer) * n)`; `$gutters` reads the same stops. `:root { --cui-spacer: .75rem }` rescales all of it at run time.
- The scale moves next to the breakpoints in `scss/layout/_tokens.scss`, so `coreui-grid.css` (layout without root) declares what its gutters and margins now read. The utilities and reboot entries forward that partial **after** `root` — forwarding it first put `@layer root {` ahead of the layer-order declaration in those bundles (the trap from the workspace notes, caught with `head -8` before pushing).
- `utilities.json` reads the stops through `$refs`; the map generator writes the three maps in var mode; the emitter drops its Sass-arithmetic evaluation. Sass parity and tokens checks unchanged.
- Docs: margin, padding, gap, space, width pages; migration entry.

## Verification

Chromium, `--cui-spacer: .5rem` on `:root` — full bundle and each standalone bundle:

| | default | spacer .5rem |
| --- | --- | --- |
| `.m-3` margin | 12px | 6px |
| `.w-2` width | 32px | 16px |
| `.me--1` margin | -4px | -2px |
| `.g-2` column padding (grid bundle) | 4px | 2px |
| `<p>` margin (reboot bundle) | 16px | 8px |

A single stop override (`--cui-spacer-3: 100px`) moves only `.m-3`. Every bundle opens with the layer-order line and declares the scale once.

## Bundle caps

Raised for the longer `var()` values (size work is scheduled for the end of v6): grid 11 → 11.5 kB (min 10 → 10.5), utilities 21.5 → 22 (min 20.25 → 20.75), reboot min 6 → 6.25. The full `coreui.css` stays under its cap (73.8 < 74).