### PR TITLE
fix(Config): drop sanitize, allowList and sanitizeFn coming from the markup

### DIFF
--- a/js/src/number-input.ts
+++ b/js/src/number-input.ts
@@ -7,7 +7,6 @@
 
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
-import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
 import {
   createControlGroupAction, ensureControlGroup, releaseControlGroup, type ControlGroup
@@ -40,8 +39,6 @@ const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="number-input"]'
 // starts it, then fast enough to cross a range without waiting.
 const REPEAT_DELAY = 400
 const REPEAT_INTERVAL = 60
-
-const DISALLOWED_ATTRIBUTES = new Set(['sanitize', 'allowList', 'sanitizeFn'])
 
 interface NumberInputConfig {
   allowList: SanitizerAllowList
@@ -262,18 +259,6 @@ class NumberInput extends BaseComponent {
 
   _sanitizeIcon(icon: string): string {
     return this._config.sanitize ? sanitizeHtml(icon, this._config.allowList, this._config.sanitizeFn) : icon
-  }
-
-  override _getConfig(config: any): any {
-    const dataAttributes = Manipulator.getDataAttributes(this._element)
-
-    for (const dataAttribute of Object.keys(dataAttributes)) {
-      if (DISALLOWED_ATTRIBUTES.has(dataAttribute)) {
-        delete dataAttributes[dataAttribute]
-      }
-    }
-
-    return super._getConfig({ ...dataAttributes, ...(typeof config === 'object' ? config : {}) })
   }
 
   // Static

--- a/js/src/util/config.ts
+++ b/js/src/util/config.ts
@@ -20,6 +20,12 @@ import { isElement, toType } from './index.js'
 type ComponentConfig = Record<string, any>
 
 /**
+ * Constants
+ */
+
+const DISALLOWED_ATTRIBUTES = new Set(['sanitize', 'allowList', 'sanitizeFn'])
+
+/**
  * Class definition
  */
 
@@ -55,11 +61,18 @@ class Config {
 
   _mergeConfigObj(config?: ComponentConfig | null, element?: Element): ComponentConfig {
     const jsonConfig = isElement(element) ? Manipulator.getDataAttribute(element, 'config') : {} // try to parse
+    const markupConfig: ComponentConfig = {
+      ...(typeof jsonConfig === 'object' ? jsonConfig : {}),
+      ...(isElement(element) ? Manipulator.getDataAttributes(element as HTMLElement) : {})
+    }
+
+    for (const key of DISALLOWED_ATTRIBUTES) {
+      delete markupConfig[key]
+    }
 
     return {
       ...this.constructor.Default,
-      ...(typeof jsonConfig === 'object' ? jsonConfig : {}),
-      ...(isElement(element) ? Manipulator.getDataAttributes(element as HTMLElement) : {}),
+      ...markupConfig,
       ...(typeof config === 'object' ? config : {})
     }
   }

--- a/js/tests/unit/number-input.spec.js
+++ b/js/tests/unit/number-input.spec.js
@@ -149,6 +149,14 @@ describe('NumberInput', () => {
 
       expect(buttons()[1].querySelector('svg').getAttribute('data-keep')).toBe('1')
     })
+
+    it('should keep sanitizing when the markup asks to turn it off', () => {
+      const numberInput = new NumberInput(markup('value="1" data-coreui-sanitize="false"'), { // eslint-disable-line no-unused-vars
+        incrementIcon: '<svg viewBox="0 0 16 16" data-keep="1"><path d="M0 0h16v16H0z"/></svg>'
+      })
+
+      expect(buttons()[1].querySelector('svg').getAttribute('data-keep')).toBeNull()
+    })
   })
 
   describe('the frame', () => {

--- a/js/tests/unit/util/config.spec.js
+++ b/js/tests/unit/util/config.spec.js
@@ -99,6 +99,39 @@ describe('Config', () => {
       expect(configResult.testInt2).toEqual(100)
     })
 
+    it('should ignore sanitize, allowList and sanitizeFn coming from the markup', () => {
+      fixtureEl.innerHTML = '<div id="test" data-coreui-sanitize="false" data-coreui-allow-list="{}" data-coreui-config=\'{"sanitize": false, "sanitizeFn": "x"}\'></div>'
+
+      spyOnProperty(DummyConfigClass, 'Default', 'get').and.returnValue({
+        allowList: { b: [] },
+        sanitize: true,
+        sanitizeFn: null
+      })
+      const instance = new DummyConfigClass()
+      const configResult = instance._mergeConfigObj({}, fixtureEl.querySelector('#test'))
+
+      expect(configResult.sanitize).toBeTrue()
+      expect(configResult.allowList).toEqual({ b: [] })
+      expect(configResult.sanitizeFn).toBeNull()
+    })
+
+    it('should let a programmatic config set sanitize, allowList and sanitizeFn', () => {
+      fixtureEl.innerHTML = '<div id="test" data-coreui-sanitize="true"></div>'
+
+      spyOnProperty(DummyConfigClass, 'Default', 'get').and.returnValue({
+        allowList: { b: [] },
+        sanitize: true,
+        sanitizeFn: null
+      })
+      const sanitizeFn = () => ''
+      const instance = new DummyConfigClass()
+      const configResult = instance._mergeConfigObj({ allowList: { i: [] }, sanitize: false, sanitizeFn }, fixtureEl.querySelector('#test'))
+
+      expect(configResult.sanitize).toBeFalse()
+      expect(configResult.allowList).toEqual({ i: [] })
+      expect(configResult.sanitizeFn).toBe(sanitizeFn)
+    })
+
     it('should omit element\'s data attribute `config` if is not an object', () => {
       fixtureEl.innerHTML = '<div id="test" data-coreui-config="foo" data-coreui-test-int="8"></div>'
 


### PR DESCRIPTION
## What changes

`Config._mergeConfigObj()` now strips `sanitize`, `allowList` and `sanitizeFn` from both markup sources — `data-coreui-*` attributes and `data-coreui-config` JSON — before the programmatic config is layered on top. Every component that reads its config through `BaseComponent._getConfig()` gets the guard automatically.

## Before / after

- Before: `<input data-coreui-sanitize="false">` (or `data-coreui-config='{"sanitize":false}'`) switched the icon/content sanitizer off for PasswordInput, DatePicker, DateRangePicker, DateTimePicker, TimePicker, ListBox, Transfer, Toaster and the other components that rely on the base merge. NumberInput had its own filter, but it called `super._getConfig()` afterwards, which re-read the element and put the keys back, so it never filtered anything.
- After: the three keys can only come from `Default` or from the JS config object. `new Component(el, { sanitize: false })` keeps working.

NumberInput's dead `_getConfig()` override is removed. Tooltip, Chip, Rating, RangeSlider and Calendar keep their local filters for now — they work, and folding them into the base is part of the config/HTML policy cleanup (R4 in the reuse audit).

## Tests

- `config.spec.js`: markup cannot set the three keys; a programmatic config can.
- `number-input.spec.js`: `data-coreui-sanitize="false"` still sanitizes the icon.

Full unit suite: 69 files, 3771 tests green; `js-typecheck` clean.

Ref: `v6-js-scss-bugs-audit-2026-09.md` JS-01.
