### PR TITLE
feat(pickers): add the jQuery interface to the date and time pickers

### DIFF
--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -447,6 +447,23 @@ class DatePicker extends BaseComponent {
       }
     })
   }
+
+  // Static
+  static jQueryInterface(this: any, config: any): void {
+    return this.each(function (this: HTMLElement) {
+      const data: any = DatePicker.getOrCreateInstance(this, config)
+
+      if (typeof config !== 'string') {
+        return
+      }
+
+      if (data[config] === undefined || config.startsWith('_') || config === 'constructor') {
+        throw new TypeError(`No method named "${config}"`)
+      }
+
+      data[config]()
+    })
+  }
 }
 
 /**
@@ -463,8 +480,6 @@ EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
  * jQuery
  */
 
-// The v2 pickers define no `jQueryInterface`, so the plugin registers as
-// `undefined` — preserved as-is; fixing it is a behaviour change.
-defineJQueryPlugin(DatePicker as any)
+defineJQueryPlugin(DatePicker)
 
 export default DatePicker

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -562,6 +562,23 @@ class DateRangePicker extends BaseComponent {
       }
     })
   }
+
+  // Static
+  static jQueryInterface(this: any, config: any): void {
+    return this.each(function (this: HTMLElement) {
+      const data: any = DateRangePicker.getOrCreateInstance(this, config)
+
+      if (typeof config !== 'string') {
+        return
+      }
+
+      if (data[config] === undefined || config.startsWith('_') || config === 'constructor') {
+        throw new TypeError(`No method named "${config}"`)
+      }
+
+      data[config]()
+    })
+  }
 }
 
 /**
@@ -578,8 +595,6 @@ EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
  * jQuery
  */
 
-// The v2 pickers define no `jQueryInterface`, so the plugin registers as
-// `undefined` — preserved as-is; fixing it is a behaviour change.
-defineJQueryPlugin(DateRangePicker as any)
+defineJQueryPlugin(DateRangePicker)
 
 export default DateRangePicker

--- a/js/src/date-time-picker.ts
+++ b/js/src/date-time-picker.ts
@@ -480,6 +480,23 @@ class DateTimePicker extends BaseComponent {
       }
     })
   }
+
+  // Static
+  static jQueryInterface(this: any, config: any): void {
+    return this.each(function (this: HTMLElement) {
+      const data: any = DateTimePicker.getOrCreateInstance(this, config)
+
+      if (typeof config !== 'string') {
+        return
+      }
+
+      if (data[config] === undefined || config.startsWith('_') || config === 'constructor') {
+        throw new TypeError(`No method named "${config}"`)
+      }
+
+      data[config]()
+    })
+  }
 }
 
 /**
@@ -496,8 +513,6 @@ EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
  * jQuery
  */
 
-// The v2 pickers define no `jQueryInterface`, so the plugin registers as
-// `undefined` — preserved as-is; fixing it is a behaviour change.
-defineJQueryPlugin(DateTimePicker as any)
+defineJQueryPlugin(DateTimePicker)
 
 export default DateTimePicker

--- a/js/src/time-picker.ts
+++ b/js/src/time-picker.ts
@@ -401,6 +401,23 @@ class TimePicker extends BaseComponent {
       }
     })
   }
+
+  // Static
+  static jQueryInterface(this: any, config: any): void {
+    return this.each(function (this: HTMLElement) {
+      const data: any = TimePicker.getOrCreateInstance(this, config)
+
+      if (typeof config !== 'string') {
+        return
+      }
+
+      if (data[config] === undefined || config.startsWith('_') || config === 'constructor') {
+        throw new TypeError(`No method named "${config}"`)
+      }
+
+      data[config]()
+    })
+  }
 }
 
 /**
@@ -417,8 +434,6 @@ EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
  * jQuery
  */
 
-// The v2 pickers define no `jQueryInterface`, so the plugin registers as
-// `undefined` — preserved as-is; fixing it is a behaviour change.
-defineJQueryPlugin(TimePicker as any)
+defineJQueryPlugin(TimePicker)
 
 export default TimePicker

