### PR TITLE
feat(dropdown): placement like Menu, and the static menu positioned from it

### DIFF
--- a/docs/src/content/docs/components/dropdowns.mdx
+++ b/docs/src/content/docs/components/dropdowns.mdx
@@ -353,7 +353,7 @@ Trigger dropdown menus at the left of the elements by adding `.dropstart` to the
     </ul>
   </div>`} />
 
-Inside a `.navbar`, or with `display: 'static'`, the menu is positioned by the direction classes alone and the option is ignored.
+Inside a `.navbar`, or with `display: 'static'`, the plugin writes the resolved placement onto the menu and the stylesheet positions it from that, so the option works there too — every placement except the centered ones.
 
 ## Menu items
 
@@ -420,35 +420,31 @@ By default, a dropdown menu is automatically positioned 100% from the top and al
 
 ### Responsive alignment
 
-If you want to use responsive alignment, disable dynamic positioning by adding the `data-coreui-display="static"` attribute and use the responsive variation classes.
-
-To align **right** the dropdown menu with the given breakpoint or larger, add `.dropdown-menu{-sm|-md|-lg|-xl|-2xl}-end`.
+Alignment that changes with the viewport is a responsive [placement](#placement-option): `data-coreui-placement="bottom-start lg:bottom-end"` aligns the menu left and switches to right from `lg` up. It works with dynamic positioning and, because the plugin writes the resolved placement onto the menu, with `data-coreui-display="static"` and inside a navbar too.
 
 <Example code={`<div class="btn-group">
-    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" data-coreui-placement="bottom-start lg:bottom-end" aria-expanded="false">
       Left-aligned but right aligned when large screen
     </button>
-    <ul class="dropdown-menu dropdown-menu-lg-end">
+    <ul class="dropdown-menu">
       <li><button class="dropdown-item" type="button">Action</button></li>
       <li><button class="dropdown-item" type="button">Another action</button></li>
       <li><button class="dropdown-item" type="button">Something else here</button></li>
     </ul>
   </div>`} />
-
-To align **left** the dropdown menu with the given breakpoint or larger, add `.dropdown-menu-end` and `.dropdown-menu{-sm|-md|-lg|-xl|-2xl}-start`.
 
 <Example code={`<div class="btn-group">
-    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" data-coreui-placement="bottom-end lg:bottom-start" aria-expanded="false">
       Right-aligned but left aligned when large screen
     </button>
-    <ul class="dropdown-menu dropdown-menu-end dropdown-menu-lg-start">
+    <ul class="dropdown-menu">
       <li><button class="dropdown-item" type="button">Action</button></li>
       <li><button class="dropdown-item" type="button">Another action</button></li>
       <li><button class="dropdown-item" type="button">Something else here</button></li>
     </ul>
   </div>`} />
 
-Note that you don't need to add a `data-coreui-display="static"` attribute to dropdown buttons in navbars, since Floating UI isn't used in navbars.
+The v5 classes `.dropdown-menu{-sm|-md|-lg|-xl|-2xl}{-start|-end}` ship in [`coreui-legacy.css`](/getting-started/install/#v5-compatibility-css) for markup that still uses them.
 
 ### Alignment options
 
@@ -477,10 +473,10 @@ Taking most of the options shown above, here's a small kitchen sink demo of vari
   </div>
 
   <div class="btn-group">
-    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" data-coreui-placement="bottom-start lg:bottom-end" aria-expanded="false">
       Left-aligned, right-aligned lg
     </button>
-    <ul class="dropdown-menu dropdown-menu-lg-end">
+    <ul class="dropdown-menu">
       <li><a class="dropdown-item" href="#">Menu item</a></li>
       <li><a class="dropdown-item" href="#">Menu item</a></li>
       <li><a class="dropdown-item" href="#">Menu item</a></li>
@@ -488,10 +484,10 @@ Taking most of the options shown above, here's a small kitchen sink demo of vari
   </div>
 
   <div class="btn-group">
-    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" aria-expanded="false">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" data-coreui-placement="bottom-end lg:bottom-start" aria-expanded="false">
       Right-aligned, left-aligned lg
     </button>
-    <ul class="dropdown-menu dropdown-menu-end dropdown-menu-lg-start">
+    <ul class="dropdown-menu">
       <li><a class="dropdown-item" href="#">Menu item</a></li>
       <li><a class="dropdown-item" href="#">Menu item</a></li>
       <li><a class="dropdown-item" href="#">Menu item</a></li>

--- a/docs/src/content/docs/components/dropdowns.mdx
+++ b/docs/src/content/docs/components/dropdowns.mdx
@@ -328,6 +328,33 @@ Trigger dropdown menus at the left of the elements by adding `.dropstart` to the
 </div>
 ```
 
