### PR TITLE
docs(utilities): cite each utility from utilities.json with UtilityDocs

### DIFF
--- a/docs/src/content/docs/customize/optimize.mdx
+++ b/docs/src/content/docs/customize/optimize.mdx
@@ -14,7 +14,7 @@ writes the utilities layer from `utilities.json`, trimmed to the classes your
 markup uses, and the same generator writes the palette, the root tokens and the
 `.theme-*` classes from `tokens.json`. Both emit what the Sass in this stack
 emits, so a build with no compiler drops `utilities/api` and `root` and takes
-those layers as files. See [the utility API](/utilities/api/#without-sass) and
+those layers as files. See [the utility API](/utilities/api/#your-own-utilitiesjson) and
 [CSS variables](/customize/css-variables/#the-root-layer-comes-from-tokensjson).
 
 If you're not using a component, comment it out or delete it entirely. For example, if you're not using the carousel, remove that `@forward` to save some file size in your compiled CSS. Keep in mind there are some dependencies between our Sass modules that may make it more difficult to omit a file.

--- a/docs/src/content/docs/customize/theme.mdx
+++ b/docs/src/content/docs/customize/theme.mdx
@@ -126,7 +126,10 @@ For a runtime-only brand — no Sass compilation — set the generic tokens on a
 
 Four style utilities pair a themed surface with its matching text color — compose them with any `.theme-{color}` class to color arbitrary markup the same way the components do. The full reference, with every pairing per color, lives on [the theme utilities page](/utilities/theme/):
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-theme" />
+<UtilityDocs name="theme-contrast" />
+<UtilityDocs name="theme-subtle" />
+<UtilityDocs name="theme-muted" />
+<UtilityDocs name="theme-border" />
 
 <Example html={[`<div class="theme-success d-flex flex-column gap-2">`, `  <div class="theme-contrast p-2 rounded">Solid surface with contrast text</div>`, `  <div class="theme-subtle p-2 rounded">Subtle surface with readable text</div>`, `  <div class="theme-muted p-2 rounded">Muted surface with emphasis text</div>`, `  <div class="theme-border p-2 rounded">Themed border</div>`, `</div>`]} />
 

--- a/docs/src/content/docs/helpers/focus-ring.mdx
+++ b/docs/src/content/docs/helpers/focus-ring.mdx
@@ -63,4 +63,4 @@ In addition to `.focus-ring`, we have several `.focus-ring-*` utilities to modif
 
 Focus ring utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-focus-ring" />
+<UtilityDocs name="focus-ring" />

--- a/docs/src/content/docs/helpers/focus-ring.mdx
+++ b/docs/src/content/docs/helpers/focus-ring.mdx
@@ -61,6 +61,6 @@ In addition to `.focus-ring`, we have several `.focus-ring-*` utilities to modif
 
 <Example code={getData('theme-colors').map((c) => `<p><a href="#" class="d-inline-flex focus-ring focus-ring-${c.name} py-1 px-2 text-decoration-none border rounded-2">${c.title} focus</a></p>`)} />
 
-Focus ring utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Focus ring utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="focus-ring" />

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -3610,7 +3610,7 @@ Upstream v6 does the same, with a `mask-icon()` mixin.
   npx coreui-utilities coreui.utilities.json css/utilities.css
   ```
 
-  The [utility API page](/utilities/api/#without-sass) covers the JSON keys, the
+  The [utility API page](/utilities/api/#your-own-utilitiesjson) covers the JSON keys, the
   `--config` module the React binding's `defineConfig()` produces, and `--scan`.
 
 - **The same holds for the tokens.** `tokens.json` carries the palette and its

--- a/docs/src/content/docs/utilities/align-content.mdx
+++ b/docs/src/content/docs/utilities/align-content.mdx
@@ -87,6 +87,6 @@ Responsive variations also exist for `align-content`.
 
 ### Utilities API
 
-Align content utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Align content utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="align-content" />

--- a/docs/src/content/docs/utilities/align-content.mdx
+++ b/docs/src/content/docs/utilities/align-content.mdx
@@ -89,4 +89,4 @@ Responsive variations also exist for `align-content`.
 
 Align content utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-align-content" />
+<UtilityDocs name="align-content" />

--- a/docs/src/content/docs/utilities/align-items.mdx
+++ b/docs/src/content/docs/utilities/align-items.mdx
@@ -57,6 +57,6 @@ Responsive variations also exist for `align-items`.
 
 ### Utilities API
 
-Align items utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Align items utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="align-items" />

--- a/docs/src/content/docs/utilities/align-items.mdx
+++ b/docs/src/content/docs/utilities/align-items.mdx
@@ -59,4 +59,4 @@ Responsive variations also exist for `align-items`.
 
 Align items utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-align-items" />
+<UtilityDocs name="align-items" />

--- a/docs/src/content/docs/utilities/align-self.mdx
+++ b/docs/src/content/docs/utilities/align-self.mdx
@@ -57,6 +57,6 @@ Responsive variations also exist for `align-self`.
 
 ### Utilities API
 
-Align self utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Align self utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="align-self" />

--- a/docs/src/content/docs/utilities/align-self.mdx
+++ b/docs/src/content/docs/utilities/align-self.mdx
@@ -59,4 +59,4 @@ Responsive variations also exist for `align-self`.
 
 Align self utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-align-self" />
+<UtilityDocs name="align-self" />

--- a/docs/src/content/docs/utilities/api.mdx
+++ b/docs/src/content/docs/utilities/api.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Utility API"
-description: "The utility API is a Sass-based tool to generate utility classes."
+description: "The utility API generates families of utility classes from utilities.json — and from the same map in Sass."
 ---
 
-CoreUI for Bootstrap utilities are generated with our utility API and can be used to modify or extend our default set of utility classes via Sass. Our utility API is based on a series of Sass maps and functions for generating families of classes with various options. If you're unfamiliar with Sass maps, read up on the [official Sass docs](https://sass-lang.com/documentation/values/maps/) to get started.
+CoreUI for Bootstrap utilities are generated with our utility API: one definition per family of classes, with options for the property, the values, responsive and print variants, states and the selector shape. The definitions live in `utilities.json` at the root of the package, and the same map exists in Sass as `$utilities` for builds that compile our source; both produce the same stylesheet, and the library refuses to ship when they differ.
 
-The `$utilities` map contains all our utilities and is later merged with your custom `$utilities` map, if present. The utility map contains a keyed list of utility groups which accept the following options:
+A definition is a keyed group which accepts the following options:
 
 | Option | Type | Default&nbsp;value | Description |
 | --- | --- | --- | --- |
@@ -24,21 +24,22 @@ Every key is checked while the utility is generated: `property` and `values` are
 
 ## API explained
 
-All utility variables are added to the `$utilities` variable within our `_utilities.scss` stylesheet. Each group of utilities looks something like this:
+Every group is an entry of `utilities.json`. The `opacity` one looks like this:
+
+```json
+"opacity": {
+  "property": "opacity",
+  "values": { "0": "0", "25": ".25", "50": ".5", "75": ".75", "100": "1" }
+}
+```
+
+In Sass the same group is a map entry of `$utilities`, with the keys unquoted:
 
 ```scss
-$utilities: (
-  "opacity": (
-    property: opacity,
-    values: (
-      0: 0,
-      25: .25,
-      50: .5,
-      75: .75,
-      100: 1,
-    )
-  )
-);
+"opacity": (
+  property: opacity,
+  values: (0: 0, 25: .25, 50: .5, 75: .75, 100: 1),
+),
 ```
 
 Which outputs the following:
@@ -437,14 +438,77 @@ again. There is no switch that brings the suffix back: the layer is the mechanis
 
 Now that you're familiar with how the utilities API works, learn how to add your own custom classes and modify our default utilities.
 
-<Callout color="info">
-### The same utilities exist as JSON
+### Your own utilities.json
 
-<AddedIn version="6.0.0" /> [`utilities.json`](#without-sass) carries every
-utility on this page, and `$utilities` is written from it. Sass stays the way to
-change them in a Sass build; making the change in JSON instead reaches the class
-list and the typed class names too, and needs no compiler.
-</Callout>
+<AddedIn version="6.0.0" /> `utilities.json` in the package lists every utility with the keys described above, and `coreui-utilities` writes the utilities stylesheet from it and from the token scales in `tokens.json`. No compiler, no build step beyond running the command — the file it writes sits next to `coreui.css` in a plain HTML page, and a change made here also reaches the typed class names of the React and Vue bindings.
+
+Describe your utilities in a JSON file. Keys are the ones from this page, written as JSON: `property` is a string, a list or an object (the [property map](#property-map)), `values` a list, an object or one of the value sources the package itself uses, and `responsive`, `print`, `state`, `child-selector` and `selector` work as above. A value can be a CSS value, a `{path}` into `tokens.json` (written as `var(--cui-…)`) or a source such as `{ "$theme": "bg" }`, which expands to one entry per theme color:
+
+```json
+// coreui.utilities.json
+{
+  "rotate": {
+    "responsive": true,
+    "property": "transform",
+    "class": "rotate",
+    "values": { "45": "rotate(45deg)", "90": "rotate(90deg)" }
+  },
+  "opacity": {
+    "property": "opacity",
+    "values": { "0": "0", "50": ".5", "100": "1" }
+  },
+  "width": null
+}
+```
+
+The file is merged over the package map with the same rules as `$utilities`: a key that already exists replaces the whole default group, `null` removes it, a new key is appended. Then:
+
+```sh
+npx coreui-utilities coreui.utilities.json css/utilities.css
+```
+
+writes the complete utilities stylesheet — the defaults with your changes applied, responsive and print variants included — to `css/utilities.css`. Load it instead of `coreui-utilities.css`, or after `coreui.css` when you keep the full bundle. With `--only` the command writes just the groups your file names, which is the right shape for a few additions on top of the shipped stylesheet:
+
+```sh
+npx coreui-utilities coreui.utilities.json --only css/my-utilities.css
+```
+
+Either way the file starts with the cascade layer order, so your classes land in the `utilities` layer whether the browser sees this file first or `coreui.css` first.
+
+### Only what you use
+
+`--scan` reads your source files and keeps only the utility classes they use — the words of a static `class` or `className` attribute, and the string literals inside `utilities={[…]}`, `:utilities="[…]"` and `ux(…)`, which is how the React and Vue components take utilities:
+
+```sh
+npx coreui-utilities --scan "src/**/*.{html,tsx,vue}" css/utilities.css
+```
+
+### In a config file
+
+The same three settings can live in a config module instead of on the command line — `extend` with the JSON shape above, `safelist` and `scan` — which is what `defineConfig()` in the React and Vue bindings produces:
+
+```js
+// coreui.config.mjs
+export default {
+  utilities: {
+    extend: { rotate: { responsive: true, property: 'transform', class: 'rotate', values: { 45: 'rotate(45deg)' } } },
+    safelist: ['mt-1'],
+    scan: ['src/**/*.{html,tsx}'],
+  },
+}
+```
+
+```sh
+npx coreui-utilities --config coreui.config.mjs css/utilities.css
+```
+
+A `.ts` config works on a Node that strips types (22.6 and later). Flags on the command line add to what the config says.
+
+The rules come out in the order of the map, not the order of use, so two utilities on one element resolve exactly as they do in the full stylesheet, and only the `@property` registrations and keyframes those rules need are written. A name built at runtime (`` `mt-${n}` ``) cannot be found this way — pass it with `--safelist mt-1,mt-2`, or keep the set of names static. During development generate the full stylesheet instead and scan for the production build.
+
+### In Sass
+
+A build that compiles our Sass changes the same groups through the `$utilities` map. The map is hand-kept next to `utilities.json` and `npm run utilities-check` compiles both and refuses a byte of difference, so whatever this section produces, the JSON path produces too.
 
 `$utilities` is a configurable variable of the `scss/utilities` module, so you change it with `@use ... with ()` rather than by reassigning it after an import. Two patterns cover every case:
 
@@ -480,7 +544,7 @@ For a utilities-only build, load the utilities module and then the API module, w
 @use "@coreui/coreui/scss/utilities/api";
 ```
 
-### Override utilities
+#### Override utilities
 
 Override an existing utility by reusing its key. For example, to make the overflow utilities responsive and change their values:
 
@@ -499,7 +563,7 @@ Override an existing utility by reusing its key. For example, to make the overfl
 
 Your group replaces the default one, so keep the `property` key or the build stops with an error.
 
-### Add utilities
+#### Add utilities
 
 Add a new utility the same way — supply only what is new:
 
@@ -517,7 +581,7 @@ Add a new utility the same way — supply only what is new:
 );
 ```
 
-### Modify utilities
+#### Modify utilities
 
 Modifying a utility means reading its default definition first, so this needs the two-file pattern. Below we add another value to the `width` utilities:
 
@@ -551,7 +615,7 @@ Load your partial first, then CoreUI:
 @use "@coreui/coreui/scss/coreui";
 ```
 
-#### Enable responsive
+##### Enable responsive
 
 You can turn on responsive classes for a group that isn't responsive by default. This keeps the rest of the definition, so it takes the two-file pattern:
 
@@ -603,7 +667,7 @@ This will now generate responsive variations of `.border` and `.border-0` for ea
 }
 ```
 
-#### Rename utilities
+##### Rename utilities
 
 Missing v4 utilities, or used to another naming convention? The utilities API can override the resulting `class` of a given utility — for example, to rename `.ms-*` back to `.ml-*`. It reads the default definition, so it takes the two-file pattern:
 
@@ -623,7 +687,7 @@ $utilities: map.merge(
 );
 ```
 
-### Remove utilities
+#### Remove utilities
 
 Set a group to `null` to drop it:
 
@@ -651,7 +715,7 @@ $utilities: map.merge(
 );
 ```
 
-### Add, remove, modify
+#### Add, remove, modify
 
 Anything that only adds or removes goes in one file:
 
@@ -703,68 +767,3 @@ $utilities: map.merge(
 );
 ```
 
-## Without Sass
-
-<AddedIn version="6.0.0" /> The same map exists as data: `utilities.json` in the package lists every utility with the keys described above, and `coreui-utilities` writes the utilities stylesheet from it and from the token scales in `tokens.json`. No Sass, no build step beyond running the command — the file it writes sits next to `coreui.css` in a plain HTML page. The library's own `npm run utilities-check` compiles the Sass map alongside it and refuses a byte of difference, so the two paths cannot drift.
-
-Describe your utilities in a JSON file. Keys are the ones from this page, written as JSON: `property` is a string, a list or an object (the [property map](#property-map)), `values` a list, an object or one of the value sources the package itself uses, and `responsive`, `print`, `state`, `child-selector` and `selector` work as above. A value can be a CSS value, a `{path}` into `tokens.json` (written as `var(--cui-…)`) or a source such as `{ "$theme": "bg" }`, which expands to one entry per theme color:
-
-```json
-// coreui.utilities.json
-{
-  "rotate": {
-    "responsive": true,
-    "property": "transform",
-    "class": "rotate",
-    "values": { "45": "rotate(45deg)", "90": "rotate(90deg)" }
-  },
-  "opacity": {
-    "property": "opacity",
-    "values": { "0": "0", "50": ".5", "100": "1" }
-  },
-  "width": null
-}
-```
-
-The file is merged over the package map with the same rules as `$utilities`: a key that already exists replaces the whole default group, `null` removes it, a new key is appended. Then:
-
-```sh
-npx coreui-utilities coreui.utilities.json css/utilities.css
-```
-
-writes the complete utilities stylesheet — the defaults with your changes applied, responsive and print variants included — to `css/utilities.css`. Load it instead of `coreui-utilities.css`, or after `coreui.css` when you keep the full bundle. With `--only` the command writes just the groups your file names, which is the right shape for a few additions on top of the shipped stylesheet:
-
-```sh
-npx coreui-utilities coreui.utilities.json --only css/my-utilities.css
-```
-
-Either way the file starts with the cascade layer order, so your classes land in the `utilities` layer whether the browser sees this file first or `coreui.css` first.
-
-### Only what you use
-
-`--scan` reads your source files and keeps only the utility classes they use — the words of a static `class` or `className` attribute, and the string literals inside `utilities={[…]}`, `:utilities="[…]"` and `ux(…)`, which is how the React and Vue components take utilities:
-
-```sh
-npx coreui-utilities --scan "src/**/*.{html,tsx,vue}" css/utilities.css
-```
-
-The same three settings can live in a config module instead of on the command line — `extend` with the JSON shape above, `safelist` and `scan` — which is what `defineConfig()` in the React binding produces:
-
-```js
-// coreui.config.mjs
-export default {
-  utilities: {
-    extend: { rotate: { responsive: true, property: 'transform', class: 'rotate', values: { 45: 'rotate(45deg)' } } },
-    safelist: ['mt-1'],
-    scan: ['src/**/*.{html,tsx}'],
-  },
-}
-```
-
-```sh
-npx coreui-utilities --config coreui.config.mjs css/utilities.css
-```
-
-A `.ts` config works on a Node that strips types (22.6 and later). Flags on the command line add to what the config says.
-
-The rules come out in the order of the map, not the order of use, so two utilities on one element resolve exactly as they do in the full stylesheet, and only the `@property` registrations and keyframes those rules need are written. A name built at runtime (`` `mt-${n}` ``) cannot be found this way — pass it with `--safelist mt-1,mt-2`, or keep the set of names static. During development generate the full stylesheet instead and scan for the production build.

--- a/docs/src/content/docs/utilities/aspect-ratio.mdx
+++ b/docs/src/content/docs/utilities/aspect-ratio.mdx
@@ -56,7 +56,7 @@ Each entry is one `.ratio-{key}` class and the ratio it sets. Add a key to defin
 
 ### Utilities API
 
-Aspect ratio utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Aspect ratio utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="aspect-ratio-attr" />
 <UtilityDocs name="aspect-ratio" />

--- a/docs/src/content/docs/utilities/aspect-ratio.mdx
+++ b/docs/src/content/docs/utilities/aspect-ratio.mdx
@@ -58,4 +58,5 @@ Each entry is one `.ratio-{key}` class and the ratio it sets. Add a key to defin
 
 Aspect ratio utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-aspect-ratio" />
+<UtilityDocs name="aspect-ratio-attr" />
+<UtilityDocs name="aspect-ratio" />

--- a/docs/src/content/docs/utilities/background.mdx
+++ b/docs/src/content/docs/utilities/background.mdx
@@ -124,4 +124,10 @@ Background color opacities are applied through a map consumed by the utilities A
 
 Background utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-bg-color" />
+<UtilityDocs name="bg-color" />
+<UtilityDocs name="bg-color-subtle" />
+<UtilityDocs name="bg-color-muted" />
+<UtilityDocs name="bg-opacity" />
+<UtilityDocs name="bg-color-subtle-legacy" />
+<UtilityDocs name="bg-color-muted-legacy" />
+<UtilityDocs name="bg-opacity-legacy" />

--- a/docs/src/content/docs/utilities/background.mdx
+++ b/docs/src/content/docs/utilities/background.mdx
@@ -122,7 +122,7 @@ Background color opacities are applied through a map consumed by the utilities A
 
 ### Utilities API
 
-Background utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Background utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="bg-color" />
 <UtilityDocs name="bg-color-subtle" />

--- a/docs/src/content/docs/utilities/border-color.mdx
+++ b/docs/src/content/docs/utilities/border-color.mdx
@@ -91,7 +91,7 @@ Override `--cui-border` to repaint the utility with another colour; the opacity 
 
 ### Utilities API
 
-Border color utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Border color utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="border-color" />
 <UtilityDocs name="border-top-color" />

--- a/docs/src/content/docs/utilities/border-color.mdx
+++ b/docs/src/content/docs/utilities/border-color.mdx
@@ -93,6 +93,13 @@ Override `--cui-border` to repaint the utility with another colour; the opacity 
 
 Border color utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-border-color" />
+<UtilityDocs name="border-color" />
+<UtilityDocs name="border-top-color" />
+<UtilityDocs name="border-end-color" />
+<UtilityDocs name="border-bottom-color" />
+<UtilityDocs name="border-start-color" />
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-border-color-subtle" />
+<UtilityDocs name="border-color-subtle" />
+<UtilityDocs name="border-opacity" />
+<UtilityDocs name="border-color-subtle-legacy" />
+<UtilityDocs name="border-opacity-legacy" />

--- a/docs/src/content/docs/utilities/border-radius.mdx
+++ b/docs/src/content/docs/utilities/border-radius.mdx
@@ -80,4 +80,9 @@ Each entry is one `--cui-radius-{step}` token as a `calc()` multiple of `--cui-r
 
 Border radius utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-border-radius" />
+<UtilityDocs name="rounded" />
+<UtilityDocs name="rounded-size" />
+<UtilityDocs name="rounded-top" />
+<UtilityDocs name="rounded-end" />
+<UtilityDocs name="rounded-bottom" />
+<UtilityDocs name="rounded-start" />

--- a/docs/src/content/docs/utilities/border-radius.mdx
+++ b/docs/src/content/docs/utilities/border-radius.mdx
@@ -78,7 +78,7 @@ Each entry is one `--cui-radius-{step}` token as a `calc()` multiple of `--cui-r
 
 ### Utilities API
 
-Border radius utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Border radius utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="rounded" />
 <UtilityDocs name="rounded-size" />

--- a/docs/src/content/docs/utilities/border.mdx
+++ b/docs/src/content/docs/utilities/border.mdx
@@ -92,6 +92,16 @@ Each entry is one `.border-{width}` class and the `--cui-border-width-{width}` t
 
 Border utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-border-sides" />
+<UtilityDocs name="border" />
+<UtilityDocs name="border-top" />
+<UtilityDocs name="border-end" />
+<UtilityDocs name="border-bottom" />
+<UtilityDocs name="border-start" />
+<UtilityDocs name="border-x" />
+<UtilityDocs name="border-y" />
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-border-width" />
+<UtilityDocs name="border-width" />
+<UtilityDocs name="border-top-width" />
+<UtilityDocs name="border-end-width" />
+<UtilityDocs name="border-bottom-width" />
+<UtilityDocs name="border-start-width" />

--- a/docs/src/content/docs/utilities/border.mdx
+++ b/docs/src/content/docs/utilities/border.mdx
@@ -90,7 +90,7 @@ Each entry is one `.border-{width}` class and the `--cui-border-width-{width}` t
 
 ### Utilities API
 
-Border utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Border utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="border" />
 <UtilityDocs name="border-top" />

--- a/docs/src/content/docs/utilities/color-scheme.mdx
+++ b/docs/src/content/docs/utilities/color-scheme.mdx
@@ -32,4 +32,4 @@ To flip the colors as well, set the theme with `data-coreui-theme="dark"`, which
 
 Color scheme utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-color-scheme" />
+<UtilityDocs name="color-scheme" />

--- a/docs/src/content/docs/utilities/color-scheme.mdx
+++ b/docs/src/content/docs/utilities/color-scheme.mdx
@@ -30,6 +30,6 @@ To flip the colors as well, set the theme with `data-coreui-theme="dark"`, which
 
 ### Utilities API
 
-Color scheme utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Color scheme utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="color-scheme" />

--- a/docs/src/content/docs/utilities/colors.mdx
+++ b/docs/src/content/docs/utilities/colors.mdx
@@ -137,4 +137,9 @@ Color opacities are applied through a map consumed by the utilities API, which m
 
 Color utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-color" />
+<UtilityDocs name="fg" />
+<UtilityDocs name="fg-emphasis" />
+<UtilityDocs name="fg-contrast" />
+<UtilityDocs name="fg-opacity" />
+<UtilityDocs name="text-color" />
+<UtilityDocs name="text-opacity" />

--- a/docs/src/content/docs/utilities/colors.mdx
+++ b/docs/src/content/docs/utilities/colors.mdx
@@ -135,7 +135,7 @@ Color opacities are applied through a map consumed by the utilities API, which m
 
 ### Utilities API
 
-Color utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Color utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="fg" />
 <UtilityDocs name="fg-emphasis" />

--- a/docs/src/content/docs/utilities/container-queries.mdx
+++ b/docs/src/content/docs/utilities/container-queries.mdx
@@ -79,4 +79,4 @@ Write your own container queries with the same breakpoint names the rest of the 
 
 Container utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-container" />
+<UtilityDocs name="container" />

--- a/docs/src/content/docs/utilities/container-queries.mdx
+++ b/docs/src/content/docs/utilities/container-queries.mdx
@@ -77,6 +77,6 @@ Write your own container queries with the same breakpoint names the rest of the 
 
 ### Utilities API
 
-Container utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Container utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="container" />

--- a/docs/src/content/docs/utilities/display.mdx
+++ b/docs/src/content/docs/utilities/display.mdx
@@ -102,4 +102,4 @@ The print and display classes can be combined.
 
 Display utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-display" />
+<UtilityDocs name="display" />

--- a/docs/src/content/docs/utilities/display.mdx
+++ b/docs/src/content/docs/utilities/display.mdx
@@ -100,6 +100,6 @@ The print and display classes can be combined.
 
 ### Utilities API
 
-Display utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Display utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="display" />

--- a/docs/src/content/docs/utilities/divide.mdx
+++ b/docs/src/content/docs/utilities/divide.mdx
@@ -54,4 +54,5 @@ can be dropped anywhere it stops making sense.
 
 Divide utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-divide" />
+<UtilityDocs name="divide-x" />
+<UtilityDocs name="divide-y" />

--- a/docs/src/content/docs/utilities/divide.mdx
+++ b/docs/src/content/docs/utilities/divide.mdx
@@ -52,7 +52,7 @@ can be dropped anywhere it stops making sense.
 
 ### Utilities API
 
-Divide utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Divide utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="divide-x" />
 <UtilityDocs name="divide-y" />

--- a/docs/src/content/docs/utilities/flex.mdx
+++ b/docs/src/content/docs/utilities/flex.mdx
@@ -321,6 +321,10 @@ And say you want to vertically center the content next to the image:
 
 Flexbox utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-flex-behavior" />
+<UtilityDocs name="flex" />
+<UtilityDocs name="flex-direction" />
+<UtilityDocs name="flex-grow" />
+<UtilityDocs name="flex-shrink" />
+<UtilityDocs name="flex-wrap" />
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-order" />
+<UtilityDocs name="order" />

--- a/docs/src/content/docs/utilities/flex.mdx
+++ b/docs/src/content/docs/utilities/flex.mdx
@@ -319,7 +319,7 @@ And say you want to vertically center the content next to the image:
 
 ### Utilities API
 
-Flexbox utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Flexbox utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="flex" />
 <UtilityDocs name="flex-direction" />

--- a/docs/src/content/docs/utilities/float.mdx
+++ b/docs/src/content/docs/utilities/float.mdx
@@ -52,4 +52,4 @@ Here are all the support classes:
 
 Float utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-float" />
+<UtilityDocs name="float" />

--- a/docs/src/content/docs/utilities/float.mdx
+++ b/docs/src/content/docs/utilities/float.mdx
@@ -50,6 +50,6 @@ Here are all the support classes:
 
 ### Utilities API
 
-Float utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Float utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="float" />

--- a/docs/src/content/docs/utilities/font-family.mdx
+++ b/docs/src/content/docs/utilities/font-family.mdx
@@ -26,6 +26,6 @@ Change a selection to our monospace font stack with `.font-monospace`.
 
 ### Utilities API
 
-Font family utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Font family utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="font-family" />

--- a/docs/src/content/docs/utilities/font-family.mdx
+++ b/docs/src/content/docs/utilities/font-family.mdx
@@ -28,4 +28,4 @@ Change a selection to our monospace font stack with `.font-monospace`.
 
 Font family utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-font-family" />
+<UtilityDocs name="font-family" />

--- a/docs/src/content/docs/utilities/font-size.mdx
+++ b/docs/src/content/docs/utilities/font-size.mdx
@@ -57,4 +57,5 @@ Each entry is one stop, pairing a font size with the line height that goes with 
 
 Font size utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-font-size" />
+<UtilityDocs name="font-size" />
+<UtilityDocs name="text-size" />

--- a/docs/src/content/docs/utilities/font-size.mdx
+++ b/docs/src/content/docs/utilities/font-size.mdx
@@ -55,7 +55,7 @@ Each entry is one stop, pairing a font size with the line height that goes with 
 
 ### Utilities API
 
-Font size utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Font size utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="font-size" />
 <UtilityDocs name="text-size" />

--- a/docs/src/content/docs/utilities/font-style.mdx
+++ b/docs/src/content/docs/utilities/font-style.mdx
@@ -20,4 +20,4 @@ Change the `font-style` of text with the `.fst-*` utilities.
 
 Font style utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-font-style" />
+<UtilityDocs name="font-style" />

--- a/docs/src/content/docs/utilities/font-style.mdx
+++ b/docs/src/content/docs/utilities/font-style.mdx
@@ -18,6 +18,6 @@ Change the `font-style` of text with the `.fst-*` utilities.
 
 ### Utilities API
 
-Font style utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Font style utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="font-style" />

--- a/docs/src/content/docs/utilities/font-weight.mdx
+++ b/docs/src/content/docs/utilities/font-weight.mdx
@@ -44,4 +44,4 @@ Components read the tokens rather than a build-time copy, so raising a weight at
 
 Font weight utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-font-weight" />
+<UtilityDocs name="font-weight" />

--- a/docs/src/content/docs/utilities/font-weight.mdx
+++ b/docs/src/content/docs/utilities/font-weight.mdx
@@ -42,6 +42,6 @@ Components read the tokens rather than a build-time copy, so raising a weight at
 
 ### Utilities API
 
-Font weight utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Font weight utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="font-weight" />

--- a/docs/src/content/docs/utilities/gap.mdx
+++ b/docs/src/content/docs/utilities/gap.mdx
@@ -58,7 +58,7 @@ Each entry is one step of the scale, generating the matching `.gap-{key}, .row-g
 
 ### Utilities API
 
-Gap utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Gap utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="gap" />
 <UtilityDocs name="row-gap" />

--- a/docs/src/content/docs/utilities/gap.mdx
+++ b/docs/src/content/docs/utilities/gap.mdx
@@ -60,4 +60,6 @@ Each entry is one step of the scale, generating the matching `.gap-{key}, .row-g
 
 Gap utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-gap" />
+<UtilityDocs name="gap" />
+<UtilityDocs name="row-gap" />
+<UtilityDocs name="column-gap" />

--- a/docs/src/content/docs/utilities/grid.mdx
+++ b/docs/src/content/docs/utilities/grid.mdx
@@ -77,6 +77,8 @@ Every utility on this page has responsive variants at each [breakpoint](/layout/
 
 ### Utilities API
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-grid" />
+<UtilityDocs name="grid-template-columns" />
+<UtilityDocs name="grid-column" />
+<UtilityDocs name="grid-auto-flow" />
 
 The block lives in the `$utilities` map, so the [utility API](/utilities/api/) can extend, restrict or remove it like any other family.

--- a/docs/src/content/docs/utilities/height.mdx
+++ b/docs/src/content/docs/utilities/height.mdx
@@ -71,4 +71,10 @@ A mobile browser resizes the viewport as it shows or hides its URL bar, so `vh-1
 
 Height utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-height" />
+<UtilityDocs name="height" />
+<UtilityDocs name="min-height" />
+<UtilityDocs name="max-height" />
+<UtilityDocs name="viewport-height" />
+<UtilityDocs name="min-viewport-height" />
+<UtilityDocs name="dynamic-viewport-height" />
+<UtilityDocs name="min-dynamic-viewport-height" />

--- a/docs/src/content/docs/utilities/height.mdx
+++ b/docs/src/content/docs/utilities/height.mdx
@@ -7,7 +7,7 @@ utility: ["h", "max-h", "min-h", "vh", "min-vh", "dvh", "min-dvh"]
 
 ## Relative to the parent
 
-Height utilities are generated from the utility API in `_utilities.scss`. Includes support for `25%`, `50%`, `75%`, `100%`, and `auto` by default. Modify those values as you need to generate different utilities here.
+Height utilities are generated from the utilities API in `utilities.json`. Includes support for `25%`, `50%`, `75%`, `100%`, and `auto` by default. Modify those values as you need to generate different utilities here.
 
 A percentage height resolves against the parent, so the parent needs a height of its own — that is what the wrapper below provides.
 
@@ -69,7 +69,7 @@ A mobile browser resizes the viewport as it shows or hides its URL bar, so `vh-1
 
 ### Utilities API
 
-Height utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Height utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="height" />
 <UtilityDocs name="min-height" />

--- a/docs/src/content/docs/utilities/justify-content.mdx
+++ b/docs/src/content/docs/utilities/justify-content.mdx
@@ -64,6 +64,6 @@ Responsive variations also exist for `justify-content`.
 
 ### Utilities API
 
-Justify content utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Justify content utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="justify-content" />

--- a/docs/src/content/docs/utilities/justify-content.mdx
+++ b/docs/src/content/docs/utilities/justify-content.mdx
@@ -66,4 +66,4 @@ Responsive variations also exist for `justify-content`.
 
 Justify content utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-justify-content" />
+<UtilityDocs name="justify-content" />

--- a/docs/src/content/docs/utilities/justify-items.mdx
+++ b/docs/src/content/docs/utilities/justify-items.mdx
@@ -31,4 +31,6 @@ utility: ["justify-items", "justify-self"]
 
 Justify items utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-justify-items" />
+<UtilityDocs name="justify-items" />
+<UtilityDocs name="justify-self" />
+<UtilityDocs name="place-items" />

--- a/docs/src/content/docs/utilities/justify-items.mdx
+++ b/docs/src/content/docs/utilities/justify-items.mdx
@@ -29,7 +29,7 @@ utility: ["justify-items", "justify-self"]
 
 ### Utilities API
 
-Justify items utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Justify items utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="justify-items" />
 <UtilityDocs name="justify-self" />

--- a/docs/src/content/docs/utilities/line-height.mdx
+++ b/docs/src/content/docs/utilities/line-height.mdx
@@ -20,6 +20,6 @@ A `.text-*` stop already carries the line height that belongs to its size — se
 
 ### Utilities API
 
-Line height utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Line height utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="line-height" />

--- a/docs/src/content/docs/utilities/line-height.mdx
+++ b/docs/src/content/docs/utilities/line-height.mdx
@@ -22,4 +22,4 @@ A `.text-*` stop already carries the line height that belongs to its size — se
 
 Line height utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-line-height" />
+<UtilityDocs name="line-height" />

--- a/docs/src/content/docs/utilities/link.mdx
+++ b/docs/src/content/docs/utilities/link.mdx
@@ -107,4 +107,10 @@ In addition to the following Sass functionality, consider reading about our incl
 
 Link utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-links" />
+<UtilityDocs name="link" />
+<UtilityDocs name="link-opacity" />
+<UtilityDocs name="underline-offset" />
+<UtilityDocs name="underline-thickness" />
+<UtilityDocs name="underline-color" />
+<UtilityDocs name="underline-opacity" />
+<UtilityDocs name="underline-opacity-legacy" />

--- a/docs/src/content/docs/utilities/link.mdx
+++ b/docs/src/content/docs/utilities/link.mdx
@@ -105,7 +105,7 @@ In addition to the following Sass functionality, consider reading about our incl
 
 ### Utilities API
 
-Link utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Link utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="link" />
 <UtilityDocs name="link-opacity" />

--- a/docs/src/content/docs/utilities/margin.mdx
+++ b/docs/src/content/docs/utilities/margin.mdx
@@ -96,7 +96,7 @@ Each entry is one step of the scale, generating the matching `.m-{key} class, an
 
 ### Utilities API
 
-Margin utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Margin utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="margin" />
 <UtilityDocs name="margin-x" />

--- a/docs/src/content/docs/utilities/margin.mdx
+++ b/docs/src/content/docs/utilities/margin.mdx
@@ -98,4 +98,10 @@ Each entry is one step of the scale, generating the matching `.m-{key} class, an
 
 Margin utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-margin" />
+<UtilityDocs name="margin" />
+<UtilityDocs name="margin-x" />
+<UtilityDocs name="margin-y" />
+<UtilityDocs name="margin-top" />
+<UtilityDocs name="margin-end" />
+<UtilityDocs name="margin-bottom" />
+<UtilityDocs name="margin-start" />

--- a/docs/src/content/docs/utilities/motion.mdx
+++ b/docs/src/content/docs/utilities/motion.mdx
@@ -51,6 +51,6 @@ To remove every transition at build time instead, set the `$enable-transitions` 
 
 Motion utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-transition" />
+<UtilityDocs name="transition" />
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-animation" />
+<UtilityDocs name="animation" />

--- a/docs/src/content/docs/utilities/motion.mdx
+++ b/docs/src/content/docs/utilities/motion.mdx
@@ -49,7 +49,7 @@ To remove every transition at build time instead, set the `$enable-transitions` 
 
 ### Utilities API
 
-Motion utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Motion utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="transition" />
 

--- a/docs/src/content/docs/utilities/object-fit.mdx
+++ b/docs/src/content/docs/utilities/object-fit.mdx
@@ -55,4 +55,4 @@ The `.object-fit-{value}` and responsive `.object-fit-{breakpoint}-{value}` util
 
 Object fit utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-object-fit" />
+<UtilityDocs name="object-fit" />

--- a/docs/src/content/docs/utilities/object-fit.mdx
+++ b/docs/src/content/docs/utilities/object-fit.mdx
@@ -53,6 +53,6 @@ The `.object-fit-{value}` and responsive `.object-fit-{breakpoint}-{value}` util
 
 ### Utilities API
 
-Object fit utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Object fit utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="object-fit" />

--- a/docs/src/content/docs/utilities/opacity.mdx
+++ b/docs/src/content/docs/utilities/opacity.mdx
@@ -23,4 +23,4 @@ Set the `opacity` of an element using `.opacity-{value}` utilities.
 
 Opacity utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-opacity" />
+<UtilityDocs name="opacity" />

--- a/docs/src/content/docs/utilities/opacity.mdx
+++ b/docs/src/content/docs/utilities/opacity.mdx
@@ -21,6 +21,6 @@ Set the `opacity` of an element using `.opacity-{value}` utilities.
 
 ### Utilities API
 
-Opacity utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Opacity utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="opacity" />

--- a/docs/src/content/docs/utilities/overflow.mdx
+++ b/docs/src/content/docs/utilities/overflow.mdx
@@ -39,7 +39,7 @@ Using Sass variables, you may customize the overflow utilities by changing the `
 
 ### Utilities API
 
-Overflow utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Overflow utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="overflow" />
 <UtilityDocs name="overflow-x" />

--- a/docs/src/content/docs/utilities/overflow.mdx
+++ b/docs/src/content/docs/utilities/overflow.mdx
@@ -41,4 +41,6 @@ Using Sass variables, you may customize the overflow utilities by changing the `
 
 Overflow utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-overflow" />
+<UtilityDocs name="overflow" />
+<UtilityDocs name="overflow-x" />
+<UtilityDocs name="overflow-y" />

--- a/docs/src/content/docs/utilities/padding.mdx
+++ b/docs/src/content/docs/utilities/padding.mdx
@@ -79,4 +79,10 @@ Each entry is one step of the scale, generating the matching `.p-{key} class and
 
 Padding utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-padding" />
+<UtilityDocs name="padding" />
+<UtilityDocs name="padding-x" />
+<UtilityDocs name="padding-y" />
+<UtilityDocs name="padding-top" />
+<UtilityDocs name="padding-end" />
+<UtilityDocs name="padding-bottom" />
+<UtilityDocs name="padding-start" />

--- a/docs/src/content/docs/utilities/padding.mdx
+++ b/docs/src/content/docs/utilities/padding.mdx
@@ -77,7 +77,7 @@ Each entry is one step of the scale, generating the matching `.p-{key} class and
 
 ### Utilities API
 
-Padding utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Padding utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="padding" />
 <UtilityDocs name="padding-x" />

--- a/docs/src/content/docs/utilities/place-items.mdx
+++ b/docs/src/content/docs/utilities/place-items.mdx
@@ -21,4 +21,6 @@ utility: "place-items"
 
 Place items utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-justify-items" />
+<UtilityDocs name="justify-items" />
+<UtilityDocs name="justify-self" />
+<UtilityDocs name="place-items" />

--- a/docs/src/content/docs/utilities/place-items.mdx
+++ b/docs/src/content/docs/utilities/place-items.mdx
@@ -19,7 +19,7 @@ utility: "place-items"
 
 ### Utilities API
 
-Place items utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Place items utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="justify-items" />
 <UtilityDocs name="justify-self" />

--- a/docs/src/content/docs/utilities/pointer-events.mdx
+++ b/docs/src/content/docs/utilities/pointer-events.mdx
@@ -26,6 +26,6 @@ If possible, the simpler solution is:
 
 ### Utilities API
 
-Pointer events utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Pointer events utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="pointer-events" />

--- a/docs/src/content/docs/utilities/pointer-events.mdx
+++ b/docs/src/content/docs/utilities/pointer-events.mdx
@@ -28,4 +28,4 @@ If possible, the simpler solution is:
 
 Pointer events utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-pointer-events" />
+<UtilityDocs name="pointer-events" />

--- a/docs/src/content/docs/utilities/position.mdx
+++ b/docs/src/content/docs/utilities/position.mdx
@@ -114,7 +114,7 @@ Default position utility values are declared in a Sass map, then used to generat
 
 ### Utilities API
 
-Position utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Position utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="position" />
 <UtilityDocs name="top" />

--- a/docs/src/content/docs/utilities/position.mdx
+++ b/docs/src/content/docs/utilities/position.mdx
@@ -116,4 +116,9 @@ Default position utility values are declared in a Sass map, then used to generat
 
 Position utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-position" />
+<UtilityDocs name="position" />
+<UtilityDocs name="top" />
+<UtilityDocs name="bottom" />
+<UtilityDocs name="start" />
+<UtilityDocs name="end" />
+<UtilityDocs name="translate-middle" />

--- a/docs/src/content/docs/utilities/shadows.mdx
+++ b/docs/src/content/docs/utilities/shadows.mdx
@@ -81,8 +81,8 @@ Setting `--cui-shadow-color` on the page changes every shadow at once, including
 
 Shadow utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-shadow" />
+<UtilityDocs name="shadow" />
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-shadow-color" />
+<UtilityDocs name="shadow-color" />
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-shadow-opacity" />
+<UtilityDocs name="shadow-opacity" />

--- a/docs/src/content/docs/utilities/shadows.mdx
+++ b/docs/src/content/docs/utilities/shadows.mdx
@@ -79,7 +79,7 @@ Setting `--cui-shadow-color` on the page changes every shadow at once, including
 
 ### Utilities API
 
-Shadow utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Shadow utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="shadow" />
 

--- a/docs/src/content/docs/utilities/space.mdx
+++ b/docs/src/content/docs/utilities/space.mdx
@@ -70,7 +70,7 @@ Each entry is one step of the scale, generating the matching `.space-x-{key} and
 
 ### Utilities API
 
-Space utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Space utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="space-x" />
 <UtilityDocs name="space-y" />

--- a/docs/src/content/docs/utilities/space.mdx
+++ b/docs/src/content/docs/utilities/space.mdx
@@ -72,4 +72,5 @@ Each entry is one step of the scale, generating the matching `.space-x-{key} and
 
 Space utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-space" />
+<UtilityDocs name="space-x" />
+<UtilityDocs name="space-y" />

--- a/docs/src/content/docs/utilities/text-alignment.mdx
+++ b/docs/src/content/docs/utilities/text-alignment.mdx
@@ -29,4 +29,4 @@ Note that we don't provide utility classes for justified text. While, aesthetica
 
 Text alignment utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-text-align" />
+<UtilityDocs name="text-align" />

--- a/docs/src/content/docs/utilities/text-alignment.mdx
+++ b/docs/src/content/docs/utilities/text-alignment.mdx
@@ -27,6 +27,6 @@ Note that we don't provide utility classes for justified text. While, aesthetica
 
 ### Utilities API
 
-Text alignment utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Text alignment utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="text-align" />

--- a/docs/src/content/docs/utilities/text-decoration.mdx
+++ b/docs/src/content/docs/utilities/text-decoration.mdx
@@ -19,6 +19,6 @@ For the underline colour, offset and thickness on links, see [link utilities](/u
 
 ### Utilities API
 
-Text decoration utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Text decoration utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="text-decoration" />

--- a/docs/src/content/docs/utilities/text-decoration.mdx
+++ b/docs/src/content/docs/utilities/text-decoration.mdx
@@ -21,4 +21,4 @@ For the underline colour, offset and thickness on links, see [link utilities](/u
 
 Text decoration utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-text-decoration" />
+<UtilityDocs name="text-decoration" />

--- a/docs/src/content/docs/utilities/text-transform.mdx
+++ b/docs/src/content/docs/utilities/text-transform.mdx
@@ -21,4 +21,4 @@ Note how `.text-capitalize` only changes the first letter of each word, leaving 
 
 Text transform utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-text-transform" />
+<UtilityDocs name="text-transform" />

--- a/docs/src/content/docs/utilities/text-transform.mdx
+++ b/docs/src/content/docs/utilities/text-transform.mdx
@@ -19,6 +19,6 @@ Note how `.text-capitalize` only changes the first letter of each word, leaving 
 
 ### Utilities API
 
-Text transform utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Text transform utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="text-transform" />

--- a/docs/src/content/docs/utilities/text-wrapping.mdx
+++ b/docs/src/content/docs/utilities/text-wrapping.mdx
@@ -42,4 +42,6 @@ Note that [breaking words isn't possible in Arabic](https://rtlstyling.com/posts
 
 Text wrapping utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-text-wrap" />
+<UtilityDocs name="white-space" />
+<UtilityDocs name="word-wrap" />
+<UtilityDocs name="text-wrap" />

--- a/docs/src/content/docs/utilities/text-wrapping.mdx
+++ b/docs/src/content/docs/utilities/text-wrapping.mdx
@@ -40,7 +40,7 @@ Note that [breaking words isn't possible in Arabic](https://rtlstyling.com/posts
 
 ### Utilities API
 
-Text wrapping utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Text wrapping utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="white-space" />
 <UtilityDocs name="word-wrap" />

--- a/docs/src/content/docs/utilities/theme.mdx
+++ b/docs/src/content/docs/utilities/theme.mdx
@@ -80,7 +80,7 @@ The theme can also come from any element above, so one wrapper themes every pair
 
 ### Utilities API
 
-Theme utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Theme utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="theme-contrast" />
 <UtilityDocs name="theme-subtle" />

--- a/docs/src/content/docs/utilities/theme.mdx
+++ b/docs/src/content/docs/utilities/theme.mdx
@@ -82,4 +82,7 @@ The theme can also come from any element above, so one wrapper themes every pair
 
 Theme utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-theme" />
+<UtilityDocs name="theme-contrast" />
+<UtilityDocs name="theme-subtle" />
+<UtilityDocs name="theme-muted" />
+<UtilityDocs name="theme-border" />

--- a/docs/src/content/docs/utilities/user-select.mdx
+++ b/docs/src/content/docs/utilities/user-select.mdx
@@ -20,6 +20,6 @@ Change the way in which the content is selected when the user interacts with it.
 
 ### Utilities API
 
-User select utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+User select utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="user-select" />

--- a/docs/src/content/docs/utilities/user-select.mdx
+++ b/docs/src/content/docs/utilities/user-select.mdx
@@ -22,4 +22,4 @@ Change the way in which the content is selected when the user interacts with it.
 
 User select utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-user-select" />
+<UtilityDocs name="user-select" />

--- a/docs/src/content/docs/utilities/vertical-align.mdx
+++ b/docs/src/content/docs/utilities/vertical-align.mdx
@@ -41,4 +41,4 @@ With table cells:
 
 Vertical align utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-vertical-align" />
+<UtilityDocs name="align" />

--- a/docs/src/content/docs/utilities/vertical-align.mdx
+++ b/docs/src/content/docs/utilities/vertical-align.mdx
@@ -39,6 +39,6 @@ With table cells:
 
 ### Utilities API
 
-Vertical align utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Vertical align utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="align" />

--- a/docs/src/content/docs/utilities/visibility.mdx
+++ b/docs/src/content/docs/utilities/visibility.mdx
@@ -32,6 +32,6 @@ Apply `.visible` or `.invisible` as needed.
 
 ### Utilities API
 
-Visibility utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Visibility utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="visibility" />

--- a/docs/src/content/docs/utilities/visibility.mdx
+++ b/docs/src/content/docs/utilities/visibility.mdx
@@ -34,4 +34,4 @@ Apply `.visible` or `.invisible` as needed.
 
 Visibility utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-visibility" />
+<UtilityDocs name="visibility" />

--- a/docs/src/content/docs/utilities/width.mdx
+++ b/docs/src/content/docs/utilities/width.mdx
@@ -82,4 +82,10 @@ Each entry is one `.w-{step}` class and the width it sets. Add a key to define a
 
 Width utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-width" />
+<UtilityDocs name="width" />
+<UtilityDocs name="max-width" />
+<UtilityDocs name="min-width" />
+<UtilityDocs name="viewport-width" />
+<UtilityDocs name="min-viewport-width" />
+<UtilityDocs name="dynamic-viewport-width" />
+<UtilityDocs name="min-dynamic-viewport-width" />

--- a/docs/src/content/docs/utilities/width.mdx
+++ b/docs/src/content/docs/utilities/width.mdx
@@ -7,7 +7,7 @@ utility: ["w", "max-w", "min-w", "vw", "min-vw", "dvw", "min-dvw"]
 
 ## Relative to the parent
 
-Width utilities are generated from the utility API in `_utilities.scss`. Includes support for `25%`, `50%`, `75%`, `100%`, and `auto` by default. Modify those values as you need to generate different utilities here.
+Width utilities are generated from the utilities API in `utilities.json`. Includes support for `25%`, `50%`, `75%`, `100%`, and `auto` by default. Modify those values as you need to generate different utilities here.
 
 <Example code={`<div class="w-25 p-3" style="background-color: #eee;">Width 25%</div>
   <div class="w-50 p-3" style="background-color: #eee;">Width 50%</div>
@@ -80,7 +80,7 @@ Each entry is one `.w-{step}` class and the width it sets. Add a key to define a
 
 ### Utilities API
 
-Width utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Width utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="width" />
 <UtilityDocs name="max-width" />

--- a/docs/src/content/docs/utilities/z-index.mdx
+++ b/docs/src/content/docs/utilities/z-index.mdx
@@ -41,6 +41,6 @@ Each entry is one `.z-{level}` class and the `z-index` it sets. Add a key to def
 
 ### Utilities API
 
-Position utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
+Position utilities are declared in our utilities API in `utilities.json`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
 <UtilityDocs name="z-index" />

--- a/docs/src/content/docs/utilities/z-index.mdx
+++ b/docs/src/content/docs/utilities/z-index.mdx
@@ -43,4 +43,4 @@ Each entry is one `.z-{level}` class and the `z-index` it sets. Add a key to def
 
 Position utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.](/utilities/api/#using-the-api)
 
-<ScssDocs file="scss/_utilities.scss" capture="utils-zindex" />
+<UtilityDocs name="z-index" />


### PR DESCRIPTION
## What

The 55 `<ScssDocs file="scss/_utilities.scss" capture="utils-*" />` blocks quoted the Sass mirror of `utilities.json`. They become `<UtilityDocs name="…" />` from the docs engine: the JSON entry verbatim plus a table of the classes it generates, resolved the way the stylesheet writes them (`$refs` → `var(--cui-spacer-3)` and so on). Captures that spanned several entries (`utils-borders`, `utils-sizing`, `utils-flex`, `utils-position`, …) expand to one `UtilityDocs` per entry — 49 pages, 55 blocks. The two remaining `ScssDocs` on `_utilities.scss` (`utilities-bg-colors`, `utilities-text-colors`) quote Sass variables, not entries, and stay.

## Depends on

`<UtilityDocs>` ships in coreui/astro-docs#94 (unreleased). This branch was built with that engine copied into `docs/node_modules` (`docs-build` green, 182 pages, no broken links; the float page renders `.float-start → float: inline-start` and the JSON block). **Do not merge before** `@coreui/astro-docs` 0.1.13 is released and the pin in `package.json` bumped — with the published 0.1.12 the build fails on the unknown component.