### PR TITLE
fix(package): export every compiled stylesheet under ./css/*

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "./css/base.css": "./dist/css/base.css",
     "./css/base.min.css": "./dist/css/base.min.css",
     "./css/components/*": "./dist/css/components/*",
+    "./css/*": "./dist/css/*",
     "./scss/*": "./scss/*",
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
## What

One `exports` entry: `"./css/*": "./dist/css/*"`, next to the existing `./css/base.css` and `./css/components/*`.

## Why

Only `base.css` and the component sheets had a `./css/` export. The whole sheets — `coreui.css`, `coreui-utilities.css`, `coreui-legacy.css` (#1203), the Bootstrap theme — resolved solely through `./dist/css/*`. Two consequences already visible:

- The React and Vue docs (`customize/optimize`) tell readers to import `@coreui/coreui-pro/css/coreui-utilities.css`, which does not resolve.
- The bindings strip CSS side-effect imports for their `/unstyled` build by the `@coreui/coreui-pro/css/` prefix, so `CFormCheck`/`CFormSwitch` in coreui/coreui-react-pro#330 had to import the legacy sheet through `dist/css/` and widen that regex.

Verified from a consumer package with `createRequire`: `css/base.css`, `css/coreui-utilities.css`, `css/coreui-legacy.css`, `css/components/buttons.css` all resolve. No build or source change.