### PR TITLE
docs: write the examples in the v6 theme and field spelling

### DIFF
--- a/docs/src/content/docs/components/dropdowns.mdx
+++ b/docs/src/content/docs/components/dropdowns.mdx
@@ -556,9 +556,9 @@ Put a form within a dropdown menu, or make it into a dropdown menu, and use [mar
         <input type="password" class="form-control" id="exampleDropdownFormPassword1" placeholder="Password">
       </div>
       <div class="mb-3">
-        <div class="form-check">
-          <input type="checkbox" class="form-check-input" id="dropdownCheck">
-          <label class="form-check-label" for="dropdownCheck">
+        <div class="form-field">
+          <input type="checkbox" class="check" id="dropdownCheck">
+          <label for="dropdownCheck">
             Remember me
           </label>
         </div>
@@ -584,9 +584,9 @@ Put a form within a dropdown menu, or make it into a dropdown menu, and use [mar
         <input type="password" class="form-control" id="exampleDropdownFormPassword2" placeholder="Password">
       </div>
       <div class="mb-3">
-        <div class="form-check">
-          <input type="checkbox" class="form-check-input" id="dropdownCheck2">
-          <label class="form-check-label" for="dropdownCheck2">
+        <div class="form-field">
+          <input type="checkbox" class="check" id="dropdownCheck2">
+          <label for="dropdownCheck2">
             Remember me
           </label>
         </div>

--- a/docs/src/content/docs/components/list-group.mdx
+++ b/docs/src/content/docs/components/list-group.mdx
@@ -208,23 +208,23 @@ Place CoreUI for Bootstrap's checkboxes and radios within list group items and c
 
 <Example code={`<ul class="list-group">
     <li class="list-group-item">
-      <input class="form-check-input me-1" type="checkbox" value="" aria-label="...">
+      <input class="check me-1" type="checkbox" value="" aria-label="...">
       First checkbox
     </li>
     <li class="list-group-item">
-      <input class="form-check-input me-1" type="checkbox" value="" aria-label="...">
+      <input class="check me-1" type="checkbox" value="" aria-label="...">
       Second checkbox
     </li>
     <li class="list-group-item">
-      <input class="form-check-input me-1" type="checkbox" value="" aria-label="...">
+      <input class="check me-1" type="checkbox" value="" aria-label="...">
       Third checkbox
     </li>
     <li class="list-group-item">
-      <input class="form-check-input me-1" type="checkbox" value="" aria-label="...">
+      <input class="check me-1" type="checkbox" value="" aria-label="...">
       Fourth checkbox
     </li>
     <li class="list-group-item">
-      <input class="form-check-input me-1" type="checkbox" value="" aria-label="...">
+      <input class="check me-1" type="checkbox" value="" aria-label="...">
       Fifth checkbox
     </li>
   </ul>`} />
@@ -233,23 +233,23 @@ And if you want `<label>`s as the `.list-group-item` for large hit areas, you ca
 
 <Example code={`<div class="list-group">
     <label class="list-group-item">
-      <input class="form-check-input me-1" type="checkbox" value="">
+      <input class="check me-1" type="checkbox" value="">
       First checkbox
     </label>
     <label class="list-group-item">
-      <input class="form-check-input me-1" type="checkbox" value="">
+      <input class="check me-1" type="checkbox" value="">
       Second checkbox
     </label>
     <label class="list-group-item">
-      <input class="form-check-input me-1" type="checkbox" value="">
+      <input class="check me-1" type="checkbox" value="">
       Third checkbox
     </label>
     <label class="list-group-item">
-      <input class="form-check-input me-1" type="checkbox" value="">
+      <input class="check me-1" type="checkbox" value="">
       Fourth checkbox
     </label>
     <label class="list-group-item">
-      <input class="form-check-input me-1" type="checkbox" value="">
+      <input class="check me-1" type="checkbox" value="">
       Fifth checkbox
     </label>
   </div>`} />

--- a/docs/src/content/docs/customize/color-modes.mdx
+++ b/docs/src/content/docs/customize/color-modes.mdx
@@ -16,7 +16,7 @@ Alternatively, you can also switch to a media query implementation thanks to our
 For example, to change the color mode of a dropdown menu, add `data-coreui-theme="light"` or `data-coreui-theme="dark"` to the parent `.dropdown`. Now, no matter the global color mode, these dropdowns will display with the specified theme value.
 
 <Example class="d-flex justify-content-between" code={`<div class="dropdown" data-coreui-theme="light">
-    <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButtonLight" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button class="btn-solid theme-secondary dropdown-toggle" type="button" id="dropdownMenuButtonLight" data-coreui-toggle="dropdown" aria-expanded="false">
       Default dropdown
     </button>
     <ul class="dropdown-menu" aria-labelledby="dropdownMenuButtonLight">
@@ -30,7 +30,7 @@ For example, to change the color mode of a dropdown menu, add `data-coreui-theme
   </div>
 
   <div class="dropdown" data-coreui-theme="dark">
-    <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButtonDark" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button class="btn-solid theme-secondary dropdown-toggle" type="button" id="dropdownMenuButtonDark" data-coreui-toggle="dropdown" aria-expanded="false">
       Dark dropdown
     </button>
     <ul class="dropdown-menu" aria-labelledby="dropdownMenuButtonDark">
@@ -144,7 +144,7 @@ For example, you can create a "blue theme" with the selector `data-coreui-theme=
 
 <ScssDocs file="@docs/_content.scss" capture="custom-color-mode" />
 
-<Example class="fg-body bg-body" theme="blue" html={[`<div class="h4">Example blue theme</div>`, `<p>Some paragraph text to show how the blue theme might look with written copy.</p>`, ``, `<hr class="my-4">`, ``, `<div class="dropdown">`, `  <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButtonCustom" data-coreui-toggle="dropdown" aria-expanded="false">`, `    Dropdown button`, `  </button>`, `  <ul class="dropdown-menu" aria-labelledby="dropdownMenuButtonCustom">`, `    <li><a class="dropdown-item active" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`]} />
+<Example class="fg-body bg-body" theme="blue" html={[`<div class="h4">Example blue theme</div>`, `<p>Some paragraph text to show how the blue theme might look with written copy.</p>`, ``, `<hr class="my-4">`, ``, `<div class="dropdown">`, `  <button class="btn-solid theme-secondary dropdown-toggle" type="button" id="dropdownMenuButtonCustom" data-coreui-toggle="dropdown" aria-expanded="false">`, `    Dropdown button`, `  </button>`, `  <ul class="dropdown-menu" aria-labelledby="dropdownMenuButtonCustom">`, `    <li><a class="dropdown-item active" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Action</a></li>`, `    <li><a class="dropdown-item" href="#">Another action</a></li>`, `    <li><a class="dropdown-item" href="#">Something else here</a></li>`, `    <li><hr class="dropdown-divider"></li>`, `    <li><a class="dropdown-item" href="#">Separated link</a></li>`, `  </ul>`, `</div>`]} />
 
 ```html
 <div data-coreui-theme="blue">

--- a/docs/src/content/docs/forms/checkbox.mdx
+++ b/docs/src/content/docs/forms/checkbox.mdx
@@ -137,27 +137,27 @@ Add a description after the label and wrap both in a `.form-field-content`, so t
 
 Create button-like checkboxes by putting `.btn-check` on a `<label>` with the button classes, and nesting the input inside it. The label is the button, so there is no `id`/`for` pair to keep in sync. They can be grouped in a [button group](/components/button-group/).
 
-<Example code={`<label class="btn btn-primary btn-check">
+<Example code={`<label class="btn-solid theme-primary btn-check">
     <input type="checkbox" autocomplete="off">
     Single toggle
   </label>
 
-  <label class="btn btn-primary btn-check">
+  <label class="btn-solid theme-primary btn-check">
     <input type="checkbox" checked autocomplete="off">
     Checked
   </label>
 
-  <label class="btn btn-primary btn-check">
+  <label class="btn-solid theme-primary btn-check">
     <input type="checkbox" disabled autocomplete="off">
     Disabled
   </label>`} />
 
-<Example code={`<label class="btn btn-outline-primary btn-check">
+<Example code={`<label class="btn-outline theme-primary btn-check">
     <input type="checkbox" autocomplete="off">
     Single toggle
   </label>
 
-  <label class="btn btn-outline-secondary btn-check">
+  <label class="btn-outline theme-secondary btn-check">
     <input type="checkbox" checked autocomplete="off">
     Checked
   </label>`} />

--- a/docs/src/content/docs/forms/checkbox.mdx
+++ b/docs/src/content/docs/forms/checkbox.mdx
@@ -51,7 +51,7 @@ Add the `disabled` attribute; the associated `<label>` is styled to match, in a 
 
 ## Stacked
 
-Any number of checkboxes that are immediate siblings stack vertically and are spaced by `.form-check`.
+Any number of checkboxes that are immediate siblings stack vertically and are spaced by `.form-field`.
 
 <Example code={`<div class="form-field">
     <input class="check" type="checkbox" value="" id="defaultCheck1">
@@ -198,11 +198,11 @@ See the [v6 migration guide](/migration/v6/) for the full picture.
 
 ## Theme variants
 
-Modify the appearance of checked checkboxes by adding a [`.theme-{color}` class](/customize/components/#theme-variants) to the `.form-check` element. This sets the checked background and border color to the theme color.
+Modify the appearance of checked checkboxes by adding a [`.theme-{color}` class](/customize/components/#theme-variants) to the `.check` input, or to any element above it. This sets the checked background and border color to the theme color.
 
-<Example class="d-flex flex-column gap-2" code={getData('theme-colors').map((c) => `<div class="form-check theme-${c.name}">
-    <input class="form-check-input" type="checkbox" id="check-${c.name}" checked>
-    <label class="form-check-label" for="check-${c.name}">${c.title} checkbox</label>
+<Example class="d-flex flex-column gap-2" code={getData('theme-colors').map((c) => `<div class="form-field theme-${c.name}">
+    <input class="check" type="checkbox" id="check-${c.name}" checked>
+    <label for="check-${c.name}">${c.title} checkbox</label>
   </div>`)} />
 
 ## Customizing

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -52,9 +52,9 @@ ever sets `disabled`, so a button you disable in the template stays disabled.
     <div class="col-lg-5">
       <div data-coreui-locale="en-US" data-coreui-toggle="date-picker">
         <template data-coreui-template="footer">
-          <button type="button" class="btn btn-sm btn-ghost-danger me-auto" data-coreui-picker-action="today">Today</button>
-          <button type="button" class="btn btn-sm btn-ghost-primary" data-coreui-picker-action="clear">Clear</button>
-          <button type="button" class="btn btn-sm btn-primary" data-coreui-picker-action="close">OK</button>
+          <button type="button" class="btn-ghost theme-danger btn-sm me-auto" data-coreui-picker-action="today">Today</button>
+          <button type="button" class="btn-ghost theme-primary btn-sm" data-coreui-picker-action="clear">Clear</button>
+          <button type="button" class="btn-solid theme-primary btn-sm" data-coreui-picker-action="close">OK</button>
         </template>
       </div>
     </div>
@@ -74,8 +74,8 @@ typing that date.
     <div class="col-lg-5">
       <div id="myDatePickerFooterToday">
         <template data-coreui-template="footer">
-          <button type="button" class="btn btn-sm btn-ghost-danger me-auto" data-coreui-picker-action="today">Today</button>
-          <button type="button" class="btn btn-sm btn-primary" data-coreui-picker-action="close">OK</button>
+          <button type="button" class="btn-ghost theme-danger btn-sm me-auto" data-coreui-picker-action="today">Today</button>
+          <button type="button" class="btn-solid theme-primary btn-sm" data-coreui-picker-action="close">OK</button>
         </template>
       </div>
     </div>

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -50,8 +50,8 @@ closing is the footer's job.
     <div class="col-lg-7">
       <div data-coreui-locale="en-US" data-coreui-toggle="date-range-picker">
         <template data-coreui-template="footer">
-          <button type="button" class="btn btn-sm btn-ghost-primary" data-coreui-picker-action="clear">Clear</button>
-          <button type="button" class="btn btn-sm btn-primary" data-coreui-picker-action="close">OK</button>
+          <button type="button" class="btn-ghost theme-primary btn-sm" data-coreui-picker-action="clear">Clear</button>
+          <button type="button" class="btn-solid theme-primary btn-sm" data-coreui-picker-action="close">OK</button>
         </template>
       </div>
     </div>
@@ -173,13 +173,13 @@ yours.
     <div class="col-lg-8">
       <div id="myDateRangePickerRanges">
         <template data-coreui-template="ranges">
-          <button type="button" class="btn btn-sm btn-ghost-primary" id="rangeLast7">Last 7 days</button>
-          <button type="button" class="btn btn-sm btn-ghost-primary" id="rangeLast30">Last 30 days</button>
-          <button type="button" class="btn btn-sm btn-ghost-primary" id="rangeThisMonth">This month</button>
+          <button type="button" class="btn-ghost theme-primary btn-sm" id="rangeLast7">Last 7 days</button>
+          <button type="button" class="btn-ghost theme-primary btn-sm" id="rangeLast30">Last 30 days</button>
+          <button type="button" class="btn-ghost theme-primary btn-sm" id="rangeThisMonth">This month</button>
         </template>
         <template data-coreui-template="footer">
-          <button type="button" class="btn btn-sm btn-ghost-primary" data-coreui-picker-action="clear">Clear</button>
-          <button type="button" class="btn btn-sm btn-primary" data-coreui-picker-action="close">OK</button>
+          <button type="button" class="btn-ghost theme-primary btn-sm" data-coreui-picker-action="clear">Clear</button>
+          <button type="button" class="btn-solid theme-primary btn-sm" data-coreui-picker-action="close">OK</button>
         </template>
       </div>
     </div>

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -50,9 +50,9 @@ keeps the day — so the popup does not auto-close.
     <div class="col-lg-6">
       <div data-coreui-locale="en-US" data-coreui-toggle="date-time-picker">
         <template data-coreui-template="footer">
-          <button type="button" class="btn btn-sm btn-ghost-danger me-auto" data-coreui-picker-action="today">Today</button>
-          <button type="button" class="btn btn-sm btn-ghost-primary" data-coreui-picker-action="clear">Clear</button>
-          <button type="button" class="btn btn-sm btn-primary" data-coreui-picker-action="close">OK</button>
+          <button type="button" class="btn-ghost theme-danger btn-sm me-auto" data-coreui-picker-action="today">Today</button>
+          <button type="button" class="btn-ghost theme-primary btn-sm" data-coreui-picker-action="clear">Clear</button>
+          <button type="button" class="btn-solid theme-primary btn-sm" data-coreui-picker-action="close">OK</button>
         </template>
       </div>
     </div>

--- a/docs/src/content/docs/forms/form-control.mdx
+++ b/docs/src/content/docs/forms/form-control.mdx
@@ -108,7 +108,7 @@ If you want to have `<input readonly />` elements in your form styled as plain t
       <input type="password" class="form-control" id="inputPassword2" placeholder="Password">
     </div>
     <div class="col-auto">
-      <button type="submit" class="btn btn-primary mb-3">Confirm identity</button>
+      <button type="submit" class="btn-solid theme-primary mb-3">Confirm identity</button>
     </div>
   </form>`} />
 

--- a/docs/src/content/docs/forms/input-group.mdx
+++ b/docs/src/content/docs/forms/input-group.mdx
@@ -133,31 +133,31 @@ Multiple add-ons are supported and can be mixed with checkbox and radio input ve
 ## Button addons
 
 <Example code={`<div class="input-group mb-3">
-    <button class="btn btn-outline-secondary" type="button" id="button-addon1">Button</button>
+    <button class="btn-outline theme-secondary" type="button" id="button-addon1">Button</button>
     <input type="text" class="form-control" placeholder="" aria-label="Example text with button addon" aria-describedby="button-addon1">
   </div>
 
   <div class="input-group mb-3">
     <input type="text" class="form-control" placeholder="Recipient's username" aria-label="Recipient's username" aria-describedby="button-addon2">
-    <button class="btn btn-outline-secondary" type="button" id="button-addon2">Button</button>
+    <button class="btn-outline theme-secondary" type="button" id="button-addon2">Button</button>
   </div>
 
   <div class="input-group mb-3">
-    <button class="btn btn-outline-secondary" type="button">Button</button>
-    <button class="btn btn-outline-secondary" type="button">Button</button>
+    <button class="btn-outline theme-secondary" type="button">Button</button>
+    <button class="btn-outline theme-secondary" type="button">Button</button>
     <input type="text" class="form-control" placeholder="" aria-label="Example text with two button addons">
   </div>
 
   <div class="input-group">
     <input type="text" class="form-control" placeholder="Recipient's username" aria-label="Recipient's username with two button addons">
-    <button class="btn btn-outline-secondary" type="button">Button</button>
-    <button class="btn btn-outline-secondary" type="button">Button</button>
+    <button class="btn-outline theme-secondary" type="button">Button</button>
+    <button class="btn-outline theme-secondary" type="button">Button</button>
   </div>`} />
 
 ## Buttons with dropdowns
 
 <Example code={`<div class="input-group mb-3">
-    <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">Dropdown</button>
+    <button class="btn-outline theme-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">Dropdown</button>
     <ul class="dropdown-menu">
       <li><a class="dropdown-item" href="#">Action</a></li>
       <li><a class="dropdown-item" href="#">Another action</a></li>
@@ -170,7 +170,7 @@ Multiple add-ons are supported and can be mixed with checkbox and radio input ve
 
   <div class="input-group mb-3">
     <input type="text" class="form-control" aria-label="Text input with dropdown button">
-    <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">Dropdown</button>
+    <button class="btn-outline theme-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">Dropdown</button>
     <ul class="dropdown-menu dropdown-menu-end">
       <li><a class="dropdown-item" href="#">Action</a></li>
       <li><a class="dropdown-item" href="#">Another action</a></li>
@@ -181,7 +181,7 @@ Multiple add-ons are supported and can be mixed with checkbox and radio input ve
   </div>
 
   <div class="input-group">
-    <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">Dropdown</button>
+    <button class="btn-outline theme-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">Dropdown</button>
     <ul class="dropdown-menu">
       <li><a class="dropdown-item" href="#">Action before</a></li>
       <li><a class="dropdown-item" href="#">Another action before</a></li>
@@ -190,7 +190,7 @@ Multiple add-ons are supported and can be mixed with checkbox and radio input ve
       <li><a class="dropdown-item" href="#">Separated link</a></li>
     </ul>
     <input type="text" class="form-control" aria-label="Text input with 2 dropdown buttons">
-    <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">Dropdown</button>
+    <button class="btn-outline theme-secondary dropdown-toggle" type="button" data-coreui-toggle="dropdown" aria-expanded="false">Dropdown</button>
     <ul class="dropdown-menu dropdown-menu-end">
       <li><a class="dropdown-item" href="#">Action</a></li>
       <li><a class="dropdown-item" href="#">Another action</a></li>
@@ -203,8 +203,8 @@ Multiple add-ons are supported and can be mixed with checkbox and radio input ve
 ## Segmented buttons
 
 <Example code={`<div class="input-group mb-3">
-    <button type="button" class="btn btn-outline-secondary">Action</button>
-    <button type="button" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button type="button" class="btn-outline theme-secondary">Action</button>
+    <button type="button" class="btn-outline theme-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
       <span class="visually-hidden">Toggle Dropdown</span>
     </button>
     <ul class="dropdown-menu">
@@ -219,8 +219,8 @@ Multiple add-ons are supported and can be mixed with checkbox and radio input ve
 
   <div class="input-group">
     <input type="text" class="form-control" aria-label="Text input with segmented dropdown button">
-    <button type="button" class="btn btn-outline-secondary">Action</button>
-    <button type="button" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
+    <button type="button" class="btn-outline theme-secondary">Action</button>
+    <button type="button" class="btn-outline theme-secondary dropdown-toggle dropdown-toggle-split" data-coreui-toggle="dropdown" aria-expanded="false">
       <span class="visually-hidden">Toggle Dropdown</span>
     </button>
     <ul class="dropdown-menu dropdown-menu-end">
@@ -259,7 +259,7 @@ Input groups include support for custom selects and custom file inputs. Browser 
   </div>
 
   <div class="input-group mb-3">
-    <button class="btn btn-outline-secondary" type="button">Button</button>
+    <button class="btn-outline theme-secondary" type="button">Button</button>
     <select class="form-control" id="inputGroupSelect03" aria-label="Example select with button addon">
       <option selected>Choose...</option>
       <option value="1">One</option>
@@ -275,7 +275,7 @@ Input groups include support for custom selects and custom file inputs. Browser 
       <option value="2">Two</option>
       <option value="3">Three</option>
     </select>
-    <button class="btn btn-outline-secondary" type="button">Button</button>
+    <button class="btn-outline theme-secondary" type="button">Button</button>
   </div>`} />
 
 ### Custom file input
@@ -291,13 +291,13 @@ Input groups include support for custom selects and custom file inputs. Browser 
   </div>
 
   <div class="input-group mb-3">
-    <button class="btn btn-outline-secondary" type="button" id="inputGroupFileAddon03">Button</button>
+    <button class="btn-outline theme-secondary" type="button" id="inputGroupFileAddon03">Button</button>
     <input type="file" class="form-control" id="inputGroupFile03" aria-describedby="inputGroupFileAddon03" aria-label="Upload">
   </div>
 
   <div class="input-group">
     <input type="file" class="form-control" id="inputGroupFile04" aria-describedby="inputGroupFileAddon04" aria-label="Upload">
-    <button class="btn btn-outline-secondary" type="button" id="inputGroupFileAddon04">Button</button>
+    <button class="btn-outline theme-secondary" type="button" id="inputGroupFileAddon04">Button</button>
   </div>`} />
 
 ## Skipping an element

--- a/docs/src/content/docs/forms/input-group.mdx
+++ b/docs/src/content/docs/forms/input-group.mdx
@@ -88,18 +88,18 @@ Add the relative form sizing classes to the `.input-group` itself and contents w
 
 ## Checkboxes and radios
 
-Place any checkbox or radio option within an input group's addon instead of text. We recommend adding `.mt-0` to the `.form-check-input` when there's no visible text next to the input.
+Place any checkbox or radio option within an input group's addon instead of text. We recommend adding `.mt-0` to the `.check` or `.radio` input when there's no visible text next to the input.
 
 <Example code={`<div class="input-group mb-3">
     <div class="input-group-text">
-      <input class="form-check-input mt-0" type="checkbox" value="" aria-label="Checkbox for following text input">
+      <input class="check mt-0" type="checkbox" value="" aria-label="Checkbox for following text input">
     </div>
     <input type="text" class="form-control" aria-label="Text input with checkbox">
   </div>
 
   <div class="input-group">
     <div class="input-group-text">
-      <input class="form-check-input mt-0" type="radio" value="" aria-label="Radio button for following text input">
+      <input class="radio mt-0" type="radio" value="" aria-label="Radio button for following text input">
     </div>
     <input type="text" class="form-control" aria-label="Text input with radio button">
   </div>`} />

--- a/docs/src/content/docs/forms/layout.mdx
+++ b/docs/src/content/docs/forms/layout.mdx
@@ -97,7 +97,7 @@ More complex layouts can also be created with the grid system.
       </div>
     </div>
     <div class="col-12">
-      <button type="submit" class="btn btn-primary">Sign in</button>
+      <button type="submit" class="btn-solid theme-primary">Sign in</button>
     </div>
   </form>`} />
 
@@ -153,7 +153,7 @@ At times, you maybe need to use margin or padding utilities to create that perfe
         </div>
       </div>
     </div>
-    <button type="submit" class="btn btn-primary">Sign in</button>
+    <button type="submit" class="btn-solid theme-primary">Sign in</button>
   </form>`} />
 
 ### Horizontal form label sizing
@@ -229,7 +229,7 @@ The example below uses a flexbox utility to vertically center the contents and c
       </div>
     </div>
     <div class="col-auto">
-      <button type="submit" class="btn btn-primary">Submit</button>
+      <button type="submit" class="btn-solid theme-primary">Submit</button>
     </div>
   </form>`} />
 
@@ -265,7 +265,7 @@ You can then remix that once again with size-specific column classes.
       </div>
     </div>
     <div class="col-auto">
-      <button type="submit" class="btn btn-primary">Submit</button>
+      <button type="submit" class="btn-solid theme-primary">Submit</button>
     </div>
   </form>`} />
 
@@ -302,6 +302,6 @@ Use the `.row-cols-*` classes to create responsive horizontal layouts. By adding
     </div>
 
     <div class="col-12">
-      <button type="submit" class="btn btn-primary">Submit</button>
+      <button type="submit" class="btn-solid theme-primary">Submit</button>
     </div>
   </form>`} />

--- a/docs/src/content/docs/forms/layout.mdx
+++ b/docs/src/content/docs/forms/layout.mdx
@@ -89,9 +89,9 @@ More complex layouts can also be created with the grid system.
       <input type="text" class="form-control" id="inputZip">
     </div>
     <div class="col-12">
-      <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="gridCheck">
-        <label class="form-check-label" for="gridCheck">
+      <div class="form-field">
+        <input class="check" type="checkbox" id="gridCheck">
+        <label for="gridCheck">
           Check me out
         </label>
       </div>
@@ -123,21 +123,21 @@ At times, you maybe need to use margin or padding utilities to create that perfe
     <fieldset class="row mb-3">
       <legend class="col-form-label col-sm-2 pt-0">Radios</legend>
       <div class="col-sm-10">
-        <div class="form-check">
-          <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios1" value="option1" checked>
-          <label class="form-check-label" for="gridRadios1">
+        <div class="form-field">
+          <input class="radio" type="radio" name="gridRadios" id="gridRadios1" value="option1" checked>
+          <label for="gridRadios1">
             First radio
           </label>
         </div>
-        <div class="form-check">
-          <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios2" value="option2">
-          <label class="form-check-label" for="gridRadios2">
+        <div class="form-field">
+          <input class="radio" type="radio" name="gridRadios" id="gridRadios2" value="option2">
+          <label for="gridRadios2">
             Second radio
           </label>
         </div>
-        <div class="form-check disabled">
-          <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios3" value="option3" disabled>
-          <label class="form-check-label" for="gridRadios3">
+        <div class="form-field">
+          <input class="radio" type="radio" name="gridRadios" id="gridRadios3" value="option3" disabled>
+          <label for="gridRadios3">
             Third disabled radio
           </label>
         </div>
@@ -145,9 +145,9 @@ At times, you maybe need to use margin or padding utilities to create that perfe
     </fieldset>
     <div class="row mb-3">
       <div class="col-sm-10 offset-sm-2">
-        <div class="form-check">
-          <input class="form-check-input" type="checkbox" id="gridCheck1">
-          <label class="form-check-label" for="gridCheck1">
+        <div class="form-field">
+          <input class="check" type="checkbox" id="gridCheck1">
+          <label for="gridCheck1">
             Example checkbox
           </label>
         </div>
@@ -221,9 +221,9 @@ The example below uses a flexbox utility to vertically center the contents and c
       </select>
     </div>
     <div class="col-auto">
-      <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="autoSizingCheck">
-        <label class="form-check-label" for="autoSizingCheck">
+      <div class="form-field">
+        <input class="check" type="checkbox" id="autoSizingCheck">
+        <label for="autoSizingCheck">
           Remember me
         </label>
       </div>
@@ -257,9 +257,9 @@ You can then remix that once again with size-specific column classes.
       </select>
     </div>
     <div class="col-auto">
-      <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="autoSizingCheck2">
-        <label class="form-check-label" for="autoSizingCheck2">
+      <div class="form-field">
+        <input class="check" type="checkbox" id="autoSizingCheck2">
+        <label for="autoSizingCheck2">
           Remember me
         </label>
       </div>
@@ -271,7 +271,7 @@ You can then remix that once again with size-specific column classes.
 
 ## Inline forms
 
-Use the `.row-cols-*` classes to create responsive horizontal layouts. By adding [gutter modifier classes](/layout/gutters/), we'll have gutters in horizontal and vertical directions. On narrow mobile viewports, the `.col-12` helps stack the form controls and more. The `.align-items-center` aligns the form elements to the middle, making the `.form-check` align properly.
+Use the `.row-cols-*` classes to create responsive horizontal layouts. By adding [gutter modifier classes](/layout/gutters/), we'll have gutters in horizontal and vertical directions. On narrow mobile viewports, the `.col-12` helps stack the form controls and more. The `.align-items-center` aligns the form elements to the middle, making the `.form-field` align properly.
 
 <Example code={`<form class="row row-cols-lg-auto g-3 align-items-center">
     <div class="col-12">
@@ -293,9 +293,9 @@ Use the `.row-cols-*` classes to create responsive horizontal layouts. By adding
     </div>
 
     <div class="col-12">
-      <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="inlineFormCheck">
-        <label class="form-check-label" for="inlineFormCheck">
+      <div class="form-field">
+        <input class="check" type="checkbox" id="inlineFormCheck">
+        <label for="inlineFormCheck">
           Remember me
         </label>
       </div>

--- a/docs/src/content/docs/forms/overview.mdx
+++ b/docs/src/content/docs/forms/overview.mdx
@@ -22,9 +22,9 @@ Here's a quick example to demonstrate CoreUI for Bootstrap's form styles. Keep r
       <label for="exampleInputPassword1" class="form-label">Password</label>
       <input type="password" class="form-control" id="exampleInputPassword1">
     </div>
-    <div class="mb-3 form-check">
-      <input type="checkbox" class="form-check-input" id="exampleCheck1">
-      <label class="form-check-label" for="exampleCheck1">Check me out</label>
+    <div class="mb-3 form-field">
+      <input type="checkbox" class="check" id="exampleCheck1">
+      <label for="exampleCheck1">Check me out</label>
     </div>
     <button type="submit" class="btn-solid theme-primary">Submit</button>
   </form>`} />
@@ -89,9 +89,9 @@ However, if your form also includes custom button-like elements such as `<a clas
         </select>
       </div>
       <div class="mb-3">
-        <div class="form-check">
-          <input class="form-check-input" type="checkbox" id="disabledFieldsetCheck" disabled>
-          <label class="form-check-label" for="disabledFieldsetCheck">
+        <div class="form-field">
+          <input class="check" type="checkbox" id="disabledFieldsetCheck" disabled>
+          <label for="disabledFieldsetCheck">
             Can't check this
           </label>
         </div>

--- a/docs/src/content/docs/forms/overview.mdx
+++ b/docs/src/content/docs/forms/overview.mdx
@@ -26,7 +26,7 @@ Here's a quick example to demonstrate CoreUI for Bootstrap's form styles. Keep r
       <input type="checkbox" class="form-check-input" id="exampleCheck1">
       <label class="form-check-label" for="exampleCheck1">Check me out</label>
     </div>
-    <button type="submit" class="btn btn-primary">Submit</button>
+    <button type="submit" class="btn-solid theme-primary">Submit</button>
   </form>`} />
 
 ## Form text
@@ -96,7 +96,7 @@ However, if your form also includes custom button-like elements such as `<a clas
           </label>
         </div>
       </div>
-      <button type="submit" class="btn btn-primary">Submit</button>
+      <button type="submit" class="btn-solid theme-primary">Submit</button>
     </fieldset>
   </form>`} />
 

--- a/docs/src/content/docs/forms/radio.mdx
+++ b/docs/src/content/docs/forms/radio.mdx
@@ -140,27 +140,27 @@ Add a description after the label and wrap both in a `.form-field-content`, so t
 
 Create button-like radios by putting `.btn-check` on a `<label>` with the button classes, and nesting the input inside it. The label is the button, so there is no `id`/`for` pair to keep in sync. They can be grouped in a [button group](/components/button-group/).
 
-<Example code={`<label class="btn btn-secondary btn-check">
+<Example code={`<label class="btn-solid theme-secondary btn-check">
     <input type="radio" name="options" checked autocomplete="off">
     Checked
   </label>
 
-  <label class="btn btn-secondary btn-check">
+  <label class="btn-solid theme-secondary btn-check">
     <input type="radio" name="options" autocomplete="off">
     Radio
   </label>
 
-  <label class="btn btn-secondary btn-check">
+  <label class="btn-solid theme-secondary btn-check">
     <input type="radio" name="options" disabled autocomplete="off">
     Disabled
   </label>`} />
 
-<Example code={`<label class="btn btn-outline-success btn-check">
+<Example code={`<label class="btn-outline theme-success btn-check">
     <input type="radio" name="options-outlined" checked autocomplete="off">
     Checked success radio
   </label>
 
-  <label class="btn btn-outline-danger btn-check">
+  <label class="btn-outline theme-danger btn-check">
     <input type="radio" name="options-outlined" autocomplete="off">
     Danger radio
   </label>`} />

--- a/docs/src/content/docs/forms/radio.mdx
+++ b/docs/src/content/docs/forms/radio.mdx
@@ -42,7 +42,7 @@ Add the `disabled` attribute; the associated `<label>` is styled to match, in a 
 
 ## Stacked
 
-Any number of radios that are immediate siblings stack vertically and are spaced by `.form-check`.
+Any number of radios that are immediate siblings stack vertically and are spaced by `.form-field`.
 
 <Example code={`<div class="form-field">
     <input class="radio" type="radio" name="exampleRadios" id="exampleRadios1" value="option1" checked>
@@ -188,11 +188,11 @@ See the [v6 migration guide](/migration/v6/) for the full picture.
 
 ## Theme variants
 
-Modify the appearance of checked radios by adding a [`.theme-{color}` class](/customize/components/#theme-variants) to the `.form-check` element. This sets the checked background and border color to the theme color.
+Modify the appearance of checked radios by adding a [`.theme-{color}` class](/customize/components/#theme-variants) to the `.radio` input, or to any element above it. This sets the checked background and border color to the theme color.
 
-<Example class="d-flex flex-column gap-2" code={getData('theme-colors').map((c) => `<div class="form-check theme-${c.name}">
-    <input class="form-check-input" type="radio" name="radio-theme-${c.name}" id="radio-${c.name}" checked>
-    <label class="form-check-label" for="radio-${c.name}">${c.title} radio</label>
+<Example class="d-flex flex-column gap-2" code={getData('theme-colors').map((c) => `<div class="form-field theme-${c.name}">
+    <input class="radio" type="radio" name="radio-theme-${c.name}" id="radio-${c.name}" checked>
+    <label for="radio-${c.name}">${c.title} radio</label>
   </div>`)} />
 
 ## Customizing

--- a/docs/src/content/docs/forms/rating.mdx
+++ b/docs/src/content/docs/forms/rating.mdx
@@ -42,7 +42,7 @@ Our Bootstrap Rating component allows users to assign and reset a star rating wi
 
 <Example pro code={`<div class="d-flex align-items-center">
     <div id="myRatingResettable" data-coreui-toggle="rating" data-coreui-value="3"></div>
-    <button class="btn btn-primary ms-3" type="button" onclick="coreui.Rating.getInstance('#myRatingResettable').reset()">reset</button>
+    <button class="btn-solid theme-primary ms-3" type="button" onclick="coreui.Rating.getInstance('#myRatingResettable').reset()">reset</button>
   </div>`} />
 
 ## Readonly

--- a/docs/src/content/docs/forms/snippets/chip-variants.js
+++ b/docs/src/content/docs/forms/snippets/chip-variants.js
@@ -3,13 +3,13 @@ const chipInput = new coreui.ChipInput(chipInputElement, {
   // Class is resolved dynamically from chip value.
   chipClassName(value) {
     const variants = {
-      approved: 'chip-success',
-      blocking: 'chip-danger',
-      feature: 'chip-primary',
-      'needs review': 'chip-warning'
+      approved: 'theme-success',
+      blocking: 'theme-danger',
+      feature: 'theme-primary',
+      'needs review': 'theme-warning'
     }
 
-    return variants[value.trim().toLowerCase()] || 'chip-secondary'
+    return variants[value.trim().toLowerCase()] || 'theme-secondary'
   },
   placeholder: 'Add a bug...'
 })

--- a/docs/src/content/docs/forms/snippets/multi-select-header.js
+++ b/docs/src/content/docs/forms/snippets/multi-select-header.js
@@ -20,28 +20,28 @@ new coreui.MultiSelect(myMultiSelectHeader, {
 
     const selectAll = document.createElement('button')
     selectAll.type = 'button'
-    selectAll.className = 'btn btn-sm btn-primary'
+    selectAll.className = 'btn-solid theme-primary btn-sm'
     selectAll.textContent = `Select all (${state.total})`
     selectAll.disabled = state.selected >= state.total
     selectAll.addEventListener('click', () => actions.selectAll())
 
     const selectFiltered = document.createElement('button')
     selectFiltered.type = 'button'
-    selectFiltered.className = 'btn btn-sm btn-secondary'
+    selectFiltered.className = 'btn-solid theme-secondary btn-sm'
     selectFiltered.textContent = `Select filtered (${state.filtered})`
     selectFiltered.disabled = state.filtered === state.filteredSelected
     selectFiltered.addEventListener('click', () => actions.selectFiltered())
 
     const deselectFiltered = document.createElement('button')
     deselectFiltered.type = 'button'
-    deselectFiltered.className = 'btn btn-sm btn-outline-secondary'
+    deselectFiltered.className = 'btn-outline theme-secondary btn-sm'
     deselectFiltered.textContent = `Deselect filtered (${state.filteredSelected})`
     deselectFiltered.disabled = state.filteredSelected === 0
     deselectFiltered.addEventListener('click', () => actions.deselectFiltered())
 
     const deselectAll = document.createElement('button')
     deselectAll.type = 'button'
-    deselectAll.className = 'btn btn-sm btn-outline-danger'
+    deselectAll.className = 'btn-outline theme-danger btn-sm'
     deselectAll.textContent = `Deselect all (${state.selected})`
     deselectAll.disabled = state.selected === 0
     deselectAll.addEventListener('click', () => actions.deselectAll())

--- a/docs/src/content/docs/forms/stepper.mdx
+++ b/docs/src/content/docs/forms/stepper.mdx
@@ -110,9 +110,9 @@ A simple multi-step form built with the Bootstrap Stepper. Each step displays fo
             <input type="password" class="form-control" id="horizontalStepper07">
           </div>
           <div class="col-12">
-            <div class="form-check">
-              <input class="form-check-input" type="checkbox" id="horizontalStepper08">
-              <label class="form-check-label" for="horizontalStepper08">
+            <div class="form-field">
+              <input class="check" type="checkbox" id="horizontalStepper08">
+              <label for="horizontalStepper08">
                 Check me out
               </label>
             </div>
@@ -251,9 +251,9 @@ Use the `.stepper-vertical` class to build a full vertical stepper, where both i
                 <input type="password" class="form-control" id="horizontalStepper207">
               </div>
               <div class="col-12">
-                <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="horizontalStepper208">
-                  <label class="form-check-label" for="horizontalStepper208">
+                <div class="form-field">
+                  <input class="check" type="checkbox" id="horizontalStepper208">
+                  <label for="horizontalStepper208">
                     Check me out
                   </label>
                 </div>

--- a/docs/src/content/docs/forms/stepper.mdx
+++ b/docs/src/content/docs/forms/stepper.mdx
@@ -67,7 +67,7 @@ A simple multi-step form built with the Bootstrap Stepper. Each step displays fo
             </div>
           </div>
         </form>
-        <button class="btn btn-primary" data-coreui-stepper-action="next">Next</button>
+        <button class="btn-solid theme-primary" data-coreui-stepper-action="next">Next</button>
       </div>
       <div class="stepper-pane active show" id="step-2">
         <form class="row g-3 mb-4">
@@ -96,8 +96,8 @@ A simple multi-step form built with the Bootstrap Stepper. Each step displays fo
             </div>
           </div>
         </form>
-        <button class="btn btn-secondary" data-coreui-stepper-action="prev">Previous</button>
-        <button class="btn btn-primary" data-coreui-stepper-action="next">Next</button>
+        <button class="btn-solid theme-secondary" data-coreui-stepper-action="prev">Previous</button>
+        <button class="btn-solid theme-primary" data-coreui-stepper-action="next">Next</button>
       </div>
       <div class="stepper-pane" id="step-3">
         <form class="row g-3 mb-4">
@@ -118,8 +118,8 @@ A simple multi-step form built with the Bootstrap Stepper. Each step displays fo
             </div>
           </div>
         </form>
-        <button class="btn btn-secondary" data-coreui-stepper-action="prev">Previous</button>
-        <button class="btn btn-success" data-coreui-stepper-action="finish">Finish</button>
+        <button class="btn-solid theme-secondary" data-coreui-stepper-action="prev">Previous</button>
+        <button class="btn-solid theme-success" data-coreui-stepper-action="finish">Finish</button>
       </div>
     </div>
   </div>`} />
@@ -192,7 +192,7 @@ Use the `.stepper-vertical` class to build a full vertical stepper, where both i
                 </div>
               </div>
             </form>
-            <button class="btn btn-primary" data-coreui-stepper-action="next">Next</button>
+            <button class="btn-solid theme-primary" data-coreui-stepper-action="next">Next</button>
           </div>
         </div>
       </li>
@@ -229,8 +229,8 @@ Use the `.stepper-vertical` class to build a full vertical stepper, where both i
                 </div>
               </div>
             </form>
-            <button class="btn btn-secondary" data-coreui-stepper-action="prev">Previous</button>
-            <button class="btn btn-primary" data-coreui-stepper-action="next">Next</button>
+            <button class="btn-solid theme-secondary" data-coreui-stepper-action="prev">Previous</button>
+            <button class="btn-solid theme-primary" data-coreui-stepper-action="next">Next</button>
           </div>
         </div>
       </li>
@@ -259,8 +259,8 @@ Use the `.stepper-vertical` class to build a full vertical stepper, where both i
                 </div>
               </div>
             </form>
-            <button class="btn btn-secondary" data-coreui-stepper-action="prev">Previous</button>
-            <button class="btn btn-success" data-coreui-stepper-action="finish">Finish</button>
+            <button class="btn-solid theme-secondary" data-coreui-stepper-action="prev">Previous</button>
+            <button class="btn-solid theme-success" data-coreui-stepper-action="finish">Finish</button>
           </div>
         </div>
       </li>
@@ -381,7 +381,7 @@ This example shows a stepper with native browser validation enabled:
             </div>
           </div>
         </form>
-        <button class="btn btn-primary" data-coreui-stepper-action="next">Next</button>
+        <button class="btn-solid theme-primary" data-coreui-stepper-action="next">Next</button>
       </div>
       <div class="stepper-pane" id="validation-step-2">
         <form class="row g-3 mb-4">
@@ -400,8 +400,8 @@ This example shows a stepper with native browser validation enabled:
             </div>
           </div>
         </form>
-        <button class="btn btn-secondary" data-coreui-stepper-action="prev">Previous</button>
-        <button class="btn btn-success" data-coreui-stepper-action="finish">Finish</button>
+        <button class="btn-solid theme-secondary" data-coreui-stepper-action="prev">Previous</button>
+        <button class="btn-solid theme-success" data-coreui-stepper-action="finish">Finish</button>
       </div>
     </div>
   </div>`} />
@@ -443,7 +443,7 @@ To disable native browser styles validation and turn on custom styles, add the `
             </div>
           </div>
         </form>
-        <button class="btn btn-primary" data-coreui-stepper-action="next">Next</button>
+        <button class="btn-solid theme-primary" data-coreui-stepper-action="next">Next</button>
       </div>
       <div class="stepper-pane" id="novalidate-step-2">
         <form class="row g-3 mb-4" novalidate>
@@ -462,8 +462,8 @@ To disable native browser styles validation and turn on custom styles, add the `
             </div>
           </div>
         </form>
-        <button class="btn btn-secondary" data-coreui-stepper-action="prev">Previous</button>
-        <button class="btn btn-success" data-coreui-stepper-action="finish">Finish</button>
+        <button class="btn-solid theme-secondary" data-coreui-stepper-action="prev">Previous</button>
+        <button class="btn-solid theme-success" data-coreui-stepper-action="finish">Finish</button>
       </div>
     </div>
   </div>`} />
@@ -505,7 +505,7 @@ To completely skip form validation and allow free navigation between steps, add 
             </div>
           </div>
         </form>
-        <button class="btn btn-primary" data-coreui-stepper-action="next">Next</button>
+        <button class="btn-solid theme-primary" data-coreui-stepper-action="next">Next</button>
       </div>
       <div class="stepper-pane" id="skip-step-2">
         <form class="row g-3 mb-4">
@@ -524,8 +524,8 @@ To completely skip form validation and allow free navigation between steps, add 
             </div>
           </div>
         </form>
-        <button class="btn btn-secondary" data-coreui-stepper-action="prev">Previous</button>
-        <button class="btn btn-success" data-coreui-stepper-action="finish">Finish</button>
+        <button class="btn-solid theme-secondary" data-coreui-stepper-action="prev">Previous</button>
+        <button class="btn-solid theme-success" data-coreui-stepper-action="finish">Finish</button>
       </div>
     </div>
   </div>`} />

--- a/docs/src/content/docs/forms/switch.mdx
+++ b/docs/src/content/docs/forms/switch.mdx
@@ -108,11 +108,11 @@ See the [v6 migration guide](/migration/v6/) for the full picture.
 
 ## Theme variants
 
-Modify the appearance of checked switches by adding a [`.theme-{color}` class](/customize/components/#theme-variants) to the `.form-check` element. This sets the checked background and border color to the theme color.
+Modify the appearance of checked switches by adding a [`.theme-{color}` class](/customize/components/#theme-variants) to the `.switch` input, or to any element above it. This sets the checked background and border color to the theme color.
 
-<Example class="d-flex flex-column gap-2" code={getData('theme-colors').map((c) => `<div class="form-check form-switch theme-${c.name}">
-    <input class="form-check-input" type="checkbox" role="switch" id="switch-${c.name}" checked>
-    <label class="form-check-label" for="switch-${c.name}">${c.title} switch</label>
+<Example class="d-flex flex-column gap-2" code={getData('theme-colors').map((c) => `<div class="form-field theme-${c.name}">
+    <input class="switch" type="checkbox" role="switch" id="switch-${c.name}" checked>
+    <label for="switch-${c.name}">${c.title} switch</label>
   </div>`)} />
 
 ## Customizing

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -58,9 +58,9 @@ child. Buttons act through `data-coreui-picker-action` (`now`, `clear`, `reset`,
     <div class="col-lg-4">
       <div data-coreui-locale="en-US" data-coreui-toggle="time-picker">
         <template data-coreui-template="footer">
-          <button type="button" class="btn btn-sm btn-ghost-danger me-auto" data-coreui-picker-action="now">Now</button>
-          <button type="button" class="btn btn-sm btn-ghost-primary" data-coreui-picker-action="clear">Clear</button>
-          <button type="button" class="btn btn-sm btn-primary" data-coreui-picker-action="close">OK</button>
+          <button type="button" class="btn-ghost theme-danger btn-sm me-auto" data-coreui-picker-action="now">Now</button>
+          <button type="button" class="btn-ghost theme-primary btn-sm" data-coreui-picker-action="clear">Clear</button>
+          <button type="button" class="btn-solid theme-primary btn-sm" data-coreui-picker-action="close">OK</button>
         </template>
       </div>
     </div>

--- a/docs/src/content/docs/forms/validation.mdx
+++ b/docs/src/content/docs/forms/validation.mdx
@@ -89,7 +89,7 @@ Custom feedback styles apply custom colors, borders, focus styles, and backgroun
       </div>
     </div>
     <div class="col-12">
-      <button class="btn btn-primary" type="submit">Submit form</button>
+      <button class="btn-solid theme-primary" type="submit">Submit form</button>
     </div>
   </form>`} sandboxJs={validateForms} />
 
@@ -141,7 +141,7 @@ While these feedback styles cannot be styled with CSS, you can still customize t
       </div>
     </div>
     <div class="col-12">
-      <button class="btn btn-primary" type="submit">Submit form</button>
+      <button class="btn-solid theme-primary" type="submit">Submit form</button>
     </div>
   </form>`} />
 
@@ -216,7 +216,7 @@ For a validated input group, wrap the group in a [`.form-field`](/forms/field/) 
       </div>
     </div>
     <div class="col-12">
-      <button class="btn btn-primary" type="submit">Submit form</button>
+      <button class="btn-solid theme-primary" type="submit">Submit form</button>
     </div>
   </form>`} />
 
@@ -274,7 +274,7 @@ Validation styles are available for the following form controls and components:
     </div>
 
     <div class="mb-3">
-      <button class="btn btn-primary" type="submit" disabled>Submit form</button>
+      <button class="btn-solid theme-primary" type="submit" disabled>Submit form</button>
     </div>
   </form>`} />
 
@@ -334,7 +334,7 @@ If your form layout allows it, you can swap the `.{valid|invalid}-feedback` clas
       </div>
     </div>
     <div class="col-12">
-      <button class="btn btn-primary" type="submit">Submit form</button>
+      <button class="btn-solid theme-primary" type="submit">Submit form</button>
     </div>
   </form>`} sandboxJs={validateForms} />
 

--- a/docs/src/content/docs/helpers/clearfix.mdx
+++ b/docs/src/content/docs/helpers/clearfix.mdx
@@ -27,6 +27,6 @@ Use the mixin in SCSS:
 The following example shows how the clearfix can be used. Without the clearfix the wrapping div would not span around the buttons which would cause a broken layout.
 
 <Example code={`<div class="bg-info clearfix">
-    <button type="button" class="btn btn-secondary float-start">Example Button floated left</button>
-    <button type="button" class="btn btn-secondary float-end">Example Button floated right</button>
+    <button type="button" class="btn-solid theme-secondary float-start">Example Button floated left</button>
+    <button type="button" class="btn-solid theme-secondary float-end">Example Button floated right</button>
   </div>`} />

--- a/docs/src/content/docs/helpers/hover-lift.mdx
+++ b/docs/src/content/docs/helpers/hover-lift.mdx
@@ -23,7 +23,7 @@ Hover the card below, or tab to it. It is an `<a>` rather than a `<div>` so the 
 
 Because it only touches those two properties, it works just as well on a control:
 
-<Example class="d-flex gap-3" code={`<button type="button" class="btn btn-primary hover-lift">Lift on hover</button>`} />
+<Example class="d-flex gap-3" code={`<button type="button" class="btn-solid theme-primary hover-lift">Lift on hover</button>`} />
 
 ## Customizing
 

--- a/docs/src/content/docs/helpers/stacks.mdx
+++ b/docs/src/content/docs/helpers/stacks.mdx
@@ -74,17 +74,17 @@ Because the width comes from the container, the same markup can be a column in a
 Use `.vstack` to stack buttons and other elements:
 
 <Example code={`<div class="vstack gap-2 col-md-5 mx-auto">
-    <button type="button" class="btn btn-secondary">Save changes</button>
-    <button type="button" class="btn btn-outline-secondary">Cancel</button>
+    <button type="button" class="btn-solid theme-secondary">Save changes</button>
+    <button type="button" class="btn-outline theme-secondary">Cancel</button>
   </div>`} />
 
 Create an inline form with `.hstack`:
 
 <Example code={`<div class="hstack gap-3">
     <input class="form-control me-auto" type="text" placeholder="Add your item here..." aria-label="Add your item here...">
-    <button type="button" class="btn btn-secondary">Submit</button>
+    <button type="button" class="btn-solid theme-secondary">Submit</button>
     <div class="vr"></div>
-    <button type="button" class="btn btn-outline-danger">Reset</button>
+    <button type="button" class="btn-outline theme-danger">Reset</button>
   </div>`} />
 
 ## Customizing

--- a/docs/src/content/docs/helpers/stretched-link.mdx
+++ b/docs/src/content/docs/helpers/stretched-link.mdx
@@ -15,7 +15,7 @@ Multiple links and tap targets are not recommended with stretched links. However
     <div class="card-body">
       <h5 class="card-title">Card with stretched link</h5>
       <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
-      <a href="#" class="btn btn-primary stretched-link">Go somewhere</a>
+      <a href="#" class="btn-solid theme-primary stretched-link">Go somewhere</a>
     </div>
   </div>`} />
 

--- a/docs/src/content/docs/templates/download.mdx
+++ b/docs/src/content/docs/templates/download.mdx
@@ -12,14 +12,14 @@ Compile CoreUI Bootstrap Admin with your own asset pipeline by downloading our s
 
 Should you require [build tools](/guides/build-tools/#tooling-setup), they are included for developing CoreUI for Bootstrap and its docs, but they're likely unsuitable for your own purposes.
 
-<a href="https://coreui.io/product/free-bootstrap-admin-template/" class="btn btn-primary">Download</a>
+<a href="https://coreui.io/product/free-bootstrap-admin-template/" class="btn-solid theme-primary">Download</a>
 
 ### PRO Templates
 
 If you have a valid PRO license you can [re-download](https://coreui.io/download/) on our website. In case if your license has been expired, or you don't have a PRO license please visit our [visit](https://coreui.io/pricing/) to buy one.
 
-<a href="https://coreui.io/download/" class="btn btn-primary">Download PRO</a>
-<a href="https://coreui.io/pricing/" class="btn btn-primary">Buy PRO</a>
+<a href="https://coreui.io/download/" class="btn-solid theme-primary">Download PRO</a>
+<a href="https://coreui.io/pricing/" class="btn-solid theme-primary">Buy PRO</a>
 
 ### Clone repo
 

--- a/docs/src/content/docs/utilities/motion.mdx
+++ b/docs/src/content/docs/utilities/motion.mdx
@@ -9,11 +9,11 @@ Components animate with CSS transitions, and the timing is customizable — see 
 
 Hover both buttons. The first eases into its hover colour; the second snaps.
 
-<Example class="d-flex gap-3" code={`<button type="button" class="btn btn-primary">Default</button>
-<button type="button" class="btn btn-primary transition-none">No hover transition</button>`} />
+<Example class="d-flex gap-3" code={`<button type="button" class="btn-solid theme-primary">Default</button>
+<button type="button" class="btn-solid theme-primary transition-none">No hover transition</button>`} />
 
 ```html
-<button type="button" class="btn btn-primary transition-none">...</button>
+<button type="button" class="btn-solid theme-primary transition-none">...</button>
 ```
 
 The utility sets the `transition` shorthand, so it removes every transition on the element at once — including any you declared yourself. To retime one component instead of removing its motion, set its `--cui-{component}-transition-duration` to `0s`.
@@ -22,8 +22,8 @@ The utility sets the `transition` shorthand, so it removes every transition on t
 
 <AddedIn version="6.0.0" /> Two keyframe animations ship as utilities: `.animation-shake` draws attention to something that went wrong, `.animation-pop` scales an element in as it appears. `.animation-none` removes an animation the way `.transition-none` removes a transition.
 
-<Example class="d-flex gap-3" code={`<button type="button" class="btn btn-danger animation-shake">Shake</button>
-<button type="button" class="btn btn-primary animation-pop">Pop</button>`} />
+<Example class="d-flex gap-3" code={`<button type="button" class="btn-solid theme-danger animation-shake">Shake</button>
+<button type="button" class="btn-solid theme-primary animation-pop">Pop</button>`} />
 
 The keyframes are named `animation-shake` and `animation-pop` rather than `shake` and `pop`, so declaring an animation of your own under either bare name does not redefine ours.
 

--- a/docs/src/content/docs/utilities/position.mdx
+++ b/docs/src/content/docs/utilities/position.mdx
@@ -81,7 +81,7 @@ By adding `.translate-middle-x` or `.translate-middle-y` classes, elements can b
 
 Here are some real life examples of these classes:
 
-<Example class="docs-example-position-examples d-flex justify-content-around align-items-center" code={`<button type="button" class="btn btn-primary position-relative">
+<Example class="docs-example-position-examples d-flex justify-content-around align-items-center" code={`<button type="button" class="btn-solid theme-primary position-relative">
     Mails <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-secondary">+99 <span class="visually-hidden">unread messages</span></span>
   </button>
 
@@ -89,7 +89,7 @@ Here are some real life examples of these classes:
     Marker <svg width="1em" height="1em" viewBox="0 0 16 16" class="position-absolute top-100 start-50 translate-middle mt-1" fill="var(--cui-secondary-base)" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M7.247 11.14L2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z"/></svg>
   </div>
 
-  <button type="button" class="btn btn-primary position-relative">
+  <button type="button" class="btn-solid theme-primary position-relative">
     Alerts <span class="position-absolute top-0 start-100 translate-middle badge border border-secondary rounded-circle bg-danger p-2"><span class="visually-hidden">unread messages</span></span>
   </button>`} />
 
@@ -99,9 +99,9 @@ You can use these classes with existing components to create new ones. Remember 
     <div class="progress" role="progressbar" aria-label="Progress" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="height: 1px;">
       <div class="progress-bar" style="width: 50%"></div>
     </div>
-    <button type="button" class="position-absolute top-0 start-0 translate-middle btn btn-sm btn-primary rounded-pill" style="width: 2rem; height:2rem;">1</button>
-    <button type="button" class="position-absolute top-0 start-50 translate-middle btn btn-sm btn-primary rounded-pill" style="width: 2rem; height:2rem;">2</button>
-    <button type="button" class="position-absolute top-0 start-100 translate-middle btn btn-sm btn-secondary rounded-pill" style="width: 2rem; height:2rem;">3</button>
+    <button type="button" class="position-absolute top-0 start-0 translate-middle btn-solid theme-primary btn-sm rounded-pill" style="width: 2rem; height:2rem;">1</button>
+    <button type="button" class="position-absolute top-0 start-50 translate-middle btn-solid theme-primary btn-sm rounded-pill" style="width: 2rem; height:2rem;">2</button>
+    <button type="button" class="position-absolute top-0 start-100 translate-middle btn-solid theme-secondary btn-sm rounded-pill" style="width: 2rem; height:2rem;">3</button>
   </div>`} />
 
 ## Customizing

--- a/docs/src/content/docs/utilities/width.mdx
+++ b/docs/src/content/docs/utilities/width.mdx
@@ -37,11 +37,11 @@ Use `.max-w-100` to cap an element at the width of its parent — the usual reas
 
 <Example code={`<div class="d-flex gap-2 border p-2 mb-2" style="max-width: 320px;">
     <div class="text-truncate">Without a floor this line pushes the button out of the box</div>
-    <button class="btn btn-primary flex-shrink-0" type="button">Action</button>
+    <button class="btn-solid theme-primary flex-shrink-0" type="button">Action</button>
   </div>
   <div class="d-flex gap-2 border p-2" style="max-width: 320px;">
     <div class="min-w-0 text-truncate">With .min-w-0 the same line truncates instead</div>
-    <button class="btn btn-primary flex-shrink-0" type="button">Action</button>
+    <button class="btn-solid theme-primary flex-shrink-0" type="button">Action</button>
   </div>`} />
 
 ## Relative to the viewport


### PR DESCRIPTION
`coreui.css` stopped shipping the v5 colour modifiers and the `.form-check`
markup in #1203; the examples on the docs pages were still written in them.
They are written in the v6 spelling now.

## Mapping applied

| v5 | v6 |
| --- | --- |
| `btn btn-{color}` | `btn-solid theme-{color}` |
| `btn btn-outline-{color}` | `btn-outline theme-{color}` |
| `btn btn-ghost-{color}` | `btn-ghost theme-{color}` |
| `btn btn-{size} btn-{color}` | `btn-solid theme-{color} btn-{size}` |
| `chip-{color}` (chip input's `chipClassName`) | `theme-{color}` |
| `<div class="form-check">` | `<div class="form-field">` |
| `<input class="form-check-input" type="checkbox">` | `<input class="check" type="checkbox">` |
| `type="radio"` / `role="switch"` | `.radio` / `.switch` |
| `<label class="form-check-label" for="x">` | `<label for="x">` |
| `.form-check.disabled` | `.form-field` — the label follows the input's `disabled` attribute |

`.btn` is dropped rather than kept next to the variant: the buttons page and
the migration guide both write `btn-solid theme-primary`, and `.btn-solid`
carries the base button styles on its own. No `light` / `dark` spellings were
found outside the migration guide, so nothing needed the `inverse` treatment.

## Pages touched (27)

**Colour spelling** — `forms/{stepper,input-group,date-picker,date-range-picker,date-time-picker,time-picker,validation,layout,overview,checkbox,radio,rating,form-control}`,
`forms/snippets/{chip-variants,multi-select-header}.js`,
`helpers/{stacks,clearfix,hover-lift,stretched-link}`,
`utilities/{position,motion,width}`, `customize/color-modes`,
`templates/download`.

**Field markup** — `forms/{checkbox,radio,switch,layout,overview,stepper,input-group}`,
`components/{list-group,dropdowns}`.

Left as they are: `migration/v6.mdx`, `getting-started/install.mdx`'s
compatibility-CSS section, and the **Deprecated markup** sections on
alerts / buttons / callout / chip / list-group / checkbox / radio / switch —
showing the old spelling is what those sections are for. The prose on
`customize/{components,color,architecture}` that names `.btn-primary` /
`.alert-danger` while explaining the base-modifier approach is also untouched;
it describes the deprecated API rather than demonstrating the current one.

## The examples were rendering grey

Worth recording, because it changes what "renders identically" means here: the
button examples in the v5 spelling were **not** rendering in their colour on
the docs site. `_library-config.scss` forwards `scss/legacy` from a file the
engine loads as configuration, so the compatibility rules land **before** the
library in the single docs stylesheet. `.btn-primary` sets `--cui-btn-bg` from
the theme slot at index 192 120 of `DocsLayout.css`, and the base
`.btn, .btn-link, .btn-icon, .btn-solid, …` rule redeclares it at 218 444 —
same specificity, same layer, later wins. Every `btn btn-primary` in the docs
came out neutral grey.

Measured before/after on 348 example blocks (bounding rect + background,
foreground, border, padding, radius and display of every descendant, so a 1 px
screenshot shift does not register): 44 differ, and each difference is one of
two things — the button taking its theme colour (grey → `oklch(.52945 .19103
278.34)` for primary), or the loss of the engine's
`.docs-example > .btn { margin: .25rem .125rem }`, which stops matching once
`.btn` is gone. That margin loss is what the buttons page already looks like
on `v6-dev`; adjacent buttons keep the ~4 px inline gap.

The colour-only components were unaffected: `.alert-*`, `.callout-*`,
`.chip-*` and `.list-group-item-*` set only `--cui-theme-*`, which nothing
redeclares, so those examples did render correctly and render the same now.

## Playwright proof

A pass over all 197 built pages collects every element whose class list matches
the legacy patterns, excluding the engine chrome (`header`, `footer`,
`.docs-sidebar`, `.docs-banner`), and reports the nearest preceding heading.
**36 elements, every one under a "Deprecated markup" heading** — the six alert,
button, callout, chip and list-group colour examples plus the `.form-check`
checkbox example (counted twice, `/forms/checkbox` and its
`/forms/checks-radios` alias).

## The `_library-config.scss` workaround stays

Removing the `scss/legacy` forward and rebuilding changes exactly the six
Deprecated-markup examples (alerts, callout, chip, list-group ×2, checkbox) and
nothing else — they lose their colours and the checkbox loses its grid. Those
sections render live, so the forward is still needed and is left in place.

It buys the engine chrome nothing either way: `Header.astro`, the PRO banner
and the 404 page in `@coreui/astro-docs` write `btn btn-primary` /
`btn btn-outline-primary`, and those already render neutral for the ordering
reason above. Fixing them needs an engine change, and the engine is shared with
the v5 editions where `.btn-primary` is the correct spelling — a separate PR.

## Gates

`npm run docs-build` (181 pages, no broken links), `npm run docs-lint` (vnu),
`npx eslint` on the two changed snippets, and the full pre-push hook.
