### PR TITLE
docs(utilities): every page tables its whole family, and only that family

### DIFF
--- a/docs/src/content/docs/utilities/background.mdx
+++ b/docs/src/content/docs/utilities/background.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Background"
 name: "Background"
 description: "Convey meaning through `background-color` and add decoration with gradients."
+utility: "bg"
 ---
 
 import { getData } from '@coreui/astro-docs/data'

--- a/docs/src/content/docs/utilities/border-color.mdx
+++ b/docs/src/content/docs/utilities/border-color.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 6 Border Color"
 name: "Border color"
 description: "Change the border color of an element with utilities built on our theme colors, and fade it with the opacity utilities."
-utility: [{prefix: "border", property: "border-color"}, "border-color-subtle", "border-opacity"]
+utility: {prefix: "border", property: "border-color"}
 ---
 
 import { getData } from '@coreui/astro-docs/data'

--- a/docs/src/content/docs/utilities/grid.mdx
+++ b/docs/src/content/docs/utilities/grid.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 6 Grid utilities"
 name: "Grid"
 description: "Lay out and align CSS Grid containers and their items with responsive utilities for track counts, auto flow, and inline-axis alignment."
-utility: ["grid-cols", "col-span", "grid-flow"]
+utility: ["grid-cols", "grid-auto-flow"]
 ---
 
 These utilities work on any CSS Grid container — our [`.grid`](/layout/css-grid/), a `.d-grid`, or an element you gave `display: grid` yourself. They do nothing in flexbox: flex has no `justify-items`, and it ignores `justify-self`.

--- a/docs/src/content/docs/utilities/link.mdx
+++ b/docs/src/content/docs/utilities/link.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 6 Link"
 name: "Link"
 description: "Link utilities are used to stylize your anchors to adjust their color, opacity, underline offset, underline color, and more."
-utility: ["link", "underline-color", "underline-offset", "underline-opacity", "underline-thickness"]
+utility: ["link", "underline"]
 ---
 
 import { getData } from '@coreui/astro-docs/data'

--- a/docs/src/content/docs/utilities/margin.mdx
+++ b/docs/src/content/docs/utilities/margin.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 6 Margin"
 name: "Margin"
 description: "Assign responsive-friendly margin values to an element or a subset of its sides with shorthand classes."
-utility: "m"
+utility: ["m", "mt", "mb", "ms", "me", "mx", "my"]
 ---
 
 ## Overview

--- a/docs/src/content/docs/utilities/overflow.mdx
+++ b/docs/src/content/docs/utilities/overflow.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Overflow"
 name: "Overflow"
 description: "Use these shorthand utilities for quickly configuring how content overflows an element."
+utility: "overflow"
 ---
 
 Adjust the `overflow` property on the fly with four default values and classes. These classes are not responsive by default.

--- a/docs/src/content/docs/utilities/padding.mdx
+++ b/docs/src/content/docs/utilities/padding.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 6 Padding"
 name: "Padding"
 description: "Assign responsive-friendly padding values to an element or a subset of its sides with shorthand classes."
-utility: ["p", "pt", "pb", "ps", "pe", "px", "py"]
+utility: ["p", "pt", "pb", "ps", {prefix: "pe", property: "padding-inline-end"}, "px", "py"]
 ---
 
 ## Overview

--- a/docs/src/content/docs/utilities/pointer-events.mdx
+++ b/docs/src/content/docs/utilities/pointer-events.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 6 Pointer Events"
 name: "Pointer events"
 description: "Prevent or add element interactions with our pointer events utilities."
-utility: "pe"
+utility: {prefix: "pe", property: "pointer-events"}
 ---
 
 ## Pointer events

--- a/docs/src/content/docs/utilities/shadows.mdx
+++ b/docs/src/content/docs/utilities/shadows.mdx
@@ -2,6 +2,7 @@
 title: "Bootstrap 6 Shadows"
 name: "Shadows"
 description: "Add or remove shadows to elements with box-shadow utilities."
+utility: ["shadow", "focus-ring"]
 ---
 
 ## Examples

--- a/docs/src/content/docs/utilities/text-wrapping.mdx
+++ b/docs/src/content/docs/utilities/text-wrapping.mdx
@@ -2,7 +2,7 @@
 title: "Bootstrap 6 Text Wrapping"
 name: "Text wrapping"
 description: "Control how text wraps, overflows, and breaks inside its container."
-utility: ["text-wrap", "text-nowrap", "text-break"]
+utility: ["text-wrap", "text-nowrap", "text-break", "text-balance", "text-pretty"]
 ---
 
 ## Wrapping


### PR DESCRIPTION
The utility class tables are generated from the compiled CSS by the families named in each page's frontmatter. Ten pages named them wrong or not at all:

| page | before | after |
| --- | --- | --- |
| margin | `m` only — 66 side classes (`.mt-*` … `.my-*`) missing | all seven, like padding |
| pointer-events / padding | both claimed bare `pe`, each showed the other's classes | `pe` narrowed by property on both |
| link | `underline-color` (no such class): `.underline-*` and the opacity steps missing; 28 `-hover` variants unreachable | `link`, `underline` |
| grid | `col-span`, `grid-flow` match nothing; `.grid-auto-flow-*` missing | `grid-cols`, `grid-auto-flow` |
| text-wrapping | `.text-balance`, `.text-pretty` missing | added |
| border-color | `border-color-subtle` matches nothing | one `border` family by `border-color` |
| background, shadows, overflow | no table at all | `bg`; `shadow` + `focus-ring`; `overflow` |

Verified on the built site: every family above renders its rows, and the build no longer warns about sub-families a parent prefix already covers.

Left for the docs engine (`astro-docs`, `UtilityClasses.astro`): `state: hover` classes (`.link-50-hover:hover`) never match the selector regex, and there is no way to opt a page into responsive rows. Tracked in the workspace TODO. React and Vue docs copy these frontmatters and get the same fix in sibling PRs.