### PR TITLE
fix: expose the offcanvas plugin as coreui.Offcanvas in the UMD bundle

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -192,6 +192,18 @@ They are no longer part of the published package. Use the built bundle instead:
 or, if you are already resolving the package by name, `import { Tooltip } from
 '@coreui/coreui-pro'` — `module` points at the same ESM bundle.
 
+#### `coreui.Offcanvas` in the UMD bundle
+
+The UMD bundle exposed the offcanvas plugin as `coreui.OffCanvas`, while the
+ESM bundle, the per-plugin file and the docs all call it `Offcanvas`. The UMD
+global now carries `coreui.Offcanvas` as well; `coreui.OffCanvas` stays as an
+alias of the same class, so existing scripts keep working:
+
+```diff
+- const offcanvas = new coreui.OffCanvas('#offcanvasExample')
++ const offcanvas = new coreui.Offcanvas('#offcanvasExample')
+```
+
 #### Lifecycle methods return a promise
 
 `show()`, `hide()`, `toggle()` and `close()` returned before the transition

--- a/js/index.umd.js
+++ b/js/index.umd.js
@@ -31,7 +31,7 @@ import Menu from './src/menu.js'
 import Modal from './src/modal.js'
 import MultiSelect from './src/multi-select.js'
 import Navigation from './src/navigation.js'
-import OffCanvas from './src/offcanvas.js'
+import Offcanvas from './src/offcanvas.js'
 import OTPInput from './src/otp-input.js'
 import NumberInput from './src/number-input.js'
 import PasswordInput from './src/password-input.js'
@@ -80,7 +80,8 @@ export default {
   Modal,
   MultiSelect,
   Navigation,
-  OffCanvas,
+  Offcanvas,
+  OffCanvas: Offcanvas,
   OTPInput,
   NumberInput,
   PasswordInput,


### PR DESCRIPTION
## Before / after

- Before: `js/index.umd.js` exported the class as `OffCanvas`, so the UMD global was `coreui.OffCanvas`, while the ESM bundle, `js/dist/offcanvas.js`, the declarations and every docs page say `Offcanvas`. Following the docs against the UMD bundle gave `undefined`.
- After: the UMD global carries `coreui.Offcanvas`. `coreui.OffCanvas` stays as an alias of the same class, so scripts written against the old name keep working. Migration guide (JavaScript section) documents both.

No change to the class, the ESM bundle or the per-plugin file.

Ref: `v6-js-scss-bugs-audit-2026-09.md`, "Dodatkowa uwaga poza głównym zakresem".
