### PR TITLE
docs(guides): CoreUI next to Tailwind CSS

### DIFF
--- a/docs/src/content/docs/customize/theme.mdx
+++ b/docs/src/content/docs/customize/theme.mdx
@@ -26,7 +26,7 @@ From this one map the library generates:
 | `danger` | `#e55353` | Destructive actions and error states |
 | `inverse` | `light-dark(var(--cui-gray-900), var(--cui-gray-100))` | Surfaces that flip against the page, e.g. a dark bar on a light page |
 
-`primary`, `success`, `info`, `warning` and `danger` take their base from the palette, so overriding `$primary` — or the `--cui-primary` token at run time — retints the whole family. `secondary` and `inverse` are `light-dark()` pairs of gray tokens rather than a hue of their own, so they follow the color mode and carry no scale; they keep a `base` slot in the map.
+`primary`, `success`, `info`, `warning` and `danger` take their base from the palette, so overriding `$primary` — or the `--cui-primary-base` token at run time — retints the whole family. `secondary` and `inverse` are `light-dark()` pairs of gray tokens rather than a hue of their own, so they follow the color mode and carry no scale; they keep a `base` slot in the map.
 
 ## Color slots
 
@@ -34,7 +34,7 @@ Every entry defines the same slots, emitted as `--cui-{color}-{slot}` on `:root`
 
 | Slot | Emitted token | Description |
 | --- | --- | --- |
-| `base` | `--cui-primary`, `--cui-primary-base` | The color itself, e.g. a solid button background. Both spellings are emitted; `-base` matches the slot name, the bare form is the one every utility and component reads |
+| `base` | `--cui-primary-base` | The color itself, e.g. a solid button background. There is no bare `--cui-primary`: the slot is the token, and every utility and component reads it |
 | — | `--cui-primary-bg` | The action-background slot: what checked, active and filled states read; points at the base |
 | `contrast` | `--cui-primary-contrast` | Text and icons sitting on the solid base |
 | `fg` | `--cui-primary-fg` | The color readable as text, one step lighter than the emphasis |
@@ -73,7 +73,7 @@ Reading a foreground against a background it was not paired with is where contra
 
 ## The runtime scale
 
-Every theme color gets a 100–900 scale of `color-mix()` tokens, mixed at runtime from the color's own token. Override `--cui-primary` (or `$primary`) and the whole family — subtle backgrounds, borders, emphasis text — follows, in both color schemes:
+Every theme color gets a 100–900 scale of `color-mix()` tokens, mixed at runtime from the color's own token. Override `--cui-primary-base` (or `$primary`) and the whole family — subtle backgrounds, borders, emphasis text — follows, in both color schemes:
 
 <ScssDocs file="scss/_colors.scss" capture="color-scale-variables" />
 

