### PR TITLE
refactor(scss): stop the button module leaking into partials that do not read it

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -1,4 +1,3 @@
-@use "buttons/button" as *;
 @use "functions/defaults" as *;
 @use "functions/escape-svg" as *;
 @use "mixins/border-radius" as *;

--- a/scss/_calendar.scss
+++ b/scss/_calendar.scss
@@ -1,4 +1,3 @@
-@use "buttons/button" as *;
 @use "functions/defaults" as *;
 @use "layout/breakpoints" as *;
 @use "mixins/border-radius" as *;

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -1,4 +1,3 @@
-@use "buttons/button" as *;
 @use "functions/defaults" as *;
 @use "functions/escape-svg" as *;
 @use "layout/breakpoints" as *;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -1,5 +1,4 @@
 @use "sass:map";
-@use "buttons/button" as *;
 @use "functions/defaults" as *;
 @use "functions/escape-svg" as *;
 @use "layout/breakpoints" as *;

--- a/scss/buttons/_button-group.scss
+++ b/scss/buttons/_button-group.scss
@@ -1,11 +1,12 @@
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
 @use "../config" as *;
-@use "button" as *;
 
-// A v6 button may carry only its variant class (`.btn-solid`), so the group
-// plumbing cannot key on `.btn` alone.
-$group-button: ":is(#{$btn-variant-selectors})" !default;
+// `[class*="btn-"]` covers the variant-only button spellings; a bare
+// `class="btn"` has no `btn-` substring, hence the explicit `.btn`. The
+// deprecated toggle input carries `.btn-check` too and is not a button.
+$group-button: ":is(.btn, [class*=\"btn-\"]):not(input)" !default;
+$group-toggle-input: "input.btn-check" !default;
 
 @layer components {
   // Make the div behave like a button
@@ -26,14 +27,14 @@ $group-button: ":is(#{$btn-variant-selectors})" !default;
 
     // Bring the hover, focused, and "active" buttons to the front to overlay
     // the borders properly
-    > #{$btn-check-deprecated}:checked + #{$group-button},
+    > #{$group-toggle-input}:checked + #{$group-button},
     > .btn-check:has(input:checked),
     > #{$group-button}:active,
     > #{$group-button}.active {
       z-index: 2;
     }
 
-    > #{$btn-check-deprecated}:focus + #{$group-button},
+    > #{$group-toggle-input}:focus + #{$group-button},
     > .btn-check:has(input:focus),
     > #{$group-button}:focus {
       z-index: 3;
@@ -79,7 +80,7 @@ $group-button: ":is(#{$btn-variant-selectors})" !default;
     @include border-radius(var(--#{$prefix}btn-input-border-radius));
 
     // Prevent double borders when buttons are next to each other
-    > :not(#{$btn-check-deprecated}:first-child) + #{$group-button},
+    > :not(#{$group-toggle-input}:first-child) + #{$group-button},
     > .btn-group:not(:first-child) {
       margin-inline-start: calc(-1 * var(--#{$prefix}btn-border-width));
     }
@@ -100,7 +101,7 @@ $group-button: ":is(#{$btn-variant-selectors})" !default;
     //   input (making it the first child visually)
     // - part of a btn-group which isn't the first child
     > #{$group-button}:nth-child(n + 3),
-    > :not(#{$btn-check-deprecated}) + #{$group-button},
+    > :not(#{$group-toggle-input}) + #{$group-button},
     > .btn-group:not(:first-child) > #{$group-button} {
       @include border-start-radius(0);
     }
@@ -115,7 +116,7 @@ $group-button: ":is(#{$btn-variant-selectors})" !default;
   // The clickable button for toggling the menu
   // Set the same inset shadow as the :active state
   .btn-group.show .dropdown-toggle {
-    @include box-shadow($btn-active-box-shadow);
+    @include box-shadow(var(--#{$prefix}btn-active-shadow));
 
     // Show no shadow for `.btn-link` since it has no other button styles.
     &.btn-link {
@@ -155,7 +156,7 @@ $group-button: ":is(#{$btn-variant-selectors})" !default;
     //   input (making it the first child visually)
     // - part of a btn-group which isn't the first child
     > #{$group-button}:nth-child(n + 3),
-    > :not(#{$btn-check-deprecated}) + #{$group-button},
+    > :not(#{$group-toggle-input}) + #{$group-button},
     > .btn-group:not(:first-child) > #{$group-button} {
       @include border-top-radius(0);
     }


### PR DESCRIPTION
Groundwork for shipping CSS per component (`TODO.md`, "cięcie coreui.css"): Sass emits a module's CSS wherever it is first loaded, so a partial that `@use`s the button module carries the whole `.btn-*` block when compiled on its own.

## Dead `@use` lines

Accordion, calendar, header and navbar loaded `buttons/button` without referencing a single member of it; the date picker inherited the block through calendar. The four lines are gone. All five compiled entrypoints are byte-identical.

## Button group without the button module

The group read `$btn-variant-selectors` and `$btn-check-deprecated` from the button module. It now matches its children the way the input group has since #952, `:is(.btn, [class*="btn-"])`, the same shape upstream uses, excluding only the deprecated toggle input (it carries `.btn-check` and stands in the DOM before its label; upstream has no such input). The deprecated toggle is spelled `input.btn-check` where the group still needs it, and the split toggle's pressed shadow reads `--cui-btn-active-shadow`. Compiled alone the group is 110 lines with no button rules (was 83 `.btn-*` rules on top).

A nested `.btn-group` matches the substring too and gets `flex: 1 1 auto` and the middle-child radius of 0, like any other child. That is intended: in a stretched group (`.d-flex`, 600 px) the nested menu wrapper used to stay at its natural 36 px while its siblings took 282 px each; now all three take 200 px. The radius sits on a box that draws nothing.

## Verification

- Byte diff of `coreui`, `coreui-grid`, `coreui-reboot`, `coreui-utilities` and the bootstrap theme after the first commit: identical.
- Chromium probe for the second commit, previous bundle vs new, twelve groups: v5 (`.btn.btn-primary`, `.btn-outline-primary`), v6 variant-only, bare `.btn`, deprecated and current toggles, nested horizontal and vertical, stretched, divider, split toggle, sizes. 40 children compared on rect, four radii, z-index, margins, flex, shadow and `::before`: the only differences are the nested wrapper's flex and radius and the stretched layout described above.
- `npm run css`, bundlewatch PASS (`coreui.css` 73.2 kB gz), `npm run docs-build` green.
