### PR TITLE
feat(css): record the cascade layers of each component stylesheet in the manifest

### DIFF
--- a/build/css-components.mjs
+++ b/build/css-components.mjs
@@ -235,6 +235,7 @@ const ownCss = name => {
 
 const banner = file => compile(`@use "banner" with ($file: "${file}");`).trim()
 const layerOrder = '@layer colors, config, root, reboot, layout, content, forms, components, custom, helpers, utilities;'
+const layerNames = layerOrder.slice('@layer '.length, -1).split(', ')
 
 const label = name => {
   const words = name.split('/').at(-1).replaceAll('-', ' ')
@@ -246,6 +247,18 @@ const render = name => {
   const order = css.startsWith(layerOrder) ? '' : `${layerOrder}\n`
 
   return `@charset "UTF-8";\n${banner(label(name))}\n${order}${css}`
+}
+
+export const layersOf = css => {
+  const found = new Set()
+
+  postcss.parse(css).walkAtRules('layer', rule => {
+    if (rule.nodes?.length) {
+      found.add(rule.params)
+    }
+  })
+
+  return [...found].toSorted((a, b) => layerNames.indexOf(a) - layerNames.indexOf(b))
 }
 
 const closure = name => {
@@ -337,7 +350,11 @@ export const classIndex = sheets => {
 
 export const stylesheets = () => {
   const sheets = new Map([['base', render('base')]])
-  const manifest = { base: { file: 'base.css', order: 0, requires: [] } }
+  const manifest = {
+    base: {
+      file: 'base.css', order: 0, layers: layersOf(sheets.get('base')), requires: []
+    }
+  }
 
   for (const group of groups) {
     const requires = closure(group.name)
@@ -347,7 +364,12 @@ export const stylesheets = () => {
     }
 
     sheets.set(group.name, render(group.name))
-    manifest[group.name] = { file: `components/${group.name}.css`, order: groups.indexOf(group) + 1, requires }
+    manifest[group.name] = {
+      file: `components/${group.name}.css`,
+      order: groups.indexOf(group) + 1,
+      layers: layersOf(sheets.get(group.name)),
+      requires
+    }
   }
 
   for (const file of ruleFree) {

--- a/build/css-components.test.mjs
+++ b/build/css-components.test.mjs
@@ -6,7 +6,7 @@
 
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { classIndex } from './css-components.mjs'
+import { classIndex, layersOf } from './css-components.mjs'
 
 const index = sheets => classIndex(new Map(Object.entries(sheets)))
 
@@ -81,5 +81,18 @@ describe('classIndex', () => {
     assert.deepEqual(Object.keys(index({ card: '.card-title { margin: 0 } .card { border: 0 } .card-body { padding: 0 }' })), [
       'card', 'card-body', 'card-title'
     ])
+  })
+})
+
+describe('layersOf', () => {
+  it('lists the layers a stylesheet writes rules into, in cascade order', () => {
+    assert.deepEqual(
+      layersOf('@layer forms, components;\n@layer components { .sidebar { display: flex } }\n@layer forms { .form-range { width: 100% } }'),
+      ['forms', 'components']
+    )
+  })
+
+  it('ignores the layer order declaration and an empty layer block', () => {
+    assert.deepEqual(layersOf('@layer colors, config, root;\n@layer root {}\n@layer components { .card { border: 0 } }'), ['components'])
   })
 })

--- a/docs/src/content/docs/getting-started/install.mdx
+++ b/docs/src/content/docs/getting-started/install.mdx
@@ -381,15 +381,16 @@ your own layers in any order:
 
 Within one layer the last rule still wins, so load the files in the order
 `css/components/manifest.json` gives — the same order `coreui.css` uses. Each
-entry names its stylesheet, its position in that order, and the components it
-needs alongside it:
+entry names its stylesheet, its position in that order, the layers its rules
+sit in, and the components it needs alongside it:
 
 ```json
 {
-  "card": { "file": "components/card.css", "order": 37, "requires": [] },
+  "card": { "file": "components/card.css", "order": 37, "layers": ["components"], "requires": [] },
   "date-picker": {
     "file": "components/date-picker.css",
     "order": 42,
+    "layers": ["components"],
     "requires": ["calendar", "forms/floating-labels", "forms/form-control", "forms/form-control-group", "forms/form-date-time", "popup", "time-picker"]
   }
 }
@@ -400,6 +401,11 @@ listed files and the component's own, and the component renders exactly as it
 does from the full bundle. The list covers markup the JavaScript renders as
 well as the Sass a component builds on — the date picker draws a calendar and a
 time picker inside a form control group, which is why it asks for all three.
+
+`layers` tells you when that order matters. Two files in different layers can
+load in either order, because the layer declaration above settles which one
+wins; only files that share a layer have to keep the manifest's order between
+them.
 
 `css/components/classes.json` maps a class name to the entry that owns it, so
 you can go from the markup you write to the files you need — look up each class,

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -59,8 +59,8 @@ description: "Track and review changes to the CoreUI for Bootstrap source files,
 
 - **`dist/css` gained `base.css` and a stylesheet per component.**
   `base.css` holds the `:root` tokens and Reboot; `css/components/` holds one
-  file per component plus `manifest.json`, which records each file's load order
-  and the components it needs alongside it. Nothing was taken away —
+  file per component plus `manifest.json`, which records each file's load order,
+  the cascade layers it writes to and the components it needs alongside it. Nothing was taken away —
   `coreui.css` still carries everything — so this is additive, and pages that
   use a few components can now ship a few kilobytes of CSS instead of the whole
   library. See [per-component CSS files](/getting-started/install/#per-component-css-files).


### PR DESCRIPTION
Every entry in `css/components/manifest.json` gains a `layers` array listing the cascade layers the stylesheet writes rules into, in the library's layer order.

`requires` is the full transitive closure and says which files a component needs alongside it. It does not say which of those edges constrain the load order: files in different layers can load in any order, because the layer declaration each file carries decides between them, while files that share a layer must keep the manifest's order. `layers` makes that distinction available to a consumer, and the React and Vue import checkers use it to stop listing cross-layer dependencies in every component file (each list box part used to import `forms/check.css` and `forms/form-control.css` although the components rendering the search field and the indicator import them on their own).

Most sheets sit in one layer; `base` spans `colors`, `root`, `reboot`, `helpers`, `forms/form-range` spans `forms` and `components`, `sidebar` spans `components` and `utilities`. An empty layer block does not count.

Docs: the manifest example on the install page and the migration note describe the field.
