### PR TITLE
fix(Chip): size chips from the frame they sit in

### DIFF
--- a/docs/src/content/docs/components/chip.mdx
+++ b/docs/src/content/docs/components/chip.mdx
@@ -128,7 +128,7 @@ Add `.active` to make chips use the solid appearance (bg/contrast). This is usef
 
 ## Sizing
 
-Use `.chip-sm` or `.chip-lg` for different sizes.
+Use `.chip-sm` or `.chip-lg` for different sizes. Chips placed in a `.form-control-sm` or `.form-control-lg` group — a multi select's selection, for example — take the matching size without a modifier.
 
 <Example code={`<div class="d-flex flex-wrap gap-1 mb-3">
     <span class="chip chip-sm">Small</span>

--- a/docs/src/content/docs/forms/multi-select.mdx
+++ b/docs/src/content/docs/forms/multi-select.mdx
@@ -412,7 +412,7 @@ Multi Select supports [floating labels](/forms/floating-labels/). Wrap the compo
 
 ## Sizing
 
-The frame carries the size. Add `.form-control-sm` or `.form-control-lg` to the `<select>` — the component copies the element's classes onto the `.form-control-group` it builds, so the field matches our similarly sized text inputs.
+The frame carries the size. Add `.form-control-sm` or `.form-control-lg` to the `<select>` — the component copies the element's classes onto the `.form-control-group` it builds, so the field matches our similarly sized text inputs. The whole selection follows: the chips, the counter text and the cleaner and toggle icons all scale with the frame.
 
 <Example pro code={`<div class="row">
     <div class="col-md-6">

--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -259,7 +259,8 @@ $chip-outline-tokens: defaults(
   }
 
   .chip-lg,
-  .chip-input-lg .chip {
+  .chip-input-lg .chip,
+  .form-control-group.form-control-lg .chip {
     @include chip-size(
       $chip-height-lg,
       $chip-padding-x-lg,
@@ -272,7 +273,8 @@ $chip-outline-tokens: defaults(
   }
 
   .chip-sm,
-  .chip-input-sm .chip {
+  .chip-input-sm .chip,
+  .form-control-group.form-control-sm .chip {
     @include chip-size(
       $chip-height-sm,
       $chip-padding-x-sm,


### PR DESCRIPTION
## What

A chip inside a sized `.form-control-group` now switches to the matching chip size scale, so a Multi Select's selection follows its frame:

| | frame height | frame font | chip height | chip font | chip remove icon | cleaner / toggle icon | counter font | chip fits padding box |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `.form-control-sm` before | 31px | 14px | **28px** | **14px** | **16px** | 14px | 14px | 28 / 29px |
| `.form-control-sm` after | 31px | 14px | **24px** | **12px** | **14px** | 14px | 14px | 24 / 29px |
| default before / after | 38px | 16px | 28px | 14px | 16px | 16px | 16px | 28 / 36px |
| `.form-control-lg` before | 48px | 20px | **28px** | **14px** | **16px** | 20px | 20px | 28 / 46px |
| `.form-control-lg` after | 48px | 20px | **32px** | **16px** | **20px** | 20px | 20px | 32 / 46px |

Measured in Chromium on the built docs (`_site`, `forms/multi-select`), two options selected in each field. Frame heights are unchanged at every size; the chip fits inside the frame's padding box at every size.

## Why

The chip read its default tokens no matter what frame it sat in. In the small frame that was a 28px chip in a 29px padding box — it filled the field edge to edge and left the frame looking overstuffed. In the large frame it stayed at default size next to 20px frame text, so it looked like a leftover from another field.

The counter text and the cleaner / toggle icons already scaled: the counter inherits the frame font through `form-control-frame()`, and the icons come from `--cui-control-group-icon-size` / `--cui-control-group-action-size`, which the group's size loop repoints. Icon size tracks the frame font 1:1 at all three sizes (14/14, 16/16, 20/20), so only the chip needed the fix.

The two size blocks at the bottom of `scss/_chip.scss` already carried this exact mapping for `.chip-input-sm` / `.chip-input-lg`; a sized group joins those selectors and reuses the same `chip-size()` call, so height, padding, gap, font, image, icon and remove button all move together. No new tokens, no per-size pixels outside the chip's own scale, nothing on `:root`.

Autocomplete shares the same chrome and carries no chips; its icons already scaled and are untouched.

## Checks

- `npm run lint` — 0 errors (10 pre-existing warnings)
- `npm run css` + `node build/check-css-components.mjs` — base.css plus 70 component stylesheets reconstruct every rule of coreui.css
- `npm run js-test-visual` — 119 passed, no baseline regeneration needed
- `npm run docs-build` — 185 pages, no broken links
- `bundlewatch` — all budgets pass (`coreui.css` 72.55KB < 73.5KB)
- pre-push hook: local CI passed
