### PR TITLE
refactor: drop the per-component sanitizer attribute filters

### DIFF
--- a/js/src/calendar.ts
+++ b/js/src/calendar.ts
@@ -52,7 +52,6 @@ const NAME = 'calendar'
 const DATA_KEY = 'coreui.calendar'
 const EVENT_KEY = `.${DATA_KEY}`
 const DATA_API_KEY = '.data-api'
-const DISALLOWED_ATTRIBUTES = new Set(['sanitize', 'allowList', 'sanitizeFn'])
 
 const ARROW_UP_KEY = 'ArrowUp'
 const ARROW_RIGHT_KEY = 'ArrowRight'
@@ -1258,26 +1257,6 @@ class Calendar extends BaseComponent {
     }
 
     return html
-  }
-
-  override _getConfig(config: any): any {
-    const dataAttributes = Manipulator.getDataAttributes(this._element)
-
-    for (const dataAttribute of Object.keys(dataAttributes)) {
-      if (DISALLOWED_ATTRIBUTES.has(dataAttribute)) {
-        delete dataAttributes[dataAttribute]
-      }
-    }
-
-    config = {
-      ...dataAttributes,
-      ...(typeof config === 'object' && config ? config : {})
-    }
-    config = this._mergeConfigObj(config)
-    config = this._configAfterMerge(config)
-    this._typeCheckConfig(config)
-
-    return config
   }
 
   // Static

--- a/js/src/chip.ts
+++ b/js/src/chip.ts
@@ -8,7 +8,6 @@
 import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