+### Placement option
+
+<AddedIn version="6.0.0" /> The direction classes above pick one of six fixed positions. `data-coreui-placement` on the toggle takes the same values the [Menu](/components/menu/#placement) takes — physical (`top`, `bottom`, `left`, `right`), logical (`start`, `end`, which mirror in RTL) and every `-start`/`-end` alignment — and it wins over the wrapper classes when both are present. Breakpoint prefixes make it responsive: `bottom-start md:top-end` reads as bottom-start below `md` and top-end from `md` up.
+
+<Example class="d-flex gap-2" code={`<div class="dropdown">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-placement="top-end" aria-expanded="false">
+      Top end
+    </button>
+    <ul class="dropdown-menu">
+      <li><a class="dropdown-item" href="#">Action</a></li>
+      <li><a class="dropdown-item" href="#">Another action</a></li>
+      <li><a class="dropdown-item" href="#">Something else here</a></li>
+    </ul>
+  </div>
+  <div class="dropdown">
+    <button type="button" class="btn-solid theme-secondary dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-placement="bottom-start md:end-start" aria-expanded="false">
+      Bottom start, end from md
+    </button>
+    <ul class="dropdown-menu">
+      <li><a class="dropdown-item" href="#">Action</a></li>
+      <li><a class="dropdown-item" href="#">Another action</a></li>
+      <li><a class="dropdown-item" href="#">Something else here</a></li>
+    </ul>
+  </div>`} />
+
+Inside a `.navbar`, or with `display: 'static'`, the menu is positioned by the direction classes alone and the option is ignored.
+
 ## Menu items
 
 You can use `<a>` or `<button>` elements as dropdown items.
@@ -722,6 +749,7 @@ Starting with CoreUI 4.2.6, all components support an **experimental** reserved 
 | `autoClose` | boolean, string | `true` | Configure the auto close behavior of the dropdown: <ul class="my-2"><li>`true` - the dropdown will be closed by clicking outside or inside the dropdown menu.</li><li>`false` - the dropdown will be closed by clicking the toggle button and manually calling `hide` or `toggle` method. (Also will not be closed by pressing <kbd>esc</kbd> key)</li><li>`'inside'` - the dropdown will be closed (only) by clicking inside the dropdown menu.</li>  <li>`'outside'` - the dropdown will be closed (only) by clicking outside the dropdown menu.</li></ul> Note: the dropdown can always be closed with the <kbd>ESC</kbd> key |
 | `boundary` | string, element | `'clippingParents'` | Overflow constraint boundary of the dropdown menu. By default it's `clippingParents` and can accept an HTMLElement reference (via JavaScript only). For more information refer to Floating UI's [detectOverflow docs](https://floating-ui.com/docs/detectOverflow/#boundary). |
 | `display` | string | `'dynamic'` | By default, we use Floating UI for dynamic positioning. Disable this with `static`. |
+| `placement` | null, string | `null` | Where the menu opens, in the [Menu](/components/menu/#placement) syntax: physical (`'top'`, `'bottom'`, `'left'`, `'right'`) or logical (`'start'`, `'end'`) placements with `-start`/`-end` alignment, and breakpoint prefixes such as `'bottom-start md:top-end'`. `null` derives the placement from the direction classes (`.dropup`, `.dropend`, `.dropstart`, `.dropdown-menu-end`). |
 | `offset` | array, string, function | `[0, 2]` |  Offset of the dropdown relative to its target. You can pass a string in data attributes with comma separated values like: `data-coreui-offset="10,20"`. When a function is used to determine the offset, it is called with an object containing the placement, the reference, and floating rects as its first argument. The triggering element DOM node is passed as the second argument. The function must return an array with two numbers: skidding (along the edge) and distance (away from it). For more information refer to Floating UI's [offset docs](https://floating-ui.com/docs/offset/#options). |
 | `floatingConfig` | null, object, function | `null` | To change CoreUI's default Floating UI config, see Floating UI's [computePosition docs](https://floating-ui.com/docs/computePosition/#options). When a function is used to create the configuration, it's called with an object that contains the default configuration. It helps you use and merge the default with your own configuration. The function must return a configuration object for Floating UI. |
 | `reference` | string, element, object | `'toggle'` | Reference element of the dropdown menu. Accepts the values of `'toggle'`, `'parent'`, an HTMLElement reference or an object providing `getBoundingClientRect`. For more information refer to Floating UI's [virtual elements docs](https://floating-ui.com/docs/virtual-elements/). |

--- a/docs/src/content/docs/customize/components.mdx
+++ b/docs/src/content/docs/customize/components.mdx
@@ -113,9 +113,9 @@ Set them on `:root` to retune every translucent surface at once, or on one eleme
 
 ## Responsive
 
-These Sass loops aren't limited to color maps, either. You can also generate responsive variations of your components. Take for example our responsive alignment of the dropdowns where we mix an `@each` loop for the `$breakpoints` Sass map with a media query include.
+These Sass loops aren't limited to color maps, either. You can also generate responsive variations of your components. Take for example the v5 responsive alignment classes of the dropdown, kept in `coreui-legacy.css`, where we mix an `@each` loop for the `$breakpoints` Sass map with a media query include.
 
-<ScssDocs file="scss/_dropdown.scss" capture="responsive-breakpoints" />
+<ScssDocs file="scss/_legacy.scss" capture="dropdown-responsive-alignment" />
 
 Should you modify your `$breakpoints`, your changes will apply to all the loops iterating over that map.
 

--- a/docs/src/content/docs/getting-started/install.mdx
+++ b/docs/src/content/docs/getting-started/install.mdx
@@ -329,6 +329,7 @@ ship in `coreui-legacy.css`, which you load after it:
 
 It is 3.4&nbsp;kB gzip and covers:
 
+- the responsive dropdown alignment classes `.dropdown-menu{-sm|-md|-lg|-xl|-2xl}{-start|-end}`, replaced by a responsive `data-coreui-placement`
 - the colour modifiers `.alert-{color}`, `.btn-{color}`, `.btn-outline-{color}`,
   `.btn-subtle-{color}`, `.btn-ghost-{color}`, `.callout-{color}`,
   `.chip-{color}` and `.list-group-item-{color}` — each an alias of the matching

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -644,6 +644,24 @@ check, radio, carousel and toggler icons already work:
   Menu's engine underneath. Where their options overlap, Dropdown also
   understands Menu's additions (for example `container`). **Deprecation
   notice: Dropdown may be removed in v7** — prefer Menu for new work.
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **The responsive alignment classes `.dropdown-menu{-sm|-md|-lg|-xl|-2xl}{-start|-end}`
+  moved to `coreui-legacy.css`, and `.dropup`/`.dropend`/`.dropstart` no longer
+  carry the menu's static position.** Alignment that changes with the viewport
+  is a responsive placement on the toggle — `data-coreui-placement="bottom-start
+  lg:bottom-end"` — which now also works with `data-coreui-display="static"` and
+  inside a navbar, because the plugin writes the resolved placement onto the
+  menu as `data-coreui-placement` and the stylesheet positions the static menu
+  from that attribute rather than from the wrapper class. `dropdown.css`
+  loses every `@media`; the direction classes keep the caret and still decide
+  the placement when no option is given. `.dropdown-menu-end` and
+  `.dropdown-menu-start` stay.
+
+  ```diff
+  - <ul class="dropdown-menu dropdown-menu-lg-end">
+  + <button data-coreui-toggle="dropdown" data-coreui-placement="bottom-start lg:bottom-end">
+  + <ul class="dropdown-menu">
+  ```
 
 
 #### Modal and Offcanvas on the native `<dialog>`

--- a/js/src/dropdown.ts
+++ b/js/src/dropdown.ts
@@ -50,11 +50,13 @@ const PLACEMENT_TOPCENTER = 'top'
 const PLACEMENT_BOTTOMCENTER = 'bottom'
 
 const Default: MenuConfig = {
-  ...Menu.Default
+  ...Menu.Default,
+  placement: null
 }
 
 const DefaultType: Record<string, string> = {
-  ...Menu.DefaultType
+  ...Menu.DefaultType,
+  placement: '(null|string)'
 }
 
 /**
@@ -102,9 +104,13 @@ class Dropdown extends Menu {
     super.update()
   }
 
-  // The v5 dropdown derives its placement from the wrapper classes and the
-  // `--cui-position` custom property, not from a `placement` option.
+  // Without a `placement` option the v5 dropdown derives its placement from
+  // the wrapper classes and the `--cui-position` custom property.
   protected override _getPlacement(): string {
+    if (this._config.placement) {
+      return super._getPlacement()
+    }
+
     const parentDropdown = this._parent
 
     if (parentDropdown.classList.contains(CLASS_NAME_DROPEND)) {

--- a/js/src/dropdown.ts
+++ b/js/src/dropdown.ts
@@ -10,6 +10,7 @@
  * --------------------------------------------------------------------------
  */
 
+import { type ReferenceElement } from '@floating-ui/dom'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
@@ -142,12 +143,26 @@ class Dropdown extends Menu {
   // In a navbar (or with static display) the menu is positioned by the
   // dropdown CSS, which keys on this attribute — the engine stays out of it.
   protected override _createFloating(): void {
-    if (this._inNavbar || this._config.display === 'static') {
+    if (this._isStatic()) {
       Manipulator.setDataAttribute(this._menu, 'popper', 'static')
+      Manipulator.setDataAttribute(this._menu, 'placement', this._getPlacement())
       return
     }
 
     super._createFloating()
+  }
+
+  protected override async _updateFloatingPosition(referenceElement: ReferenceElement | null = null): Promise<void> {
+    if (this._isStatic()) {
+      Manipulator.setDataAttribute(this._menu, 'placement', this._getPlacement())
+      return
+    }
+
+    return super._updateFloatingPosition(referenceElement)
+  }
+
+  private _isStatic(): boolean {
+    return this._inNavbar || this._config.display === 'static'
   }
 
   protected override _removeMenuAttributes(): void {

--- a/js/src/menu.ts
+++ b/js/src/menu.ts
@@ -108,7 +108,7 @@ type MenuConfig = {
   offset: FloatingOffsetOption
   floatingConfig: FloatingConfigOption
   menu: HTMLElement | null
-  placement: string
+  placement: string | null
   reference: string | Element | Record<string, any>
   strategy: string
   submenuTrigger: string
@@ -438,7 +438,7 @@ class Menu extends BaseComponent {
   protected _getPlacement(): string {
     const placement = this._responsivePlacements ?
       getResponsivePlacement(this._responsivePlacements, DEFAULT_PLACEMENT) :
-      this._config.placement
+      (this._config.placement ?? DEFAULT_PLACEMENT)
 
     return resolveLogicalPlacement(placement)
   }

--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -250,6 +250,63 @@ describe('Dropdown', () => {
     })
   })
 
+  describe('static display', () => {
+    it('should write the resolved placement onto the menu when positioned by the stylesheet', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div class="dropup">',
+          '  <button class="btn dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static">Dropdown</button>',
+          '  <div class="dropdown-menu">',
+          '    <a class="dropdown-item" href="#">Secondary link</a>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnDropdown = fixtureEl.querySelector('[data-coreui-toggle="dropdown"]')
+        const dropdownMenu = fixtureEl.querySelector('.dropdown-menu')
+        const dropdown = new Dropdown(btnDropdown)
+
+        btnDropdown.addEventListener('shown.coreui.dropdown', () => {
+          expect(dropdownMenu.getAttribute('data-coreui-popper')).toEqual('static')
+          expect(dropdownMenu.getAttribute('data-coreui-placement')).toEqual('top-start')
+          resolve()
+        })
+
+        dropdown.show()
+      })
+    })
+
+    it('should re-resolve a responsive placement on the static menu when the breakpoint changes', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div class="dropdown">',
+          '  <button class="btn dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-display="static" data-coreui-placement="bottom-start md:bottom-end">Dropdown</button>',
+          '  <div class="dropdown-menu">',
+          '    <a class="dropdown-item" href="#">Secondary link</a>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnDropdown = fixtureEl.querySelector('[data-coreui-toggle="dropdown"]')
+        const dropdownMenu = fixtureEl.querySelector('.dropdown-menu')
+        const dropdown = new Dropdown(btnDropdown)
+        const innerWidth = spyOnProperty(window, 'innerWidth', 'get').and.returnValue(500)
+
+        btnDropdown.addEventListener('shown.coreui.dropdown', async () => {
+          expect(dropdownMenu.getAttribute('data-coreui-placement')).toEqual('bottom-start')
+
+          innerWidth.and.returnValue(1000)
+          await dropdown._updateFloatingPosition()
+
+          expect(dropdownMenu.getAttribute('data-coreui-placement')).toEqual('bottom-end')
+          resolve()
+        })
+
+        dropdown.show()
+      })
+    })
+  })
+
   describe('toggle', () => {
     it('should toggle a dropdown', () => {
       return new Promise(resolve => {

--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -178,6 +178,76 @@ describe('Dropdown', () => {
       }))
       expect(floatingConfig.placement).toEqual('left')
     })
+
+    it('should derive the placement from the wrapper classes without a placement option', () => {
+      fixtureEl.innerHTML = [
+        '<div class="dropup">',
+        '  <button class="btn dropdown-toggle" data-coreui-toggle="dropdown">Dropdown</button>',
+        '  <div class="dropdown-menu dropdown-menu-end" style="--cui-position: end">',
+        '    <a class="dropdown-item" href="#">Secondary link</a>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const btnDropdown = fixtureEl.querySelector('[data-coreui-toggle="dropdown"]')
+      const dropdown = new Dropdown(btnDropdown)
+
+      expect(dropdown._config.placement).toBeNull()
+      expect(dropdown._getPlacement()).toEqual('top-end')
+    })
+
+    it('should let the placement option win over the wrapper classes', () => {
+      fixtureEl.innerHTML = [
+        '<div class="dropup">',
+        '  <button class="btn dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-placement="bottom-end">Dropdown</button>',
+        '  <div class="dropdown-menu">',
+        '    <a class="dropdown-item" href="#">Secondary link</a>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const btnDropdown = fixtureEl.querySelector('[data-coreui-toggle="dropdown"]')
+      const dropdown = new Dropdown(btnDropdown)
+
+      expect(dropdown._getPlacement()).toEqual('bottom-end')
+    })
+
+    it('should resolve a logical placement like Menu does', () => {
+      fixtureEl.innerHTML = [
+        '<div class="dropdown">',
+        '  <button class="btn dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-placement="end-start">Dropdown</button>',
+        '  <div class="dropdown-menu">',
+        '    <a class="dropdown-item" href="#">Secondary link</a>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const btnDropdown = fixtureEl.querySelector('[data-coreui-toggle="dropdown"]')
+      const dropdown = new Dropdown(btnDropdown)
+
+      expect(dropdown._getPlacement()).toEqual('right-start')
+    })
+
+    it('should resolve a responsive placement like Menu does', () => {
+      fixtureEl.innerHTML = [
+        '<div class="dropdown">',
+        '  <button class="btn dropdown-toggle" data-coreui-toggle="dropdown" data-coreui-placement="bottom-start md:top-end">Dropdown</button>',
+        '  <div class="dropdown-menu">',
+        '    <a class="dropdown-item" href="#">Secondary link</a>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const btnDropdown = fixtureEl.querySelector('[data-coreui-toggle="dropdown"]')
+      const dropdown = new Dropdown(btnDropdown)
+      const innerWidth = spyOnProperty(window, 'innerWidth', 'get')
+
+      innerWidth.and.returnValue(500)
+      expect(dropdown._getPlacement()).toEqual('bottom-start')
+
+      innerWidth.and.returnValue(1000)
+      expect(dropdown._getPlacement()).toEqual('top-end')
+    })
   })
 
   describe('toggle', () => {

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -166,85 +166,68 @@ $dropdown-dark-tokens: defaults(
       inset-inline-start: 0;
       top: 100%;
       margin-top: var(--#{$prefix}dropdown-spacer);
-    }
-  }
 
-  // scss-docs-start responsive-breakpoints
-  // We deliberately hardcode the `cui-` prefix because we check
-  // this custom property in JS to determine Popper's positioning
-
-  @each $breakpoint in map.keys($breakpoints) {
-    @include media-breakpoint-up($breakpoint) {
-      $infix: breakpoint-infix($breakpoint, $breakpoints);
-
-      .dropdown-menu#{$infix}-start {
-        // Read by the plugin, so the name stays outside `$prefix`.
-        --cui-position: start;
-
-        &[data-coreui-popper] {
-          inset-inline-start: 0;
-          inset-inline-end: auto;
-        }
+      &[data-coreui-placement$="-start"] {
+        right: auto;
+        left: 0;
       }
 
-      .dropdown-menu#{$infix}-end {
-        --cui-position: end;
-
-        &[data-coreui-popper] {
-          inset-inline-start: auto;
-          inset-inline-end: 0;
-        }
+      &[data-coreui-placement$="-end"] {
+        right: 0;
+        left: auto;
       }
-    }
-  }
-  // scss-docs-end responsive-breakpoints
 
-  // Allow for dropdowns to go bottom up (aka, dropup-menu)
-  // Just add .dropup after the standard .dropdown class and you're set.
-  .dropup {
-    .dropdown-menu[data-coreui-popper] {
-      top: auto;
-      bottom: 100%;
-      margin-top: 0;
-      margin-bottom: var(--#{$prefix}dropdown-spacer);
-    }
+      &[data-coreui-placement^="top"] {
+        top: auto;
+        bottom: 100%;
+        margin-top: 0;
+        margin-bottom: var(--#{$prefix}dropdown-spacer);
+      }
 
-    .dropdown-toggle {
-      @include caret(up);
-    }
-  }
+      &[data-coreui-placement^="right"] {
+        top: 0;
+        right: auto;
+        left: 100%;
+        margin-inline-start: var(--#{$prefix}dropdown-spacer);
+        margin-top: 0;
+      }
 
-  .dropend {
-    .dropdown-menu[data-coreui-popper] {
-      inset-inline-start: 100%;
-      inset-inline-end: auto;
-      top: 0;
-      margin-inline-start: var(--#{$prefix}dropdown-spacer);
-      margin-top: 0;
-    }
-
-    .dropdown-toggle {
-      @include caret(end);
-      &::after {
-        vertical-align: 0;
+      &[data-coreui-placement^="left"] {
+        top: 0;
+        right: 100%;
+        left: auto;
+        margin-inline-end: var(--#{$prefix}dropdown-spacer);
+        margin-top: 0;
       }
     }
   }
 
-  .dropstart {
-    .dropdown-menu[data-coreui-popper] {
-      inset-inline-start: auto;
-      inset-inline-end: 100%;
-      top: 0;
-      margin-inline-end: var(--#{$prefix}dropdown-spacer);
-      margin-top: 0;
-    }
+  // scss-docs-start dropdown-alignment
+  // Read by the plugin, so the name stays outside `$prefix`.
+  .dropdown-menu-start {
+    --cui-position: start;
+  }
 
-    .dropdown-toggle {
-      @include caret(start);
-      &::before {
-        vertical-align: 0;
-      }
+  .dropdown-menu-end {
+    --cui-position: end;
+  }
+  // scss-docs-end dropdown-alignment
+
+  .dropup .dropdown-toggle {
+    @include caret(up);
+  }
+
+  .dropend .dropdown-toggle {
+    @include caret(end);
+    &::after {
+      vertical-align: 0;
+    }
+  }
+
+  .dropstart .dropdown-toggle {
+    @include caret(start);
+    &::before {
+      vertical-align: 0;
     }
   }
 

--- a/scss/_legacy.scss
+++ b/scss/_legacy.scss
@@ -2,6 +2,7 @@
 @use "sass:map";
 @use "sass:string";
 @use "functions/defaults" as *;
+@use "layout/breakpoints" as *;
 @use "mixins/box-shadow" as *;
 @use "mixins/button" as *;
 @use "mixins/check" as *;
@@ -134,6 +135,32 @@ $switch-selector: ".form-switch .form-check-input" !default;
 }
 
 @layer components {
+  // scss-docs-start dropdown-responsive-alignment
+  @each $breakpoint in map.keys($breakpoints) {
+    @include media-breakpoint-up($breakpoint) {
+      $infix: breakpoint-infix($breakpoint, $breakpoints);
+
+      .dropdown-menu#{$infix}-start {
+        --cui-position: start;
+
+        &[data-coreui-popper] {
+          inset-inline-start: 0;
+          inset-inline-end: auto;
+        }
+      }
+
+      .dropdown-menu#{$infix}-end {
+        --cui-position: end;
+
+        &[data-coreui-popper] {
+          inset-inline-start: auto;
+          inset-inline-end: 0;
+        }
+      }
+    }
+  }
+  // scss-docs-end dropdown-responsive-alignment
+
   // Deprecated in v6: the class on the input, with a sibling `.btn` label.
   #{$btn-check-deprecated} {
     position: absolute;


### PR DESCRIPTION
## 1. The `placement` option works the way it does on Menu

`Dropdown` extends `Menu` but overrode `_getPlacement()` to read only the wrapper classes, so a `data-coreui-placement` on the toggle was parsed by `Menu` and then ignored. Now:

- `placement` given → `Menu`'s resolution: physical (`top`, `bottom`, `left`, `right`) and logical (`start`, `end`, mirrored in RTL) placements, `-start`/`-end` alignment, and breakpoint prefixes (`bottom-start md:top-end`, with the same media-query listeners Menu uses). It wins over `.dropup`/`.dropend`/`.dropstart`/`.dropdown-menu-end`.
- `placement: null` (the new Dropdown default) → the v5 class-driven placement, unchanged.

`MenuConfig.placement` widens to `string | null`; `Menu` itself keeps `'bottom-start'`.

## 2. The static menu is positioned from the resolved placement

`dropdown.css` carried five breakpoints of `.dropdown-menu-{bp}-{start,end}` and one static-position block per direction class, all so that a menu laid out by the stylesheet (navbar, `display: 'static'`) could be aligned without the engine. Now the plugin writes the resolved placement onto the menu as `data-coreui-placement` in static mode too — and on every breakpoint change — and one attribute rule per side (`$="-start"`, `$="-end"`, `^="top"`, `^="right"`, `^="left"`) replaces the class-keyed blocks. So a responsive placement works in a navbar as well.

- The direction classes keep the caret and still decide the placement when no option is given.
- `.dropdown-menu-end` / `.dropdown-menu-start` stay as the non-responsive shorthand.
- `.dropdown-menu-{sm|md|lg|xl|2xl}-{start|end}` move to `coreui-legacy.css` (migration entry, install page list). Deliberate divergence from upstream, recorded in the parity audit.
- `dropdown.min.css`: 1445 → 1341 B gzip, 313 → 233 lines, **no `@media` left** — one of the twelve component sheets with baked-in breakpoints, closed.

## Tests

Six new specs in `dropdown.spec.js`: class-derived placement with a null option (fixture carries `--cui-position: end` inline, since the unit suite loads no stylesheet), option beating the classes, logical `end-start` → `right-start`, responsive `bottom-start md:top-end` at 500/1000 px, static dropup writing `data-coreui-placement="top-start"`, static responsive placement re-resolving on a breakpoint change. Dropdown 93 + Menu 151 green.

## Docs

`components/dropdowns`: **Placement option** under Directions with two live examples; **Responsive alignment** rewritten onto `data-coreui-placement` (also in the kitchen-sink demo); `placement` row in the options table. `customize/components` cites the loop from `_legacy.scss`. `docs-build` green.

## Bindings

coreui-react-pro#332 (open) and the Vue PR mirror part 1; both are being extended so `alignment` no longer emits the responsive classes and static mode writes the attribute.