### PR TITLE
fix(sidebar): make the sidebar nav lay out its items without nav.css

### DIFF
--- a/scss/sidebar/_sidebar-nav.scss
+++ b/scss/sidebar/_sidebar-nav.scss
@@ -185,6 +185,7 @@ $sidebar-nav-tree-tokens: defaults(
     list-style-type: "";
 
     .nav-item {
+      display: flex;
       flex-direction: column;
     }
 


### PR DESCRIPTION
The CSS-import lint (#1199 / react-pro#326 / vue-pro#264) showed the sidebar navigation spread over two stylesheets: `nav-title` and `nav-group-items` live in `sidebar.css`, while the item layout leaned on `nav.css`. Measured what `nav.css` actually contributes to the docs sidebar example on top of `base` + `transitions` + `sidebar`: two things — `.nav-item { display: flex }` (without it the `<li>` stays a `list-item`, so the Safari marker line from #916 returns and the nested group list loses its column layout) and a `min-height` reset on `.nav-link`. Everything else is overridden by `.sidebar-nav`.

`.sidebar-nav .nav-item` now declares `display: flex` itself. After the change the same probe reports 50 elements with no differences between the two stylesheets, so `sidebar.css` stands on its own and the shared `nav-*` class names remain an API question, not a stylesheet one (TODO.md).

`npm run css`, bundlewatch PASS (`sidebar.css` 4.0 kB gz), `npm run docs-build` green.
