### PR TITLE
fix(PasswordInput): detach the toggle listener on dispose

### DIFF
--- a/js/src/password-input.ts
+++ b/js/src/password-input.ts
@@ -24,6 +24,8 @@ const DATA_KEY = 'coreui.password-input'
 const EVENT_KEY = `.${DATA_KEY}`
 const DATA_API_KEY = '.data-api'
 
+const EVENT_CLICK = `click${EVENT_KEY}`
+
 const CLASS_NAME_ACTION = 'form-control-action'
 const CLASS_NAME_PASSWORD_INPUT = 'password-input'
 
@@ -94,7 +96,10 @@ class PasswordInput extends BaseComponent {
   }
 
   override dispose(): void {
-    this._toggleElement?.remove()
+    if (this._toggleElement) {
+      EventHandler.off(this._toggleElement, EVENT_KEY)
+      this._toggleElement.remove()
+    }
 
     if (this._group) {
       this._group.element.classList.remove(CLASS_NAME_PASSWORD_INPUT)
@@ -119,7 +124,7 @@ class PasswordInput extends BaseComponent {
       sanitizeIcon: (icon: string) => this._sanitizeIcon(icon)
     })
 
-    EventHandler.on(this._toggleElement, 'click', () => this.toggle())
+    EventHandler.on(this._toggleElement, EVENT_CLICK, () => this.toggle())
     this._group.element.append(this._toggleElement)
   }
 

--- a/js/tests/unit/password-input.spec.js
+++ b/js/tests/unit/password-input.spec.js
@@ -287,6 +287,16 @@ describe('PasswordInput', () => {
       expect(toggle.getAttribute('aria-pressed')).toBe('false')
     })
 
+    it('should drop the button listener on dispose', () => {
+      const input = initialized('<input type="password" class="form-control" data-coreui-toggle="password-input">')
+      const toggle = fixtureEl.querySelector('.form-control-action')
+
+      PasswordInput.getInstance(input).dispose()
+      toggle.dispatchEvent(createEvent('click'))
+
+      expect(input.type).toBe('password')
+    })
+
     it('should disable its button for a disabled control', () => {
       initialized('<input type="password" class="form-control" disabled data-coreui-toggle="password-input">')
 


### PR DESCRIPTION
## Before / after

- Before: the toggle's `click` handler was registered without the component namespace and `dispose()` only removed the button from the DOM. `BaseComponent.dispose()` detaches events from the input, not the button, so the EventHandler registry kept the wrapper, and with it the button, the instance and the input, reachable after dispose. A click on a detached button still toggled the field.
- After: the handler is `click.coreui.password-input` and `dispose()` calls `EventHandler.off(button, EVENT_KEY)` before dropping the button, the same way NumberInput already does.

## Tests

`password-input.spec.js`: a click on the toggle after `dispose()` no longer changes the input type.

Ref: `v6-js-scss-bugs-audit-2026-09.md` JS-12. React/Vue manage the button listener through the framework, nothing to port.
