### PR TITLE
fix(NumberInput): follow a form reset and step fields with step="any"

### DIFF
--- a/js/src/number-input.ts
+++ b/js/src/number-input.ts
@@ -28,6 +28,7 @@ const EVENT_CHANGE = `change${EVENT_KEY}`
 const EVENT_CLICK = `click${EVENT_KEY}`
 const EVENT_INPUT = `input${EVENT_KEY}`
 const EVENT_POINTERDOWN = `pointerdown${EVENT_KEY}`
+const EVENT_RESET = `reset${EVENT_KEY}`
 const EVENTS_STOP_REPEAT = ['pointerup', 'pointercancel', 'pointerleave'].map(event => `${event}${EVENT_KEY}`)
 
 const CLASS_NAME_ACTION = 'form-control-action'
@@ -87,6 +88,9 @@ class NumberInput extends BaseComponent {
   private _repeatTimeout: ReturnType<typeof setTimeout> | null = null
   private _repeatInterval: ReturnType<typeof setInterval> | null = null
   private _stopRepeatingHandler = (): void => this._stopRepeating()
+  private _resetHandler = (): void => {
+    setTimeout(() => this._updateButtonState())
+  }
 
   constructor(element: string | Element, config?: Partial<NumberInputConfig>) {
     super(element, config)
@@ -125,6 +129,8 @@ class NumberInput extends BaseComponent {
       EventHandler.off(document, event, this._stopRepeatingHandler)
     }
 
+    EventHandler.off(this._element.form, EVENT_RESET, this._resetHandler)
+
     for (const button of [this._decrementElement, this._incrementElement]) {
       EventHandler.off(button, EVENT_KEY)
       button?.remove()
@@ -148,18 +154,43 @@ class NumberInput extends BaseComponent {
       return
     }
 
-    if (this._element.value === '') {
+    const previousValue = this._element.value
+
+    if (previousValue === '') {
       this._element.value = this._element.min === '' ? '0' : this._element.min
+    } else if (this._element.step === 'any') {
+      this._stepByOne(direction)
     } else if (direction === 'up') {
       this._element.stepUp()
     } else {
       this._element.stepDown()
     }
 
+    if (this._element.value === previousValue) {
+      return
+    }
+
     this._updateButtonState()
     EventHandler.trigger(this._element, 'input', { bubbles: true })
     EventHandler.trigger(this._element, 'change', { bubbles: true })
     EventHandler.trigger(this._element, EVENT_CHANGE, { value: this._element.value })
+  }
+
+  // stepUp()/stepDown() throw on step="any"; the native spinner moves such a
+  // field by one, so the buttons do the same.
+  _stepByOne(direction: 'up' | 'down'): void {
+    const { max, min, value } = this._element
+    let next = Number(value) + (direction === 'up' ? 1 : -1)
+
+    if (min !== '') {
+      next = Math.max(next, Number(min))
+    }
+
+    if (max !== '') {
+      next = Math.min(next, Number(max))
+    }
+
+    this._element.value = String(next)
   }
 
   _createButtons(): void {
@@ -213,9 +244,13 @@ class NumberInput extends BaseComponent {
       }
     }
 
-    // The value can change without the buttons — typing, a form reset, a script
-    // — and the bounds have to follow it.
+    // The value can change without the buttons — typing, a form reset — and the
+    // bounds have to follow it. The reset event precedes the reset itself.
     EventHandler.on(this._element, EVENT_INPUT, () => this._updateButtonState())
+
+    if (this._element.form) {
+      EventHandler.on(this._element.form, EVENT_RESET, this._resetHandler)
+    }
 
     for (const event of EVENTS_STOP_REPEAT) {
       EventHandler.on(document, event, this._stopRepeatingHandler)

--- a/js/tests/unit/number-input.spec.js
+++ b/js/tests/unit/number-input.spec.js
@@ -85,6 +85,31 @@ describe('NumberInput', () => {
       expect(input.value).toBe('1')
     })
 
+    it('should step by one when step is any', () => {
+      const input = markup('value="1.5" step="any" max="2"')
+      const numberInput = new NumberInput(input)
+
+      numberInput.increment()
+      expect(input.value).toBe('2')
+
+      numberInput.decrement()
+      numberInput.decrement()
+      expect(input.value).toBe('0')
+    })
+
+    it('should not fire events when the value cannot move', () => {
+      const input = markup('value="2" max="2"')
+      const numberInput = new NumberInput(input)
+      const seen = []
+
+      input.addEventListener('input', () => seen.push('input'))
+      input.addEventListener('change.coreui.number-input', () => seen.push('change'))
+
+      numberInput.increment()
+
+      expect(seen).toEqual([])
+    })
+
     it('should fire input and change on the element', () => {
       const input = markup('value="1"')
       const numberInput = new NumberInput(input)
@@ -111,6 +136,25 @@ describe('NumberInput', () => {
 
       expect(buttons()[0].disabled).toBe(false)
       expect(buttons()[1].disabled).toBe(true)
+    })
+
+    it('should follow a form reset', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<form><input type="number" class="form-control" value="1" max="2"></form>'
+        const input = fixtureEl.querySelector('input')
+        const numberInput = new NumberInput(input)
+
+        numberInput.increment()
+        expect(buttons()[1].disabled).toBe(true)
+
+        fixtureEl.querySelector('form').reset()
+
+        setTimeout(() => {
+          expect(input.value).toBe('1')
+          expect(buttons()[1].disabled).toBe(false)
+          resolve()
+        }, 10)
+      })
     })
 
     it('should follow a value typed into the input', () => {
@@ -241,6 +285,23 @@ describe('NumberInput', () => {
       input.dispatchEvent(new Event('input'))
 
       expect(input.value).toBe('2')
+    })
+
+    it('should drop its form listener', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<form><input type="number" class="form-control" value="1" max="2"></form>'
+        const input = fixtureEl.querySelector('input')
+        const numberInput = new NumberInput(input)
+        const spy = spyOn(numberInput, '_updateButtonState').and.callThrough()
+
+        numberInput.dispose()
+        fixtureEl.querySelector('form').reset()
+
+        setTimeout(() => {
+          expect(spy).not.toHaveBeenCalled()
+          resolve()
+        }, 10)
+      })
     })
 
     it('should drop its document listeners', () => {


### PR DESCRIPTION
## Before / after

- **Form reset (JS-10).** The buttons' disabled state followed only `input`, and a native reset fires none. Value 1, max 2, increment to 2 disables plus; reset restores 1 and plus stayed disabled. The component now listens to `reset` on the owning form (per-instance handler, removed on dispose) and refreshes the state once the reset has landed.
- **`step="any"` (JS-11).** `stepUp()`/`stepDown()` throw `InvalidStateError` on such a field. The buttons now move it by one, clamped to `min`/`max`, the way the native spinner does.
- **No-op steps.** A step that cannot move the value (already at a bound) no longer fires `input`, `change` and `change.coreui.number-input`.

## Tests

`number-input.spec.js`: step by one on `step="any"`, silent no-op at a bound, button state after `form.reset()`, form listener gone after `dispose()`.

Ref: `v6-js-scss-bugs-audit-2026-09.md` JS-10, JS-11.