--- a/docs/src/content/docs/guides/tailwind.mdx
+++ b/docs/src/content/docs/guides/tailwind.mdx
@@ -1,0 +1,92 @@
+---
+title: "CoreUI & Tailwind CSS"
+description: "How to run CoreUI's components next to Tailwind's utilities: one cascade layer order, no second reset, and Tailwind reading our design tokens."
+---
+
+## Two libraries, one cascade
+
+CoreUI ships its utilities as a separate stylesheet, so a project that prefers Tailwind's utilities can leave ours out entirely and keep the components. What has to be agreed between the two is the cascade: both libraries put their rules in named `@layer`s, and two of the names are the same.
+
+CoreUI declares:
+
+```css
+@layer colors, config, root, reboot, layout, content, forms, components, custom, helpers, utilities;
+```
+
+Tailwind 4 declares:
+
+```css
+@layer theme, base, components, utilities;
+```
+
+Layers with the same name are one layer, and the browser fixes the order of every layer at its **first** mention. Import Tailwind first and CoreUI's `root`, `reboot` and `forms` land after Tailwind's `utilities`, so a `.p-4` loses to Reboot. Import CoreUI first and Tailwind's `base` — its reset, Preflight — lands after our `forms` and `utilities`, and undoes them on every element it touches. Neither order works on its own.
+
+The fix is one line, written by you, before either stylesheet: a single `@layer` statement that interleaves the two lists. The shared `components` and `utilities` names merge, which is what you want — Tailwind's `@utility` additions sit in the same layer as ours, and your `@layer components` in the same layer as our components.
+
+```css
+/* app.css */
+@layer theme, base, colors, config, root, reboot, layout, content, forms, components, custom, helpers, utilities;
+
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/utilities.css" layer(utilities);
+
+@import "@coreui/coreui-pro/css/base.css";
+@import "@coreui/coreui-pro/css/components/buttons.css";
+@import "@coreui/coreui-pro/css/components/card.css";
+```
+
+Two decisions are baked into that file:
+
+- **One reset, not two.** `@import "tailwindcss"` also brings Preflight; the two explicit imports above bring Tailwind's theme and utilities and leave the reset out, because `base.css` already carries [Reboot](/content/reboot/). Two resets on one page never agree on form controls and headings.
+- **CoreUI's utilities stay out.** `coreui-utilities.css` is not imported. Nothing in a component depends on it, so the components render the same. If you do want both sets, import ours too — they share the `utilities` layer, and the later file wins on a name both define.
+
+## Class names both libraries use
+
+Sixty-odd class names exist in both utility sets — `flex`, `border`, `shadow`, `rounded`, `p-1`, `text-center` — which stops mattering the moment our utilities are not loaded. Four names are CoreUI **component or layout** classes that Tailwind also defines as utilities:
+
+| Class | CoreUI | Tailwind |
+| --- | --- | --- |
+| `.grid` | the [CSS grid](/layout/css-grid/) container: twelve columns and a gap | `display: grid` |
+| `.container` | the [responsive container](/layout/containers/) with its max-widths | a max-width container of its own |
+| `.table` | the [table](/content/tables/) component | `display: table` |
+| `.collapse` | the [collapse](/components/collapse/) component | `border-collapse: collapse` |
+
+`.table` and `.collapse` are harmless — Tailwind's declaration is one the component already carries. `.grid` and `.container` are not: writing Tailwind's `grid` on an element gives it our twelve-column template and gutter. Either leave `layout/grid.css` and `layout/containers.css` out when you use Tailwind's, or give Tailwind a prefix so its classes cannot meet ours:
+
+```css
+@import "tailwindcss/theme.css" layer(theme) prefix(tw);
+@import "tailwindcss/utilities.css" layer(utilities) prefix(tw);
+```
+
+Tailwind's classes are then written `tw:grid`, `tw:p-4`, and no name is shared.
+
+## Tailwind reading CoreUI's tokens
+
+Tailwind's utilities take their values from its `@theme` block, and a theme value can be a `var()`. Point the entries at CoreUI's tokens and `bg-primary`, `p-4` and `rounded-md` follow our palette, spacing scale and radius — including the color mode, because our tokens resolve through `light-dark()`:
+
+```css
+@theme {
+  --color-primary: var(--cui-primary-base);
+  --color-primary-fg: var(--cui-primary-fg);
+  --color-success: var(--cui-success-base);
+  --color-danger: var(--cui-danger-base);
+  --color-body: var(--cui-bg-body);
+  --color-fg: var(--cui-fg-body);
+
+  --spacing: var(--cui-spacer-1);
+
+  --radius-sm: var(--cui-radius-2);
+  --radius-md: var(--cui-radius-3);
+  --radius-lg: var(--cui-radius-5);
+
+  --font-sans: var(--cui-font-sans-serif);
+}
+```
+
+`--spacing` is Tailwind's multiplier — `p-4` is four times it — and `--cui-spacer-1` is a quarter of `--cui-spacer`, so the two scales line up. Override `--cui-primary-base` on `:root` and both libraries repaint. Every token that can be mapped is listed on the [CSS variables](/customize/css-variables/) page.
+
+The other direction needs nothing: a component reads its color from the [theme slots](/customize/theme/) on the element, so `<button class="btn btn-solid theme-primary">` is themed the same way whether Tailwind is on the page or not, and a `.theme-brand` class of your own works next to Tailwind's `bg-*` classes.
+
+## What CoreUI's components never need
+
+The components do not use utility classes internally, so leaving `coreui-utilities.css` out cannot break one. The classes our JavaScript toggles — `show`, `active`, `collapsing`, `disabled` — are component states that live in the component stylesheets, not utilities, and they are unaffected by Tailwind's content scanning: they are not in your markup, and they do not need to be.