--- a/js/tests/unit/date-picker.spec.js
+++ b/js/tests/unit/date-picker.spec.js
@@ -1,5 +1,5 @@
 import DatePicker from '../../src/date-picker.js'
-import { clearFixture, getFixture } from '../helpers/fixture.js'
+import { clearFixture, getFixture, jQueryMock } from '../helpers/fixture.js'
 
 describe('DatePicker', () => {
   let fixtureEl
@@ -513,6 +513,65 @@ describe('DatePicker', () => {
       fixtureEl.querySelector('[data-coreui-picker-action="clear"]').click()
 
       expect(picker.getDate()).toBeNull()
+    })
+  })
+
+  describe('jQueryInterface', () => {
+    it('should create date-picker', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+
+      jQueryMock.fn.datePicker = DatePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      jQueryMock.fn.datePicker.call(jQueryMock)
+
+      expect(DatePicker.getInstance(el)).not.toBeNull()
+      DatePicker.getInstance(el).dispose()
+    })
+
+    it('should not re-create date-picker', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+      const picker = new DatePicker(el)
+
+      jQueryMock.fn.datePicker = DatePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      jQueryMock.fn.datePicker.call(jQueryMock)
+
+      expect(DatePicker.getInstance(el)).toEqual(picker)
+      picker.dispose()
+    })
+
+    it('should call a public method by name', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+      const picker = new DatePicker(el)
+      const spy = spyOn(picker, 'show')
+
+      jQueryMock.fn.datePicker = DatePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      jQueryMock.fn.datePicker.call(jQueryMock, 'show')
+
+      expect(spy).toHaveBeenCalled()
+      picker.dispose()
+    })
+
+    it('should throw error on undefined method', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+      const picker = new DatePicker(el)
+
+      jQueryMock.fn.datePicker = DatePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      expect(() => {
+        jQueryMock.fn.datePicker.call(jQueryMock, 'undefinedMethod')
+      }).toThrowError(TypeError, 'No method named "undefinedMethod"')
+
+      picker.dispose()
     })
   })
 

--- a/js/tests/unit/date-range-picker.spec.js
+++ b/js/tests/unit/date-range-picker.spec.js
@@ -1,5 +1,5 @@
 import DateRangePicker from '../../src/date-range-picker.js'
-import { clearFixture, getFixture } from '../helpers/fixture.js'
+import { clearFixture, getFixture, jQueryMock } from '../helpers/fixture.js'
 
 describe('DateRangePicker', () => {
   let fixtureEl
@@ -253,6 +253,65 @@ describe('DateRangePicker', () => {
 
       expect(picker.getStartDate()).toBeNull()
       expect(picker.getEndDate()).toBeNull()
+    })
+  })
+
+  describe('jQueryInterface', () => {
+    it('should create date-range-picker', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+
+      jQueryMock.fn.dateRangePicker = DateRangePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      jQueryMock.fn.dateRangePicker.call(jQueryMock)
+
+      expect(DateRangePicker.getInstance(el)).not.toBeNull()
+      DateRangePicker.getInstance(el).dispose()
+    })
+
+    it('should not re-create date-range-picker', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+      const picker = new DateRangePicker(el)
+
+      jQueryMock.fn.dateRangePicker = DateRangePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      jQueryMock.fn.dateRangePicker.call(jQueryMock)
+
+      expect(DateRangePicker.getInstance(el)).toEqual(picker)
+      picker.dispose()
+    })
+
+    it('should call a public method by name', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+      const picker = new DateRangePicker(el)
+      const spy = spyOn(picker, 'show')
+
+      jQueryMock.fn.dateRangePicker = DateRangePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      jQueryMock.fn.dateRangePicker.call(jQueryMock, 'show')
+
+      expect(spy).toHaveBeenCalled()
+      picker.dispose()
+    })
+
+    it('should throw error on undefined method', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+      const picker = new DateRangePicker(el)
+
+      jQueryMock.fn.dateRangePicker = DateRangePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      expect(() => {
+        jQueryMock.fn.dateRangePicker.call(jQueryMock, 'undefinedMethod')
+      }).toThrowError(TypeError, 'No method named "undefinedMethod"')
+
+      picker.dispose()
     })
   })
 

