### PR TITLE
fix(Popup): position with physical offsets only

### DIFF
--- a/js/src/util/popup.ts
+++ b/js/src/util/popup.ts
@@ -342,7 +342,6 @@ class Popup extends Config {
       }
 
       Object.assign(this._content.style, {
-        insetInlineStart: '0',
         left: `${x}px`,
         position: 'absolute',
         top: `${y}px`

--- a/js/tests/unit/util/popup.spec.js
+++ b/js/tests/unit/util/popup.spec.js
@@ -507,6 +507,36 @@ describe('Popup', () => {
       expect(fixtureEl.querySelector('#content').style.position).toEqual('')
     })
 
+    it('should position with physical offsets only, so RTL gets no competing inline-start', () => {
+      return new Promise((resolve, reject) => {
+        document.documentElement.dir = 'rtl'
+        const popup = buildPopup({ mobileBreakpoint: 0 })
+        const content = fixtureEl.querySelector('#content')
+        popup.show()
+
+        const waitForPosition = deadline => {
+          if (content.style.position === 'absolute') {
+            document.documentElement.dir = ''
+            expect(content.style.left).not.toEqual('')
+            expect(content.style.right).toEqual('')
+            expect(content.style.insetInlineStart).toEqual('')
+            resolve()
+            return
+          }
+
+          if (Date.now() > deadline) {
+            document.documentElement.dir = ''
+            reject(new Error('content was never positioned'))
+            return
+          }
+
+          setTimeout(() => waitForPosition(deadline), 25)
+        }
+
+        waitForPosition(Date.now() + 2000)
+      })
+    })
+
     it('should absolutely position the content after show', () => {
       return new Promise((resolve, reject) => {
         const popup = buildPopup({ mobileBreakpoint: 0 })


### PR DESCRIPTION
## Before / after

- Before: `_updatePosition()` set `inset-inline-start: 0` alongside the `left`/`top` Floating UI computed. In LTR both resolve to `left` and the later `left` won, so nothing showed. In RTL `inset-inline-start` is `right`, so the panel carried `right: 0` and `left: x` at once: an auto-width panel stretched across the gap, a fixed-width one had two competing constraints.
- After: the panel gets `left`/`top` only. Floating UI returns physical coordinates, so this is the one coordinate model the code now uses. No LTR change.

## Tests

`popup.spec.js`: under `dir="rtl"` the positioned panel has `left` set and neither `right` nor `inset-inline-start`. Popup, DatePicker and TimePicker suites green.

Ref: `v6-js-scss-bugs-audit-2026-09.md` JS-06.
