### PR TITLE
fix(DialogBase): finish the lifecycle when the dialog is closed natively

### DIFF
--- a/js/src/dialog-base.ts
+++ b/js/src/dialog-base.ts
@@ -36,13 +36,16 @@ class DialogBase extends BaseComponent {
   protected declare _element: HTMLDialogElement
   protected declare _isTransitioning: boolean
   protected declare _openedAsModal: boolean
+  protected declare _closedByComponent: boolean
   protected declare _cancelHandler: (event: Event) => void
+  protected declare _closeHandler: (event: Event) => void
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
     super(element, config)
 
     this._isTransitioning = false
     this._openedAsModal = false
+    this._closedByComponent = false
     this._addDialogListeners()
   }
 
@@ -107,10 +110,7 @@ class DialogBase extends BaseComponent {
         this._closeAndCleanup()
       }
 
-      this._element.classList.remove(CLASS_NAME_HIDING)
-      this._onAfterHide()
-      this._isTransitioning = false
-      EventHandler.trigger(this._element, this.constructor.eventName('hidden'))
+      this._finishHide()
     }, this._element, this._isAnimated())
   }
 
@@ -122,9 +122,10 @@ class DialogBase extends BaseComponent {
       this._closeAndCleanup()
     }
 
-    // The `cancel` listener is unnamespaced, so super.dispose()'s EVENT_KEY
-    // teardown misses it.
+    // The `cancel` and `close` listeners are unnamespaced, so super.dispose()'s
+    // EVENT_KEY teardown misses them.
     EventHandler.off(this._element, 'cancel', this._cancelHandler)
+    EventHandler.off(this._element, 'close', this._closeHandler)
 
     super.dispose()
   }
