### PR TITLE
fix(forms): mirror the floating label's scale origin and shift in RTL

### DIFF
--- a/js/tests/visual/floating-labels.spec.js
+++ b/js/tests/visual/floating-labels.spec.js
@@ -151,6 +151,35 @@ describe('floating labels', () => {
     expect(labelFloats(root)).toBeTrue()
   })
 
+  // The label anchors its scale at the inline start, so in RTL the origin and
+  // the inline shift have to mirror or the label drifts off its own field.
+  it('scales the label from the inline-start edge in RTL', () => {
+    document.documentElement.dir = 'rtl'
+
+    try {
+      const root = mount('<input type="text" class="form-control" id="host" placeholder=" " value="x">')
+      const label = root.querySelector('label')
+      const { transform, transformOrigin } = getComputedStyle(label)
+      const [originX] = transformOrigin.split(' ')
+      const translateX = Number(transform.match(/matrix\((?:[^,]+,){4}\s*([^,]+)/)[1])
+
+      expect(Math.round(Number.parseFloat(originX))).toBe(label.offsetWidth)
+      expect(translateX).toBeLessThan(0)
+    } finally {
+      document.documentElement.dir = ''
+    }
+  })
+
+  it('scales the label from the left edge in LTR', () => {
+    const root = mount('<input type="text" class="form-control" id="host" placeholder=" " value="x">')
+    const label = root.querySelector('label')
+    const { transform, transformOrigin } = getComputedStyle(label)
+    const translateX = Number(transform.match(/matrix\((?:[^,]+,){4}\s*([^,]+)/)[1])
+
+    expect(transformOrigin).toMatch(/^0px 0px/)
+    expect(translateX).toBeGreaterThan(0)
+  })
+
   // `floatingLabel` puts the field inside `.form-floating` inside the group, so
   // the cleaner and validation rules keyed to `> .form-date-time` must reach
   // one level deeper as well.

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -1,5 +1,6 @@
 @use "../functions/defaults" as *;
 @use "../mixins/border-radius" as *;
+@use "../mixins/ltr-rtl" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
 @use "../config" as *;
@@ -15,6 +16,7 @@ $form-floating-input-padding-b:         .625rem !default;
 $form-floating-label-height:            1.5em !default;
 $form-floating-label-opacity:           .65 !default;
 $form-floating-label-transform:         scale(.85) translateY(-.5rem) translateX(.15rem) !default;
+$form-floating-label-transform-rtl:     scale(.85) translateY(-.5rem) translateX(-.15rem) !default;
 $form-floating-label-disabled-color:    var(--#{$prefix}fg-3) !default;
 // The label is a sibling of the control, so it cannot inherit the control's own
 // background — the textarea mask has to be told the same colour a second time.
@@ -27,6 +29,8 @@ $form-floating-transition-timing:       ease-in-out !default;
 // scss-docs-end form-floating-variables
 
 // stylelint-disable scss/dollar-variable-default
+
+// stylelint-disable custom-property-no-missing-var-function
 
 // scss-docs-start form-floating-tokens
 $form-floating-tokens: () !default;
@@ -53,6 +57,8 @@ $form-floating-tokens: defaults(
 );
 // scss-docs-end form-floating-tokens
 
+// stylelint-enable custom-property-no-missing-var-function
+
 // stylelint-enable scss/dollar-variable-default
 
 @layer forms {
@@ -64,6 +70,10 @@ $form-floating-tokens: defaults(
     @include tokens($form-floating-tokens);
 
     position: relative;
+
+    @include rtl() {
+      --#{$prefix}form-floating-label-transform: #{$form-floating-label-transform-rtl};
+    }
 
     > .form-control,
     > .form-control-plaintext,
@@ -90,7 +100,7 @@ $form-floating-tokens: defaults(
       white-space: nowrap;
       pointer-events: none;
       border: var(--#{$prefix}btn-input-border-width) solid transparent; // Required for aligning label's text with the input as it affects inner box model
-      transform-origin: 0 0;
+      @include ltr-rtl-value-only("transform-origin", 0 0, 100% 0);
       @include transition-props(
         var(--#{$prefix}form-floating-transition-property),
         var(--#{$prefix}form-floating-transition-duration),


### PR DESCRIPTION
## Before / after

- Before: the label is positioned with `inset-inline-start`, but it scaled from `transform-origin: 0 0` and shifted by a positive `translateX(.15rem)`. Under `dir="rtl"` the left edge stayed the anchor while the label's start was on the right, so the floated label drifted away from its field.
- After: under `[dir="rtl"]` the label scales from `100% 0` and the `--cui-form-floating-label-transform` token switches to `scale(.85) translateY(-.5rem) translateX(-.15rem)`. New Sass knob `$form-floating-label-transform-rtl` (in the `form-floating-variables` docs block). LTR output is byte-identical; the compiled diff is the two RTL rules.

## Tests

`js/tests/visual/floating-labels.spec.js` (Chromium): in RTL the computed origin x equals the label's layout width and the matrix translate is negative; in LTR the origin stays `0 0` and the translate positive.

Ref: `v6-js-scss-bugs-audit-2026-09.md` SCSS-04. SCSS ships from this package, nothing to port.
