### PR TITLE
fix(forms): reach a floating-labelled field inside a control group

### DIFF
--- a/js/tests/visual/floating-labels.spec.js
+++ b/js/tests/visual/floating-labels.spec.js
@@ -151,6 +151,42 @@ describe('floating labels', () => {
     expect(labelFloats(root)).toBeTrue()
   })
 
+  // `floatingLabel` puts the field inside `.form-floating` inside the group, so
+  // the cleaner and validation rules keyed to `> .form-date-time` must reach
+  // one level deeper as well.
+  const buildLabelled = config => {
+    container = document.createElement('div')
+    container.style.cssText = 'padding: 1rem; width: 420px;'
+    container.innerHTML = '<div id="host"></div>'
+    document.body.append(container)
+
+    new DatePicker(container.querySelector('#host'), { locale: 'en-US', floatingLabel: 'Delivery date', ...config })
+    return container.querySelector('.form-control-group')
+  }
+
+  it('hides the cleaner of a floating-labelled picker while it is empty', () => {
+    const group = buildLabelled({})
+    expect(getComputedStyle(group.querySelector('.form-control-cleaner')).display).toBe('none')
+  })
+
+  it('shows the cleaner of a floating-labelled picker once it is filled', () => {
+    const group = buildLabelled({ date: DATE })
+    expect(getComputedStyle(group.querySelector('.form-control-cleaner')).display).not.toBe('none')
+  })
+
+  it('carries the invalid state of a floating-labelled field to the frame', () => {
+    const plain = build(HOST_DIV, DatePicker, { locale: 'en-US', date: DATE })
+    plain.querySelector('.form-date-time').classList.add('is-invalid')
+    const reference = getComputedStyle(plain.querySelector('.form-control-group')).borderColor
+
+    const valid = buildLabelled({ date: DATE })
+    expect(getComputedStyle(valid).borderColor).not.toBe(reference)
+
+    const invalid = buildLabelled({ date: DATE })
+    invalid.querySelector('.form-date-time').classList.add('is-invalid')
+    expect(getComputedStyle(invalid).borderColor).toBe(reference)
+  })
+
   // The per-field mode: startLabel / endLabel render a label inside the group
   // over each date, no wrapper markup. Each floats on its own field's state.
   const buildTwoLabel = config => {

--- a/scss/forms/_form-date-time.scss
+++ b/scss/forms/_form-date-time.scss
@@ -29,7 +29,7 @@ $form-date-time-tokens: defaults(
 // stylelint-enable scss/dollar-variable-default
 
 @layer forms {
-  .form-control-group:has(> .form-date-time):not(:has(> .form-date-time-filled)) > .form-control-cleaner {
+  .form-control-group:has(> .form-date-time, > .form-floating > .form-date-time):not(:has(> .form-date-time-filled, > .form-floating > .form-date-time-filled)) > .form-control-cleaner {
     display: none;
   }
 

--- a/scss/forms/_validation.scss
+++ b/scss/forms/_validation.scss
@@ -101,24 +101,28 @@
   // The state has to reach the group: a custom property set on the control
   // inside it only inherits downwards, never back up to the frame.
   .form-control-group.is-#{$state},
-  .form-control-group:has(> .form-control.is-#{$state}) {
+  .form-control-group:has(> .form-control.is-#{$state}),
+  .form-control-group:has(> .form-floating > .form-control.is-#{$state}) {
     @include form-control-group-validation-state($color, $border-color, $focus-ring-color);
   }
 
   @if $state == "invalid" {
     [data-coreui-validate] .form-control-group:has(> .form-control:user-invalid),
+    [data-coreui-validate] .form-control-group:has(> .form-floating > .form-control:user-invalid),
     [data-coreui-validate] .form-control-group:has(> select:user-invalid) {
       @include form-control-group-validation-state($color, $border-color, $focus-ring-color);
     }
   } @else if $state == "valid" {
     [data-coreui-validate~="valid"] .form-control-group:has(> .form-control:user-valid),
+    [data-coreui-validate~="valid"] .form-control-group:has(> .form-floating > .form-control:user-valid),
     [data-coreui-validate~="valid"] .form-control-group:has(> select:user-valid) {
       @include form-control-group-validation-state($color, $border-color, $focus-ring-color);
     }
   }
 
   @if $enable-validation-icons {
-    .form-control-group > .form-control {
+    .form-control-group > .form-control,
+    .form-control-group > .form-floating > .form-control {
       @include form-validation-state-selector($state) {
         background-image: none;
       }


### PR DESCRIPTION
## Before / after

A picker built with `floatingLabel` renders `.form-control-group > .form-floating > .form-date-time`, one level deeper than the bare `.form-control-group > .form-date-time`.

- **Cleaner (SCSS-03).** The rule hiding the cleaner of an empty field matched only the direct child, so an empty labelled picker kept its clear button. It now matches both structures.
- **Validation (SCSS-02).** `.form-control-group:has(> .form-control.is-invalid)` and the `[data-coreui-validate]` `:user-invalid`/`:user-valid` variants matched only the direct child, so a state on the inner field never reached the frame, and the inner field's own border is zeroed by the group. Both now match `> .form-floating > .form-control` as well, and the validation-icon suppression covers the inner control too.

Compiled CSS diff is limited to those selectors; layer order unchanged.

## Tests

`js/tests/visual/floating-labels.spec.js` (real Chromium, computed styles): the cleaner of a labelled picker is hidden while empty and shown once filled; `.is-invalid` on the labelled field gives the frame the same border colour as on a bare picker.

Ref: `v6-js-scss-bugs-audit-2026-09.md` SCSS-02, SCSS-03. SCSS ships from this package, nothing to port.