--- a/js/tests/unit/date-time-picker.spec.js
+++ b/js/tests/unit/date-time-picker.spec.js
@@ -1,5 +1,5 @@
 import DateTimePicker from '../../src/date-time-picker.js'
-import { clearFixture, getFixture } from '../helpers/fixture.js'
+import { clearFixture, getFixture, jQueryMock } from '../helpers/fixture.js'
 
 describe('DateTimePicker', () => {
   let fixtureEl
@@ -221,6 +221,65 @@ describe('DateTimePicker', () => {
       picker.getContext().clear()
 
       expect(picker.getDate()).toBeNull()
+    })
+  })
+
+  describe('jQueryInterface', () => {
+    it('should create date-time-picker', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+
+      jQueryMock.fn.dateTimePicker = DateTimePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      jQueryMock.fn.dateTimePicker.call(jQueryMock)
+
+      expect(DateTimePicker.getInstance(el)).not.toBeNull()
+      DateTimePicker.getInstance(el).dispose()
+    })
+
+    it('should not re-create date-time-picker', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+      const picker = new DateTimePicker(el)
+
+      jQueryMock.fn.dateTimePicker = DateTimePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      jQueryMock.fn.dateTimePicker.call(jQueryMock)
+
+      expect(DateTimePicker.getInstance(el)).toEqual(picker)
+      picker.dispose()
+    })
+
+    it('should call a public method by name', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+      const picker = new DateTimePicker(el)
+      const spy = spyOn(picker, 'show')
+
+      jQueryMock.fn.dateTimePicker = DateTimePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      jQueryMock.fn.dateTimePicker.call(jQueryMock, 'show')
+
+      expect(spy).toHaveBeenCalled()
+      picker.dispose()
+    })
+
+    it('should throw error on undefined method', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+      const picker = new DateTimePicker(el)
+
+      jQueryMock.fn.dateTimePicker = DateTimePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      expect(() => {
+        jQueryMock.fn.dateTimePicker.call(jQueryMock, 'undefinedMethod')
+      }).toThrowError(TypeError, 'No method named "undefinedMethod"')
+
+      picker.dispose()
     })
   })
 

--- a/js/tests/unit/jquery.spec.js
+++ b/js/tests/unit/jquery.spec.js
@@ -3,12 +3,16 @@ import Alert from '../../src/alert.js'
 import Button from '../../src/button.js'
 import Carousel from '../../src/carousel.js'
 import Collapse from '../../src/collapse.js'
+import DatePicker from '../../src/date-picker.js'
+import DateRangePicker from '../../src/date-range-picker.js'
+import DateTimePicker from '../../src/date-time-picker.js'
 import Dropdown from '../../src/dropdown.js'
 import Modal from '../../src/modal.js'
 import Offcanvas from '../../src/offcanvas.js'
 import Popover from '../../src/popover.js'
 import ScrollSpy from '../../src/scrollspy.js'
 import Tab from '../../src/tab.js'
+import TimePicker from '../../src/time-picker.js'
 import Toast from '../../src/toast.js'
 import Tooltip from '../../src/tooltip.js'
 import { clearFixture, getFixture } from '../helpers/fixture.js'
@@ -29,12 +33,16 @@ describe('jQuery', () => {
     expect(Button.jQueryInterface).toEqual(jQuery.fn.button)
     expect(Carousel.jQueryInterface).toEqual(jQuery.fn.carousel)
     expect(Collapse.jQueryInterface).toEqual(jQuery.fn.collapse)
+    expect(DatePicker.jQueryInterface).toEqual(jQuery.fn['date-picker'])
+    expect(DateRangePicker.jQueryInterface).toEqual(jQuery.fn['date-range-picker'])
+    expect(DateTimePicker.jQueryInterface).toEqual(jQuery.fn['date-time-picker'])
     expect(Dropdown.jQueryInterface).toEqual(jQuery.fn.dropdown)
     expect(Modal.jQueryInterface).toEqual(jQuery.fn.modal)
     expect(Offcanvas.jQueryInterface).toEqual(jQuery.fn.offcanvas)
     expect(Popover.jQueryInterface).toEqual(jQuery.fn.popover)
     expect(ScrollSpy.jQueryInterface).toEqual(jQuery.fn.scrollspy)
     expect(Tab.jQueryInterface).toEqual(jQuery.fn.tab)
+    expect(TimePicker.jQueryInterface).toEqual(jQuery.fn['time-picker'])
     expect(Toast.jQueryInterface).toEqual(jQuery.fn.toast)
     expect(Tooltip.jQueryInterface).toEqual(jQuery.fn.tooltip)
   })

