### PR TITLE
fix(form-control-group): keep state classes and js- hooks on the control

### DIFF
--- a/docs/src/content/docs/forms/number-input.mdx
+++ b/docs/src/content/docs/forms/number-input.mdx
@@ -58,6 +58,12 @@ class you wrote except `.form-control` itself**. Spacing, width and the rest
 describe the field as a whole, and the field is now the frame; leaving `mb-3`
 on the input would put the margin inside the border.
 
+State classes stay where you wrote them: `.is-valid`, `.is-invalid` and
+anything else starting with `is-` or `was-`, plus `js-` hooks your own code
+selects by. The frame picks the validation state up from the input, so
+`document.querySelector('.form-control.is-invalid')` still finds the control
+and a validator that toggles the class keeps working.
+
 <Example pro code={`<input type="number" class="form-control form-control-sm mb-3" value="3" aria-label="Quantity" data-coreui-toggle="number-input">
   <input type="number" class="form-control form-control-lg" value="3" aria-label="Quantity" data-coreui-toggle="number-input">`} />
 

--- a/docs/src/content/docs/forms/password-input.mdx
+++ b/docs/src/content/docs/forms/password-input.mdx
@@ -100,7 +100,9 @@ An input already inside a `.form-control-group` is left where you put it, so a
 password field can share a frame with other adornments; only a frame the
 component built is removed on `dispose()`. Classes you write on the input other
 than `.form-control` move onto that frame, because they describe the field and
-the field is the frame.
+the field is the frame — except state classes (`is-*`, `was-*`) and `js-*`
+hooks, which stay on the input so validators and your own selectors keep
+finding it; the frame reads the state from the input.
 
 ### CSS variables
 

--- a/js/src/util/form-control-group.ts
+++ b/js/src/util/form-control-group.ts
@@ -14,6 +14,7 @@ import { getUID } from './index.js'
 const CLASS_NAME_FORM_FLOATING = 'form-floating'
 const CLASS_NAME_GROUP = 'form-control-group'
 const CLASS_NAME_FORM_CONTROL = 'form-control'
+const CLASS_NAME_STAYS_ON_CONTROL = /^(?:is|was|js)-/
 
 export type ControlGroup = {
   created: boolean
@@ -29,7 +30,9 @@ export type ControlGroup = {
  * Everything the author wrote on that control except `.form-control` moves to
  * the group: a class on the control describes the field, and once it is
  * wrapped the field is the frame — a margin left behind would sit inside the
- * border.
+ * border. State classes (`is-*`, `was-*`) and `js-*` hooks stay: the control
+ * is the source of truth the frame reads through `:has()`, and application
+ * code keeps finding the control it wrote them on.
  * @param {HTMLElement} element The control.
  * @returns {ControlGroup} The group, whether it was created, and the classes moved onto it.
  */
@@ -43,7 +46,7 @@ export const ensureControlGroup = (element: HTMLElement): ControlGroup => {
   const group = document.createElement('div')
   group.classList.add(CLASS_NAME_GROUP)
 
-  const movedClassNames = [...element.classList].filter(name => name !== CLASS_NAME_FORM_CONTROL)
+  const movedClassNames = [...element.classList].filter(name => name !== CLASS_NAME_FORM_CONTROL && !CLASS_NAME_STAYS_ON_CONTROL.test(name))
   element.classList.remove(...movedClassNames)
   group.classList.add(...movedClassNames)
 

--- a/js/tests/unit/number-input.spec.js
+++ b/js/tests/unit/number-input.spec.js
@@ -231,6 +231,25 @@ describe('NumberInput', () => {
       expect(group.classList.contains('form-control')).toBe(false)
     })
 
+    it('should keep state classes and js- hooks on the input', () => {
+      fixtureEl.innerHTML = '<input type="number" class="form-control is-invalid was-validated js-price mb-3" value="1">'
+      const input = fixtureEl.querySelector('input')
+      const numberInput = new NumberInput(input)
+      const group = input.parentElement
+
+      for (const name of ['is-invalid', 'was-validated', 'js-price']) {
+        expect(input.classList.contains(name)).toBe(true)
+        expect(group.classList.contains(name)).toBe(false)
+      }
+
+      expect(group.classList.contains('mb-3')).toBe(true)
+      expect(group.matches(':has(> .form-control.is-invalid)')).toBe(true)
+
+      numberInput.dispose()
+
+      expect(input.className).toBe('form-control is-invalid was-validated js-price mb-3')
+    })
+
     it('should use a group the author already wrote', () => {
       const input = markup('value="1"')
       const group = input.closest('.form-control-group')

--- a/js/tests/unit/password-input.spec.js
+++ b/js/tests/unit/password-input.spec.js
@@ -335,6 +335,13 @@ describe('PasswordInput', () => {
       expect(fixtureEl.querySelector('.form-control-group')).toBeNull()
     })
 
+    it('should keep state classes on the input', () => {
+      const input = initialized('<input type="password" class="form-control is-invalid js-secret" data-coreui-toggle="password-input">')
+
+      expect(input.className).toBe('form-control is-invalid js-secret')
+      expect(input.parentElement.classList.contains('is-invalid')).toBe(false)
+    })
+
     it('should keep a group the author wrote', () => {
       fixtureEl.innerHTML = `<div class="form-control-group">
           <span class="form-control-icon"></span>


### PR DESCRIPTION
## Before / after

- Before: `ensureControlGroup()` moved every class but `.form-control` from the input onto the frame. `input.is-invalid` became `div.is-invalid`, so the `:has(> .form-control.is-invalid)` rule never matched and the frame was red only thanks to the fallback `.form-control-group.is-invalid` rule; a validator toggling `is-invalid` on the input afterwards changed nothing visible; `.js-*` selectors written for the input returned the frame.
- After: classes starting with `is-`, `was-` or `js-` stay on the control. Presentational classes (`form-control-lg`, `mb-3`, `w-50`) still move to the frame. The frame derives the validation state from the input through `:has()`, which the CSS already has. One helper, so NumberInput, PasswordInput and all pickers change together. React and Vue already render `is-*` on the input.

Docs: paragraphs on the Number Input and Password Input pages.

## Tests

`number-input.spec.js`: `is-invalid`, `was-validated`, `js-price` stay on the input, `mb-3` moves, the frame matches `:has(> .form-control.is-invalid)`, dispose restores the class list. `password-input.spec.js`: same for `is-invalid` and `js-secret`.

Ref: `v6-js-scss-bugs-audit-2026-09.md` JS-13 (mrholek, 2026-09-11: state on the control, look on the frame).
