### PR TITLE
feat(Transfer): build both lists from items and support external search

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -58,27 +58,27 @@
     },
     {
       "path": "./dist/js/coreui.bundle.js",
-      "maxSize": "143KB"
+      "maxSize": "143.5KB"
     },
     {
       "path": "./dist/js/coreui.bundle.min.js",
-      "maxSize": "93.5KB"
+      "maxSize": "94KB"
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "132KB"
+      "maxSize": "132.5KB"
     },
     {
       "path": "./dist/js/coreui.esm.min.js",
-      "maxSize": "96.5KB"
+      "maxSize": "97KB"
     },
     {
       "path": "./dist/js/coreui.js",
-      "maxSize": "133KB"
+      "maxSize": "133.5KB"
     },
     {
       "path": "./dist/js/coreui.min.js",
-      "maxSize": "87.5KB"
+      "maxSize": "88KB"
     }
   ],
   "ci": {

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -58,7 +58,7 @@
     },
     {
       "path": "./dist/js/coreui.bundle.js",
-      "maxSize": "143.5KB"
+      "maxSize": "144KB"
     },
     {
       "path": "./dist/js/coreui.bundle.min.js",
@@ -66,7 +66,7 @@
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "132.5KB"
+      "maxSize": "133KB"
     },
     {
       "path": "./dist/js/coreui.esm.min.js",
@@ -74,7 +74,7 @@
     },
     {
       "path": "./dist/js/coreui.js",
-      "maxSize": "133.5KB"
+      "maxSize": "134KB"
     },
     {
       "path": "./dist/js/coreui.min.js",

--- a/build/css-components.mjs
+++ b/build/css-components.mjs
@@ -25,13 +25,13 @@ const tailModules = ['helpers', 'utilities/api']
 const renders = {
   autocomplete: ['combobox', 'forms/form-control', 'forms/form-control-group'],
   'chip-set': ['chip', 'helpers/visually-hidden'],
-  'list-box': ['forms/check'],
+  'list-box': ['forms/check', 'forms/form-control'],
   'loading-button': ['buttons', 'spinner'],
   'date-picker': ['forms/floating-labels', 'forms/form-control', 'forms/form-control-group', 'forms/form-date-time', 'popup'],
   'range-slider': ['tooltip'],
   sidebar: ['transitions'],
   'time-picker': ['forms/floating-labels', 'forms/form-control', 'forms/form-control-group', 'forms/form-date-time', 'popup'],
-  transfer: ['list-box', 'buttons', 'forms/form-control', 'helpers/visually-hidden', 'icon']
+  transfer: ['list-box', 'buttons', 'helpers/visually-hidden', 'icon']
 }
 
 const groups = [

--- a/docs/src/content/docs/components/list-box.mdx
+++ b/docs/src/content/docs/components/list-box.mdx
@@ -198,7 +198,7 @@ The checkbox is a decorative `<span class="list-box-option-indicator check">`, n
 
 `counter` puts a `{selected}/{available} selected` readout in the header — the last child of `.list-box-header`, a `.list-box-subtitle` carrying `data-coreui-list-box-counter`. There is no header in the markup? One is created. Bring your own element with that attribute and the plugin writes into it wherever you put it.
 
-What it counts is what the user can actually act on: the options that are visible and enabled, which is the same scope the select-all button works on. Filter the list and the denominator drops with it; disable an option and it never appears in either number. `selectedCounterText` is the word after the count, so a translated list reads in its own language.
+Both numbers read the same set — the options that are visible and enabled, which is also what the select-all button works on — so the counter always describes what is on screen. Filter the list and the denominator drops with it, and a selected value the filter hid drops out of the numerator too: it stays selected, it just stops being counted, so `2/4` can become `1/1` without anything being deselected. A disabled option never appears in either number. `selectedCounterText` is the word after the count, so a translated list reads in its own language.
 
 <Example code={`<div class="list-box" data-coreui-toggle="list-box" data-coreui-counter="true" data-coreui-search="true" data-coreui-selection-mode="multiple" data-coreui-indicator="checkbox" style="max-width: 20rem">
     <div class="list-box-header">

--- a/docs/src/content/docs/components/list-box.mdx
+++ b/docs/src/content/docs/components/list-box.mdx
@@ -194,6 +194,26 @@ Nothing marks the selection on its own — `aria-selected` and the `.selected` b
 
 The checkbox is a decorative `<span class="list-box-option-indicator check">`, not an input, so it never takes the focus and never has a state of its own — the `.selected` and `.indeterminate` classes drive it. The select-all button gets the same indicator, its own `mixed` state included, and stays a button: focusable, operable, and named by its text.
 
+## Counter
+
+`counter` puts a `{selected}/{available} selected` readout in the header — the last child of `.list-box-header`, a `.list-box-subtitle` carrying `data-coreui-list-box-counter`. There is no header in the markup? One is created. Bring your own element with that attribute and the plugin writes into it wherever you put it.
+
+What it counts is what the user can actually act on: the options that are visible and enabled, which is the same scope the select-all button works on. Filter the list and the denominator drops with it; disable an option and it never appears in either number. `selectedCounterText` is the word after the count, so a translated list reads in its own language.
+
+<Example code={`<div class="list-box" data-coreui-toggle="list-box" data-coreui-counter="true" data-coreui-search="true" data-coreui-selection-mode="multiple" data-coreui-indicator="checkbox" style="max-width: 20rem">
+    <div class="list-box-header">
+      <button type="button" class="list-box-select-all" data-coreui-select-all>Fruit</button>
+    </div>
+    <div class="list-box-options" role="listbox" aria-label="Fruit">
+      <div class="list-box-option" data-coreui-value="apple">Apple</div>
+      <div class="list-box-option" data-coreui-value="apricot">Apricot</div>
+      <div class="list-box-option" data-coreui-value="banana">Banana</div>
+      <div class="list-box-option disabled" data-coreui-value="blueberry">Blueberry</div>
+      <div class="list-box-option" data-coreui-value="cherry">Cherry</div>
+      <div class="list-box-empty">No fruit matches</div>
+    </div>
+  </div>`} />
+
 ## Sections
 
 Group options in a `.list-box-section` and name it with a `.list-box-section-label`. The plugin adds `role="group"`; point `aria-labelledby` at the label so the group is announced with its name.
@@ -335,6 +355,7 @@ Add `data-coreui-toggle="list-box"` to a `.list-box` and the plugin initializes 
 | `data-coreui-value` | The value of an option. Defaults to the option's text. |
 | `data-coreui-select-all` | Marks a button anywhere in the container as the switch for the whole list. |
 | `data-coreui-indicator="checkbox"` | Renders the checkbox indicator in front of every option. |
+| `data-coreui-list-box-counter` | Marks the element that holds the `{selected}/{available}` counter. Created in the header when `counter` is on and the markup has none. |
 | `data-coreui-list-box-search` | Marks an input as the search field of the list. Built for you when `search` is on and the markup has none. |
 | `data-coreui-loading="true"` | Marks the list as loading: `aria-busy` on the options element, `.loading` on the container, empty state held back. |
 
@@ -366,6 +387,7 @@ const listBox = new coreui.ListBox('#myListBox', {
 | `activeDescendant` | null, string, element | `null` | Field that keeps the focus. The plugin drops the roving `tabindex`, gives the options ids, and writes `aria-activedescendant` and `aria-controls` on the field. The keyboard is handled on the field. |
 | `allowList` | object | [Default value](/getting-started/javascript/#sanitizer) | Object which contains allowed attributes and tags for the labels rendered from `items`. |
 | `ariaSearchLabel` | string | `'Search options'` | Accessible name of the search field. An input with its own `aria-label` keeps it. |
+| `counter` | boolean | `false` | Puts a `{selected}/{available} selected` readout in the header, counting the visible, enabled options. Builds the header when the markup has none. |
 | `disabled` | boolean | `false` | Turns the whole list box off: `aria-disabled` on `.list-box-options` and the select-all button disabled. |
 | `html` | boolean | `false` | Parses the labels rendered from `items` as HTML instead of inserting them as text. |
 | `indicator` | string | `'none'` | `'checkbox'` puts a decorative checkbox in front of every option and marks the container with `data-coreui-indicator="checkbox"`, which is what lays the options out in two columns. |
@@ -376,6 +398,7 @@ const listBox = new coreui.ListBox('#myListBox', {
 | `search` | boolean, string | `false` | Builds a search field above the options. `true` filters the list itself; `'external'` filters nothing and fires `search.coreui.list-box` instead. An input the markup already carries is used either way. |
 | `searchPlaceholder` | string | `'Search'` | Placeholder of the built search field. |
 | `selected` | null, string, array | `null` | Initially selected values. In `single` mode only the first one is taken. |
+| `selectedCounterText` | string | `'selected'` | The word after the count in the header. |
 | `selectionLimit` | null, number | `null` | How many options can be selected at once in `multiple` mode. Further selections are refused and reported through `selectionLimit.coreui.list-box`; nothing is disabled and deselecting always works. |
 | `selectionMode` | string | `'single'` | `'none'`, `'single'` or `'multiple'`. |
 | `typeahead` | boolean | `true` | Move the highlight to the option matching what the user types. The buffer resets after 500 ms. |

--- a/docs/src/content/docs/components/list-box.mdx
+++ b/docs/src/content/docs/components/list-box.mdx
@@ -6,6 +6,7 @@ otherFrameworks:
   - list-box
 ---
 
+import listBoxExternalSearch from './snippets/list-box-external-search.js?raw'
 import listBoxInput from './snippets/list-box-input.js?raw'
 import listBoxItems from './snippets/list-box-items.js?raw'
 import listBoxRemote from './snippets/list-box-remote.js?raw'
@@ -141,6 +142,39 @@ Leave an empty `.list-box-options` in the markup so you can name it; the plugin 
   </div>`} sandboxJs={listBoxRemote} />
 
 <Code code={listBoxRemote} lang="js" />
+
+## Search
+
+`search` puts a search field between the header and the options. It hides what does not match, and because a hidden option leaves the navigation, everything downstream follows: the arrows skip it, the select-all button takes only what is left on screen, and the empty state appears when nothing matches. The selection itself survives filtering — filter something out and it stays selected.
+
+The field is a `.form-control.list-box-search` carrying `data-coreui-list-box-search`, built for you unless the markup already has an input with that attribute — put one there and it is used as it is, wherever you placed it. `searchPlaceholder` fills the placeholder and `ariaSearchLabel` the accessible name; `--cui-list-box-search-margin` sets how it sits between the two.
+
+<Example code={`<div class="list-box" data-coreui-toggle="list-box" data-coreui-search="true" data-coreui-selection-mode="multiple" data-coreui-indicator="checkbox" style="max-width: 20rem">
+    <div class="list-box-header">
+      <button type="button" class="list-box-select-all" data-coreui-select-all>Fruit</button>
+    </div>
+    <div class="list-box-options" role="listbox" aria-label="Fruit">
+      <div class="list-box-option" data-coreui-value="apple">Apple</div>
+      <div class="list-box-option" data-coreui-value="apricot">Apricot</div>
+      <div class="list-box-option" data-coreui-value="banana">Banana</div>
+      <div class="list-box-option" data-coreui-value="blueberry">Blueberry</div>
+      <div class="list-box-option" data-coreui-value="cherry">Cherry</div>
+      <div class="list-box-option" data-coreui-value="cranberry">Cranberry</div>
+      <div class="list-box-empty">No fruit matches</div>
+    </div>
+  </div>`} />
+
+### External search
+
+`search: 'external'` builds the same field and filters nothing. Every keystroke fires `search.coreui.list-box` with the `query`, and you answer with `setItems()` — the list shows what you hand it, so the query is yours to interpret. Debounce the request and put `setLoading()` around it, and the list dims instead of flickering between two answers.
+
+<Example code={`<div class="list-box" id="listBoxExternalSearch" style="max-width: 22rem">
+    <div class="list-box-options" role="listbox" aria-label="Users" style="max-height: 14rem; overflow-y: auto">
+      <div class="list-box-empty">No users</div>
+    </div>
+  </div>`} sandboxJs={listBoxExternalSearch} />
+
+<Code code={listBoxExternalSearch} lang="js" />
 
 ## Checkboxes
 
@@ -301,6 +335,7 @@ Add `data-coreui-toggle="list-box"` to a `.list-box` and the plugin initializes 
 | `data-coreui-value` | The value of an option. Defaults to the option's text. |
 | `data-coreui-select-all` | Marks a button anywhere in the container as the switch for the whole list. |
 | `data-coreui-indicator="checkbox"` | Renders the checkbox indicator in front of every option. |
+| `data-coreui-list-box-search` | Marks an input as the search field of the list. Built for you when `search` is on and the markup has none. |
 | `data-coreui-loading="true"` | Marks the list as loading: `aria-busy` on the options element, `.loading` on the container, empty state held back. |
 
 ```html
@@ -330,6 +365,7 @@ const listBox = new coreui.ListBox('#myListBox', {
 | --- | --- | --- | --- |
 | `activeDescendant` | null, string, element | `null` | Field that keeps the focus. The plugin drops the roving `tabindex`, gives the options ids, and writes `aria-activedescendant` and `aria-controls` on the field. The keyboard is handled on the field. |
 | `allowList` | object | [Default value](/getting-started/javascript/#sanitizer) | Object which contains allowed attributes and tags for the labels rendered from `items`. |
+| `ariaSearchLabel` | string | `'Search options'` | Accessible name of the search field. An input with its own `aria-label` keeps it. |
 | `disabled` | boolean | `false` | Turns the whole list box off: `aria-disabled` on `.list-box-options` and the select-all button disabled. |
 | `html` | boolean | `false` | Parses the labels rendered from `items` as HTML instead of inserting them as text. |
 | `indicator` | string | `'none'` | `'checkbox'` puts a decorative checkbox in front of every option and marks the container with `data-coreui-indicator="checkbox"`, which is what lays the options out in two columns. |
@@ -337,6 +373,8 @@ const listBox = new coreui.ListBox('#myListBox', {
 | `loading` | boolean | `false` | Marks the list as loading: `aria-busy` on the options element, `.loading` on the container, empty state held back. |
 | `sanitize` | boolean | `true` | Enables the sanitization of the labels rendered from `items` with `html`. |
 | `sanitizeFn` | null, function | `null` | Sanitization function of your own, used instead of the built-in one. |
+| `search` | boolean, string | `false` | Builds a search field above the options. `true` filters the list itself; `'external'` filters nothing and fires `search.coreui.list-box` instead. An input the markup already carries is used either way. |
+| `searchPlaceholder` | string | `'Search'` | Placeholder of the built search field. |
 | `selected` | null, string, array | `null` | Initially selected values. In `single` mode only the first one is taken. |
 | `selectionLimit` | null, number | `null` | How many options can be selected at once in `multiple` mode. Further selections are refused and reported through `selectionLimit.coreui.list-box`; nothing is disabled and deselecting always works. |
 | `selectionMode` | string | `'single'` | `'none'`, `'single'` or `'multiple'`. |
@@ -377,6 +415,7 @@ Events fire on the `.list-box` element.
 | `change.coreui.list-box` | Fired once per operation after the selection settled; `event.selected` is the array of selected values. |
 | `selectionLimit.coreui.list-box` | Fired once per interaction when `selectionLimit` refused a selection; `event.limit` is the cap and `event.value` the first refused value. |
 | `activate.coreui.list-box` | Fired when the highlight moves; `event.value` is the newly highlighted value. |
+| `search.coreui.list-box` | Fired on every keystroke in the search field with `search: 'external'`; `event.query` is what was typed. Nothing is filtered — answer with `setItems()`. |
 | `action.coreui.list-box` | Fired when an option is activated in `none` mode or when the option is a link; `event.value` is the value and `event.relatedTarget` the option. |
 
 ```js

--- a/docs/src/content/docs/components/snippets/list-box-external-search.js
+++ b/docs/src/content/docs/components/snippets/list-box-external-search.js
@@ -1,0 +1,35 @@
+const element = document.getElementById('listBoxExternalSearch')
+const listBox = coreui.ListBox.getOrCreateInstance(element, {
+  loading: true,
+  search: 'external',
+  searchPlaceholder: 'Search users'
+})
+
+const loadUsers = async (query = '') => {
+  listBox.setLoading(true)
+
+  try {
+    const response = await fetch(`https://apitest.coreui.io/demos/users?first_name=${query}&limit=10`)
+    const { records } = await response.json()
+
+    listBox.setItems(records.map(user => ({
+      value: String(user.id),
+      label: `${user.first_name} ${user.last_name}`,
+      description: user.email
+    })))
+  } catch (error) {
+    console.error('Error fetching users:', error)
+    listBox.setItems([])
+  } finally {
+    listBox.setLoading(false)
+  }
+}
+
+let debounceTimer = null
+
+element.addEventListener('search.coreui.list-box', event => {
+  clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => loadUsers(event.query), 200)
+})
+
+loadUsers()

--- a/docs/src/content/docs/components/snippets/transfer-external-search.js
+++ b/docs/src/content/docs/components/snippets/transfer-external-search.js
@@ -1,6 +1,5 @@
 const element = document.getElementById('transferExternalSearch')
 const transfer = coreui.Transfer.getOrCreateInstance(element, {
-  loading: true,
   search: 'external',
   sourceTitle: 'Users',
   targetTitle: 'Invited'

--- a/docs/src/content/docs/components/snippets/transfer-external-search.js
+++ b/docs/src/content/docs/components/snippets/transfer-external-search.js
@@ -1,0 +1,54 @@
+const element = document.getElementById('transferExternalSearch')
+const transfer = coreui.Transfer.getOrCreateInstance(element, {
+  loading: true,
+  search: 'external',
+  sourceTitle: 'Users',
+  targetTitle: 'Invited'
+})
+
+const invited = new Map()
+
+const loadUsers = async (query = '') => {
+  transfer.setLoading(true, 'source')
+
+  try {
+    const response = await fetch(`https://apitest.coreui.io/demos/users?first_name=${query}&limit=10`)
+    const { records } = await response.json()
+    const users = records.map(user => ({
+      value: String(user.id),
+      label: `${user.first_name} ${user.last_name}`,
+      description: user.email
+    }))
+    const found = new Set(users.map(user => user.value))
+
+    transfer.setItems([...users, ...[...invited.values()].filter(user => !found.has(user.value))])
+  } catch (error) {
+    console.error('Error fetching users:', error)
+    transfer.setItems([...invited.values()])
+  } finally {
+    transfer.setLoading(false, 'source')
+  }
+}
+
+element.addEventListener('change.coreui.transfer', event => {
+  const users = new Map(transfer.getItems().map(user => [user.value, user]))
+
+  invited.clear()
+
+  for (const value of event.targetValues) {
+    invited.set(value, users.get(value))
+  }
+})
+
+let debounceTimer = null
+
+element.addEventListener('search.coreui.transfer', event => {
+  if (event.side !== 'source') {
+    return
+  }
+
+  clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => loadUsers(event.query), 200)
+})
+
+loadUsers()

--- a/docs/src/content/docs/components/snippets/transfer-items.js
+++ b/docs/src/content/docs/components/snippets/transfer-items.js
@@ -1,0 +1,26 @@
+const element = document.getElementById('transferItems')
+
+coreui.Transfer.getOrCreateInstance(element, {
+  items: [
+    {
+      label: 'Engineering',
+      items: [
+        { value: 'ada', label: 'Ada Lovelace', description: 'Analyst' },
+        { value: 'grace', label: 'Grace Hopper', description: 'Compilers' },
+        {
+          value: 'alan', label: 'Alan Turing', description: 'Cryptanalysis', disabled: true
+        }
+      ]
+    },
+    {
+      label: 'Design',
+      items: [
+        { value: 'ray', label: 'Ray Eames' },
+        { value: 'dieter', label: 'Dieter Rams' }
+      ]
+    }
+  ],
+  sourceTitle: 'Team',
+  targetTitle: 'On call',
+  value: ['grace']
+})

--- a/docs/src/content/docs/components/transfer.mdx
+++ b/docs/src/content/docs/components/transfer.mdx
@@ -45,7 +45,7 @@ A transfer moves values between two lists — what is available on the left, wha
 
 Everything inside a list is the list box's: the options and their values, the selection, the arrow keys, the typeahead and the select-all button. The transfer owns what happens between the lists, so nothing here is a second implementation of the same behavior — read the [List box](/components/list-box/) page for the parts a list is made of.
 
-Each side is a `.list-box.transfer-list` marked `data-coreui-transfer-list="source"` or `="target"`, and each button a `[data-coreui-transfer-move]` naming what it does: `target` and `source` move the selection, `target-all` and `source-all` move everything the list currently shows. The rest is filled in for you: an empty select-all button takes the list's title, an empty move button takes its chevron, the header gets a `{selected}/{visible} selected` counter, the options element gets the title as its accessible name, and the buttons get their labels and an `aria-controls`.
+Each side is a `.list-box.transfer-list` marked `data-coreui-transfer-list="source"` or `="target"`, and each button a `[data-coreui-transfer-move]` naming what it does: `target` and `source` move the selection, `target-all` and `source-all` move everything the list currently shows. The rest is filled in for you: an empty select-all button takes the list's title, an empty move button takes its chevron, each header gets the list box's `{selected}/{available} selected` counter, the options element gets the title as its accessible name, and the buttons get their labels and an `aria-controls`.
 
 "All" is the same scope the select-all button works on — the visible, enabled options — so with a search running, the all button moves what the search left behind and nothing more.
 
@@ -88,7 +88,7 @@ Leave an empty `.list-box-options` in each list so you can name it; the plugin a
 
 ## Search
 
-The search belongs to the list box — `search` and `searchPlaceholder` are passed to both of them, so each list gets its own field and filters itself; how it works, and how to bring your own input, is on the [List box](/components/list-box/#search) page. What the transfer adds is that a filtered list still counts: the header reads `{selected}/{visible}`, the select-all button takes only what is left on screen, and "all" moves exactly that.
+The search belongs to the list box — `search` and `searchPlaceholder` are passed to both of them, so each list gets its own field and filters itself; how it works, and how to bring your own input, is on the [List box](/components/list-box/#search) page. What the transfer adds is that a filtered list still counts: the [counter](/components/list-box/#counter) in the header drops what the search hid, the select-all button takes only what is left on screen, and "all" moves exactly that.
 
 <Example code={`<div class="transfer" data-coreui-toggle="transfer" data-coreui-search="true">
     <div class="list-box transfer-list" data-coreui-transfer-list="source">
@@ -309,7 +309,6 @@ Add `data-coreui-toggle="transfer"` to a `.transfer` and the plugin initializes 
 | `data-coreui-toggle="transfer"` | Initializes the transfer on page load. |
 | `data-coreui-transfer-list` | Marks a `.list-box` as the `source` or the `target` list. |
 | `data-coreui-transfer-move` | Marks a move button: `target` / `source` move the selection, `target-all` / `source-all` move every visible, enabled option. |
-| `data-coreui-transfer-counter` | Marks the element that holds the `{selected}/{visible}` counter. Created in the header when it is missing. |
 
 A move button left empty gets the chevron its direction calls for; put anything of your own in it — a label, your own icon — and that is what stays.
 
@@ -372,7 +371,7 @@ const transfer = new coreui.Transfer('#myTransfer', {
 | `sanitizeFn` | null, function | `null` | Your own sanitizer, used instead of the built-in one. |
 | `search` | boolean, string | `false` | Passed to both list boxes: builds a search field above each list. `'external'` filters nothing — every keystroke fires `search.coreui.transfer` and you answer with `setItems()`. |
 | `searchPlaceholder` | string | `'Search'` | Passed to both list boxes as the placeholder of their search field, and used as the first half of each field's accessible name so the two are told apart. |
-| `selectedCounterText` | string | `'selected'` | The word after the `{selected}/{visible}` counter in each header. |
+| `selectedCounterText` | string | `'selected'` | Passed to both list boxes: the word after the count in each header. The transfer turns their [counter](/components/list-box/#counter) on. |
 | `sourceTitle` | string | `'Available'` | Title of the source list: its select-all label when the button is empty, and its accessible name. |
 | `targetTitle` | string | `'Chosen'` | Title of the target list. |
 | `typeahead` | boolean | `true` | Passed to both list boxes: move the highlight to the option matching what the user types. |
@@ -392,7 +391,7 @@ const transfer = new coreui.Transfer('#myTransfer', {
 | `setItems(items)` | Rebuilds both lists from a new `items` array. The values the target holds keep their place as long as the new items still carry them; everything else goes to the source in the items order. Both selections come back empty. |
 | `getItems()` | The items array both lists were built from. |
 | `setLoading(loading, list?)` | Marks a list busy while you fetch: pass `'source'` or `'target'` for one of them, nothing for both. A list left busy stays dimmed and unclickable, so release every list you marked. |
-| `update` | Re-reads the DOM: options added or removed reach both list boxes, the search is re-applied, and the counters and the buttons are re-evaluated. |
+| `update` | Re-reads the DOM: options added or removed reach both list boxes, which re-apply their search and counter, and the move buttons are re-evaluated. |
 | `dispose` | Destroys the transfer and both list boxes, and removes the live region. |
 | `getInstance` | Static method which allows you to get the transfer instance associated to a DOM element, you can use it like this: `coreui.Transfer.getInstance(element)`. |
 | `getOrCreateInstance` | Static method which returns a transfer instance associated to a DOM element or creates a new one in case it wasn't initialized. You can use it like this: `coreui.Transfer.getOrCreateInstance(element)`. |

--- a/docs/src/content/docs/components/transfer.mdx
+++ b/docs/src/content/docs/components/transfer.mdx
@@ -125,7 +125,9 @@ Put your own `[data-coreui-transfer-search]` input in a list and it is used as i
 
 `search: 'external'` hands the searching over to you: the fields are still built, but nothing is filtered and no option is hidden. Every keystroke fires `search.coreui.transfer` with the `side` that was typed in and the `query`, and you answer with `setItems()` — one method for both lists, so pass the whole set you want shown and leave out what the query rules out. Values already in the target stay there as long as your set still carries them, which is why the example below keeps the chosen users in what it sends back.
 
-`loading` covers the wait: `setLoading(true, 'source')` writes `aria-busy="true"` on that list's options element and dims it until the answer arrives; without a second argument it covers both lists.
+`loading` covers the wait: `setLoading(true, 'source')` writes `aria-busy="true"` on that list's options element and dims it until the answer arrives. The second argument is what scopes it — `setLoading(true)` and the `loading` option both cover *both* lists, so a list you never fetch for stays dimmed and unclickable until something releases it. Fetch one list, mark one list.
+
+Rebuilding is a fresh start for the selection: after `setItems()` neither list has anything checked, and `selected` on an item applies to the first render only, so a re-fetch never brings the checkboxes back. Moving options across clears the destination's selection too — what arrives is ready to be picked, not already picked.
 
 <Example code={`<div class="transfer" id="transferExternalSearch">
     <div class="list-box transfer-list" data-coreui-transfer-list="source">
@@ -362,8 +364,8 @@ const transfer = new coreui.Transfer('#myTransfer', {
 | `disabled` | boolean | `false` | Turns the whole transfer off: both list boxes, both move buttons and both search fields. |
 | `html` | boolean | `false` | Parse the labels and descriptions of `items` as markup instead of text. Passed to both list boxes. |
 | `indicator` | string | `'checkbox'` | Passed to both list boxes. `'none'` drops the checkbox in front of every option. |
-| `items` | array | `[]` | The options of both lists, rendered instead of the markup: `{ value, label, description, disabled, selected }`, or `{ label, items }` for a section. `value` decides which of them start in the target list. |
-| `loading` | boolean | `false` | Marks both lists as busy: `aria-busy="true"` on the options element and `.loading` on the list. |
+| `items` | array | `[]` | The options of both lists, rendered instead of the markup: `{ value, label, description, disabled, selected }`, or `{ label, items }` for a section. `value` decides which of them start in the target list, `selected` which start checked — on the first render only. |
+| `loading` | boolean | `false` | Marks both lists as busy: `aria-busy="true"` on the options element and `.loading` on the list, which dims it and stops it responding. Release it with `setLoading(false)`, or scope it per list with `setLoading(value, list)`. |
 | `moveAllToSourceIcon` | string | `cil-chevron-double-left-alt` | Icon of the button that moves everything back. Inline SVG, put in the button only when the markup left it empty. |
 | `moveAllToTargetIcon` | string | `cil-chevron-double-right-alt` | Icon of the button that moves everything across. |
 | `moveToSourceIcon` | string | `cil-chevron-left-alt` | Icon of the button that moves the selection back. |
@@ -390,9 +392,9 @@ const transfer = new coreui.Transfer('#myTransfer', {
 | `getSource()` | The values in the source list, in document order. |
 | `getTarget()` | The values in the target list, in document order. |
 | `getSelected(list)` | The selected values of `'source'` or `'target'`. |
-| `setItems(items)` | Rebuilds both lists from a new `items` array. The values the target holds keep their place as long as the new items still carry them; everything else goes to the source in the items order. |
+| `setItems(items)` | Rebuilds both lists from a new `items` array. The values the target holds keep their place as long as the new items still carry them; everything else goes to the source in the items order. Both selections come back empty. |
 | `getItems()` | The items array both lists were built from. |
-| `setLoading(loading, list?)` | Marks a list busy while you fetch: pass `'source'` or `'target'` for one of them, nothing for both. |
+| `setLoading(loading, list?)` | Marks a list busy while you fetch: pass `'source'` or `'target'` for one of them, nothing for both. A list left busy stays dimmed and unclickable, so release every list you marked. |
 | `update` | Re-reads the DOM: options added or removed reach both list boxes, the search is re-applied, and the counters and the buttons are re-evaluated. |
 | `dispose` | Destroys the transfer and both list boxes, and removes the live region. |
 | `getInstance` | Static method which allows you to get the transfer instance associated to a DOM element, you can use it like this: `coreui.Transfer.getInstance(element)`. |

--- a/docs/src/content/docs/components/transfer.mdx
+++ b/docs/src/content/docs/components/transfer.mdx
@@ -6,6 +6,9 @@ otherFrameworks:
   - transfer
 ---
 
+import transferExternalSearch from './snippets/transfer-external-search.js?raw'
+import transferItems from './snippets/transfer-items.js?raw'
+
 ## Overview
 
 <AddedIn version="6.0.0" />
@@ -50,6 +53,39 @@ The two lists order themselves differently, and on purpose: the target keeps the
 
 The transfer caps how tall a list gets — `--cui-transfer-list-max-height` puts a `max-height` and `overflow-y: auto` on `.list-box-options`, so a long list scrolls inside its own box instead of stretching the row.
 
+## Items from configuration
+
+Instead of writing every option by hand, hand the plugin an `items` array and it renders both lists — the same markup the sections above document, so every class, role and attribute is where you would have put it. An item is `{ value, label, description, disabled, selected }`; an entry with its own `items` array is a section. `value` names what starts in the target list, in the order you list it, and everything else lands in the source in the order the items came in — including a value moved back later, which returns to its place among the items rather than to the end.
+
+Labels are text: they land as `textContent`, so a label carrying markup shows up as characters. Set `html: true` to have them parsed instead — the result runs through the sanitizer first, and `sanitize`, `sanitizeFn` and `allowList` steer it the same way they do everywhere else.
+
+Leave an empty `.list-box-options` in each list so you can name it; the plugin appends one when it is missing, but then the list has no accessible name. Options already written inside it are replaced — `items` owns both lists from the moment it is set.
+
+<Example code={`<div class="transfer" id="transferItems">
+    <div class="list-box transfer-list" data-coreui-transfer-list="source">
+      <div class="list-box-header">
+        <button type="button" class="list-box-select-all" data-coreui-select-all></button>
+      </div>
+      <div class="list-box-options" role="listbox" aria-label="Team"></div>
+    </div>
+    <div class="transfer-actions">
+      <button type="button" class="btn btn-subtle btn-sm" data-coreui-transfer-move="target-all"></button>
+      <button type="button" class="btn btn-subtle btn-sm" data-coreui-transfer-move="target"></button>
+      <button type="button" class="btn btn-subtle btn-sm" data-coreui-transfer-move="source"></button>
+      <button type="button" class="btn btn-subtle btn-sm" data-coreui-transfer-move="source-all"></button>
+    </div>
+    <div class="list-box transfer-list" data-coreui-transfer-list="target">
+      <div class="list-box-header">
+        <button type="button" class="list-box-select-all" data-coreui-select-all></button>
+      </div>
+      <div class="list-box-options" role="listbox" aria-label="On call"></div>
+    </div>
+  </div>`} sandboxJs={transferItems} />
+
+<Code code={transferItems} lang="js" />
+
+`setItems(items)` rebuilds both lists at any time: the values the target holds survive the rebuild as long as the new items still carry them, in the order they were chosen, and the rest go back to the source. A value that is gone drops out. `getItems()` hands back the array as it was given.
+
 ## Search
 
 `search` puts a search field above each list. It hides the options that do not match what was typed, and because a hidden option leaves the list box's navigation, everything downstream follows: the arrows skip it, the counter drops it, and the select-all button takes only what is left on screen. The selection itself survives filtering.
@@ -84,6 +120,35 @@ The transfer caps how tall a list gets — `--cui-transfer-list-max-height` puts
   </div>`} />
 
 Put your own `[data-coreui-transfer-search]` input in a list and it is used as it is, `search` option or not — that is how you change its classes, its placeholder or its position.
+
+## External search
+
+`search: 'external'` hands the searching over to you: the fields are still built, but nothing is filtered and no option is hidden. Every keystroke fires `search.coreui.transfer` with the `side` that was typed in and the `query`, and you answer with `setItems()` — one method for both lists, so pass the whole set you want shown and leave out what the query rules out. Values already in the target stay there as long as your set still carries them, which is why the example below keeps the chosen users in what it sends back.
+
+`loading` covers the wait: `setLoading(true, 'source')` writes `aria-busy="true"` on that list's options element and dims it until the answer arrives; without a second argument it covers both lists.
+
+<Example code={`<div class="transfer" id="transferExternalSearch">
+    <div class="list-box transfer-list" data-coreui-transfer-list="source">
+      <div class="list-box-header">
+        <button type="button" class="list-box-select-all" data-coreui-select-all></button>
+      </div>
+      <div class="list-box-options" role="listbox" aria-label="Users"></div>
+    </div>
+    <div class="transfer-actions">
+      <button type="button" class="btn btn-subtle btn-sm" data-coreui-transfer-move="target-all"></button>
+      <button type="button" class="btn btn-subtle btn-sm" data-coreui-transfer-move="target"></button>
+      <button type="button" class="btn btn-subtle btn-sm" data-coreui-transfer-move="source"></button>
+      <button type="button" class="btn btn-subtle btn-sm" data-coreui-transfer-move="source-all"></button>
+    </div>
+    <div class="list-box transfer-list" data-coreui-transfer-list="target">
+      <div class="list-box-header">
+        <button type="button" class="list-box-select-all" data-coreui-select-all></button>
+      </div>
+      <div class="list-box-options" role="listbox" aria-label="Invited"></div>
+    </div>
+  </div>`} sandboxJs={transferExternalSearch} />
+
+<Code code={transferExternalSearch} lang="js" />
 
 ## One way
 
@@ -295,7 +360,10 @@ const transfer = new coreui.Transfer('#myTransfer', {
 | `ariaMoveToTargetLabel` | string | `'Move to chosen'` | Accessible name of the button that moves the selection to the target list. |
 | `ariaMovedAnnouncement` | string | `'{count} moved to {title}'` | What the live region says after a move. `{count}` is how many options moved, `{title}` the destination's title. |
 | `disabled` | boolean | `false` | Turns the whole transfer off: both list boxes, both move buttons and both search fields. |
+| `html` | boolean | `false` | Parse the labels and descriptions of `items` as markup instead of text. Passed to both list boxes. |
 | `indicator` | string | `'checkbox'` | Passed to both list boxes. `'none'` drops the checkbox in front of every option. |
+| `items` | array | `[]` | The options of both lists, rendered instead of the markup: `{ value, label, description, disabled, selected }`, or `{ label, items }` for a section. `value` decides which of them start in the target list. |
+| `loading` | boolean | `false` | Marks both lists as busy: `aria-busy="true"` on the options element and `.loading` on the list. |
 | `moveAllToSourceIcon` | string | `cil-chevron-double-left-alt` | Icon of the button that moves everything back. Inline SVG, put in the button only when the markup left it empty. |
 | `moveAllToTargetIcon` | string | `cil-chevron-double-right-alt` | Icon of the button that moves everything across. |
 | `moveToSourceIcon` | string | `cil-chevron-left-alt` | Icon of the button that moves the selection back. |
@@ -303,12 +371,13 @@ const transfer = new coreui.Transfer('#myTransfer', {
 | `oneWay` | boolean | `false` | Hides and disables both buttons that move back, and makes `moveToSource()` and `moveAllToSource()` no-ops. |
 | `sanitize` | boolean | `true` | Run the icon strings through the sanitizer. |
 | `sanitizeFn` | null, function | `null` | Your own sanitizer, used instead of the built-in one. |
-| `search` | boolean | `false` | Builds a search field above each list. An input the markup already carries is used instead. |
+| `search` | boolean, string | `false` | Builds a search field above each list. An input the markup already carries is used instead. `'external'` builds the fields but filters nothing — every keystroke fires `search.coreui.transfer` and you answer with `setItems()`. |
 | `searchPlaceholder` | string | `'Search'` | Placeholder of the built search field, and the first half of its accessible name. |
 | `selectedCounterText` | string | `'selected'` | The word after the `{selected}/{visible}` counter in each header. |
 | `sourceTitle` | string | `'Available'` | Title of the source list: its select-all label when the button is empty, and its accessible name. |
 | `targetTitle` | string | `'Chosen'` | Title of the target list. |
 | `typeahead` | boolean | `true` | Passed to both list boxes: move the highlight to the option matching what the user types. |
+| `value` | array | `[]` | The values of `items` that start in the target list, in the order given. The rest go to the source list. |
 
 ### Methods
 
@@ -321,6 +390,9 @@ const transfer = new coreui.Transfer('#myTransfer', {
 | `getSource()` | The values in the source list, in document order. |
 | `getTarget()` | The values in the target list, in document order. |
 | `getSelected(list)` | The selected values of `'source'` or `'target'`. |
+| `setItems(items)` | Rebuilds both lists from a new `items` array. The values the target holds keep their place as long as the new items still carry them; everything else goes to the source in the items order. |
+| `getItems()` | The items array both lists were built from. |
+| `setLoading(loading, list?)` | Marks a list busy while you fetch: pass `'source'` or `'target'` for one of them, nothing for both. |
 | `update` | Re-reads the DOM: options added or removed reach both list boxes, the search is re-applied, and the counters and the buttons are re-evaluated. |
 | `dispose` | Destroys the transfer and both list boxes, and removes the live region. |
 | `getInstance` | Static method which allows you to get the transfer instance associated to a DOM element, you can use it like this: `coreui.Transfer.getInstance(element)`. |
@@ -334,6 +406,7 @@ Events fire on the `.transfer` element.
 | --- | --- |
 | `move.coreui.transfer` | Fires before options are moved; `event.direction` is `'source'` or `'target'` and `event.values` the values about to move. Cancelable — calling `preventDefault()` leaves both lists as they were. |
 | `moved.coreui.transfer` | Fired after the options were moved, with the same `direction` and `values`. |
+| `search.coreui.transfer` | Fired on every keystroke in a search field with `search: 'external'`; `event.side` is `'source'` or `'target'` and `event.query` what was typed. Nothing is filtered — answer with `setItems()`. |
 | `change.coreui.transfer` | Fired after a move settled; `event.sourceValues` and `event.targetValues` are the values of the two lists. The names avoid `event.target`, which stays the `.transfer` element. |
 
 ```js

--- a/docs/src/content/docs/components/transfer.mdx
+++ b/docs/src/content/docs/components/transfer.mdx
@@ -88,7 +88,7 @@ Leave an empty `.list-box-options` in each list so you can name it; the plugin a
 
 ## Search
 
-The search belongs to the list box — `search` and `searchPlaceholder` are passed to both of them, so each list gets its own field and filters itself; how it works, and how to bring your own input, is on the [List box](/components/list-box/#search) page. What the transfer adds is that a filtered list still counts: the [counter](/components/list-box/#counter) in the header drops what the search hid, the select-all button takes only what is left on screen, and "all" moves exactly that.
+The search belongs to the list box — `search` and `searchPlaceholder` are passed to both of them, so each list gets its own field and filters itself; how it works, and how to bring your own input, is on the [List box](/components/list-box/#search) page. What the transfer adds is that a filtered list still counts: the [counter](/components/list-box/#counter) in the header reads only what the search left — on both sides of the slash, so a selected value it hid stops counting without being deselected — the select-all button takes only what is left on screen, and "all" moves exactly that.
 
 <Example code={`<div class="transfer" data-coreui-toggle="transfer" data-coreui-search="true">
     <div class="list-box transfer-list" data-coreui-transfer-list="source">

--- a/docs/src/content/docs/components/transfer.mdx
+++ b/docs/src/content/docs/components/transfer.mdx
@@ -88,7 +88,7 @@ Leave an empty `.list-box-options` in each list so you can name it; the plugin a
 
 ## Search
 
-`search` puts a search field above each list. It hides the options that do not match what was typed, and because a hidden option leaves the list box's navigation, everything downstream follows: the arrows skip it, the counter drops it, and the select-all button takes only what is left on screen. The selection itself survives filtering.
+The search belongs to the list box — `search` and `searchPlaceholder` are passed to both of them, so each list gets its own field and filters itself; how it works, and how to bring your own input, is on the [List box](/components/list-box/#search) page. What the transfer adds is that a filtered list still counts: the header reads `{selected}/{visible}`, the select-all button takes only what is left on screen, and "all" moves exactly that.
 
 <Example code={`<div class="transfer" data-coreui-toggle="transfer" data-coreui-search="true">
     <div class="list-box transfer-list" data-coreui-transfer-list="source">
@@ -119,11 +119,9 @@ Leave an empty `.list-box-options` in each list so you can name it; the plugin a
     </div>
   </div>`} />
 
-Put your own `[data-coreui-transfer-search]` input in a list and it is used as it is, `search` option or not — that is how you change its classes, its placeholder or its position.
-
 ## External search
 
-`search: 'external'` hands the searching over to you: the fields are still built, but nothing is filtered and no option is hidden. Every keystroke fires `search.coreui.transfer` with the `side` that was typed in and the `query`, and you answer with `setItems()` — one method for both lists, so pass the whole set you want shown and leave out what the query rules out. Values already in the target stay there as long as your set still carries them, which is why the example below keeps the chosen users in what it sends back.
+`search: 'external'` hands the searching over to you — the [list box's external mode](/components/list-box/#external-search) on both lists at once. The transfer re-emits what they report as `search.coreui.transfer`, adding the `side` that was typed in, and you answer with `setItems()` — one method for both lists, so pass the whole set you want shown and leave out what the query rules out. Values already in the target stay there as long as your set still carries them, which is why the example below keeps the chosen users in what it sends back.
 
 `loading` covers the wait: `setLoading(true, 'source')` writes `aria-busy="true"` on that list's options element and dims it until the answer arrives. The second argument is what scopes it — `setLoading(true)` and the `loading` option both cover *both* lists, so a list you never fetch for stays dimmed and unclickable until something releases it. Fetch one list, mark one list.
 
@@ -311,7 +309,6 @@ Add `data-coreui-toggle="transfer"` to a `.transfer` and the plugin initializes 
 | `data-coreui-toggle="transfer"` | Initializes the transfer on page load. |
 | `data-coreui-transfer-list` | Marks a `.list-box` as the `source` or the `target` list. |
 | `data-coreui-transfer-move` | Marks a move button: `target` / `source` move the selection, `target-all` / `source-all` move every visible, enabled option. |
-| `data-coreui-transfer-search` | Marks an input as the search field of the list it sits in. |
 | `data-coreui-transfer-counter` | Marks the element that holds the `{selected}/{visible}` counter. Created in the header when it is missing. |
 
 A move button left empty gets the chevron its direction calls for; put anything of your own in it — a label, your own icon — and that is what stays.
@@ -373,8 +370,8 @@ const transfer = new coreui.Transfer('#myTransfer', {
 | `oneWay` | boolean | `false` | Hides and disables both buttons that move back, and makes `moveToSource()` and `moveAllToSource()` no-ops. |
 | `sanitize` | boolean | `true` | Run the icon strings through the sanitizer. |
 | `sanitizeFn` | null, function | `null` | Your own sanitizer, used instead of the built-in one. |
-| `search` | boolean, string | `false` | Builds a search field above each list. An input the markup already carries is used instead. `'external'` builds the fields but filters nothing — every keystroke fires `search.coreui.transfer` and you answer with `setItems()`. |
-| `searchPlaceholder` | string | `'Search'` | Placeholder of the built search field, and the first half of its accessible name. |
+| `search` | boolean, string | `false` | Passed to both list boxes: builds a search field above each list. `'external'` filters nothing — every keystroke fires `search.coreui.transfer` and you answer with `setItems()`. |
+| `searchPlaceholder` | string | `'Search'` | Passed to both list boxes as the placeholder of their search field, and used as the first half of each field's accessible name so the two are told apart. |
 | `selectedCounterText` | string | `'selected'` | The word after the `{selected}/{visible}` counter in each header. |
 | `sourceTitle` | string | `'Available'` | Title of the source list: its select-all label when the button is empty, and its accessible name. |
 | `targetTitle` | string | `'Chosen'` | Title of the target list. |

--- a/js/src/list-box.ts
+++ b/js/src/list-box.ts
@@ -41,6 +41,7 @@ const EVENT_ACTIVATE = 'activate'
 const EVENT_CHANGE = 'change'
 const EVENT_DESELECT = 'deselect'
 const EVENT_DESELECTED = 'deselected'
+const EVENT_SEARCH = 'search'
 const EVENT_SELECT = 'select'
 const EVENT_SELECTED = 'selected'
 const EVENT_SELECTION_LIMIT = 'selectionLimit'
@@ -48,11 +49,13 @@ const EVENT_SELECTION_LIMIT = 'selectionLimit'
 const EVENT_CLICK = 'click'
 const EVENT_FOCUSIN = 'focusin'
 const EVENT_FOCUSOUT = 'focusout'
+const EVENT_INPUT = 'input'
 const EVENT_KEYDOWN = 'keydown'
 
 const CLASS_NAME_ACTIVE = 'active'
 const CLASS_NAME_CHECK = 'check'
 const CLASS_NAME_DISABLED = 'disabled'
+const CLASS_NAME_FORM_CONTROL = 'form-control'
 const CLASS_NAME_INDETERMINATE = 'indeterminate'
 const CLASS_NAME_LOADING = 'loading'
 const CLASS_NAME_OPTION = 'list-box-option'
@@ -60,6 +63,7 @@ const CLASS_NAME_OPTION_DESCRIPTION = 'list-box-option-description'
 const CLASS_NAME_OPTION_INDICATOR = 'list-box-option-indicator'
 const CLASS_NAME_OPTION_LABEL = 'list-box-option-label'
 const CLASS_NAME_OPTIONS = 'list-box-options'
+const CLASS_NAME_SEARCH = 'list-box-search'
 const CLASS_NAME_SECTION = 'list-box-section'
 const CLASS_NAME_SECTION_LABEL = 'list-box-section-label'
 const CLASS_NAME_SELECTED = 'selected'
@@ -70,12 +74,15 @@ const SELECTOR_OPTION = '.list-box-option'
 const SELECTOR_OPTION_INDICATOR = '.list-box-option-indicator'
 const SELECTOR_OPTION_LABEL = '.list-box-option-label'
 const SELECTOR_OPTIONS = '.list-box-options'
+const SELECTOR_SEARCH = '[data-coreui-list-box-search]'
 const SELECTOR_SECTION = '.list-box-section'
 const SELECTOR_SELECT_ALL = '[data-coreui-select-all]'
 
 const ATTRIBUTE_INDICATOR = 'data-coreui-indicator'
 
 const INDICATOR_CHECKBOX = 'checkbox'
+
+const SEARCH_EXTERNAL = 'external'
 
 const SELECTION_MODE_MULTIPLE = 'multiple'
 const SELECTION_MODE_NONE = 'none'
@@ -99,6 +106,7 @@ type ListBoxEntry = ListBoxItem | ListBoxGroup
 type ListBoxConfig = {
   activeDescendant: string | Element | null
   allowList: SanitizerAllowList
+  ariaSearchLabel: string
   disabled: boolean
   html: boolean
   indicator: string
@@ -106,6 +114,8 @@ type ListBoxConfig = {
   loading: boolean
   sanitize: boolean
   sanitizeFn: ((unsafeHtml: string) => string) | null
+  search: boolean | string
+  searchPlaceholder: string
   selected: string | string[] | null
   selectionLimit: number | null
   selectionMode: string
@@ -115,6 +125,7 @@ type ListBoxConfig = {
 const Default: ListBoxConfig = {
   activeDescendant: null,
   allowList: DefaultAllowlist,
+  ariaSearchLabel: 'Search options',
   disabled: false,
   html: false,
   indicator: 'none',
@@ -122,6 +133,8 @@ const Default: ListBoxConfig = {
   loading: false,
   sanitize: true,
   sanitizeFn: null,
+  search: false,
+  searchPlaceholder: 'Search',
   selected: null,
   selectionLimit: null,
   selectionMode: SELECTION_MODE_SINGLE,
@@ -131,6 +144,7 @@ const Default: ListBoxConfig = {
 const DefaultType: Record<string, string> = {
   activeDescendant: '(string|element|null)',
   allowList: 'object',
+  ariaSearchLabel: 'string',
   disabled: 'boolean',
   html: 'boolean',
   indicator: 'string',
@@ -138,6 +152,8 @@ const DefaultType: Record<string, string> = {
   loading: 'boolean',
   sanitize: 'boolean',
   sanitizeFn: '(null|function)',
+  search: '(boolean|string)',
+  searchPlaceholder: 'string',
   selected: '(string|array|null)',
   selectionLimit: '(null|number)',
   selectionMode: 'string',
@@ -157,6 +173,7 @@ class ListBox extends BaseComponent {
   protected declare _limited: string | null
   protected declare _list: HTMLElement
   protected declare _search: string
+  protected declare _searchField: HTMLInputElement | null
   protected declare _searchTimeout: ReturnType<typeof setTimeout> | null
   protected declare _selected: Set<string>
   protected declare _selectAll: HTMLButtonElement | null
@@ -172,6 +189,7 @@ class ListBox extends BaseComponent {
     this._limited = null
     this._list = this._resolveList()
     this._search = ''
+    this._searchField = this._resolveSearch()
     this._searchTimeout = null
     this._selectAll = SelectorEngine.findOne(SELECTOR_SELECT_ALL, this._element) as HTMLButtonElement | null
     this._selected = new Set(this._initialSelection())
@@ -315,6 +333,9 @@ class ListBox extends BaseComponent {
   update(): void {
     this._list.setAttribute('role', 'listbox')
 
+    this._decorateSearch()
+    this._filter()
+
     if (this._config.indicator === INDICATOR_CHECKBOX) {
       this._element.setAttribute(ATTRIBUTE_INDICATOR, INDICATOR_CHECKBOX)
     }
@@ -409,6 +430,56 @@ class ListBox extends BaseComponent {
   }
 
   // Private
+  _resolveSearch(): HTMLInputElement | null {
+    const existing = SelectorEngine.findOne(SELECTOR_SEARCH, this._element) as HTMLInputElement | null
+
+    if (existing || !this._config.search) {
+      return existing
+    }
+
+    const search = document.createElement('input')
+
+    search.type = 'search'
+    search.className = `${CLASS_NAME_FORM_CONTROL} ${CLASS_NAME_SEARCH}`
+    search.setAttribute('data-coreui-list-box-search', '')
+    this._list.before(search)
+
+    return search
+  }
+
+  _decorateSearch(): void {
+    if (!this._searchField) {
+      return
+    }
+
+    if (!this._list.id) {
+      this._list.id = getUID(`${NAME}-options-`)
+    }
+
+    if (!this._searchField.placeholder) {
+      this._searchField.placeholder = this._config.searchPlaceholder
+    }
+
+    if (!this._searchField.hasAttribute('aria-label')) {
+      this._searchField.setAttribute('aria-label', this._config.ariaSearchLabel)
+    }
+
+    this._searchField.setAttribute('aria-controls', this._list.id)
+    this._searchField.disabled = this._config.disabled
+  }
+
+  _filter(): void {
+    if (!this._searchField || this._config.search === SEARCH_EXTERNAL) {
+      return
+    }
+
+    const query = this._searchField.value.trim().toLowerCase()
+
+    for (const option of this._allOptions()) {
+      option.toggleAttribute('hidden', query !== '' && !this._optionText(option).includes(query))
+    }
+  }
+
   _initialSelection(): string[] {
     const { selected } = this._config
     const configured = selected === null ? [] : (Array.isArray(selected) ? selected : [selected])
@@ -876,6 +947,16 @@ class ListBox extends BaseComponent {
         this._focused = false
         this.update()
       }
+    })
+    EventHandler.on(this._element, this.constructor.eventName(EVENT_INPUT), SELECTOR_SEARCH, (event: any) => {
+      if (this._config.search === SEARCH_EXTERNAL) {
+        EventHandler.trigger(this._element, this.constructor.eventName(EVENT_SEARCH), {
+          query: (event.target as HTMLInputElement).value
+        })
+        return
+      }
+
+      this.update()
     })
     EventHandler.on(this._element, this.constructor.eventName(EVENT_FOCUSIN), SELECTOR_OPTION, (event: any) => {
       if (!this._config.disabled && !this._field) {

--- a/js/src/list-box.ts
+++ b/js/src/list-box.ts
@@ -56,6 +56,7 @@ const CLASS_NAME_ACTIVE = 'active'
 const CLASS_NAME_CHECK = 'check'
 const CLASS_NAME_DISABLED = 'disabled'
 const CLASS_NAME_FORM_CONTROL = 'form-control'
+const CLASS_NAME_HEADER = 'list-box-header'
 const CLASS_NAME_INDETERMINATE = 'indeterminate'
 const CLASS_NAME_LOADING = 'loading'
 const CLASS_NAME_OPTION = 'list-box-option'
@@ -66,10 +67,13 @@ const CLASS_NAME_OPTIONS = 'list-box-options'
 const CLASS_NAME_SEARCH = 'list-box-search'
 const CLASS_NAME_SECTION = 'list-box-section'
 const CLASS_NAME_SECTION_LABEL = 'list-box-section-label'
+const CLASS_NAME_SUBTITLE = 'list-box-subtitle'
 const CLASS_NAME_SELECTED = 'selected'
 
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="list-box"]'
+const SELECTOR_COUNTER = '[data-coreui-list-box-counter]'
 const SELECTOR_EMPTY = '.list-box-empty'
+const SELECTOR_HEADER = '.list-box-header'
 const SELECTOR_OPTION = '.list-box-option'
 const SELECTOR_OPTION_INDICATOR = '.list-box-option-indicator'
 const SELECTOR_OPTION_LABEL = '.list-box-option-label'
@@ -107,6 +111,7 @@ type ListBoxConfig = {
   activeDescendant: string | Element | null
   allowList: SanitizerAllowList
   ariaSearchLabel: string
+  counter: boolean
   disabled: boolean
   html: boolean
   indicator: string
@@ -117,6 +122,7 @@ type ListBoxConfig = {
   search: boolean | string
   searchPlaceholder: string
   selected: string | string[] | null
+  selectedCounterText: string
   selectionLimit: number | null
   selectionMode: string
   typeahead: boolean
@@ -126,6 +132,7 @@ const Default: ListBoxConfig = {
   activeDescendant: null,
   allowList: DefaultAllowlist,
   ariaSearchLabel: 'Search options',
+  counter: false,
   disabled: false,
   html: false,
   indicator: 'none',
@@ -136,6 +143,7 @@ const Default: ListBoxConfig = {
   search: false,
   searchPlaceholder: 'Search',
   selected: null,
+  selectedCounterText: 'selected',
   selectionLimit: null,
   selectionMode: SELECTION_MODE_SINGLE,
   typeahead: true
@@ -145,6 +153,7 @@ const DefaultType: Record<string, string> = {
   activeDescendant: '(string|element|null)',
   allowList: 'object',
   ariaSearchLabel: 'string',
+  counter: 'boolean',
   disabled: 'boolean',
   html: 'boolean',
   indicator: 'string',
@@ -155,6 +164,7 @@ const DefaultType: Record<string, string> = {
   search: '(boolean|string)',
   searchPlaceholder: 'string',
   selected: '(string|array|null)',
+  selectedCounterText: 'string',
   selectionLimit: '(null|number)',
   selectionMode: 'string',
   typeahead: 'boolean'
@@ -167,6 +177,7 @@ const DefaultType: Record<string, string> = {
 class ListBox extends BaseComponent {
   protected declare _active: string | null
   protected declare _anchor: string | null
+  protected declare _counter: HTMLElement | null
   protected declare _field: HTMLElement | null
   protected declare _items: ListBoxEntry[] | null
   protected declare _focused: boolean
@@ -188,6 +199,7 @@ class ListBox extends BaseComponent {
     this._focused = false
     this._limited = null
     this._list = this._resolveList()
+    this._counter = this._resolveCounter()
     this._search = ''
     this._searchField = this._resolveSearch()
     this._searchTimeout = null
@@ -407,6 +419,7 @@ class ListBox extends BaseComponent {
     }
 
     this._updateSelectAll()
+    this._updateCounter()
     this._updateActiveDescendant()
   }
 
@@ -430,6 +443,48 @@ class ListBox extends BaseComponent {
   }
 
   // Private
+  _resolveCounter(): HTMLElement | null {
+    const existing = SelectorEngine.findOne(SELECTOR_COUNTER, this._element) as HTMLElement | null
+
+    if (existing || !this._config.counter) {
+      return existing
+    }
+
+    const counter = document.createElement('div')
+
+    counter.classList.add(CLASS_NAME_SUBTITLE)
+    counter.setAttribute('data-coreui-list-box-counter', '')
+    this._resolveHeader().append(counter)
+
+    return counter
+  }
+
+  _resolveHeader(): HTMLElement {
+    const existing = SelectorEngine.findOne(SELECTOR_HEADER, this._element) as HTMLElement | null
+
+    if (existing) {
+      return existing
+    }
+
+    const header = document.createElement('div')
+
+    header.classList.add(CLASS_NAME_HEADER)
+    this._element.prepend(header)
+
+    return header
+  }
+
+  _updateCounter(): void {
+    if (!this._counter) {
+      return
+    }
+
+    const navigable = this._navigableOptions()
+    const count = navigable.filter(option => this._selected.has(this._optionValue(option))).length
+
+    this._counter.textContent = `${count}/${navigable.length} ${this._config.selectedCounterText}`
+  }
+
   _resolveSearch(): HTMLInputElement | null {
     const existing = SelectorEngine.findOne(SELECTOR_SEARCH, this._element) as HTMLInputElement | null
 

--- a/js/src/transfer.ts
+++ b/js/src/transfer.ts
@@ -30,25 +30,23 @@ const EVENT_SEARCH = 'search'
 const EVENT_CLICK = 'click'
 const EVENT_INPUT = 'input'
 const EVENT_LIST_BOX_CHANGE = 'change.coreui.list-box'
+const EVENT_LIST_BOX_SEARCH = 'search.coreui.list-box'
 
 const CLASS_NAME_ANNOUNCER = 'transfer-announcer'
 const CLASS_NAME_DISABLED = 'disabled'
 const CLASS_NAME_OPTIONS = 'list-box-options'
-const CLASS_NAME_SEARCH = 'transfer-search'
 const CLASS_NAME_SUBTITLE = 'list-box-subtitle'
 const CLASS_NAME_VISUALLY_HIDDEN = 'visually-hidden'
 
 const SELECTOR_COUNTER = '[data-coreui-transfer-counter]'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="transfer"]'
 const SELECTOR_HEADER = '.list-box-header'
+const SELECTOR_LIST = '[data-coreui-transfer-list]'
 const SELECTOR_MOVE = '[data-coreui-transfer-move]'
 const SELECTOR_OPTION = '.list-box-option'
-const SELECTOR_OPTION_LABEL = '.list-box-option-label'
 const SELECTOR_OPTIONS = '.list-box-options'
-const SELECTOR_SEARCH = '[data-coreui-transfer-search]'
+const SELECTOR_SEARCH = '[data-coreui-list-box-search]'
 const SELECTOR_SELECT_ALL = '[data-coreui-select-all]'
-
-const SEARCH_EXTERNAL = 'external'
 
 const SIDE_SOURCE = 'source'
 const SIDE_TARGET = 'target'
@@ -65,8 +63,8 @@ type TransferSide = {
   counter: HTMLElement | null
   element: HTMLElement
   listBox: ListBox
+  name: string
   options: HTMLElement
-  search: HTMLInputElement | null
   selectAll: HTMLElement | null
   title: string
 }
@@ -164,6 +162,7 @@ class Transfer extends BaseComponent {
   protected declare _itemRanks: Map<string, number>
   protected declare _items: ListBoxEntry[] | null
   protected declare _onListBoxChange: () => void
+  protected declare _onListBoxSearch: (event: Event) => void
   protected declare _order: WeakMap<HTMLElement, number>
   protected declare _ranks: number
   protected declare _rendered: boolean
@@ -180,6 +179,7 @@ class Transfer extends BaseComponent {
       [SIDE_TARGET]: this._createSide(SIDE_TARGET)
     }
     this._onListBoxChange = () => this._refresh()
+    this._onListBoxSearch = (event: Event) => this._reportSearch(event)
     this._order = new WeakMap()
     this._ranks = 0
     this._rendered = false
@@ -261,7 +261,6 @@ class Transfer extends BaseComponent {
 
     for (const side of Object.values(this._sides)) {
       this._decorateSide(side)
-      this._filter(side)
       side.listBox.update()
     }
 
@@ -271,6 +270,7 @@ class Transfer extends BaseComponent {
 
   override dispose(): void {
     this._element.removeEventListener(EVENT_LIST_BOX_CHANGE, this._onListBoxChange)
+    this._element.removeEventListener(EVENT_LIST_BOX_SEARCH, this._onListBoxSearch)
     EventHandler.off(this._element, EVENT_KEY)
 
     for (const side of Object.values(this._sides)) {
@@ -308,17 +308,20 @@ class Transfer extends BaseComponent {
       element,
       listBox: ListBox.getOrCreateInstance(element, {
         allowList: this._config.allowList,
+        ariaSearchLabel: `${this._config.searchPlaceholder} ${title}`,
         disabled: this._config.disabled,
         html: this._config.html,
         indicator: this._config.indicator,
         loading: this._config.loading,
         sanitize: this._config.sanitize,
         sanitizeFn: this._config.sanitizeFn,
+        search: this._config.search,
+        searchPlaceholder: this._config.searchPlaceholder,
         selectionMode: 'multiple',
         typeahead: this._config.typeahead
       }) as ListBox,
+      name,
       options,
-      search: this._resolveSearch(element, options, title),
       selectAll: SelectorEngine.findOne(SELECTOR_SELECT_ALL, element),
       title
     }
@@ -365,25 +368,6 @@ class Transfer extends BaseComponent {
     return counter
   }
 
-  _resolveSearch(element: HTMLElement, options: HTMLElement, title: string): HTMLInputElement | null {
-    const existing = SelectorEngine.findOne(SELECTOR_SEARCH, element) as HTMLInputElement | null
-
-    if (existing || !this._config.search) {
-      return existing
-    }
-
-    const search = document.createElement('input')
-
-    search.type = 'search'
-    search.className = `form-control ${CLASS_NAME_SEARCH}`
-    search.setAttribute('data-coreui-transfer-search', '')
-    search.placeholder = this._config.searchPlaceholder
-    search.setAttribute('aria-label', `${this._config.searchPlaceholder} ${title}`)
-    options.before(search)
-
-    return search
-  }
-
   _decorateSide(side: TransferSide): void {
     if (!side.options.id) {
       side.options.id = getUID(`${NAME}-options-`)
@@ -395,14 +379,6 @@ class Transfer extends BaseComponent {
 
     if (side.selectAll && side.selectAll.textContent?.trim() === '') {
       side.selectAll.textContent = side.title
-    }
-
-    if (side.search) {
-      side.search.disabled = this._config.disabled
-
-      if (!side.search.hasAttribute('aria-label')) {
-        side.search.setAttribute('aria-label', `${this._config.searchPlaceholder} ${side.title}`)
-      }
     }
   }
 
@@ -605,21 +581,23 @@ class Transfer extends BaseComponent {
     return option.dataset.coreuiValue ?? option.textContent?.trim() ?? ''
   }
 
-  _optionText(option: HTMLElement): string {
-    const label = SelectorEngine.findOne(SELECTOR_OPTION_LABEL, option)
-    return (label ?? option).textContent?.trim().toLowerCase() ?? ''
+  _sideOf(element: HTMLElement): TransferSide | null {
+    const list = element.closest(SELECTOR_LIST) as HTMLElement | null
+
+    return list ? this._sides[list.dataset.coreuiTransferList as string] ?? null : null
   }
 
-  _filter(side: TransferSide): void {
-    if (!side.search || this._config.search === SEARCH_EXTERNAL) {
+  _reportSearch(event: Event): void {
+    const side = this._sideOf(event.target as HTMLElement)
+
+    if (!side) {
       return
     }
 
-    const query = side.search.value.trim().toLowerCase()
-
-    for (const option of this._options(side)) {
-      option.toggleAttribute('hidden', query !== '' && !this._optionText(option).includes(query))
-    }
+    EventHandler.trigger(this._element, this.constructor.eventName(EVENT_SEARCH), {
+      query: (event as CustomEvent & { query: string }).query,
+      side: side.name
+    })
   }
 
   _refresh(): void {
@@ -686,8 +664,6 @@ class Transfer extends BaseComponent {
     }
 
     to.listBox.clear()
-    this._filter(from)
-    this._filter(to)
     from.listBox.update()
     to.listBox.update()
     this._refresh()
@@ -732,26 +708,16 @@ class Transfer extends BaseComponent {
     })
 
     EventHandler.on(this._element, this.constructor.eventName(EVENT_INPUT), SELECTOR_SEARCH, (event: any) => {
-      const name = Object.keys(this._sides).find(key => this._sides[key].search === event.target)
+      const side = this._sideOf(event.target as HTMLElement)
 
-      if (!name) {
-        return
+      if (side) {
+        side.listBox.update()
+        this._refresh()
       }
-
-      if (this._config.search === SEARCH_EXTERNAL) {
-        EventHandler.trigger(this._element, this.constructor.eventName(EVENT_SEARCH), {
-          query: (event.target as HTMLInputElement).value,
-          side: name
-        })
-        return
-      }
-
-      this._filter(this._sides[name])
-      this._sides[name].listBox.update()
-      this._refresh()
     })
 
     this._element.addEventListener(EVENT_LIST_BOX_CHANGE, this._onListBoxChange)
+    this._element.addEventListener(EVENT_LIST_BOX_SEARCH, this._onListBoxSearch)
   }
 
   // Static

--- a/js/src/transfer.ts
+++ b/js/src/transfer.ts
@@ -35,12 +35,9 @@ const EVENT_LIST_BOX_SEARCH = 'search.coreui.list-box'
 const CLASS_NAME_ANNOUNCER = 'transfer-announcer'
 const CLASS_NAME_DISABLED = 'disabled'
 const CLASS_NAME_OPTIONS = 'list-box-options'
-const CLASS_NAME_SUBTITLE = 'list-box-subtitle'
 const CLASS_NAME_VISUALLY_HIDDEN = 'visually-hidden'
 
-const SELECTOR_COUNTER = '[data-coreui-transfer-counter]'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="transfer"]'
-const SELECTOR_HEADER = '.list-box-header'
 const SELECTOR_LIST = '[data-coreui-transfer-list]'
 const SELECTOR_MOVE = '[data-coreui-transfer-move]'
 const SELECTOR_OPTION = '.list-box-option'
@@ -60,7 +57,6 @@ const CHEVRON_DOUBLE_LEFT_ICON: string = '<svg class="icon" xmlns="http://www.w3
 const CHEVRON_DOUBLE_RIGHT_ICON: string = '<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" aria-hidden="true"><path fill="var(--ci-primary-color, currentcolor)" d="m95.314 447.313-22.628-22.626L245.373 252 72.686 79.313l22.628-22.626L290.627 252z" class="ci-primary"/><path fill="var(--ci-primary-color, currentcolor)" d="m255.314 447.313-22.628-22.626L405.373 252 232.686 79.313l22.628-22.626L450.627 252z" class="ci-primary"/></svg>'
 
 type TransferSide = {
-  counter: HTMLElement | null
   element: HTMLElement
   listBox: ListBox
   name: string
@@ -304,11 +300,11 @@ class Transfer extends BaseComponent {
     const options = this._resolveOptions(element)
 
     return {
-      counter: this._resolveCounter(element),
       element,
       listBox: ListBox.getOrCreateInstance(element, {
         allowList: this._config.allowList,
         ariaSearchLabel: `${this._config.searchPlaceholder} ${title}`,
+        counter: true,
         disabled: this._config.disabled,
         html: this._config.html,
         indicator: this._config.indicator,
@@ -317,6 +313,7 @@ class Transfer extends BaseComponent {
         sanitizeFn: this._config.sanitizeFn,
         search: this._config.search,
         searchPlaceholder: this._config.searchPlaceholder,
+        selectedCounterText: this._config.selectedCounterText,
         selectionMode: 'multiple',
         typeahead: this._config.typeahead
       }) as ListBox,
@@ -344,28 +341,6 @@ class Transfer extends BaseComponent {
     element.append(options)
 
     return options
-  }
-
-  _resolveCounter(element: HTMLElement): HTMLElement | null {
-    const existing = SelectorEngine.findOne(SELECTOR_COUNTER, element)
-
-    if (existing) {
-      return existing
-    }
-
-    const header = SelectorEngine.findOne(SELECTOR_HEADER, element)
-
-    if (!header) {
-      return null
-    }
-
-    const counter = document.createElement('div')
-
-    counter.classList.add(CLASS_NAME_SUBTITLE)
-    counter.setAttribute('data-coreui-transfer-counter', '')
-    header.append(counter)
-
-    return counter
   }
 
   _decorateSide(side: TransferSide): void {
@@ -601,23 +576,7 @@ class Transfer extends BaseComponent {
   }
 
   _refresh(): void {
-    for (const side of Object.values(this._sides)) {
-      this._refreshCounter(side)
-    }
-
     this._refreshMoveButtons()
-  }
-
-  _refreshCounter(side: TransferSide): void {
-    if (!side.counter) {
-      return
-    }
-
-    const visible = this._visibleOptions(side)
-    const selected = side.listBox.getSelected()
-    const count = visible.filter(option => selected.includes(this._optionValue(option))).length
-
-    side.counter.textContent = `${count}/${visible.length} ${this._config.selectedCounterText}`
   }
 
   _refreshMoveButtons(): void {

--- a/js/src/transfer.ts
+++ b/js/src/transfer.ts
@@ -166,6 +166,7 @@ class Transfer extends BaseComponent {
   protected declare _onListBoxChange: () => void
   protected declare _order: WeakMap<HTMLElement, number>
   protected declare _ranks: number
+  protected declare _rendered: boolean
   protected declare _sides: Record<string, TransferSide>
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
@@ -181,6 +182,7 @@ class Transfer extends BaseComponent {
     this._onListBoxChange = () => this._refresh()
     this._order = new WeakMap()
     this._ranks = 0
+    this._rendered = false
 
     if (this._items) {
       this._applyItems(this._config.value)
@@ -243,6 +245,10 @@ class Transfer extends BaseComponent {
   }
 
   setLoading(loading: boolean, side?: string): void {
+    if (side === undefined) {
+      this._config.loading = loading
+    }
+
     for (const [name, entry] of Object.entries(this._sides)) {
       if (side === undefined || side === name) {
         entry.listBox.setLoading(loading)
@@ -476,8 +482,41 @@ class Transfer extends BaseComponent {
     const chosen = (Array.isArray(values) ? values : []).filter(value => byValue.has(value))
     const taken = new Set(chosen)
 
-    this._sides[SIDE_TARGET].listBox.setItems(chosen.map(value => byValue.get(value) as ListBoxItem))
-    this._sides[SIDE_SOURCE].listBox.setItems(this._availableItems(items, taken))
+    this._sides[SIDE_TARGET].listBox.setItems(this._forwardItems(chosen.map(value => byValue.get(value) as ListBoxItem)))
+    this._sides[SIDE_SOURCE].listBox.setItems(this._forwardItems(this._availableItems(items, taken)))
+
+    if (this._rendered) {
+      for (const side of Object.values(this._sides)) {
+        side.listBox.clear()
+      }
+    }
+
+    this._rendered = true
+  }
+
+  _forwardItems(entries: ListBoxEntry[]): ListBoxEntry[] {
+    if (!this._rendered) {
+      return entries
+    }
+
+    return entries.map(entry => {
+      if (Array.isArray((entry as ListBoxGroup).items)) {
+        const group = entry as ListBoxGroup
+        return { label: group.label, items: group.items.map(item => this._unmarked(item)) }
+      }
+
+      return this._unmarked(entry as ListBoxItem)
+    })
+  }
+
+  _unmarked(item: ListBoxItem): ListBoxItem {
+    if (!item.selected) {
+      return item
+    }
+
+    const { selected, ...rest } = item
+
+    return rest
   }
 
   _availableItems(items: ListBoxEntry[], taken: Set<string>): ListBoxEntry[] {
@@ -646,6 +685,7 @@ class Transfer extends BaseComponent {
       this._insertInOriginalOrder(to, options)
     }
 
+    to.listBox.clear()
     this._filter(from)
     this._filter(to)
     from.listBox.update()

--- a/js/src/transfer.ts
+++ b/js/src/transfer.ts
@@ -6,7 +6,7 @@
  */
 
 import BaseComponent from './base-component.js'
-import ListBox from './list-box.js'
+import ListBox, { type ListBoxEntry, type ListBoxGroup, type ListBoxItem } from './list-box.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
@@ -25,6 +25,7 @@ const DATA_API_KEY = '.data-api'
 const EVENT_CHANGE = 'change'
 const EVENT_MOVE = 'move'
 const EVENT_MOVED = 'moved'
+const EVENT_SEARCH = 'search'
 
 const EVENT_CLICK = 'click'
 const EVENT_INPUT = 'input'
@@ -32,6 +33,7 @@ const EVENT_LIST_BOX_CHANGE = 'change.coreui.list-box'
 
 const CLASS_NAME_ANNOUNCER = 'transfer-announcer'
 const CLASS_NAME_DISABLED = 'disabled'
+const CLASS_NAME_OPTIONS = 'list-box-options'
 const CLASS_NAME_SEARCH = 'transfer-search'
 const CLASS_NAME_SUBTITLE = 'list-box-subtitle'
 const CLASS_NAME_VISUALLY_HIDDEN = 'visually-hidden'
@@ -45,6 +47,8 @@ const SELECTOR_OPTION_LABEL = '.list-box-option-label'
 const SELECTOR_OPTIONS = '.list-box-options'
 const SELECTOR_SEARCH = '[data-coreui-transfer-search]'
 const SELECTOR_SELECT_ALL = '[data-coreui-select-all]'
+
+const SEARCH_EXTERNAL = 'external'
 
 const SIDE_SOURCE = 'source'
 const SIDE_TARGET = 'target'
@@ -75,7 +79,10 @@ type TransferConfig = {
   ariaMoveToTargetLabel: string
   ariaMovedAnnouncement: string
   disabled: boolean
+  html: boolean
   indicator: string
+  items: ListBoxEntry[]
+  loading: boolean
   moveAllToSourceIcon: string
   moveAllToTargetIcon: string
   moveToSourceIcon: string
@@ -83,12 +90,13 @@ type TransferConfig = {
   oneWay: boolean
   sanitize: boolean
   sanitizeFn: ((unsafeHtml: string) => string) | null
-  search: boolean
+  search: boolean | string
   searchPlaceholder: string
   selectedCounterText: string
   sourceTitle: string
   targetTitle: string
   typeahead: boolean
+  value: string[]
 }
 
 const Default: TransferConfig = {
@@ -99,7 +107,10 @@ const Default: TransferConfig = {
   ariaMoveToTargetLabel: 'Move to chosen',
   ariaMovedAnnouncement: '{count} moved to {title}',
   disabled: false,
+  html: false,
   indicator: 'checkbox',
+  items: [],
+  loading: false,
   moveAllToSourceIcon: CHEVRON_DOUBLE_LEFT_ICON,
   moveAllToTargetIcon: CHEVRON_DOUBLE_RIGHT_ICON,
   moveToSourceIcon: CHEVRON_LEFT_ICON,
@@ -112,7 +123,8 @@ const Default: TransferConfig = {
   selectedCounterText: 'selected',
   sourceTitle: 'Available',
   targetTitle: 'Chosen',
-  typeahead: true
+  typeahead: true,
+  value: []
 }
 
 const DefaultType: Record<string, string> = {
@@ -123,7 +135,10 @@ const DefaultType: Record<string, string> = {
   ariaMoveToTargetLabel: 'string',
   ariaMovedAnnouncement: 'string',
   disabled: 'boolean',
+  html: 'boolean',
   indicator: 'string',
+  items: 'array',
+  loading: 'boolean',
   moveAllToSourceIcon: 'string',
   moveAllToTargetIcon: 'string',
   moveToSourceIcon: 'string',
@@ -131,12 +146,13 @@ const DefaultType: Record<string, string> = {
   oneWay: 'boolean',
   sanitize: 'boolean',
   sanitizeFn: '(function|null)',
-  search: 'boolean',
+  search: '(boolean|string)',
   searchPlaceholder: 'string',
   selectedCounterText: 'string',
   sourceTitle: 'string',
   targetTitle: 'string',
-  typeahead: 'boolean'
+  typeahead: 'boolean',
+  value: 'array'
 }
 
 /**
@@ -145,6 +161,8 @@ const DefaultType: Record<string, string> = {
 
 class Transfer extends BaseComponent {
   protected declare _announcer: HTMLElement
+  protected declare _itemRanks: Map<string, number>
+  protected declare _items: ListBoxEntry[] | null
   protected declare _onListBoxChange: () => void
   protected declare _order: WeakMap<HTMLElement, number>
   protected declare _ranks: number
@@ -154,6 +172,8 @@ class Transfer extends BaseComponent {
     super(element, config)
 
     this._announcer = this._createAnnouncer()
+    this._itemRanks = new Map()
+    this._items = this._config.items.length > 0 ? this._config.items : null
     this._sides = {
       [SIDE_SOURCE]: this._createSide(SIDE_SOURCE),
       [SIDE_TARGET]: this._createSide(SIDE_TARGET)
@@ -161,6 +181,10 @@ class Transfer extends BaseComponent {
     this._onListBoxChange = () => this._refresh()
     this._order = new WeakMap()
     this._ranks = 0
+
+    if (this._items) {
+      this._applyItems(this._config.value)
+    }
 
     this._addEventListeners()
     this.update()
@@ -208,6 +232,24 @@ class Transfer extends BaseComponent {
     return this._sides[side].listBox.getSelected()
   }
 
+  setItems(items: ListBoxEntry[]): void {
+    this._items = Array.isArray(items) ? items : []
+    this._applyItems(this.getTarget())
+    this.update()
+  }
+
+  getItems(): ListBoxEntry[] {
+    return this._items ?? []
+  }
+
+  setLoading(loading: boolean, side?: string): void {
+    for (const [name, entry] of Object.entries(this._sides)) {
+      if (side === undefined || side === name) {
+        entry.listBox.setLoading(loading)
+      }
+    }
+  }
+
   update(): void {
     this._rankOptions()
 
@@ -253,14 +295,19 @@ class Transfer extends BaseComponent {
     }
 
     const title = name === SIDE_SOURCE ? this._config.sourceTitle : this._config.targetTitle
-    const options = (SelectorEngine.findOne(SELECTOR_OPTIONS, element) ?? element) as HTMLElement
+    const options = this._resolveOptions(element)
 
     return {
       counter: this._resolveCounter(element),
       element,
       listBox: ListBox.getOrCreateInstance(element, {
+        allowList: this._config.allowList,
         disabled: this._config.disabled,
+        html: this._config.html,
         indicator: this._config.indicator,
+        loading: this._config.loading,
+        sanitize: this._config.sanitize,
+        sanitizeFn: this._config.sanitizeFn,
         selectionMode: 'multiple',
         typeahead: this._config.typeahead
       }) as ListBox,
@@ -269,6 +316,25 @@ class Transfer extends BaseComponent {
       selectAll: SelectorEngine.findOne(SELECTOR_SELECT_ALL, element),
       title
     }
+  }
+
+  _resolveOptions(element: HTMLElement): HTMLElement {
+    const existing = SelectorEngine.findOne(SELECTOR_OPTIONS, element) as HTMLElement | null
+
+    if (existing) {
+      return existing
+    }
+
+    if (!this._items) {
+      return element
+    }
+
+    const options = document.createElement('div')
+
+    options.classList.add(CLASS_NAME_OPTIONS)
+    element.append(options)
+
+    return options
   }
 
   _resolveCounter(element: HTMLElement): HTMLElement | null {
@@ -400,7 +466,62 @@ class Transfer extends BaseComponent {
     return this._options(side).filter(option => !option.hasAttribute('hidden'))
   }
 
+  _applyItems(values: string[]): void {
+    const items = this._items ?? []
+    const flat = this._flatItems(items)
+    const byValue = new Map(flat.map(item => [this._itemValue(item), item]))
+
+    this._itemRanks = new Map([...byValue.keys()].map((value, index) => [value, index]))
+
+    const chosen = (Array.isArray(values) ? values : []).filter(value => byValue.has(value))
+    const taken = new Set(chosen)
+
+    this._sides[SIDE_TARGET].listBox.setItems(chosen.map(value => byValue.get(value) as ListBoxItem))
+    this._sides[SIDE_SOURCE].listBox.setItems(this._availableItems(items, taken))
+  }
+
+  _availableItems(items: ListBoxEntry[], taken: Set<string>): ListBoxEntry[] {
+    const available: ListBoxEntry[] = []
+
+    for (const entry of items) {
+      if (entry === null || typeof entry !== 'object') {
+        continue
+      }
+
+      if (!Array.isArray((entry as ListBoxGroup).items)) {
+        if (!taken.has(this._itemValue(entry as ListBoxItem))) {
+          available.push(entry)
+        }
+
+        continue
+      }
+
+      const group = entry as ListBoxGroup
+      const rest = group.items.filter(item => !taken.has(this._itemValue(item)))
+
+      if (rest.length > 0) {
+        available.push({ label: group.label, items: rest })
+      }
+    }
+
+    return available
+  }
+
+  _flatItems(items: ListBoxEntry[]): ListBoxItem[] {
+    return items
+      .filter(entry => entry !== null && typeof entry === 'object')
+      .flatMap(entry => (Array.isArray((entry as ListBoxGroup).items) ? (entry as ListBoxGroup).items : [entry as ListBoxItem]))
+  }
+
+  _itemValue(item: ListBoxItem): string {
+    return String(item.value ?? item.label ?? '')
+  }
+
   _rankOptions(): void {
+    if (this._items) {
+      return
+    }
+
     for (const side of [this._sides[SIDE_SOURCE], this._sides[SIDE_TARGET]]) {
       for (const option of this._options(side)) {
         if (!this._order.has(option)) {
@@ -411,6 +532,10 @@ class Transfer extends BaseComponent {
   }
 
   _rankOf(option: HTMLElement): number {
+    if (this._items) {
+      return this._itemRanks.get(this._optionValue(option)) ?? Number.MAX_SAFE_INTEGER
+    }
+
     return this._order.get(option) ?? Number.MAX_SAFE_INTEGER
   }
 
@@ -447,7 +572,7 @@ class Transfer extends BaseComponent {
   }
 
   _filter(side: TransferSide): void {
-    if (!side.search) {
+    if (!side.search || this._config.search === SEARCH_EXTERNAL) {
       return
     }
 
@@ -567,13 +692,23 @@ class Transfer extends BaseComponent {
     })
 
     EventHandler.on(this._element, this.constructor.eventName(EVENT_INPUT), SELECTOR_SEARCH, (event: any) => {
-      const side = Object.values(this._sides).find(({ search }) => search === event.target)
+      const name = Object.keys(this._sides).find(key => this._sides[key].search === event.target)
 
-      if (side) {
-        this._filter(side)
-        side.listBox.update()
-        this._refresh()
+      if (!name) {
+        return
       }
+
+      if (this._config.search === SEARCH_EXTERNAL) {
+        EventHandler.trigger(this._element, this.constructor.eventName(EVENT_SEARCH), {
+          query: (event.target as HTMLInputElement).value,
+          side: name
+        })
+        return
+      }
+
+      this._filter(this._sides[name])
+      this._sides[name].listBox.update()
+      this._refresh()
     })
 
     this._element.addEventListener(EVENT_LIST_BOX_CHANGE, this._onListBoxChange)

--- a/js/tests/unit/list-box.spec.js
+++ b/js/tests/unit/list-box.spec.js
@@ -90,6 +90,7 @@ describe('ListBox', () => {
         activeDescendant: null,
         allowList: DefaultAllowlist,
         ariaSearchLabel: 'Search options',
+        counter: false,
         disabled: false,
         html: false,
         indicator: 'none',
@@ -100,6 +101,7 @@ describe('ListBox', () => {
         search: false,
         searchPlaceholder: 'Search',
         selected: null,
+        selectedCounterText: 'selected',
         selectionLimit: null,
         selectionMode: 'single',
         typeahead: true
@@ -1123,6 +1125,76 @@ describe('ListBox', () => {
       })
 
       expect(item(el, 'a').querySelector('em').textContent).toEqual('Ok')
+    })
+  })
+
+  describe('counter', () => {
+    it('should count the selection in the header', () => {
+      const el = setMarkup('', null, selectAllMarkup)
+      const listBox = new ListBox(el, { counter: true, selectionMode: 'multiple' })
+      const counter = el.querySelector('[data-coreui-list-box-counter]')
+
+      expect(counter.parentElement.classList.contains('list-box-header')).toBeTrue()
+      expect(counter.previousElementSibling.classList.contains('list-box-select-all')).toBeTrue()
+      expect(counter.classList.contains('list-box-subtitle')).toBeTrue()
+      expect(counter.textContent).toEqual('0/4 selected')
+
+      listBox.select('tomato')
+
+      expect(counter.textContent).toEqual('1/4 selected')
+
+      listBox.deselect('tomato')
+
+      expect(counter.textContent).toEqual('0/4 selected')
+    })
+
+    it('should count against the options the search left', () => {
+      const el = setMarkup()
+      const listBox = new ListBox(el, { counter: true, search: true, selectionMode: 'multiple' })
+      const counter = el.querySelector('[data-coreui-list-box-counter]')
+
+      listBox.select('tomato')
+
+      expect(counter.textContent).toEqual('1/4 selected')
+
+      type(searchField(el), 'on')
+
+      expect(counter.textContent).toEqual('0/1 selected')
+    })
+
+    it('should follow the items it was given', () => {
+      const el = setMarkup()
+      const listBox = new ListBox(el, { counter: true, selectedCounterText: 'picked', selectionMode: 'multiple' })
+      const counter = el.querySelector('[data-coreui-list-box-counter]')
+
+      listBox.setItems([{ value: 'ada', label: 'Ada' }, { value: 'bob', label: 'Bob', selected: true }])
+
+      expect(counter.textContent).toEqual('1/2 picked')
+    })
+
+    it('should build the header when the markup has none', () => {
+      const el = setMarkup()
+      // eslint-disable-next-line no-new
+      new ListBox(el, { counter: true })
+
+      const header = el.querySelector('.list-box-header')
+
+      expect(header).not.toBeNull()
+      expect(el.firstElementChild).toEqual(header)
+      expect(header.querySelector('[data-coreui-list-box-counter]')).not.toBeNull()
+    })
+
+    it('should use the counter the markup already carries', () => {
+      const el = setMarkup('', null, [
+        '<div class="list-box-header">',
+        '<span class="list-box-subtitle" data-coreui-list-box-counter></span>',
+        '</div>'
+      ].join(''))
+      // eslint-disable-next-line no-new
+      new ListBox(el, { counter: true })
+
+      expect(el.querySelectorAll('[data-coreui-list-box-counter]').length).toEqual(1)
+      expect(el.querySelector('[data-coreui-list-box-counter]').tagName).toEqual('SPAN')
     })
   })
 

--- a/js/tests/unit/list-box.spec.js
+++ b/js/tests/unit/list-box.spec.js
@@ -40,6 +40,12 @@ describe('ListBox', () => {
     '</div>'
   ].join('')
   const list = element => element.querySelector('.list-box-options')
+  const searchField = element => element.querySelector('[data-coreui-list-box-search]')
+
+  const type = (element, value) => {
+    element.value = value
+    element.dispatchEvent(new Event('input', { bubbles: true }))
+  }
 
   const keydown = (target, key, modifiers = {}) => {
     target.dispatchEvent(new KeyboardEvent('keydown', {
@@ -83,6 +89,7 @@ describe('ListBox', () => {
       expect(ListBox.Default).toEqual({
         activeDescendant: null,
         allowList: DefaultAllowlist,
+        ariaSearchLabel: 'Search options',
         disabled: false,
         html: false,
         indicator: 'none',
@@ -90,6 +97,8 @@ describe('ListBox', () => {
         loading: false,
         sanitize: true,
         sanitizeFn: null,
+        search: false,
+        searchPlaceholder: 'Search',
         selected: null,
         selectionLimit: null,
         selectionMode: 'single',
@@ -1114,6 +1123,83 @@ describe('ListBox', () => {
       })
 
       expect(item(el, 'a').querySelector('em').textContent).toEqual('Ok')
+    })
+  })
+
+  describe('search', () => {
+    it('should build the search field between the header and the options', () => {
+      const el = setMarkup('', null, selectAllMarkup)
+      // eslint-disable-next-line no-new
+      new ListBox(el, { search: true, searchPlaceholder: 'Filter' })
+
+      const field = searchField(el)
+
+      expect(field).not.toBeNull()
+      expect(field.previousElementSibling.classList.contains('list-box-header')).toBeTrue()
+      expect(field.nextElementSibling.classList.contains('list-box-options')).toBeTrue()
+      expect(field.placeholder).toEqual('Filter')
+      expect(field.getAttribute('aria-label')).toEqual('Search options')
+      expect(field.getAttribute('aria-controls')).toEqual(list(el).id)
+    })
+
+    it('should use the search field the markup already carries', () => {
+      const el = setMarkup()
+      list(el).insertAdjacentHTML(
+        'beforebegin',
+        '<input class="form-control list-box-search" type="search" data-coreui-list-box-search aria-label="Find">'
+      )
+      // eslint-disable-next-line no-new
+      new ListBox(el, { search: true })
+
+      expect(el.querySelectorAll('[data-coreui-list-box-search]').length).toEqual(1)
+      expect(searchField(el).getAttribute('aria-label')).toEqual('Find')
+    })
+
+    it('should filter the options with the built-in search', () => {
+      const el = setMarkup()
+      const listBox = new ListBox(el, { search: true })
+
+      type(searchField(el), 'to')
+
+      expect(item(el, 'tomato').hasAttribute('hidden')).toBeFalse()
+      expect(item(el, 'lettuce').hasAttribute('hidden')).toBeTrue()
+      expect(listBox.getActive()).toBeNull()
+
+      type(searchField(el), '')
+
+      expect(item(el, 'lettuce').hasAttribute('hidden')).toBeFalse()
+    })
+
+    it('should let select all take only the options left by the search', () => {
+      const el = setMarkup('', null, selectAllMarkup)
+      const listBox = new ListBox(el, { search: true, selectionMode: 'multiple' })
+
+      type(searchField(el), 'on')
+      listBox.selectAll()
+
+      expect(listBox.getSelected()).toEqual(['onion'])
+    })
+
+    it('should not filter in external search mode and report the query', () => {
+      const el = setMarkup()
+      // eslint-disable-next-line no-new
+      new ListBox(el, { search: 'external' })
+      const spy = jasmine.createSpy('search')
+
+      el.addEventListener('search.coreui.list-box', event => spy(event.query))
+      type(searchField(el), 'zzz')
+
+      expect(spy).toHaveBeenCalledWith('zzz')
+      expect(item(el, 'lettuce').hasAttribute('hidden')).toBeFalse()
+      expect(item(el, 'tomato').hasAttribute('hidden')).toBeFalse()
+    })
+
+    it('should disable the search field with the list box', () => {
+      const el = setMarkup()
+      // eslint-disable-next-line no-new
+      new ListBox(el, { disabled: true, search: true })
+
+      expect(searchField(el).disabled).toBeTrue()
     })
   })
 

--- a/js/tests/unit/list-box.spec.js
+++ b/js/tests/unit/list-box.spec.js
@@ -1148,18 +1148,25 @@ describe('ListBox', () => {
       expect(counter.textContent).toEqual('0/4 selected')
     })
 
-    it('should count against the options the search left', () => {
+    it('should count both sides against the visible, enabled options', () => {
       const el = setMarkup()
       const listBox = new ListBox(el, { counter: true, search: true, selectionMode: 'multiple' })
       const counter = el.querySelector('[data-coreui-list-box-counter]')
 
       listBox.select('tomato')
+      listBox.select('onion')
 
-      expect(counter.textContent).toEqual('1/4 selected')
+      expect(counter.textContent).toEqual('2/4 selected')
 
       type(searchField(el), 'on')
 
-      expect(counter.textContent).toEqual('0/1 selected')
+      expect(item(el, 'tomato').hasAttribute('hidden')).toBeTrue()
+      expect(counter.textContent).toEqual('1/1 selected')
+      expect(listBox.getSelected()).toEqual(['tomato', 'onion'])
+
+      type(searchField(el), 'ham')
+
+      expect(counter.textContent).toEqual('0/0 selected')
     })
 
     it('should follow the items it was given', () => {

--- a/js/tests/unit/transfer.spec.js
+++ b/js/tests/unit/transfer.spec.js
@@ -601,6 +601,87 @@ describe('Transfer', () => {
       expect(transfer.getSource()).toEqual(['ada'])
     })
 
+    it('should leave the target unselected after setItems', () => {
+      const el = setMarkup('', [], [])
+      const transfer = new Transfer(el, { items: users, value: ['cleo'] })
+
+      transfer.moveToTarget(['ada'])
+
+      const chosen = option(el, 'target', 'cleo')
+
+      chosen.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+      click(chosen)
+
+      expect(transfer.getSelected('target')).toEqual(['cleo'])
+
+      transfer.setItems([...users, { value: 'dan', label: 'Dan' }])
+
+      expect(transfer.getTarget()).toEqual(['cleo', 'ada'])
+      expect(transfer.getSelected('target')).toEqual([])
+      expect(transfer.getSelected('source')).toEqual([])
+      expect(option(el, 'target', 'cleo').getAttribute('aria-selected')).toEqual('false')
+    })
+
+    it('should let a target option be toggled after an external re-fetch', () => {
+      const el = setMarkup('', [], [])
+      const transfer = new Transfer(el, { items: users, search: 'external', value: ['cleo'] })
+
+      type(searchField(el, 'source'), 'a')
+      transfer.setItems(users)
+
+      const target = option(el, 'target', 'cleo')
+
+      target.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+      click(target)
+
+      expect(transfer.getSelected('target')).toEqual(['cleo'])
+      expect(target.hasAttribute('aria-disabled')).toBeFalse()
+      expect(side(el, 'target').classList.contains('loading')).toBeFalse()
+
+      transfer.moveToSource(['cleo'])
+
+      expect(transfer.getTarget()).toEqual([])
+      expect(transfer.getSource()).toEqual(['ada', 'bob', 'cleo'])
+    })
+
+    it('should honour a selected item on the first render only', () => {
+      const el = setMarkup('', [], [])
+      const marked = [{ value: 'ada', label: 'Ada', selected: true }, { value: 'bob', label: 'Bob' }]
+      const transfer = new Transfer(el, { items: marked })
+
+      expect(transfer.getSelected('source')).toEqual(['ada'])
+
+      transfer.setItems(marked)
+
+      expect(transfer.getSelected('source')).toEqual([])
+    })
+
+    it('should clear the destination selection after a move', () => {
+      const el = setMarkup('', [], [])
+      const transfer = new Transfer(el, { items: users, value: ['cleo'] })
+
+      const chosen = option(el, 'target', 'cleo')
+
+      chosen.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+      click(chosen)
+      transfer.moveToTarget(['ada'])
+
+      expect(transfer.getSelected('target')).toEqual([])
+    })
+
+    it('should release both lists when setLoading is called without a side', () => {
+      const el = setMarkup('', [], [])
+      const transfer = new Transfer(el, { items: users, loading: true })
+
+      expect(side(el, 'source').classList.contains('loading')).toBeTrue()
+      expect(side(el, 'target').classList.contains('loading')).toBeTrue()
+
+      transfer.setLoading(false)
+
+      expect(side(el, 'source').classList.contains('loading')).toBeFalse()
+      expect(side(el, 'target').classList.contains('loading')).toBeFalse()
+    })
+
     it('should mark a loading list as busy', () => {
       const el = setMarkup('', [], [])
       const transfer = new Transfer(el, { items: users })

--- a/js/tests/unit/transfer.spec.js
+++ b/js/tests/unit/transfer.spec.js
@@ -18,7 +18,7 @@ describe('Transfer', () => {
 
   const setMarkup = (attrs = '', source = ['one', 'two', 'three'], target = ['four'], search = false) => {
     const searchInput = search ?
-      '<input class="form-control transfer-search" type="search" data-coreui-transfer-search>' :
+      '<input class="form-control list-box-search" type="search" data-coreui-list-box-search>' :
       ''
 
     fixtureEl.innerHTML = [
@@ -56,7 +56,7 @@ describe('Transfer', () => {
   const side = (el, name) => el.querySelector(`[data-coreui-transfer-list="${name}"]`)
   const moveButton = (el, name) => el.querySelector(`[data-coreui-transfer-move="${name}"]`)
   const counter = (el, name) => side(el, name).querySelector('[data-coreui-transfer-counter]')
-  const searchField = (el, name) => side(el, name).querySelector('[data-coreui-transfer-search]')
+  const searchField = (el, name) => side(el, name).querySelector('[data-coreui-list-box-search]')
   const option = (el, name, value) => side(el, name).querySelector(`[data-coreui-value="${value}"]`)
 
   const click = element => {

--- a/js/tests/unit/transfer.spec.js
+++ b/js/tests/unit/transfer.spec.js
@@ -55,7 +55,7 @@ describe('Transfer', () => {
 
   const side = (el, name) => el.querySelector(`[data-coreui-transfer-list="${name}"]`)
   const moveButton = (el, name) => el.querySelector(`[data-coreui-transfer-move="${name}"]`)
-  const counter = (el, name) => side(el, name).querySelector('[data-coreui-transfer-counter]')
+  const counter = (el, name) => side(el, name).querySelector('[data-coreui-list-box-counter]')
   const searchField = (el, name) => side(el, name).querySelector('[data-coreui-list-box-search]')
   const option = (el, name, value) => side(el, name).querySelector(`[data-coreui-value="${value}"]`)
 

--- a/js/tests/unit/transfer.spec.js
+++ b/js/tests/unit/transfer.spec.js
@@ -103,7 +103,10 @@ describe('Transfer', () => {
         ariaMoveToTargetLabel: 'Move to chosen',
         ariaMovedAnnouncement: '{count} moved to {title}',
         disabled: false,
+        html: false,
         indicator: 'checkbox',
+        items: [],
+        loading: false,
         moveAllToSourceIcon: jasmine.any(String),
         moveAllToTargetIcon: jasmine.any(String),
         moveToSourceIcon: jasmine.any(String),
@@ -116,7 +119,8 @@ describe('Transfer', () => {
         selectedCounterText: 'selected',
         sourceTitle: 'Available',
         targetTitle: 'Chosen',
-        typeahead: true
+        typeahead: true,
+        value: []
       })
     })
   })
@@ -512,6 +516,110 @@ describe('Transfer', () => {
     })
   })
 
+  describe('items', () => {
+    const users = [
+      { value: 'ada', label: 'Ada' },
+      { value: 'bob', label: 'Bob' },
+      { value: 'cleo', label: 'Cleo' }
+    ]
+
+    it('should build both lists from the items and the value', () => {
+      const el = setMarkup('', [], [])
+      const transfer = new Transfer(el, { items: users, value: ['cleo', 'ada'] })
+
+      expect(transfer.getSource()).toEqual(['bob'])
+      expect(transfer.getTarget()).toEqual(['cleo', 'ada'])
+      expect(option(el, 'source', 'bob').textContent).toEqual('Bob')
+    })
+
+    it('should return the configured items', () => {
+      const el = setMarkup('', [], [])
+      const transfer = new Transfer(el, { items: users })
+
+      expect(transfer.getItems()).toEqual(users)
+    })
+
+    it('should keep a group together in the source list', () => {
+      const el = setMarkup('', [], [])
+      const transfer = new Transfer(el, {
+        items: [{ label: 'Crew', items: users }],
+        value: ['bob']
+      })
+
+      expect(transfer.getSource()).toEqual(['ada', 'cleo'])
+      expect(side(el, 'source').querySelector('.list-box-section-label').textContent).toEqual('Crew')
+    })
+
+    it('should build the options element when the markup has none', () => {
+      fixtureEl.innerHTML = [
+        '<div class="transfer">',
+        '<div class="list-box transfer-list" data-coreui-transfer-list="source"></div>',
+        '<div class="list-box transfer-list" data-coreui-transfer-list="target"></div>',
+        '</div>'
+      ].join('')
+      const el = fixtureEl.querySelector('.transfer')
+      const transfer = new Transfer(el, { items: users, value: ['ada'] })
+
+      expect(transfer.getSource()).toEqual(['bob', 'cleo'])
+      expect(transfer.getTarget()).toEqual(['ada'])
+    })
+
+    it('should put a value returned to the source back in the items order', () => {
+      const el = setMarkup('', [], [])
+      const transfer = new Transfer(el, { items: users, value: ['ada'] })
+
+      transfer.moveToSource(['ada'])
+
+      expect(transfer.getSource()).toEqual(['ada', 'bob', 'cleo'])
+    })
+
+    it('should keep the target when the items change', () => {
+      const el = setMarkup('', [], [])
+      const transfer = new Transfer(el, { items: users, value: ['cleo'] })
+
+      transfer.setItems([...users, { value: 'dan', label: 'Dan' }])
+
+      expect(transfer.getTarget()).toEqual(['cleo'])
+      expect(transfer.getSource()).toEqual(['ada', 'bob', 'dan'])
+    })
+
+    it('should drop a target value that the new items no longer carry', () => {
+      const el = setMarkup('', [], [])
+      const transfer = new Transfer(el, { items: users, value: ['cleo'] })
+
+      transfer.setItems([{ value: 'ada', label: 'Ada' }])
+
+      expect(transfer.getTarget()).toEqual([])
+      expect(transfer.getSource()).toEqual(['ada'])
+    })
+
+    it('should parse a label as markup only with the html option', () => {
+      const el = setMarkup('', [], [])
+      const transfer = new Transfer(el, { html: true, items: [{ value: 'ada', label: '<b>Ada</b>' }] })
+
+      expect(option(el, 'source', 'ada').querySelector('b')).not.toBeNull()
+      expect(transfer.getSource()).toEqual(['ada'])
+    })
+
+    it('should mark a loading list as busy', () => {
+      const el = setMarkup('', [], [])
+      const transfer = new Transfer(el, { items: users })
+
+      transfer.setLoading(true, 'source')
+
+      expect(side(el, 'source').querySelector('.list-box-options').getAttribute('aria-busy')).toEqual('true')
+      expect(side(el, 'target').querySelector('.list-box-options').hasAttribute('aria-busy')).toBeFalse()
+
+      transfer.setLoading(true)
+
+      expect(side(el, 'target').querySelector('.list-box-options').getAttribute('aria-busy')).toEqual('true')
+
+      transfer.setLoading(false)
+
+      expect(side(el, 'source').querySelector('.list-box-options').hasAttribute('aria-busy')).toBeFalse()
+    })
+  })
+
   describe('search', () => {
     it('should hide the options that do not match', () => {
       const el = setMarkup('', ['one', 'two', 'three'], ['four'], true)
@@ -553,6 +661,35 @@ describe('Transfer', () => {
 
       expect(option(el, 'source', 'one').hasAttribute('hidden')).toBeFalse()
       expect(transfer.getSource()).toEqual(['one'])
+    })
+
+    it('should not filter in external search mode and report the query', () => {
+      const el = setMarkup('', [], [])
+      const transfer = new Transfer(el, {
+        items: [{ value: 'ada', label: 'Ada' }, { value: 'bob', label: 'Bob' }],
+        search: 'external'
+      })
+      const spy = jasmine.createSpy('search')
+
+      el.addEventListener('search.coreui.transfer', event => spy(event.side, event.query))
+      type(searchField(el, 'source'), 'zzz')
+
+      expect(spy).toHaveBeenCalledWith('source', 'zzz')
+      expect(option(el, 'source', 'ada').hasAttribute('hidden')).toBeFalse()
+      expect(option(el, 'source', 'bob').hasAttribute('hidden')).toBeFalse()
+      expect(transfer.getSource()).toEqual(['ada', 'bob'])
+    })
+
+    it('should report the side the external search was typed in', () => {
+      const el = setMarkup('', [], [])
+      // eslint-disable-next-line no-new
+      new Transfer(el, { items: [{ value: 'ada', label: 'Ada' }], search: 'external', value: ['ada'] })
+      const spy = jasmine.createSpy('search')
+
+      el.addEventListener('search.coreui.transfer', event => spy(event.side, event.query))
+      type(searchField(el, 'target'), 'ad')
+
+      expect(spy).toHaveBeenCalledWith('target', 'ad')
     })
 
     it('should build the search field when the search option is on', () => {

--- a/scss/_list-box.scss
+++ b/scss/_list-box.scss
@@ -141,10 +141,14 @@ $list-box-tokens: defaults(
   }
 
   .list-box-subtitle {
-    flex: 0 0 auto;
-    margin-inline-start: auto;
     font-size: var(--#{$prefix}list-box-subtitle-font-size);
     color: var(--#{$prefix}list-box-subtitle-color);
+  }
+
+  .list-box-header .list-box-subtitle {
+    flex: 0 0 auto;
+    margin-inline-start: auto;
+    margin-inline-end: var(--#{$prefix}list-box-option-padding-x);
   }
 
   .list-box-search {

--- a/scss/_list-box.scss
+++ b/scss/_list-box.scss
@@ -141,6 +141,8 @@ $list-box-tokens: defaults(
   }
 
   .list-box-subtitle {
+    flex: 0 0 auto;
+    margin-inline-start: auto;
     font-size: var(--#{$prefix}list-box-subtitle-font-size);
     color: var(--#{$prefix}list-box-subtitle-color);
   }

--- a/scss/_list-box.scss
+++ b/scss/_list-box.scss
@@ -28,6 +28,8 @@ $list-box-title-color:                  var(--#{$prefix}fg-body) !default;
 $list-box-subtitle-font-size:           calc(var(--#{$prefix}body-font-size) * .875) !default;
 $list-box-subtitle-color:               var(--#{$prefix}fg-3) !default;
 
+$list-box-search-margin:                1rem 1rem 0 !default;
+
 $list-box-option-padding-y:             .5rem !default;
 $list-box-option-padding-x:             .75rem !default;
 $list-box-option-gap:                   .5rem !default;
@@ -73,6 +75,7 @@ $list-box-tokens: defaults(
     --#{$prefix}list-box-title-color: #{$list-box-title-color},
     --#{$prefix}list-box-subtitle-font-size: #{$list-box-subtitle-font-size},
     --#{$prefix}list-box-subtitle-color: #{$list-box-subtitle-color},
+    --#{$prefix}list-box-search-margin: #{$list-box-search-margin},
     --#{$prefix}list-box-option-padding-y: #{$list-box-option-padding-y},
     --#{$prefix}list-box-option-padding-x: #{$list-box-option-padding-x},
     --#{$prefix}list-box-option-gap: #{$list-box-option-gap},
@@ -140,6 +143,11 @@ $list-box-tokens: defaults(
   .list-box-subtitle {
     font-size: var(--#{$prefix}list-box-subtitle-font-size);
     color: var(--#{$prefix}list-box-subtitle-color);
+  }
+
+  .list-box-search {
+    width: auto;
+    margin: var(--#{$prefix}list-box-search-margin);
   }
 
   .list-box-options {

--- a/scss/_transfer.scss
+++ b/scss/_transfer.scss
@@ -8,7 +8,6 @@ $transfer-gap:              1rem !default;
 $transfer-actions-gap:      .5rem !default;
 $transfer-list-min-height:  8rem !default;
 $transfer-list-max-height:  16rem !default;
-$transfer-search-margin:    1rem 1rem 0 !default;
 // scss-docs-end transfer-variables
 
 $transfer-tokens: () !default;
@@ -22,7 +21,6 @@ $transfer-tokens: defaults(
     --#{$prefix}transfer-actions-gap: #{$transfer-actions-gap},
     --#{$prefix}transfer-list-min-height: #{$transfer-list-min-height},
     --#{$prefix}transfer-list-max-height: #{$transfer-list-max-height},
-    --#{$prefix}transfer-search-margin: #{$transfer-search-margin},
   ),
   $transfer-tokens
 );
@@ -65,11 +63,6 @@ $transfer-tokens: defaults(
     min-height: var(--#{$prefix}transfer-list-min-height);
     max-height: var(--#{$prefix}transfer-list-max-height);
     overflow-y: auto;
-  }
-
-  .transfer-search {
-    width: auto;
-    margin: var(--#{$prefix}transfer-search-margin);
   }
 
   .transfer-actions {

--- a/scss/_transfer.scss
+++ b/scss/_transfer.scss
@@ -45,18 +45,9 @@ $transfer-tokens: defaults(
     min-width: 0;
   }
 
-  .transfer-list .list-box-header {
-    justify-content: space-between;
-  }
-
   .transfer-list .list-box-select-all {
-    flex: 1 1 auto;
     width: auto;
     min-width: 0;
-  }
-
-  .transfer-list .list-box-subtitle {
-    flex: 0 0 auto;
   }
 
   .transfer-list .list-box-options {


### PR DESCRIPTION
## What changes

The transfer could only take its options from markup. It now accepts them as configuration and can hand the searching over to the host.

**Configuration-driven lists.** `items` is the full set of options (`{ value, label, description, disabled, selected }`, or `{ label, items }` for a section) and `value` names which of them start in the target list, in the order given; everything else lands in the source in the items order. Both lists are rendered through the two list boxes, so groups, descriptions, disabled options and `html` / `sanitize` / `sanitizeFn` / `allowList` come from there rather than being re-implemented. A list without a `.list-box-options` gets one built.

`setItems(items)` rebuilds both lists and keeps the values the target already holds as long as the new items still carry them; the rest go back to the source. `getItems()` returns what was given. A value moved back to the source now lands in the items order instead of at the end of the list.

**External search.** `search` widens to `false | true | 'external'`. In external mode the fields are still built but nothing is filtered and no option is hidden — every keystroke fires `search.coreui.transfer` with `side` and `query`, and the host answers with `setItems()`. `loading` and `setLoading(loading, side?)` mark one or both lists busy while that answer is fetched.

## API

- Options: `html`, `items`, `loading`, `value`; `search` is now `(boolean|string)`.
- Methods: `setItems(items)`, `getItems()`, `setLoading(loading, list?)`.
- Event: `search.coreui.transfer` with `side` and `query`.

## Docs

Two new sections on the Transfer page — "Items from configuration" and "External search" (fetching from `apitest.coreui.io` with a debounced input, `setLoading` around the request) — plus the new options, methods and event in the tables. Both examples were driven in Chromium against the built site: the grouped `items` example splits correctly on `value`, and the external example re-fetches on typing while a chosen user survives a new query.

## Bundlewatch

The JS budgets go up 0.5 KB each. The feature adds ~0.7 KB gzip and crossed four ceilings; the two that still passed had under 0.05 KB of headroom, so they were raised in the same step rather than leaving a tripwire for the next PR.

## Gates

`npm run lint`, `npm run js`, `npm run js-test` (3683 tests, coverage 96.03 % statements / 89.18 % branches), `npm run docs-build`, bundlewatch, and the pre-push hook — all green.