--- a/js/tests/unit/time-picker.spec.js
+++ b/js/tests/unit/time-picker.spec.js
@@ -1,5 +1,5 @@
 import TimePicker from '../../src/time-picker.js'
-import { clearFixture, getFixture } from '../helpers/fixture.js'
+import { clearFixture, getFixture, jQueryMock } from '../helpers/fixture.js'
 
 describe('TimePicker', () => {
   let fixtureEl
@@ -338,6 +338,65 @@ describe('TimePicker', () => {
       first.focus()
       first.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
       expect(document.activeElement).toEqual(first)
+    })
+  })
+
+  describe('jQueryInterface', () => {
+    it('should create time-picker', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+
+      jQueryMock.fn.timePicker = TimePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      jQueryMock.fn.timePicker.call(jQueryMock)
+
+      expect(TimePicker.getInstance(el)).not.toBeNull()
+      TimePicker.getInstance(el).dispose()
+    })
+
+    it('should not re-create time-picker', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+      const picker = new TimePicker(el)
+
+      jQueryMock.fn.timePicker = TimePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      jQueryMock.fn.timePicker.call(jQueryMock)
+
+      expect(TimePicker.getInstance(el)).toEqual(picker)
+      picker.dispose()
+    })
+
+    it('should call a public method by name', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+      const picker = new TimePicker(el)
+      const spy = spyOn(picker, 'show')
+
+      jQueryMock.fn.timePicker = TimePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      jQueryMock.fn.timePicker.call(jQueryMock, 'show')
+
+      expect(spy).toHaveBeenCalled()
+      picker.dispose()
+    })
+
+    it('should throw error on undefined method', () => {
+      fixtureEl.innerHTML = '<div id="host"></div>'
+      const el = fixtureEl.querySelector('#host')
+      const picker = new TimePicker(el)
+
+      jQueryMock.fn.timePicker = TimePicker.jQueryInterface
+      jQueryMock.elements = [el]
+
+      expect(() => {
+        jQueryMock.fn.timePicker.call(jQueryMock, 'undefinedMethod')
+      }).toThrowError(TypeError, 'No method named "undefinedMethod"')
+
+      picker.dispose()
     })
   })
 


### PR DESCRIPTION
## Before / after

- Before: DatePicker, DateRangePicker, DateTimePicker and TimePicker called `defineJQueryPlugin()` without a `jQueryInterface`. With jQuery on the page the helper assigned `undefined` to `$.fn[name]` and threw setting `.Constructor` on it. Loaded before `DOMContentLoaded` this aborted the shared callback loop, so every plugin registered after the picker was skipped. The source comment said the plugin "registers as undefined"; it actually throws.
- After: the four pickers carry the same interface as the other 42 components (shape taken from Dialog): `$(el).datePicker()` creates or reuses the instance, a string argument calls a public method by name, an unknown name throws `TypeError: No method named "…"`. The `as any` casts are gone, so a future component without the member fails type-checking instead of runtime.

## Tests

- Each picker spec: create, reuse, call a method by name, throw on an unknown method (`jQueryMock`).
- `jquery.spec.js` (`JQUERY=true`, real jQuery): the four pickers are now in the "adds all plugins" list. Before this change importing them there threw.

Full picker suites green (135 tests), typecheck clean.

Ref: `v6-js-scss-bugs-audit-2026-09.md` JS-02 (mrholek, 2026-09-11: option a, add the interface).