--- a/docs/src/content/docs/guides/tailwind.mdx
+++ b/docs/src/content/docs/guides/tailwind.mdx
@@ -85,7 +85,7 @@ Tailwind's utilities take their values from its `@theme` block, and a theme valu
 
 `--spacing` is Tailwind's multiplier — `p-4` is four times it — and `--cui-spacer-1` is a quarter of `--cui-spacer`, so the two scales line up. Override `--cui-primary-base` on `:root` and both libraries repaint. Every token that can be mapped is listed on the [CSS variables](/customize/css-variables/) page.
 
-The other direction needs nothing: a component reads its color from the [theme slots](/customize/theme/) on the element, so `<button class="btn btn-solid theme-primary">` is themed the same way whether Tailwind is on the page or not, and a `.theme-brand` class of your own works next to Tailwind's `bg-*` classes.
+The other direction needs nothing: a component reads its color from the [theme slots](/customize/theme/) on the element, so `<button class="btn-solid theme-primary">` is themed the same way whether Tailwind is on the page or not, and a `.theme-brand` class of your own works next to Tailwind's `bg-*` classes.
 
 ## What CoreUI's components never need
 

--- a/docs/src/data/sidebar.yml
+++ b/docs/src/data/sidebar.yml
@@ -33,6 +33,8 @@
       to: /guides/vite/
     - title: Laravel
       to: /guides/laravel/
+    - title: Tailwind CSS
+      to: /guides/tailwind/
     - title: Django
       to: /guides/django/
     - title: Build tools


### PR DESCRIPTION
## What

A new Guides page, **CoreUI & Tailwind CSS**, for projects that keep our components and take their utilities from Tailwind 4, plus a correction on the Theme page.

### The guide

- **One cascade.** Both libraries name a `components` and a `utilities` layer, and the browser fixes the order of every layer at its first mention. Importing Tailwind first puts our `root`/`reboot`/`forms` after its `utilities`; importing CoreUI first puts Preflight after our `forms`/`utilities`. The fix is one interleaved `@layer` statement written by the user before either stylesheet — the page shows it, and explains why the shared `components`/`utilities` names merging is what you want.
- **One reset.** Tailwind imported as `theme.css` + `utilities.css` (no Preflight), because `base.css` already carries Reboot.
- **Class names both define.** The 60-odd shared utility names stop mattering once our utilities are not loaded; four component/layout classes remain — `grid` and `container` collide for real, `table` and `collapse` are harmless — with `prefix(tw)` on both imports as the way out (verified against Tailwind's Preflight page, which says the prefix has to go on both).
- **Tokens.** An `@theme` block mapping Tailwind's color, `--spacing`, radius and font values to `--cui-*` tokens, so both libraries follow one palette and one color mode. Every token named in the block was checked against the compiled `base.css`.
- **What components never need:** they do not use utilities internally, and JS-toggled states live in the component sheets.

### Theme page

`customize/theme.mdx` still said `--cui-primary` and `--cui-primary-base` are both emitted and that overriding `--cui-primary` retints the family. The bare token went away in #1148 (the migration guide records it); the compiled CSS declares and reads `--cui-primary-base` only. Three sentences fixed.

## Gates

`npm run docs-build`: 182 pages, no broken links. No library code touched.

Same page lands in `coreui-react-pro` and `coreui-vue-pro` (`docs/tailwind-guide-v6`), adapted to component-side CSS imports.