-import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { sanitizeHtml, SVGAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
 import { CHECK_ICON, REMOVE_ICON } from './util/icons.js'
@@ -41,8 +40,6 @@ const CLASS_NAME_CHIP_CLICKABLE = 'chip-clickable'
 const CLASS_NAME_CHIP_REMOVE = 'chip-remove'
 const CLASS_NAME_ACTIVE = 'active'
 const CLASS_NAME_DISABLED = 'disabled'
-
-const DISALLOWED_ATTRIBUTES = new Set(['sanitize', 'allowList', 'sanitizeFn'])
 
 type ChipConfig = {
   allowList: SanitizerAllowList
@@ -367,26 +364,6 @@ class Chip extends BaseComponent {
 
   _sanitizeIcon(icon: string): string {
     return this._config.sanitize ? sanitizeHtml(icon, this._config.allowList, this._config.sanitizeFn) : icon
-  }
-
-  _getConfig(config: any): any {
-    const dataAttributes = Manipulator.getDataAttributes(this._element)
-
-    for (const dataAttribute of Object.keys(dataAttributes)) {
-      if (DISALLOWED_ATTRIBUTES.has(dataAttribute)) {
-        delete dataAttributes[dataAttribute]
-      }
-    }
-
-    config = {
-      ...dataAttributes,
-      ...(typeof config === 'object' && config ? config : {})
-    }
-    config = this._mergeConfigObj(config)
-    config = this._configAfterMerge(config)
-    this._typeCheckConfig(config)
-
-    return config
   }
 
   // Static

--- a/js/src/range-slider.ts
+++ b/js/src/range-slider.ts
@@ -21,7 +21,6 @@ const NAME = 'range-slider'
 const DATA_KEY = 'coreui.range-slider'
 const EVENT_KEY = `.${DATA_KEY}`
 const DATA_API_KEY = '.data-api'
-const DISALLOWED_ATTRIBUTES = new Set(['sanitize', 'allowList', 'sanitizeFn'])
 
 const EVENT_CHANGE = `change${EVENT_KEY}`
 const EVENT_INPUT = `input${EVENT_KEY}`
@@ -662,26 +661,6 @@ class RangeSlider extends BaseComponent {
     if (typeof config.value === 'string') {
       config.value = config.value.split(/,\s*/).map(Number)
     }
-
-    return config
-  }
-
-  override _getConfig(config: any): any {
-    const dataAttributes = Manipulator.getDataAttributes(this._element)
-
-    for (const dataAttribute of Object.keys(dataAttributes)) {
-      if (DISALLOWED_ATTRIBUTES.has(dataAttribute)) {
-        delete dataAttributes[dataAttribute]
-      }
-    }
-
-    config = {
-      ...dataAttributes,
-      ...(typeof config === 'object' && config ? config : {})
-    }
-    config = this._mergeConfigObj(config)
-    config = this._configAfterMerge(config)
-    this._typeCheckConfig(config)
 
     return config
   }

--- a/js/src/rating.ts
+++ b/js/src/rating.ts
@@ -8,7 +8,6 @@
 import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
-import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 import { defineJQueryPlugin, getUID } from './util/index.js'
@@ -22,7 +21,6 @@ const NAME = 'rating'
 const DATA_KEY = 'coreui.rating'
 const EVENT_KEY = `.${DATA_KEY}`
 const DATA_API_KEY = '.data-api'
-const DISALLOWED_ATTRIBUTES = new Set(['sanitize', 'allowList', 'sanitizeFn'])
 
 const EVENT_CHANGE = `change${EVENT_KEY}`
 const EVENT_CLICK = `click${EVENT_KEY}`
@@ -471,26 +469,6 @@ class Rating extends BaseComponent {
 
   _sanitizeIcon(icon: any): any {
     return this._config.sanitize ? sanitizeHtml(icon, this._config.allowList, this._config.sanitizeFn) : icon
-  }
-
-  override _getConfig(config?: any): ComponentConfig {
-    const dataAttributes = Manipulator.getDataAttributes(this._element)
-
-    for (const dataAttribute of Object.keys(dataAttributes)) {
-      if (DISALLOWED_ATTRIBUTES.has(dataAttribute)) {
-        delete dataAttributes[dataAttribute]
-      }
-    }
-
-    config = {
-      ...dataAttributes,
-      ...(typeof config === 'object' && config ? config : {})
-    }
-    config = this._mergeConfigObj(config)
-    config = this._configAfterMerge(config)
-    this._typeCheckConfig(config)
-
-    return config
   }
 
   // Static

--- a/js/src/tooltip.ts
+++ b/js/src/tooltip.ts
@@ -45,7 +45,6 @@ import {
  */
 
 const NAME = 'tooltip'
-const DISALLOWED_ATTRIBUTES = new Set(['sanitize', 'allowList', 'sanitizeFn'])
 
 const ESCAPE_KEY = 'Escape'
 
@@ -854,25 +853,6 @@ class Tooltip extends BaseComponent {
 
   protected _isWithActiveTrigger(): boolean {
     return Object.values(this._activeTrigger).includes(true)
-  }
-
-  override _getConfig(config?: ComponentConfig | null): ComponentConfig {
-    const dataAttributes = Manipulator.getDataAttributes(this._element)
-
-    for (const dataAttribute of Object.keys(dataAttributes)) {
-      if (DISALLOWED_ATTRIBUTES.has(dataAttribute)) {
-        delete dataAttributes[dataAttribute]
-      }
-    }
-
-    config = {
-      ...dataAttributes,
-      ...(typeof config === 'object' && config ? config : {})
-    }
-    config = this._mergeConfigObj(config)
-    config = this._configAfterMerge(config)
-    this._typeCheckConfig(config)
-    return config
   }
 
   override _configAfterMerge(config: ComponentConfig): ComponentConfig {

--- a/js/tests/unit/chip.spec.js
+++ b/js/tests/unit/chip.spec.js
@@ -78,6 +78,15 @@ describe('Chip', () => {
       expect(chip._selected).toBeTrue()
     })
 
+    it('should initialize as disabled via data-coreui-config', () => {
+      fixtureEl.innerHTML = '<span class="chip" data-coreui-config=\'{"disabled": true}\'>Tag</span>'
+
+      const chipEl = fixtureEl.querySelector('.chip')
+      const chip = new Chip(chipEl)
+
+      expect(chip._disabled).toBeTrue()
+    })
+
     it('should initialize as disabled via config', () => {
       fixtureEl.innerHTML = '<span class="chip">Tag</span>'
 


### PR DESCRIPTION
Stacked on #1226 — merge that one first, then rebase this onto `v6-dev`.

## What changes

Calendar, Chip, Rating, RangeSlider and Tooltip each carried their own copy of the `sanitize`/`allowList`/`sanitizeFn` filter in `_getConfig()`, merging the config without the element afterwards. Since #1226 `Config._mergeConfigObj()` applies that filter for every component, so the five overrides and their `DISALLOWED_ATTRIBUTES` constants are removed (87 lines).

## Side effect

These five now honour `data-coreui-config` like the rest of the library. Their element-less merge had been skipping the JSON attribute entirely. Covered by a new Chip test.

Tooltip diverges from upstream here on purpose (no `_getConfig()` override); noted in the JS parity audit.

## Tests

Full unit suite: 69 files, 3772 tests green; `js-typecheck` clean.
