### PR TITLE
fix(multi-select): update() no longer stacks keydown handlers on the native select

### DIFF
--- a/js/src/multi-select.ts
+++ b/js/src/multi-select.ts
@@ -199,6 +199,7 @@ class MultiSelect extends Combobox {
   protected declare _searchElement: any
   protected declare _wrapperElement: any
   protected declare _refocusOnHide: boolean
+  protected declare _nativeKeydownHandler: any
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
     super(element, config)
@@ -218,6 +219,7 @@ class MultiSelect extends Combobox {
 
     this._wrapperElement = null
     this._menu = null
+    this._nativeKeydownHandler = null
     this._selected = []
     this._options = this._getOptions()
     this._floatingCleanup = null
@@ -455,7 +457,11 @@ class MultiSelect extends Combobox {
     this._addTogglerKeydownListeners()
 
     // Validation focuses the overlay select; hand its keystrokes to the custom control.
-    EventHandler.on(this._element, EVENT_KEYDOWN, (event: any) => {
+    if (this._nativeKeydownHandler) {
+      EventHandler.off(this._element, EVENT_KEYDOWN, this._nativeKeydownHandler)
+    }
+
+    this._nativeKeydownHandler = (event: any) => {
       if (event.key === TAB_KEY || event.key === ESCAPE_KEY) {
         return
       }
@@ -481,7 +487,9 @@ class MultiSelect extends Combobox {
       } else {
         this._togglerElement.focus()
       }
-    })
+    }
+
+    EventHandler.on(this._element, EVENT_KEYDOWN, this._nativeKeydownHandler)
 
     EventHandler.on(this._indicatorElement, EVENT_CLICK, (event: any) => {
       event.preventDefault()

--- a/js/tests/unit/multi-select.spec.js
+++ b/js/tests/unit/multi-select.spec.js
@@ -240,6 +240,19 @@ describe('MultiSelect', () => {
       expect(document.activeElement).toBe(multiSelect._togglerElement)
     })
 
+    it('should hand a keystroke on the native select to the control once after update()', () => {
+      fixtureEl.innerHTML = '<select></select>'
+      const selectEl = fixtureEl.querySelector('select')
+      const multiSelect = new MultiSelect(selectEl, { options: [{ value: '1', text: 'Option 1' }] })
+      const spy = spyOn(multiSelect, 'show')
+
+      multiSelect.update({ options: [{ value: '2', text: 'Option 2' }] })
+      multiSelect.update({ options: [{ value: '3', text: 'Option 3' }] })
+      selectEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }))
+
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
     it('should not intercept Tab on the native select', () => {
       fixtureEl.innerHTML = '<select></select>'
       const selectEl = fixtureEl.querySelector('select')


### PR DESCRIPTION
Every `update()` rebuilt the control and registered a fresh `keydown` handler on the native `<select>` without removing the previous one, so after N updates a keystroke reached the control N+1 times (N+1 `show()` calls, N+1 injected search characters). The handler is kept on the instance and the previous one is removed before the new one is bound; a blanket `EventHandler.off` would also strip the user's `changed.coreui.multi-select` listeners, so only that reference is removed.

Spec: after two `update()` calls an ArrowDown on the native select calls `show()` once.

Closes the last open blocker of §2 in `audits/v6-js-pre-alpha-audit-2026-08.md`.