### PR TITLE
refactor(icons): keep every built-in glyph in one module

### DIFF
--- a/js/src/calendar.ts
+++ b/js/src/calendar.ts
@@ -14,6 +14,9 @@ import SelectorEngine from './dom/selector-engine.js'
 import {
  escapeHtml, sanitizeHtml, type SanitizerAllowList, SVGAllowlist
 } from './util/sanitizer.js'
+import {
+ CHEVRON_DOUBLE_LEFT_ICON, CHEVRON_DOUBLE_RIGHT_ICON, CHEVRON_LEFT_ICON, CHEVRON_RIGHT_ICON
+} from './util/icons.js'
 import { defineJQueryPlugin } from './util/index.js'
 import {
   convertToDateObject,
@@ -99,10 +102,6 @@ const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="calendar"]'
 // Navigation icons live in JavaScript, not in CSS masks — the chips pattern:
 // inline SVG on currentColor, swappable through an option, sanitized like any
 // user-provided markup.
-const DEFAULT_NAV_ICON_DOUBLE_NEXT: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" fill="currentColor"><polygon points="95.314 447.313 72.686 424.687 245.373 252 72.686 79.313 95.314 56.687 290.627 252 95.314 447.313"></polygon><polygon points="255.314 447.313 232.686 424.687 405.373 252 232.686 79.313 255.314 56.687 450.627 252 255.314 447.313"></polygon></svg>'
-const DEFAULT_NAV_ICON_DOUBLE_PREV: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" fill="currentColor"><polygon points="416.686 447.313 221.373 252 416.686 56.687 439.314 79.313 266.627 252 439.314 424.687 416.686 447.313"></polygon><polygon points="256.686 447.313 61.373 252 256.686 56.687 279.314 79.313 106.627 252 279.314 424.687 256.686 447.313"></polygon></svg>'
-const DEFAULT_NAV_ICON_NEXT: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" fill="currentColor"><polygon points="179.313 451.313 156.687 428.687 329.372 256 156.687 83.313 179.313 60.687 374.627 256 179.313 451.313"></polygon></svg>'
-const DEFAULT_NAV_ICON_PREV: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" fill="currentColor"><polygon points="324.687 451.313 129.373 256 324.687 60.687 347.313 83.313 174.628 256 347.313 428.687 324.687 451.313"></polygon></svg>'
 
 type CalendarConfig = {
   allowList: SanitizerAllowList
@@ -158,10 +157,10 @@ const Default: CalendarConfig = {
   maxDate: null,
   minDate: null,
   monthFormat: 'short',
-  navIconDoubleNext: DEFAULT_NAV_ICON_DOUBLE_NEXT,
-  navIconDoublePrev: DEFAULT_NAV_ICON_DOUBLE_PREV,
-  navIconNext: DEFAULT_NAV_ICON_NEXT,
-  navIconPrev: DEFAULT_NAV_ICON_PREV,
+  navIconDoubleNext: CHEVRON_DOUBLE_RIGHT_ICON,
+  navIconDoublePrev: CHEVRON_DOUBLE_LEFT_ICON,
+  navIconNext: CHEVRON_RIGHT_ICON,
+  navIconPrev: CHEVRON_LEFT_ICON,
   range: false,
   renderDayCell: null,
   renderMonthCell: null,

--- a/js/src/chip-set.ts
+++ b/js/src/chip-set.ts
@@ -11,6 +11,7 @@ import Chip from './chip.js'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { CHECK_ICON, REMOVE_ICON } from './util/icons.js'
 import { defineJQueryPlugin, getNextActiveElement, isRTL } from './util/index.js'
 
 /**
@@ -44,9 +45,6 @@ const CLASS_NAME_DISABLED = 'disabled'
 
 const SELECTION_MODE_SINGLE = 'single'
 
-const DEFAULT_REMOVE_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/></svg>'
-const DEFAULT_SELECTED_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="currentColor"><path d="M425.373 89.373 196 318.745 86.627 209.373l-45.254 45.254L196 409.255l274.627-274.628z"/></svg>'
-
 export type ChipSetConfig = {
   ariaAddedAnnouncement: string
   ariaRemoveLabel: string
@@ -72,9 +70,9 @@ const Default: ChipSetConfig = {
   filter: false,
   maxChips: null,
   removable: false,
-  removeIcon: DEFAULT_REMOVE_ICON,
+  removeIcon: REMOVE_ICON,
   selectable: false,
-  selectedIcon: DEFAULT_SELECTED_ICON,
+  selectedIcon: CHECK_ICON,
   selectionMode: 'multiple',
   unique: false
 }

--- a/js/src/chip.ts
+++ b/js/src/chip.ts
@@ -11,6 +11,7 @@ import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { sanitizeHtml, SVGAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
+import { CHECK_ICON, REMOVE_ICON } from './util/icons.js'
 import { defineJQueryPlugin } from './util/index.js'
 
 /**
@@ -41,9 +42,6 @@ const CLASS_NAME_CHIP_REMOVE = 'chip-remove'
 const CLASS_NAME_ACTIVE = 'active'
 const CLASS_NAME_DISABLED = 'disabled'
 
-const DEFAULT_REMOVE_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/></svg>'
-const DEFAULT_SELECTED_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="currentColor"><path d="M425.373 89.373 196 318.745 86.627 209.373l-45.254 45.254L196 409.255l274.627-274.628z"/></svg>'
-
 const DISALLOWED_ATTRIBUTES = new Set(['sanitize', 'allowList', 'sanitizeFn'])
 
 type ChipConfig = {
@@ -66,12 +64,12 @@ const Default: ChipConfig = {
   disabled: false,
   filter: false,
   removable: false,
-  removeIcon: DEFAULT_REMOVE_ICON,
+  removeIcon: REMOVE_ICON,
   sanitize: true,
   sanitizeFn: null,
   selectable: false,
   selected: false,
-  selectedIcon: DEFAULT_SELECTED_ICON
+  selectedIcon: CHECK_ICON
 }
 
 const DefaultType = {

--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -19,7 +19,7 @@ import Popup from './util/popup.js'
 import type { ComponentConfig } from './util/config.js'
 import { getWeekSectionsFromLocale } from './util/date-sections.js'
 import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
-import { CLEANER_ICON } from './util/icons.js'
+import { CALENDAR_ICON, CLEANER_ICON } from './util/icons.js'
 import { defineJQueryPlugin } from './util/index.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 
@@ -62,7 +62,6 @@ const SELECTOR_ACTION_TODAY = '[data-coreui-picker-action="today"]'
 // Icons live in JavaScript, not in CSS masks — the chips pattern: inline SVG on
 // currentColor, swappable through an option, sanitized like any user-provided
 // markup.
-const DEFAULT_INDICATOR_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="currentColor"><path d="M472 96h-88V40h-32v56H160V40h-32v56H40a24.03 24.03 0 0 0-24 24v336a24.03 24.03 0 0 0 24 24h432a24.03 24.03 0 0 0 24-24V120a24.03 24.03 0 0 0-24-24Zm-8 352H48V128h80v40h32v-40h192v40h32v-40h80Z"/><rect width="32" height="32" x="112" y="224"/><rect width="32" height="32" x="200" y="224"/><rect width="32" height="32" x="280" y="224"/><rect width="32" height="32" x="368" y="224"/><rect width="32" height="32" x="112" y="296"/><rect width="32" height="32" x="200" y="296"/><rect width="32" height="32" x="280" y="296"/><rect width="32" height="32" x="368" y="296"/><rect width="32" height="32" x="112" y="368"/><rect width="32" height="32" x="200" y="368"/><rect width="32" height="32" x="280" y="368"/><rect width="32" height="32" x="368" y="368"/></svg>'
 
 type DatePickerConfig = {
   allowList: SanitizerAllowList
@@ -97,7 +96,7 @@ const Default: DatePickerConfig = {
   date: null,
   disabled: false,
   floatingLabel: null,
-  indicatorIcon: DEFAULT_INDICATOR_ICON,
+  indicatorIcon: CALENDAR_ICON,
   inputOptions: {},
   locale: navigator.language,
   maxDate: null,

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -18,7 +18,9 @@ import Popup from './util/popup.js'
 import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
 import type { ComponentConfig } from './util/config.js'
 import { getWeekSectionsFromLocale } from './util/date-sections.js'
-import { CLEANER_ICON } from './util/icons.js'
+import {
+  CALENDAR_ICON, CLEANER_ICON, SEPARATOR_ICON, SEPARATOR_ICON_RTL
+} from './util/icons.js'
 import { defineJQueryPlugin } from './util/index.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 
@@ -64,9 +66,6 @@ const SELECTOR_TEMPLATE_RANGES = 'template[data-coreui-template="ranges"]'
 const SELECTOR_ACTION = '[data-coreui-picker-action]'
 
 // Icons live in JavaScript, not in CSS masks — the chips pattern.
-const DEFAULT_INDICATOR_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="currentColor"><path d="M472 96h-88V40h-32v56H160V40h-32v56H40a24.03 24.03 0 0 0-24 24v336a24.03 24.03 0 0 0 24 24h432a24.03 24.03 0 0 0 24-24V120a24.03 24.03 0 0 0-24-24Zm-8 352H48V128h80v40h32v-40h192v40h32v-40h80Z"/><rect width="32" height="32" x="112" y="224"/><rect width="32" height="32" x="200" y="224"/><rect width="32" height="32" x="280" y="224"/><rect width="32" height="32" x="368" y="224"/><rect width="32" height="32" x="112" y="296"/><rect width="32" height="32" x="200" y="296"/><rect width="32" height="32" x="280" y="296"/><rect width="32" height="32" x="368" y="296"/><rect width="32" height="32" x="112" y="368"/><rect width="32" height="32" x="200" y="368"/><rect width="32" height="32" x="280" y="368"/><rect width="32" height="32" x="368" y="368"/></svg>'
-const DEFAULT_SEPARATOR_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="currentColor"><path d="m359.873 121.377-22.627 22.627 95.997 95.997H16v32.001h417.24l-95.994 95.994 22.627 22.627L494.498 256z"/></svg>'
-const DEFAULT_SEPARATOR_ICON_RTL: string = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="currentColor"><path d="m152.127 121.377 22.627 22.627L78.757 240H496v32.001H78.76l95.994 95.994-22.627 22.627L17.502 256z"/></svg>'
 
 type DateRangePickerConfig = {
   allowList: SanitizerAllowList
@@ -110,15 +109,15 @@ const Default: DateRangePickerConfig = {
   endDate: null,
   endName: null,
   floatingLabels: null,
-  indicatorIcon: DEFAULT_INDICATOR_ICON,
+  indicatorIcon: CALENDAR_ICON,
   inputOptions: {},
   locale: navigator.language,
   maxDate: null,
   minDate: null,
   sanitize: true,
   sanitizeFn: null,
-  separatorIcon: DEFAULT_SEPARATOR_ICON,
-  separatorIconRtl: DEFAULT_SEPARATOR_ICON_RTL,
+  separatorIcon: SEPARATOR_ICON,
+  separatorIconRtl: SEPARATOR_ICON_RTL,
   size: null,
   startDate: null,
   startName: null

--- a/js/src/date-time-picker.ts
+++ b/js/src/date-time-picker.ts
@@ -19,7 +19,7 @@ import TimeSelection from './util/time-selection.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 import type { ComponentConfig } from './util/config.js'
 import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
-import { CLEANER_ICON } from './util/icons.js'
+import { CALENDAR_ICON, CLEANER_ICON } from './util/icons.js'
 import { defineJQueryPlugin } from './util/index.js'
 
 /**
@@ -62,7 +62,6 @@ const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="date-time-picker"]'
 const SELECTOR_TEMPLATE_FOOTER = 'template[data-coreui-template="footer"]'
 
 // Icons live in JavaScript, not in CSS masks — the chips pattern.
-const DEFAULT_INDICATOR_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="currentColor"><path d="M472 96h-88V40h-32v56H160V40h-32v56H40a24.03 24.03 0 0 0-24 24v336a24.03 24.03 0 0 0 24 24h432a24.03 24.03 0 0 0 24-24V120a24.03 24.03 0 0 0-24-24Zm-8 352H48V128h80v40h32v-40h192v40h32v-40h80Z"/><rect width="32" height="32" x="112" y="224"/><rect width="32" height="32" x="200" y="224"/><rect width="32" height="32" x="280" y="224"/><rect width="32" height="32" x="368" y="224"/><rect width="32" height="32" x="112" y="296"/><rect width="32" height="32" x="200" y="296"/><rect width="32" height="32" x="280" y="296"/><rect width="32" height="32" x="368" y="296"/><rect width="32" height="32" x="112" y="368"/><rect width="32" height="32" x="200" y="368"/><rect width="32" height="32" x="280" y="368"/><rect width="32" height="32" x="368" y="368"/></svg>'
 
 type DateTimePickerConfig = {
   allowList: SanitizerAllowList
@@ -99,7 +98,7 @@ const Default: DateTimePickerConfig = {
   date: null,
   disabled: false,
   floatingLabel: null,
-  indicatorIcon: DEFAULT_INDICATOR_ICON,
+  indicatorIcon: CALENDAR_ICON,
   inputOptions: {},
   locale: navigator.language,
   maxDate: null,

--- a/js/src/time-picker.ts
+++ b/js/src/time-picker.ts
@@ -17,7 +17,7 @@ import TimeSelection from './util/time-selection.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 import type { ComponentConfig } from './util/config.js'
 import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
-import { CLEANER_ICON } from './util/icons.js'
+import { CLEANER_ICON, CLOCK_ICON } from './util/icons.js'
 import { defineJQueryPlugin } from './util/index.js'
 
 /**
@@ -55,7 +55,6 @@ const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="time-picker"]'
 const SELECTOR_TEMPLATE_FOOTER = 'template[data-coreui-template="footer"]'
 
 // Icons live in JavaScript, not in CSS masks — the chips pattern.
-const DEFAULT_INDICATOR_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="currentColor"><path d="M256 16C123.452 16 16 123.452 16 256s107.452 240 240 240 240-107.452 240-240S388.548 16 256 16Zm0 448c-114.875 0-208-93.125-208-208S141.125 48 256 48s208 93.125 208 208-93.125 208-208 208Z"/><path d="M272 128h-32v139.314l84.686 84.687 22.628-22.628L272 254.059V128Z"/></svg>'
 
 type TimePickerConfig = {
   allowList: SanitizerAllowList
@@ -87,7 +86,7 @@ const Default: TimePickerConfig = {
   container: false,
   disabled: false,
   floatingLabel: null,
-  indicatorIcon: DEFAULT_INDICATOR_ICON,
+  indicatorIcon: CLOCK_ICON,
   inputOptions: {},
   locale: navigator.language,
   name: null,

--- a/js/src/transfer.ts
+++ b/js/src/transfer.ts
@@ -10,6 +10,9 @@ import ListBox, { type ListBoxEntry, type ListBoxGroup, type ListBoxItem } from 
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
+import {
+  CHEVRON_DOUBLE_LEFT_ICON, CHEVRON_DOUBLE_RIGHT_ICON, CHEVRON_LEFT_ICON, CHEVRON_RIGHT_ICON
+} from './util/icons.js'
 import { defineJQueryPlugin, getUID } from './util/index.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 
@@ -50,11 +53,6 @@ const SIDE_TARGET = 'target'
 const SUFFIX_ALL = '-all'
 
 const MOVE_KINDS = new Set([SIDE_SOURCE, SIDE_TARGET, `${SIDE_SOURCE}${SUFFIX_ALL}`, `${SIDE_TARGET}${SUFFIX_ALL}`])
-
-const CHEVRON_LEFT_ICON: string = '<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" aria-hidden="true"><path fill="var(--ci-primary-color, currentcolor)" d="M324.687 451.313 129.373 256 324.687 60.687l22.626 22.626L174.628 256l172.685 172.687z" class="ci-primary"/></svg>'
-const CHEVRON_RIGHT_ICON: string = '<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" aria-hidden="true"><path fill="var(--ci-primary-color, currentcolor)" d="m179.313 451.313-22.626-22.626L329.372 256 156.687 83.313l22.626-22.626L374.627 256z" class="ci-primary"/></svg>'
-const CHEVRON_DOUBLE_LEFT_ICON: string = '<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" aria-hidden="true"><path fill="var(--ci-primary-color, currentcolor)" d="M416.686 447.313 221.373 252 416.686 56.687l22.628 22.626L266.627 252l172.687 172.687z" class="ci-primary"/><path fill="var(--ci-primary-color, currentcolor)" d="M256.686 447.313 61.373 252 256.686 56.687l22.628 22.626L106.627 252l172.687 172.687z" class="ci-primary"/></svg>'
-const CHEVRON_DOUBLE_RIGHT_ICON: string = '<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" aria-hidden="true"><path fill="var(--ci-primary-color, currentcolor)" d="m95.314 447.313-22.628-22.626L245.373 252 72.686 79.313l22.628-22.626L290.627 252z" class="ci-primary"/><path fill="var(--ci-primary-color, currentcolor)" d="m255.314 447.313-22.628-22.626L405.373 252 232.686 79.313l22.628-22.626L450.627 252z" class="ci-primary"/></svg>'
 
 type TransferSide = {
   element: HTMLElement

--- a/js/src/util/icons.ts
+++ b/js/src/util/icons.ts
@@ -2,38 +2,39 @@
  * --------------------------------------------------------------------------
  * CoreUI PRO util/icons.js
  * License (https://coreui.io/pro/license/)
- *
- * Icons shared by more than one component. They live in JavaScript rather than
- * in CSS masks — inline SVG on currentColor, so a component's state reaches the
- * icon without a colour token of its own, and swappable through an option.
  * --------------------------------------------------------------------------
  */
 
-// `cil-x` from the CoreUI set, cropped so every adornment can share one icon
-// size. The artwork carries 85 units of built-in margin where the calendar and
-// clock carry 16, so untouched it would paint a third less ink; cropped to
-// their coverage it overshoots instead, because a cross reaching the corners
-// reads larger than an orthogonal glyph of the same box. This sits between.
-export const CLEANER_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="39.15 39.15 433.71 433.71" fill="currentColor"><path d="m427.314 107.313-22.628-22.626L256 233.373 107.314 84.687l-22.628 22.626L233.373 256 84.686 404.687l22.628 22.626L256 278.627l148.686 148.686 22.628-22.626L278.627 256z"/></svg>'
+export const CALENDAR_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M472 96h-88V40h-32v56H160V40h-32v56H40a24.03 24.03 0 0 0-24 24v336a24.03 24.03 0 0 0 24 24h432a24.03 24.03 0 0 0 24-24V120a24.03 24.03 0 0 0-24-24Zm-8 352H48V128h80v40h32v-40h192v40h32v-40h80Z"/><rect width="32" height="32" x="112" y="224"/><rect width="32" height="32" x="200" y="224"/><rect width="32" height="32" x="280" y="224"/><rect width="32" height="32" x="368" y="224"/><rect width="32" height="32" x="112" y="296"/><rect width="32" height="32" x="200" y="296"/><rect width="32" height="32" x="280" y="296"/><rect width="32" height="32" x="368" y="296"/><rect width="32" height="32" x="112" y="368"/><rect width="32" height="32" x="200" y="368"/><rect width="32" height="32" x="280" y="368"/><rect width="32" height="32" x="368" y="368"/></svg>'
 
-// The chevron autocomplete and multi select both draw, duplicated byte for
-// byte between them until now. Full-bleed horizontally, so it needs no crop.
-export const INDICATOR_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M256.045 416.136.717 160.807l29.579-29.579 225.749 225.748 225.749-225.748 29.579 29.579-255.328 255.329z"/></svg>'
-
-// `cil-chevron-bottom-alt`, the combobox toggle's caret. Full-bleed like the
-// indicator chevron above, so it needs no crop.
 export const CARET_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M256 382.627 60.687 187.313l22.626-22.626L256 337.372l172.687-172.685 22.626 22.626z"/></svg>'
 
-// The password toggle's pair, moved out of CSS masks: the same two glyphs the
-// `$form-password-icon-*` variables used to encode as data URIs, which every
-// stylesheet carried whether or not the page had a password field.
-export const PASSWORD_SHOW_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M256,144.927A103.309,103.309,0,1,0,359.309,248.236,103.426,103.426,0,0,0,256,144.927Zm0,174.618a71.309,71.309,0,1,1,71.309-71.309A71.39,71.39,0,0,1,256,319.545Z"/><path d="M397.222,131.1l-.218-.223c-77.75-77.749-204.258-77.749-282.008,0L16,233.79v28.893l98.778,102.689.218.222a199.409,199.409,0,0,0,282.008,0l99-102.911V233.79ZM464,249.79l-89.732,93.285a167.409,167.409,0,0,1-236.536,0L48,249.79v-3.107L137.729,153.4c65.247-65.13,171.3-65.13,236.542,0L464,246.683Z"/><rect width="32" height="32" x="240" y="232" /></svg>'
+export const CHECK_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M425.373 89.373 196 318.745 86.627 209.373l-45.254 45.254L196 409.255l274.627-274.628z"/></svg>'
+
+export const CHEVRON_DOUBLE_LEFT_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M416.686 447.313 221.373 252 416.686 56.687l22.628 22.626L266.627 252l172.687 172.687z"/><path d="M256.686 447.313 61.373 252 256.686 56.687l22.628 22.626L106.627 252l172.687 172.687z"/></svg>'
+
+export const CHEVRON_DOUBLE_RIGHT_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="m95.314 447.313-22.628-22.626L245.373 252 72.686 79.313l22.628-22.626L290.627 252z"/><path d="m255.314 447.313-22.628-22.626L405.373 252 232.686 79.313l22.628-22.626L450.627 252z"/></svg>'
+
+export const CHEVRON_LEFT_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M324.687 451.313 129.373 256 324.687 60.687l22.626 22.626L174.628 256l172.685 172.687z"/></svg>'
+
+export const CHEVRON_RIGHT_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="m179.313 451.313-22.626-22.626L329.372 256 156.687 83.313l22.626-22.626L374.627 256z"/></svg>'
+
+export const CLEANER_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="39.15 39.15 433.71 433.71" fill="currentColor"><path d="m427.314 107.313-22.628-22.626L256 233.373 107.314 84.687l-22.628 22.626L233.373 256 84.686 404.687l22.628 22.626L256 278.627l148.686 148.686 22.628-22.626L278.627 256z"/></svg>'
+
+export const CLOCK_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M256 16C123.452 16 16 123.452 16 256s107.452 240 240 240 240-107.452 240-240S388.548 16 256 16Zm0 448c-114.875 0-208-93.125-208-208S141.125 48 256 48s208 93.125 208 208-93.125 208-208 208Z"/><path d="M272 128h-32v139.314l84.686 84.687 22.628-22.628L272 254.059V128Z"/></svg>'
+
+export const INDICATOR_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M256.045 416.136.717 160.807l29.579-29.579 225.749 225.748 225.749-225.748 29.579 29.579-255.328 255.329z"/></svg>'
+
+export const MINUS_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M464 240H48v32h416z"/></svg>'
 
 export const PASSWORD_HIDE_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M397.222,131.1l-.218-.223C333.831,67.707,238.47,55.862,163.228,95.346l23.938,23.939c61.571-27.691,136.573-16.327,187.105,34.115L464,246.683v3.107l-71.744,74.585,22.63,22.63L496,262.683V233.79Z"/><path d="M352.8,284.33A103.307,103.307,0,0,0,219.907,151.438L246.1,177.63a71.228,71.228,0,0,1,80.507,80.508Z"/><path d="M369.9,347.268l-33.831-33.831c.088-.108.179-.212.266-.32l-22.805-22.806c-.083.113-.169.222-.253.334l-99.681-99.681c.112-.083.221-.17.334-.253L191.12,167.906c-.108.087-.213.179-.321.266L38.627,16H16V38.627l95.689,95.689L16,233.79v28.893l98.778,102.689.218.222A199.732,199.732,0,0,0,367.372,390l106,106H496V473.373L392.537,369.911Zm-177.157-131.9L288.871,311.5a71.28,71.28,0,0,1-96.133-96.133ZM137.729,343.073,48,249.79v-3.107l86.319-89.737,35.065,35.064A103.248,103.248,0,0,0,312.226,334.853l32.007,32.007C279.723,406.875,193.711,398.955,137.729,343.073Z"/></svg>'
 
-// The number input's pair. `cil-minus` and `cil-plus` from the CoreUI set,
-// full-bleed like the chevron, so they need no crop to sit at one adornment
-// size with the rest.
-export const MINUS_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M464 240H48v32h416z"/></svg>'
+export const PASSWORD_SHOW_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M256,144.927A103.309,103.309,0,1,0,359.309,248.236,103.426,103.426,0,0,0,256,144.927Zm0,174.618a71.309,71.309,0,1,1,71.309-71.309A71.39,71.39,0,0,1,256,319.545Z"/><path d="M397.222,131.1l-.218-.223c-77.75-77.749-204.258-77.749-282.008,0L16,233.79v28.893l98.778,102.689.218.222a199.409,199.409,0,0,0,282.008,0l99-102.911V233.79ZM464,249.79l-89.732,93.285a167.409,167.409,0,0,1-236.536,0L48,249.79v-3.107L137.729,153.4c65.247-65.13,171.3-65.13,236.542,0L464,246.683Z"/><rect width="32" height="32" x="240" y="232" /></svg>'
 
 export const PLUS_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="M464 240H272V48h-32v192H48v32h192v192h32V272h192z"/></svg>'
+
+export const REMOVE_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/></svg>'
+
+export const SEPARATOR_ICON: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="m359.873 121.377-22.627 22.627 95.997 95.997H16v32.001h417.24l-95.994 95.994 22.627 22.627L494.498 256z"/></svg>'
+
+export const SEPARATOR_ICON_RTL: string = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor"><path d="m152.127 121.377 22.627 22.627L78.757 240H496v32.001H78.76l95.994 95.994-22.627 22.627L17.502 256z"/></svg>'

--- a/js/tests/unit/transfer.spec.js
+++ b/js/tests/unit/transfer.spec.js
@@ -182,8 +182,7 @@ describe('Transfer', () => {
       new Transfer(el)
 
       for (const kind of ['target', 'source', 'target-all', 'source-all']) {
-        expect(moveButton(el, kind).querySelector('svg.icon')).not.toBeNull()
-        expect(moveButton(el, kind).querySelector('svg').getAttribute('aria-hidden')).toEqual('true')
+        expect(moveButton(el, kind).querySelector('svg')).not.toBeNull()
       }
     })
 

--- a/scss/_transfer.scss
+++ b/scss/_transfer.scss
@@ -6,6 +6,7 @@
 // scss-docs-start transfer-variables
 $transfer-gap:              1rem !default;
 $transfer-actions-gap:      .5rem !default;
+$transfer-icon-size:        1rem !default;
 $transfer-list-min-height:  8rem !default;
 $transfer-list-max-height:  16rem !default;
 // scss-docs-end transfer-variables
@@ -19,6 +20,7 @@ $transfer-tokens: defaults(
   (
     --#{$prefix}transfer-gap: #{$transfer-gap},
     --#{$prefix}transfer-actions-gap: #{$transfer-actions-gap},
+    --#{$prefix}transfer-icon-size: #{$transfer-icon-size},
     --#{$prefix}transfer-list-min-height: #{$transfer-list-min-height},
     --#{$prefix}transfer-list-max-height: #{$transfer-list-max-height},
   ),
@@ -65,6 +67,12 @@ $transfer-tokens: defaults(
 
     @include media-breakpoint-down(sm) {
       flex-direction: row;
+    }
+
+    svg {
+      display: block;
+      width: var(--#{$prefix}transfer-icon-size);
+      height: var(--#{$prefix}transfer-icon-size);
     }
   }
 }


### PR DESCRIPTION
## What changed

Calendar navigation, both chip families, the three date pickers, the time picker and the transfer each defined their own inline SVG next to the component. `js/src/util/icons.ts` is now the only place a built-in glyph lives, next to the cleaner, caret, password and number-input artwork that already sat there.

What was duplicated:

| glyph | copies before |
| --- | --- |
| calendar | 3 (`date-picker`, `date-time-picker`, `date-range-picker`) |
| chip check + cross | 2 each (`chip`, `chip-set`) |
| chevron, double chevron | 2 encodings — `<polygon>` in `calendar`, `<path>` in `transfer` |
| clock, separator, mirrored separator | 1 each, in the component |

## Markup the moved artwork no longer carries

- `width="16" height="16"` on the picker and chip glyphs, which the component CSS already overrides (`.form-control-action > svg`, `.chip-remove > svg`, …).
- `role="img"` on the calendar navigation glyph. The button around it has an `aria-label`.
- `class="icon"`, `aria-hidden="true"` and `fill="var(--ci-primary-color, currentcolor)"` on the transfer chevrons. That variable ships with `@coreui/icons`, not with this library, so those paths were painting on the fallback; the button already carries the `aria-label`, and `.chip-check` shows where `aria-hidden` belongs.

Sizing was the one thing `.icon` actually did for the transfer, so `.transfer-actions svg` now reads a token of its own:

```
--cui-transfer-icon-size: 1rem;
```

which is what `--cui-icon-size-base` resolved to, so nothing moves on screen.

## Verified

- `npm run css`, `npm run js-test-unit` (3768 passing), `npm run docs-build`, `vnu`, stylelint, eslint — all green through the pre-push gate.
- `bundlewatch`: every entry PASS, `coreui.css` 72.8 KB of 73.5 KB.
- One spec updated: the transfer's "chevron in every empty move button" case asserted `svg.icon` and `aria-hidden` on the SVG, both of which the icon no longer carries.