@@ -189,12 +190,23 @@ class DialogBase extends BaseComponent {
 
   // Safe to call multiple times — close() is a no-op on a closed dialog.
   protected _closeAndCleanup(): void {
-    this._element.close()
+    if (this._element.open) {
+      this._closedByComponent = true
+      this._element.close()
+    }
+
     this._openedAsModal = false
 
     if (!document.querySelector('dialog[open]:modal')) {
       document.documentElement.classList.remove(CLASS_NAME_OPEN)
     }
+  }
+
+  protected _finishHide(): void {
+    this._element.classList.remove(CLASS_NAME_HIDING)
+    this._onAfterHide()
+    this._isTransitioning = false
+    EventHandler.trigger(this._element, this.constructor.eventName('hidden'))
   }
 
   protected _triggerBackdropTransition(): void {
@@ -253,6 +265,24 @@ class DialogBase extends BaseComponent {
     }
 
     EventHandler.on(this._element, 'cancel', this._cancelHandler)
+
+    // The native close event also follows the component's own close(), a task
+    // later — `_closedByComponent` tells that one apart from a form with
+    // method="dialog", a consumer's dialog.close() or any other native path,
+    // which skip hide() and would otherwise leave the scroll lock and the
+    // lifecycle state behind.
+    this._closeHandler = () => {
+      if (this._closedByComponent) {
+        this._closedByComponent = false
+        return
+      }
+
+      this._hideChildComponents()
+      this._closeAndCleanup()
+      this._finishHide()
+    }
+
+    EventHandler.on(this._element, 'close', this._closeHandler)
 
     // Escape for non-modal dialogs — native cancel doesn't fire for show()
     EventHandler.on(this._element, `keydown${eventKey}`, event => {

--- a/js/tests/unit/dialog.spec.js
+++ b/js/tests/unit/dialog.spec.js
@@ -369,6 +369,107 @@ describe('Dialog', () => {
     })
   })
 
+  describe('native close', () => {
+    it('should finish the lifecycle when the dialog is closed natively', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<dialog class="dialog dialog-instant"></dialog>'
+
+        const dialogEl = fixtureEl.querySelector('.dialog')
+        const dialog = new Dialog(dialogEl)
+        const hideSpy = jasmine.createSpy('hide')
+
+        dialogEl.addEventListener('hide.coreui.dialog', hideSpy)
+
+        dialogEl.addEventListener('shown.coreui.dialog', () => {
+          dialogEl.close()
+        })
+
+        dialogEl.addEventListener('hidden.coreui.dialog', () => {
+          expect(dialogEl.open).toBeFalse()
+          expect(document.documentElement.classList.contains('dialog-open')).toBeFalse()
+          expect(dialog._openedAsModal).toBeFalse()
+          expect(hideSpy).not.toHaveBeenCalled()
+          resolve()
+        })
+
+        dialog.show()
+      })
+    })
+
+    it('should finish the lifecycle when a form with method="dialog" is submitted', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<dialog class="dialog dialog-instant">',
+          '  <form method="dialog"><button type="submit">Save</button></form>',
+          '</dialog>'
+        ].join('')
+
+        const dialogEl = fixtureEl.querySelector('.dialog')
+        const dialog = new Dialog(dialogEl)
+
+        dialogEl.addEventListener('shown.coreui.dialog', () => {
+          dialogEl.querySelector('button').click()
+        })
+
+        dialogEl.addEventListener('hidden.coreui.dialog', () => {
+          expect(dialogEl.open).toBeFalse()
+          expect(document.documentElement.classList.contains('dialog-open')).toBeFalse()
+          resolve()
+        })
+
+        dialog.show()
+      })
+    })
+
+    it('should fire hidden once when hide() closes the dialog', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<dialog class="dialog dialog-instant"></dialog>'
+
+        const dialogEl = fixtureEl.querySelector('.dialog')
+        const dialog = new Dialog(dialogEl)
+        const hiddenSpy = jasmine.createSpy('hidden')
+
+        dialogEl.addEventListener('hidden.coreui.dialog', hiddenSpy)
+
+        dialogEl.addEventListener('shown.coreui.dialog', () => {
+          dialog.hide()
+        })
+
+        dialog.show()
+
+        setTimeout(() => {
+          expect(hiddenSpy).toHaveBeenCalledTimes(1)
+          expect(dialog._closedByComponent).toBeFalse()
+          resolve()
+        }, 50)
+      })
+    })
+
+    it('should not react to a native close after dispose', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<dialog class="dialog dialog-instant"></dialog>'
+
+        const dialogEl = fixtureEl.querySelector('.dialog')
+        const dialog = new Dialog(dialogEl)
+        const hiddenSpy = jasmine.createSpy('hidden')
+
+        dialogEl.addEventListener('hidden.coreui.dialog', hiddenSpy)
+
+        dialogEl.addEventListener('shown.coreui.dialog', () => {
+          dialog.dispose()
+          dialogEl.dispatchEvent(createEvent('close'))
+
+          setTimeout(() => {
+            expect(hiddenSpy).not.toHaveBeenCalled()
+            resolve()
+          }, 50)
+        })
+
+        dialog.show()
+      })
+    })
+  })
+
   describe('backdrop static', () => {
     it('should not close dialog when backdrop is static and backdrop is clicked', () => {
       return new Promise(resolve => {


### PR DESCRIPTION
## Before / after

- Before: a `<form method="dialog">` submit, a consumer's `dialog.close()` or any other native close path removed `open` without going through `hide()`. The `dialog-open` scroll lock stayed on `<html>`, `_openedAsModal` kept its stale value and no `hidden.coreui.*` event fired. `dispose()` did not help either — it only cleans up while `open` is still set.
- After: `DialogBase` listens to the native `close` event. `_closeAndCleanup()` flags the closes it makes itself, so the listener only acts on closes from outside: it hides child tooltips/popovers/toasts, releases the lock and runs the same `_finishHide()` that `hide()` ends with. `hidden` fires exactly once on either path.

No `hide` event is emitted for a native close — the dialog is already closed, so there is nothing left to prevent. Applies to Dialog, Modal, Drawer and Offcanvas alike.

## Tests (`dialog.spec.js`, "native close")

- `dialogEl.close()` → `hidden`, lock released, `_openedAsModal` reset, no `hide` event.
- `<form method="dialog">` submit → same.
- `hide()` still fires `hidden` once and leaves the flag clear.
- A `close` after `dispose()` is ignored.

Full unit suite: 69 files, 3776 tests green; `js-typecheck` clean.

Ref: `v6-js-scss-bugs-audit-2026-09.md` JS-03. React/Vue `useDialog` share the gap; ports follow in their repos.
