### PR TITLE
refactor(scss): compute the spacing and border-width scales in the browser

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -2,11 +2,11 @@
   "files": [
     {
       "path": "./dist/css/coreui-grid.css",
-      "maxSize": "11 kB"
+      "maxSize": "11.5 kB"
     },
     {
       "path": "./dist/css/coreui-grid.min.css",
-      "maxSize": "10 kB"
+      "maxSize": "10.5 kB"
     },
     {
       "path": "./dist/css/coreui-reboot.css",
@@ -14,15 +14,15 @@
     },
     {
       "path": "./dist/css/coreui-reboot.min.css",
-      "maxSize": "6 kB"
+      "maxSize": "6.25 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.css",
-      "maxSize": "21.5 kB"
+      "maxSize": "22 kB"
     },
     {
       "path": "./dist/css/coreui-utilities.min.css",
-      "maxSize": "20.25 kB"
+      "maxSize": "20.75 kB"
     },
     {
       "path": "./dist/css/coreui.css",

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -3751,6 +3751,22 @@ Nothing existing changes; these are additions. See
   a `--cui-spacer-*` key no longer reaches it — override the custom property
   instead.
 
+#### The border-width scale is computed from `--cui-border-width` in the browser
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`--cui-border-width-1` … `-5` and `-keyline` are `calc()` multiples of
+  `--cui-border-width`, and the `.border-*` width classes read them.**
+  `$border-widths` shipped literal pixel values and every `.border-2`,
+  `.border-top-3`, `.border-start-5` class carried the length, so changing
+  `--cui-border-width` re-weighted the components and left the utilities
+  where they were. Now `:root` declares the stops as multiples of
+  `--cui-border-width` (`1px`): `-keyline` is half of it, `-1` the base,
+  `-2` … `-5` its multiples, and the width classes write
+  `var(--cui-border-width-n)`. `:root { --cui-border-width: 2px }` re-weights
+  utilities and components together; overriding one stop re-weights every
+  class on it. `--cui-border-width-keyline` keeps its name and moves into the
+  scale.
+
 #### Spacing utilities write logical shorthands
 
 `.mx-*`, `.my-*`, `.px-*` and `.py-*` (and their negative-margin variants)

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -3733,6 +3733,24 @@ Nothing existing changes; these are additions. See
   instead of restating declarations, so state styling follows any control
   automatically.
 
+#### The spacing scale is computed from `--cui-spacer` in the browser
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`--cui-spacer-1` … `-9` are `calc()` multiples of `--cui-spacer`, and the
+  spacing utilities read the stops.** `$spacers` used to multiply `$spacer`
+  when the stylesheet was built and every `.m-*`, `.p-*`, `.gap-*`,
+  `.space-*` and `.g-*` class carried the literal length, so the only way to
+  rescale spacing was to recompile. Now `:root` declares `--cui-spacer`
+  (`$spacer`, 1rem) and the stops as `calc(var(--cui-spacer) * n)`, the
+  utilities write `var(--cui-spacer-n)`, the negative margins and the
+  `.w-*` sizes `calc(var(--cui-spacer) * n)`, and the gutters read the same
+  stops. `:root { --cui-spacer: .75rem }` rescales all of it at run time,
+  and overriding one stop re-spaces every utility on it. The scale moved
+  next to the breakpoints in `scss/layout/_tokens.scss`, so the grid,
+  utilities and reboot bundles each declare it; a `$root-tokens` override of
+  a `--cui-spacer-*` key no longer reaches it — override the custom property
+  instead.
+
 #### Spacing utilities write logical shorthands
 
 `.mx-*`, `.my-*`, `.px-*` and `.py-*` (and their negative-margin variants)

--- a/docs/src/content/docs/utilities/border.mdx
+++ b/docs/src/content/docs/utilities/border.mdx
@@ -35,6 +35,8 @@ Or remove borders:
 
 <AddedIn version="6.0.0" /> `.border-keyline` sits below `1px`, for a hairline that stays hairline on a high-density screen instead of thickening to a full device pixel.
 
+The widths are a scale on `--cui-border-width`: `.border-1` is the base, `.border-keyline` half of it, `.border-2` … `.border-5` its multiples, computed in the browser. `:root { --cui-border-width: 2px }` re-weights every width class and every component border at once.
+
 <Example class="docs-example-border-utils" code={`<span class="border border-keyline"></span>
   <span class="border border-1"></span>
   <span class="border border-2"></span>
@@ -67,6 +69,10 @@ Or remove borders:
 
 <ScssDocs file="scss/_root.scss" capture="root-border-var" />
 
+Each stop of the width scale is one token, `--cui-border-width-{key}`, a `calc()` multiple of `--cui-border-width`; the `.border-{key}` classes read the stops, so overriding one stop re-weights every class on it:
+
+<ScssDocs file="scss/_root.scss" capture="root-border-width-loop" />
+
 ### Sass variables
 
 <ScssDocs file="scss/_config.scss" capture="border-variables" />
@@ -78,7 +84,7 @@ Each neutral border is one entry: the key is one `.border-{key}` utility and the
 
 <ScssDocs file="scss/_theme.scss" capture="theme-borders-map" />
 
-Each entry is one `.border-{width}` class and the width it sets. Add a key to define a width, or set one to `null` to drop it:
+Each entry is one `.border-{width}` class and the `--cui-border-width-{width}` token it reads. Add a key to define a width (`6: calc(var(--cui-border-width) * 6)`), or set one to `null` to drop it:
 
 <ScssDocs file="scss/_config.scss" capture="border-widths-map" />
 

--- a/docs/src/content/docs/utilities/gap.mdx
+++ b/docs/src/content/docs/utilities/gap.mdx
@@ -46,7 +46,7 @@ Support includes responsive options for all of CoreUI's grid breakpoints, as wel
 
 ### Sass variables
 
-`$spacer` is the step the whole scale is built from, so changing it rescales every spacing utility at once.
+`$spacer` sets the default of `--cui-spacer`, the step the whole scale is built from: the stops `--cui-spacer-1` … `-9` are `calc()` multiples of it on `:root`, the utilities read the stops, so `:root { --cui-spacer: .75rem }` rescales every spacing utility at run time, no recompile.
 
 <ScssDocs file="scss/_config.scss" capture="spacer-variables" />
 

--- a/docs/src/content/docs/utilities/margin.mdx
+++ b/docs/src/content/docs/utilities/margin.mdx
@@ -76,7 +76,7 @@ Additionally, CoreUI for Bootstrap also includes an `.mx-auto` class for horizon
 
 ## Negative margin
 
-Two negative steps ship for the inline margins, `.me--1`, `.me--2`, `.ms--1` and `.ms--2`, for pulling an element back over its neighbour's gap. They come from the `$negative-spacers` map; add a key there to extend the set (`"-3": $spacer * -.75`), or set one to `null` to drop it. The block margins have no negative form.
+Two negative steps ship for the inline margins, `.me--1`, `.me--2`, `.ms--1` and `.ms--2`, for pulling an element back over its neighbour's gap. They come from the `$negative-spacers` map; add a key there to extend the set (`"-3": calc(var(--cui-spacer) * -.75)`), or set one to `null` to drop it. The block margins have no negative form.
 
 <ScssDocs file="scss/_config.scss" capture="negative-spacers-map" />
 
@@ -84,7 +84,7 @@ Two negative steps ship for the inline margins, `.me--1`, `.me--2`, `.ms--1` and
 
 ### Sass variables
 
-`$spacer` is the step the whole scale is built from, so changing it rescales every spacing utility at once.
+`$spacer` sets the default of `--cui-spacer`, the step the whole scale is built from: the stops `--cui-spacer-1` … `-9` are `calc()` multiples of it on `:root`, the utilities read the stops, so `:root { --cui-spacer: .75rem }` rescales every spacing utility at run time, no recompile.
 
 <ScssDocs file="scss/_config.scss" capture="spacer-variables" />
 

--- a/docs/src/content/docs/utilities/padding.mdx
+++ b/docs/src/content/docs/utilities/padding.mdx
@@ -30,10 +30,10 @@ Where *sides* is one of:
 Where *size* is one of:
 
 - `0` - for classes that eliminate the `padding` by setting it to `0`
-- `1` - (by default) for classes that set the `padding` to `$spacer * .25`
-- `2` - (by default) for classes that set the `padding` to `$spacer * .5`
-- `3` - (by default) for classes that set the `padding` to `$spacer * .75`
-- `4` - (by default) for classes that set the `padding` to `$spacer`
+- `1` - (by default) for classes that set the `padding` to `--cui-spacer-1` (`calc(var(--cui-spacer) * .25)`)
+- `2` - (by default) for classes that set the `padding` to `--cui-spacer-2` (`calc(var(--cui-spacer) * .5)`)
+- `3` - (by default) for classes that set the `padding` to `--cui-spacer-3` (`calc(var(--cui-spacer) * .75)`)
+- `4` - (by default) for classes that set the `padding` to `--cui-spacer-4` (`var(--cui-spacer)`)
 - `5` - (by default) for classes that set the `padding` to `$spacer * 1.25`
 - `6` - (by default) for classes that set the `padding` to `$spacer * 1.5`
 - `7` - (by default) for classes that set the `padding` to `$spacer * 2`

--- a/docs/src/content/docs/utilities/space.mdx
+++ b/docs/src/content/docs/utilities/space.mdx
@@ -58,7 +58,7 @@ sit in a row, and `space-x-md-3` takes over along the inline axis.
 
 ### Sass variables
 
-`$spacer` is the step the whole scale is built from, so changing it rescales every spacing utility at once.
+`$spacer` sets the default of `--cui-spacer`, the step the whole scale is built from: the stops `--cui-spacer-1` … `-9` are `calc()` multiples of it on `:root`, the utilities read the stops, so `:root { --cui-spacer: .75rem }` rescales every spacing utility at run time, no recompile.
 
 <ScssDocs file="scss/_config.scss" capture="spacer-variables" />
 

--- a/docs/src/content/docs/utilities/width.mdx
+++ b/docs/src/content/docs/utilities/width.mdx
@@ -17,7 +17,7 @@ Width utilities are generated from the utility API in `_utilities.scss`. Include
 
 ## Fixed widths
 
-`.w-1` through `.w-12` set a width from the `$sizes` map, one `$spacer` (1rem) per step, for boxes that should hold their size whatever the parent does — an avatar column, a fixed label, a swatch.
+`.w-1` through `.w-12` set a width from the `$sizes` map, one `--cui-spacer` (1rem) per step, computed in the browser, for boxes that should hold their size whatever the parent does — an avatar column, a fixed label, a swatch.
 
 <Example code={`<div class="w-4 p-2 bg-2">.w-4</div>
 <div class="w-8 p-2 bg-2">.w-8</div>

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -198,12 +198,12 @@ $border-widths: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $border-widths: defaults(
   (
-    keyline: .5px,
-    1: 1px,
-    2: 2px,
-    3: 3px,
-    4: 4px,
-    5: 5px
+    keyline: calc(var(--#{$prefix}border-width) * .5),
+    1: var(--#{$prefix}border-width),
+    2: calc(var(--#{$prefix}border-width) * 2),
+    3: calc(var(--#{$prefix}border-width) * 3),
+    4: calc(var(--#{$prefix}border-width) * 4),
+    5: calc(var(--#{$prefix}border-width) * 5)
   ),
   $border-widths
 );

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 @use "functions/assert-ascending" as *;
 @use "functions/assert-starts-at-zero" as *;
 @use "functions/defaults" as *;
@@ -62,15 +63,15 @@ $spacers: () !default;
 $spacers: defaults(
   (
     0: 0,
-    1: $spacer * .25,
-    2: $spacer * .5,
-    3: $spacer * .75,
-    4: $spacer,
-    5: $spacer * 1.25,
-    6: $spacer * 1.5,
-    7: $spacer * 2,
-    8: $spacer * 2.5,
-    9: $spacer * 3,
+    1: calc(var(--#{$prefix}spacer) * .25),
+    2: calc(var(--#{$prefix}spacer) * .5),
+    3: calc(var(--#{$prefix}spacer) * .75),
+    4: var(--#{$prefix}spacer),
+    5: calc(var(--#{$prefix}spacer) * 1.25),
+    6: calc(var(--#{$prefix}spacer) * 1.5),
+    7: calc(var(--#{$prefix}spacer) * 2),
+    8: calc(var(--#{$prefix}spacer) * 2.5),
+    9: calc(var(--#{$prefix}spacer) * 3),
   ),
   $spacers
 );
@@ -81,8 +82,8 @@ $negative-spacers: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $negative-spacers: defaults(
   (
-    "-1": $spacer * -.25,
-    "-2": $spacer * -.5,
+    "-1": calc(var(--#{$prefix}spacer) * -.25),
+    "-2": calc(var(--#{$prefix}spacer) * -.5),
   ),
   $negative-spacers
 );
@@ -93,18 +94,18 @@ $sizes: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $sizes: defaults(
   (
-    1: $spacer,
-    2: $spacer * 2,
-    3: $spacer * 3,
-    4: $spacer * 4,
-    5: $spacer * 5,
-    6: $spacer * 6,
-    7: $spacer * 7,
-    8: $spacer * 8,
-    9: $spacer * 9,
-    10: $spacer * 10,
-    11: $spacer * 11,
-    12: $spacer * 12
+    1: var(--#{$prefix}spacer),
+    2: calc(var(--#{$prefix}spacer) * 2),
+    3: calc(var(--#{$prefix}spacer) * 3),
+    4: calc(var(--#{$prefix}spacer) * 4),
+    5: calc(var(--#{$prefix}spacer) * 5),
+    6: calc(var(--#{$prefix}spacer) * 6),
+    7: calc(var(--#{$prefix}spacer) * 7),
+    8: calc(var(--#{$prefix}spacer) * 8),
+    9: calc(var(--#{$prefix}spacer) * 9),
+    10: calc(var(--#{$prefix}spacer) * 10),
+    11: calc(var(--#{$prefix}spacer) * 11),
+    12: calc(var(--#{$prefix}spacer) * 12)
   ),
   $sizes
 );
@@ -155,7 +156,13 @@ $grid-gutter-y:               0 !default;
 // fusv-disable
 $grid-gutter-width:           $grid-gutter-x !default; // Deprecated in v6.0.0, removed in v7
 // fusv-enable
-$gutters:                     $spacers !default;
+$gutters:                     null !default;
+@if $gutters == null {
+  $gutters: ();
+  @each $key in map.keys($spacers) {
+    $gutters: map.set($gutters, $key, var(--#{$prefix}spacer-#{$key}));
+  }
+}
 
 // Container padding
 

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -137,15 +137,6 @@ $root-token-defaults: theme-color-tokens();
 }
 // scss-docs-end root-font-size-loop
 
-// scss-docs-start root-spacer-loop
-// One token per stop of the spacing scale, so rescaling the system is a
-// runtime change rather than a recompile. Components read these instead of
-// multiplying `$spacer` when the stylesheet is built.
-@each $key, $value in $spacers {
-  $root-token-defaults: map.set($root-token-defaults, --#{$prefix}spacer-#{$key}, $value);
-}
-// scss-docs-end root-spacer-loop
-
 // scss-docs-start root-radius-loop
 // One token per stop of the radius scale, so a page can re-round the library
 // at runtime; components read stops instead of the one global radius.
@@ -229,7 +220,6 @@ $root-token-defaults: map.merge(
     // drawer, menu and popup. One override restyles all four.
     --#{$prefix}transition-timing-overlay: $transition-timing-overlay,
     // scss-docs-end root-transition-variables
-    --#{$prefix}spacer: $spacer,
     // Focus styles
     // scss-docs-start root-focus-variables
     --#{$prefix}focus-ring-width: $focus-ring-width,

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -147,6 +147,12 @@ $root-token-defaults: map.set($root-token-defaults, --#{$prefix}radius, $radius)
 $root-token-defaults: map.set($root-token-defaults, --#{$prefix}radius-pill, 50rem);
 // scss-docs-end root-radius-loop
 
+// scss-docs-start root-border-width-loop
+@each $key, $value in $border-widths {
+  $root-token-defaults: map.set($root-token-defaults, --#{$prefix}border-width-#{$key}, $value);
+}
+// scss-docs-end root-border-width-loop
+
 // scss-docs-start root-zindex-loop
 // One token per stop of the z-axis, so a page can relayer the library without
 // recompiling — a third-party overlay that must sit above the modal sets
@@ -208,7 +214,6 @@ $root-token-defaults: map.merge(
     --#{$prefix}mark-bg: $mark-bg,
     // scss-docs-start root-border-var
     --#{$prefix}border-width: $border-width,
-    --#{$prefix}border-width-keyline: #{map.get($border-widths, keyline)},
     --#{$prefix}border-style: $border-style,
     --#{$prefix}border-color: $border-color,
     --#{$prefix}border-color-translucent: $border-color-translucent,

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -46,6 +46,7 @@ $utilities-border-subtle: theme-color-refs("border", "-subtle") !default;
 // scss-docs-end utilities-border-colors
 
 $utilities-links-underline: theme-color-refs("fg") !default;
+$utilities-border-widths: theme-token-refs($border-widths, "border-width") !default;
 $utilities-radii: theme-token-refs($radii, "radius") !default;
 $utilities-spacers: theme-token-refs($spacers, "spacer") !default;
 
@@ -335,27 +336,27 @@ $utilities: map.merge(
     "border-width": (
       property: border-width,
       class: border,
-      values: map.merge($border-widths, (keyline: var(--#{$prefix}border-width-keyline)))
+      values: $utilities-border-widths
     ),
     "border-top-width": (
       property: border-top-width,
       class: border-top,
-      values: $border-widths
+      values: $utilities-border-widths
     ),
     "border-end-width": (
       property: border-inline-end-width,
       class: border-end,
-      values: $border-widths,
+      values: $utilities-border-widths,
     ),
     "border-bottom-width": (
       property: border-bottom-width,
       class: border-bottom,
-      values: $border-widths
+      values: $utilities-border-widths
     ),
     "border-start-width": (
       property: border-inline-start-width,
       class: border-start,
-      values: $border-widths,
+      values: $utilities-border-widths,
     ),
     // scss-docs-end utils-border-width
     // scss-docs-start utils-border-color-subtle

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -47,6 +47,7 @@ $utilities-border-subtle: theme-color-refs("border", "-subtle") !default;
 
 $utilities-links-underline: theme-color-refs("fg") !default;
 $utilities-radii: theme-token-refs($radii, "radius") !default;
+$utilities-spacers: theme-token-refs($spacers, "spacer") !default;
 
 // scss-docs-start font-sizes-legacy
 // The numeric keys v5 shipped, kept so `.fs-1` … `.fs-6` keep rendering. They
@@ -674,43 +675,43 @@ $utilities: map.merge(
       responsive: true,
       property: margin,
       class: m,
-      values: map.merge($spacers, (auto: auto))
+      values: map.merge($utilities-spacers, (auto: auto))
     ),
     "margin-x": (
       responsive: true,
       property: margin-inline,
       class: mx,
-      values: map.merge($spacers, (auto: auto))
+      values: map.merge($utilities-spacers, (auto: auto))
     ),
     "margin-y": (
       responsive: true,
       property: margin-block,
       class: my,
-      values: map.merge($spacers, (auto: auto))
+      values: map.merge($utilities-spacers, (auto: auto))
     ),
     "margin-top": (
       responsive: true,
       property: margin-top,
       class: mt,
-      values: map.merge($spacers, (auto: auto))
+      values: map.merge($utilities-spacers, (auto: auto))
     ),
     "margin-end": (
       responsive: true,
       property: margin-inline-end,
       class: me,
-      values: map-merge-multiple($spacers, $negative-spacers, (auto: auto)),
+      values: map-merge-multiple($utilities-spacers, $negative-spacers, (auto: auto)),
     ),
     "margin-bottom": (
       responsive: true,
       property: margin-bottom,
       class: mb,
-      values: map.merge($spacers, (auto: auto))
+      values: map.merge($utilities-spacers, (auto: auto))
     ),
     "margin-start": (
       responsive: true,
       property: margin-inline-start,
       class: ms,
-      values: map-merge-multiple($spacers, $negative-spacers, (auto: auto)),
+      values: map-merge-multiple($utilities-spacers, $negative-spacers, (auto: auto)),
     ),
     // Padding utilities
     // scss-docs-end utils-margin
@@ -719,43 +720,43 @@ $utilities: map.merge(
       responsive: true,
       property: padding,
       class: p,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "padding-x": (
       responsive: true,
       property: padding-inline,
       class: px,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "padding-y": (
       responsive: true,
       property: padding-block,
       class: py,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "padding-top": (
       responsive: true,
       property: padding-top,
       class: pt,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "padding-end": (
       responsive: true,
       property: padding-inline-end,
       class: pe,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "padding-bottom": (
       responsive: true,
       property: padding-bottom,
       class: pb,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "padding-start": (
       responsive: true,
       property: padding-inline-start,
       class: ps,
-      values: $spacers
+      values: $utilities-spacers
     ),
     // Gap utility
     // scss-docs-end utils-padding
@@ -764,19 +765,19 @@ $utilities: map.merge(
       responsive: true,
       property: gap,
       class: gap,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "row-gap": (
       responsive: true,
       property: row-gap,
       class: row-gap,
-      values: $spacers
+      values: $utilities-spacers
     ),
     "column-gap": (
       responsive: true,
       property: column-gap,
       class: column-gap,
-      values: $spacers
+      values: $utilities-spacers
     ),
     // scss-docs-end utils-gap
     // scss-docs-end utils-spacing
@@ -786,14 +787,14 @@ $utilities: map.merge(
       property: margin-inline-end,
       class: space-x,
       child-selector: "> :not(:last-child)",
-      values: $spacers
+      values: $utilities-spacers
     ),
     "space-y": (
       responsive: true,
       property: margin-block-end,
       class: space-y,
       child-selector: "> :not(:last-child)",
-      values: $spacers
+      values: $utilities-spacers
     ),
     // scss-docs-end utils-space
     // scss-docs-start utils-divide

--- a/scss/coreui-reboot.scss
+++ b/scss/coreui-reboot.scss
@@ -5,4 +5,5 @@
 @forward "config";
 
 @forward "root";
+@forward "layout/tokens";
 @forward "content/reboot";

--- a/scss/coreui-utilities.scss
+++ b/scss/coreui-utilities.scss
@@ -7,6 +7,7 @@
 @forward "utilities";
 
 @forward "root";
+@forward "layout/tokens";
 
 // Helpers
 @forward "helpers";

--- a/scss/layout/_tokens.scss
+++ b/scss/layout/_tokens.scss
@@ -1,14 +1,23 @@
 @use "../config" as *;
 
-// The breakpoint scale as custom properties, for consumers reading it at runtime.
-// It lives with layout rather than in _root.scss because coreui-grid.scss ships
-// layout without root, and it is forwarded ahead of the layout partials so the
-// root layer registers before the layout one in that bundle too.
+// The breakpoint and spacing scales as custom properties, for consumers reading
+// them at runtime. They live with layout rather than in _root.scss because
+// coreui-grid.scss ships layout without root, and the partial is forwarded ahead
+// of the layout partials so the root layer registers before the layout one in
+// that bundle too.
 
 @layer root {
   :root {
     @each $name, $value in $breakpoints {
       --#{$prefix}breakpoint-#{$name}: #{$value};
     }
+
+    // scss-docs-start root-spacer-loop
+    --#{$prefix}spacer: #{$spacer};
+
+    @each $key, $value in $spacers {
+      --#{$prefix}spacer-#{$key}: #{$value};
+    }
+    // scss-docs-end root-spacer-loop
   }
 }


### PR DESCRIPTION
Two scales that were still multiplied in Sass now follow the radius scale (#1188): one root token, stops as `calc()` multiples of it, utilities reading the stops.

## Spacing

- `:root` declares `--cui-spacer` (`$spacer`) and `--cui-spacer-1` … `-9` as `calc(var(--cui-spacer) * n)`.
- `.m-*`, `.p-*`, `.gap-*`, `.row-gap-*`, `.column-gap-*`, `.space-*` write `var(--cui-spacer-n)`; the negative margins and `.w-1` … `.w-12` write `calc(var(--cui-spacer) * n)`; `$gutters` reads the same stops.
- The scale lives in `scss/layout/_tokens.scss` next to the breakpoints, so `coreui-grid.css` declares what its gutters read; the utilities and reboot entries forward that partial after `root` so the layer-order declaration stays first.
- Bundle caps raised for the longer values: grid 11 → 11.5 kB (min 10 → 10.5), utilities 21.5 → 22 (min 20.25 → 20.75), reboot min 6 → 6.25.

## Border width

- `:root` declares `--cui-border-width-keyline` (half the base), `--cui-border-width-1` (the base) and `-2` … `-5` as `calc(var(--cui-border-width) * n)`; `--cui-border-width-keyline` keeps its name and joins the loop.
- `.border-*`, `.border-top-*`, `.border-end-*`, `.border-bottom-*`, `.border-start-*` widths write `var(--cui-border-width-n)`, so `--cui-border-width` re-weights utilities and components together.

## Verification

- All five entrypoints compiled before and after: the only differences are the spacer and border-width values, the new root declarations and the `@layer root` block in the grid, utilities and reboot bundles; the layer-order declaration stays on line 7 of each.
- Chromium probe on `coreui.css`, `coreui-utilities.css` and `coreui-grid.css`: `--cui-border-width: 2px` turns `.border-3` from 3 px to 6 px; `--cui-spacer: 2rem` doubles `.p-4`, `.w-3`, `.ms--2` and the `.g-3` gutter in every bundle that ships them.
- `npm run css`, bundlewatch PASS, `npm run docs-build` green (new `root-border-width-loop` capture documented on the border page), migration entries for both scales.
