### PR TITLE
feat(pickers): one event contract for show, hide, dateChange and reset

### DIFF
--- a/docs/src/content/docs/forms/autocomplete.mdx
+++ b/docs/src/content/docs/forms/autocomplete.mdx
@@ -347,9 +347,9 @@ The Autocomplete component exposes several events for integrating with applicati
 | Event | Description |
 | --- | --- |
 | `changed.coreui.autocomplete` | Fires when an option is selected or the input value changes. |
-| `show.coreui.autocomplete` | Event fires immediately when the show method is called. |
+| `show.coreui.autocomplete` | Event fires immediately when the show method is called. Call `event.preventDefault()` to keep the menu closed. |
 | `shown.coreui.autocomplete` | Fired when the dropdown has been made visible and CSS transitions completed. |
-| `hide.coreui.autocomplete` | Event fires immediately when the hide method is called. |
+| `hide.coreui.autocomplete` | Event fires immediately when the hide method is called. Call `event.preventDefault()` to keep the menu open. |
 | `hidden.coreui.autocomplete` | Fired when the dropdown has been hidden and CSS transitions completed. |
 | `input.coreui.autocomplete` | Fires when the search input value changes. |
 

--- a/docs/src/content/docs/forms/date-input.mdx
+++ b/docs/src/content/docs/forms/date-input.mdx
@@ -333,7 +333,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 | --- | --- |
 | `clear` | Clear all sections |
 | `getDate` | Return the current date, or `null` when incomplete or invalid |
-| `reset` | Reset the field to its initial date |
+| `reset` | Reset the field to the date it was created with, emitting `dateChange` when the value moves. A native form reset does the same. |
 | `update` | Update the configuration and re-render |
 
 ```javascript

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -427,10 +427,10 @@ context.disabled         // disabled state
 
 | Event | Description |
 | --- | --- |
-| `dateChange.coreui.date-picker` | Fired when the value changes — from the calendar, the field, or a context action. `event.date` carries the new value. |
-| `show.coreui.date-picker` | Fired immediately when `show` is called. |
+| `dateChange.coreui.date-picker` | Fired when the value changes — from the calendar, the field, or a context action. `event.date` is the validated `Date`, or `null`; `event.formattedDate` is the same value in the shape of `selectionType` (`2026-01`, `2026W03`, `2026Q1`, `2026`, or the `Date` itself for `day`). |
+| `show.coreui.date-picker` | Fired immediately when `show` is called. Call `event.preventDefault()` to keep the popup closed. |
 | `shown.coreui.date-picker` | Fired when the popup has been made visible. |
-| `hide.coreui.date-picker` | Fired immediately when `hide` is called. |
+| `hide.coreui.date-picker` | Fired immediately when `hide` is called — by the API, the indicator, Escape or an outside click. Call `event.preventDefault()` to keep the popup open. |
 | `hidden.coreui.date-picker` | Fired when the popup has been hidden. |
 
 The field's own events (`dateChange.coreui.date-input`,

--- a/docs/src/content/docs/forms/date-range-picker.mdx
+++ b/docs/src/content/docs/forms/date-range-picker.mdx
@@ -351,9 +351,9 @@ context.disabled               // disabled state
 
 | Event | Description |
 | --- | --- |
-| `startDateChange.coreui.date-range-picker` | Fired when the start changes. `event.date` is formatted per `selectionType`, `event.dateObject` is the `Date`. |
+| `startDateChange.coreui.date-range-picker` | Fired when the start changes. `event.date` is the validated `Date`, or `null`; `event.formattedDate` is the same value in the shape of `selectionType` (`2026-01`, `2026W03`, `2026Q1`, `2026`, or the `Date` itself for `day`). |
 | `endDateChange.coreui.date-range-picker` | Fired when the end changes, with the same payload shape. |
-| `show.coreui.date-range-picker` | Fired immediately when `show` is called. |
+| `show.coreui.date-range-picker` | Fired immediately when `show` is called. Call `event.preventDefault()` to keep the popup closed. |
 | `shown.coreui.date-range-picker` | Fired when the popup has been made visible. |
 | `hide.coreui.date-range-picker` | Fired immediately when `hide` is called. |
 | `hidden.coreui.date-range-picker` | Fired when the popup has been hidden. |
@@ -361,7 +361,7 @@ context.disabled               // disabled state
 ```js
 const myPicker = document.getElementById('myPicker')
 myPicker.addEventListener('endDateChange.coreui.date-range-picker', event => {
-  console.log(event.date, event.dateObject)
+  console.log(event.date, event.formattedDate)
 })
 ```
 

--- a/docs/src/content/docs/forms/multi-select.mdx
+++ b/docs/src/content/docs/forms/multi-select.mdx
@@ -571,9 +571,9 @@ Multi Select component exposes a few events for hooking into multi select functi
 | --- | --- |
 | `changed.coreui.multi-select` | Fires immediately when an option is selected or deselected. |
 | `selectionLimit.coreui.multi-select` | Fires when selecting an option is blocked because the selection limit has been reached. |
-| `show.coreui.multi-select` | Fires immediately when the show instance method is called. |
+| `show.coreui.multi-select` | Fires immediately when the show instance method is called. Call `event.preventDefault()` to keep the menu closed. |
 | `shown.coreui.multi-select` | Fired when the multi select options have been made visible to the user and CSS transitions have completed. |
-| `hide.coreui.multi-select` | Fires immediately when the hide instance method has been called. |
+| `hide.coreui.multi-select` | Fires immediately when the hide instance method has been called. Call `event.preventDefault()` to keep the menu open. |
 | `hidden.coreui.multi-select` | Fired when the multi select options have finished being hidden from the user and CSS transitions have completed. |
 
 ```js

--- a/docs/src/content/docs/forms/snippets/date-range-picker-disabled-dates.js
+++ b/docs/src/content/docs/forms/snippets/date-range-picker-disabled-dates.js
@@ -13,5 +13,5 @@ const dateRangePickerDisabledDates = new coreui.DateRangePicker(myDateRangePicke
 })
 
 myDateRangePickerDisabledDates.addEventListener('endDateChange.coreui.date-range-picker', event => {
-  console.log('endDateChange', event.date, event.dateObject)
+  console.log('endDateChange', event.date, event.formattedDate)
 })

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -937,8 +937,34 @@ behaviour, v5 is the reference. Mapping:
   calendar is built then); later opens are unchanged. Code reaching into the
   private `picker._calendar` before the first open now finds `null`.
 
+#### Picker events can be cancelled, and `dateChange` has one shape
+
+- <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+  **`dateChange` / `startDateChange` / `endDateChange` on the Date Picker and
+  Date Range Picker carry the same payload whichever way the date arrived.**
+  `event.date` is the validated `Date` (or `null`) the field holds, and
+  `event.formattedDate` is that value in the shape of `selectionType`. A
+  selection from the calendar used to put the formatted value in `event.date`
+  and the `Date` in `event.dateObject`, while a date typed into the field put
+  the `Date` in `event.date` — the same listener saw two shapes.
+
+  ```diff
+  - const date = event.dateObject ?? event.date
+  + const date = event.date
+  ```
+
+- **`show` and `hide` can be cancelled** on the Autocomplete, Multi Select,
+  Date Picker, Date Range Picker, Date Time Picker and Time Picker, the way
+  they already could on Modal and Dialog: `event.preventDefault()` in a `show`
+  listener keeps the panel closed, in a `hide` listener keeps it open, and the
+  matching `shown` / `hidden` does not fire. `hide` on a panel that is not
+  shown no longer emits anything.
+
 #### Date Input / Time Input / Date Time Input
 
+- **`reset()` restores the date the field was created with**, not the last one
+  passed to `update()`, and emits `dateChange` when the value moves. A native
+  form reset (`form.reset()`, a reset button) now resets the field too.
 - **RTL keyboard navigation now follows the visual direction in nested RTL
   contexts.** Arrow keys (and `Home`/`End`) mirror when the field renders
   right-to-left; the direction is read from the element's computed style

--- a/js/src/combobox-base.ts
+++ b/js/src/combobox-base.ts
@@ -73,7 +73,12 @@ class ComboboxBase extends BaseComponent {
       return
     }
 
-    EventHandler.trigger(this._element, this.constructor.eventName('show'))
+    const showEvent = EventHandler.trigger(this._element, this.constructor.eventName('show'))
+
+    if (showEvent.defaultPrevented) {
+      return
+    }
+
     const showTarget = this._getShowTarget()
     this._mountMenu()
     showTarget.classList.add(CLASS_NAME_SHOW)
@@ -91,7 +96,16 @@ class ComboboxBase extends BaseComponent {
   }
 
   hide(): void {
-    EventHandler.trigger(this._element, this.constructor.eventName('hide'))
+    if (!this._isShown()) {
+      return
+    }
+
+    const hideEvent = EventHandler.trigger(this._element, this.constructor.eventName('hide'))
+
+    if (hideEvent.defaultPrevented) {
+      return
+    }
+
     this._onHideStart()
 
     this._disposeFloating()

--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -16,6 +16,7 @@ import DateInput from './date-input.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import Popup from './util/popup.js'
+import { getDateBySelectionType } from './util/calendar.js'
 import type { ComponentConfig } from './util/config.js'
 import { getWeekSectionsFromLocale } from './util/date-sections.js'
 import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
@@ -333,7 +334,7 @@ class DatePicker extends BaseComponent {
     EventHandler.on(inputEl, DateInput.eventName(DateInput.CHANGE_EVENT_NAME), (event: any) => {
       if (!this._syncingFromPanel) {
         this._calendar?.update({ startDate: event.date })
-        EventHandler.trigger(this._element, EVENT_DATE_CHANGE, { date: event.date })
+        this._triggerDateChange()
       }
     })
 
@@ -390,15 +391,20 @@ class DatePicker extends BaseComponent {
     }, this._config.calendarOptions))
 
     EventHandler.on(this._calendar._element, 'startDateChange.coreui.calendar', event => {
-      // `date` is formatted per selectionType ("2026-01", "2026Q1", …);
-      // `dateObject` is the underlying Date the section field can hold
-      const { date, dateObject } = event
       this._syncingFromPanel = true
-      this._input.update({ date: dateObject })
+      this._input.update({ date: event.dateObject })
       this._syncingFromPanel = false
-      EventHandler.trigger(this._element, EVENT_DATE_CHANGE, { date, dateObject })
+      this._triggerDateChange()
       this.hide()
     })
+  }
+
+  // The field validates the date, so the event reports what the field holds —
+  // a selection the field refused (min/max) is announced as null, not as the
+  // day that was clicked.
+  _triggerDateChange(): void {
+    const date = this.getDate()
+    EventHandler.trigger(this._element, EVENT_DATE_CHANGE, { date, formattedDate: getDateBySelectionType(date, this._config.selectionType) })
   }
 
   _createPopup(): void {
@@ -406,19 +412,19 @@ class DatePicker extends BaseComponent {
       anchor: this._element,
       container: this._config.container,
       content: this._menu,
+      onBeforeHide: () => !EventHandler.trigger(this._element, EVENT_HIDE)?.defaultPrevented,
+      onBeforeShow: () => !EventHandler.trigger(this._element, EVENT_SHOW)?.defaultPrevented,
       onHidden: () => EventHandler.trigger(this._element, EVENT_HIDDEN),
       onHide: () => {
         this._menu.classList.remove(CLASS_NAME_SHOW)
         this._element.classList.remove(CLASS_NAME_SHOW)
         this._element.setAttribute('aria-expanded', 'false')
-        EventHandler.trigger(this._element, EVENT_HIDE)
       },
       onShow: () => {
         this._ensureCalendar()
         this._menu.classList.add(CLASS_NAME_SHOW)
         this._element.classList.add(CLASS_NAME_SHOW)
         this._element.setAttribute('aria-expanded', 'true')
-        EventHandler.trigger(this._element, EVENT_SHOW)
       },
       onShown: () => EventHandler.trigger(this._element, EVENT_SHOWN)
     })

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -16,6 +16,7 @@ import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import Popup from './util/popup.js'
 import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
+import { getDateBySelectionType } from './util/calendar.js'
 import type { ComponentConfig } from './util/config.js'
 import { getWeekSectionsFromLocale } from './util/date-sections.js'
 import {
@@ -409,14 +410,14 @@ class DateRangePicker extends BaseComponent {
     EventHandler.on(start.inputEl, DateInput.eventName(DateInput.CHANGE_EVENT_NAME), (event: any) => {
       if (!this._syncingFromPanel) {
         this._calendar?.update({ startDate: event.date })
-        EventHandler.trigger(this._element, EVENT_START_DATE_CHANGE, { date: event.date })
+        this._triggerDateChange(EVENT_START_DATE_CHANGE, this._startInput)
       }
     })
 
     EventHandler.on(end.inputEl, DateInput.eventName(DateInput.CHANGE_EVENT_NAME), (event: any) => {
       if (!this._syncingFromPanel) {
         this._calendar?.update({ endDate: event.date })
-        EventHandler.trigger(this._element, EVENT_END_DATE_CHANGE, { date: event.date })
+        this._triggerDateChange(EVENT_END_DATE_CHANGE, this._endInput)
       }
     })
 
@@ -484,24 +485,30 @@ class DateRangePicker extends BaseComponent {
     })
 
     EventHandler.on(this._calendar._element, 'startDateChange.coreui.calendar', event => {
-      const { date, dateObject } = event
       this._syncingFromPanel = true
-      this._startInput.update({ date: dateObject })
+      this._startInput.update({ date: event.dateObject })
       this._syncingFromPanel = false
-      EventHandler.trigger(this._element, EVENT_START_DATE_CHANGE, { date, dateObject })
+      this._triggerDateChange(EVENT_START_DATE_CHANGE, this._startInput)
     })
 
     EventHandler.on(this._calendar._element, 'endDateChange.coreui.calendar', event => {
-      const { date, dateObject } = event
       this._syncingFromPanel = true
-      this._endInput.update({ date: dateObject })
+      this._endInput.update({ date: event.dateObject })
       this._syncingFromPanel = false
-      EventHandler.trigger(this._element, EVENT_END_DATE_CHANGE, { date, dateObject })
+      this._triggerDateChange(EVENT_END_DATE_CHANGE, this._endInput)
 
-      if (dateObject && this.getStartDate() && !this._footerTemplate) {
+      if (this.getEndDate() && this.getStartDate() && !this._footerTemplate) {
         this.hide()
       }
     })
+  }
+
+  // The field validates the date, so the event reports what the field holds —
+  // a selection the field refused (min/max) is announced as null, not as the
+  // day that was clicked.
+  _triggerDateChange(eventName: string, input: any): void {
+    const date = input.getDate()
+    EventHandler.trigger(this._element, eventName, { date, formattedDate: getDateBySelectionType(date, this._config.selectionType) })
   }
 
   _createPopup(): void {
@@ -509,19 +516,19 @@ class DateRangePicker extends BaseComponent {
       anchor: this._element,
       container: this._config.container,
       content: this._menu,
+      onBeforeHide: () => !EventHandler.trigger(this._element, EVENT_HIDE)?.defaultPrevented,
+      onBeforeShow: () => !EventHandler.trigger(this._element, EVENT_SHOW)?.defaultPrevented,
       onHidden: () => EventHandler.trigger(this._element, EVENT_HIDDEN),
       onHide: () => {
         this._menu.classList.remove(CLASS_NAME_SHOW)
         this._element.classList.remove(CLASS_NAME_SHOW)
         this._element.setAttribute('aria-expanded', 'false')
-        EventHandler.trigger(this._element, EVENT_HIDE)
       },
       onShow: () => {
         this._ensureCalendar()
         this._menu.classList.add(CLASS_NAME_SHOW)
         this._element.classList.add(CLASS_NAME_SHOW)
         this._element.setAttribute('aria-expanded', 'true')
-        EventHandler.trigger(this._element, EVENT_SHOW)
       },
       onShown: () => EventHandler.trigger(this._element, EVENT_SHOWN)
     })

--- a/js/src/date-time-picker.ts
+++ b/js/src/date-time-picker.ts
@@ -437,12 +437,13 @@ class DateTimePicker extends BaseComponent {
       anchor: this._element,
       container: this._config.container,
       content: this._menu,
+      onBeforeHide: () => !EventHandler.trigger(this._element, EVENT_HIDE)?.defaultPrevented,
+      onBeforeShow: () => !EventHandler.trigger(this._element, EVENT_SHOW)?.defaultPrevented,
       onHidden: () => EventHandler.trigger(this._element, EVENT_HIDDEN),
       onHide: () => {
         this._menu.classList.remove(CLASS_NAME_SHOW)
         this._element.classList.remove(CLASS_NAME_SHOW)
         this._element.setAttribute('aria-expanded', 'false')
-        EventHandler.trigger(this._element, EVENT_HIDE)
       },
       onShow: () => {
         // the classes come first: the selection body scrolls the selected cell
@@ -451,7 +452,6 @@ class DateTimePicker extends BaseComponent {
         this._element.classList.add(CLASS_NAME_SHOW)
         this._ensureBodies()
         this._element.setAttribute('aria-expanded', 'true')
-        EventHandler.trigger(this._element, EVENT_SHOW)
       },
       onShown: () => EventHandler.trigger(this._element, EVENT_SHOWN)
     })

--- a/js/src/section-input.ts
+++ b/js/src/section-input.ts
@@ -159,6 +159,8 @@ class SectionInput extends BaseComponent {
   protected declare _inputElement: any
   protected declare _monthFormatter: any
   protected declare _form: HTMLFormElement | null
+  protected declare _initialDate: Date | null
+  protected declare _resetHandler: () => void
   protected declare _submitHandler: () => void
 
   constructor(element?: string | Element | null, config?: ComponentConfig | null) {
@@ -176,10 +178,15 @@ class SectionInput extends BaseComponent {
     this._inputElement = null
     this._monthFormatter = new Intl.DateTimeFormat(this._config.locale, { month: 'long' })
     this._form = null
+    this._resetHandler = () => {
+      setTimeout(() => this.reset())
+    }
+
     this._submitHandler = () => this._onFormSubmit()
 
     this._createSectionInput()
     this._date = this._applyValidationState()
+    this._initialDate = this._date
     this._addEventListeners()
 
     if (this._config.autofocus && !this._config.disabled) {
@@ -209,14 +216,10 @@ class SectionInput extends BaseComponent {
   }
 
   reset(): void {
-    this._date = this._config.date ? this._convertDate(this._config.date) : null
-    this._sections = setSectionsFromDate(this._sections, this._date)
-    this._date = getDateFromSections(this._sections)
+    this._sections = setSectionsFromDate(this._sections, this._initialDate)
     this._draft = ''
     this._syncSections()
-    this._setHiddenInputValue()
-    this._element.classList.toggle(CLASS_NAME_FILLED, this._date !== null)
-    this._element.classList.remove(CLASS_NAME_IS_INVALID)
+    this._updateDate()
   }
 
   getDate(): Date | null {
@@ -261,6 +264,7 @@ class SectionInput extends BaseComponent {
   }
 
   override dispose(): void {
+    EventHandler.off(this._form, this.constructor.eventName('reset'), this._resetHandler)
     EventHandler.off(this._form, this.constructor.eventName('submit'), this._submitHandler)
     super.dispose()
   }
@@ -369,6 +373,7 @@ class SectionInput extends BaseComponent {
     this._form = this._element.closest('form')
 
     if (this._form) {
+      EventHandler.on(this._form, eventName('reset'), this._resetHandler)
       EventHandler.on(this._form, eventName('submit'), this._submitHandler)
     }
 

--- a/js/src/time-picker.ts
+++ b/js/src/time-picker.ts
@@ -358,12 +358,13 @@ class TimePicker extends BaseComponent {
       anchor: this._element,
       container: this._config.container,
       content: this._menu,
+      onBeforeHide: () => !EventHandler.trigger(this._element, EVENT_HIDE)?.defaultPrevented,
+      onBeforeShow: () => !EventHandler.trigger(this._element, EVENT_SHOW)?.defaultPrevented,
       onHidden: () => EventHandler.trigger(this._element, EVENT_HIDDEN),
       onHide: () => {
         this._menu.classList.remove(CLASS_NAME_SHOW)
         this._element.classList.remove(CLASS_NAME_SHOW)
         this._element.setAttribute('aria-expanded', 'false')
-        EventHandler.trigger(this._element, EVENT_HIDE)
       },
       onShow: () => {
         // the classes come first: the selection body scrolls the selected cell
@@ -372,7 +373,6 @@ class TimePicker extends BaseComponent {
         this._element.classList.add(CLASS_NAME_SHOW)
         this._ensureSelection()
         this._element.setAttribute('aria-expanded', 'true')
-        EventHandler.trigger(this._element, EVENT_SHOW)
       },
       onShown: () => EventHandler.trigger(this._element, EVENT_SHOWN)
     })

--- a/js/src/util/popup.ts
+++ b/js/src/util/popup.ts
@@ -38,6 +38,8 @@ type PopupConfig = {
   focusTrap: boolean
   mobileBreakpoint: number
   offset: [number, number]
+  onBeforeHide: (() => boolean | void) | null
+  onBeforeShow: (() => boolean | void) | null
   onHidden: (() => void) | null
   onHide: (() => void) | null
   onShow: (() => void) | null
@@ -54,6 +56,8 @@ const Default: PopupConfig = {
   focusTrap: true,
   mobileBreakpoint: 768,
   offset: [0, 2],
+  onBeforeHide: null,
+  onBeforeShow: null,
   onHidden: null,
   onHide: null,
   onShow: null,
@@ -70,6 +74,8 @@ const DefaultType = {
   focusTrap: 'boolean',
   mobileBreakpoint: 'number',
   offset: 'array',
+  onBeforeHide: '(null|function)',
+  onBeforeShow: '(null|function)',
   onHidden: '(function|null)',
   onHide: '(function|null)',
   onShow: '(function|null)',
@@ -194,7 +200,7 @@ class Popup extends Config {
 
   // Public
   show(): void {
-    if (this._isShown) {
+    if (this._isShown || execute(this._config.onBeforeShow) === false) {
       return
     }
 
@@ -229,10 +235,16 @@ class Popup extends Config {
   }
 
   hide(): any {
-    if (!this._isShown) {
+    if (!this._isShown || execute(this._config.onBeforeHide) === false) {
       return
     }
 
+    this._hide()
+  }
+
+  // Dispose goes through here: the owner is going away, so `onBeforeHide`
+  // gets no say.
+  _hide(): void {
     execute(this._config.onHide)
     this._isShown = false
     this._stopPositioning()
@@ -266,7 +278,10 @@ class Popup extends Config {
   }
 
   dispose(): void {
-    this.hide()
+    if (this._isShown) {
+      this._hide()
+    }
+
     this._unmount()
 
     if (this._anchorKeydownListener) {

--- a/js/tests/unit/autocomplete.spec.js
+++ b/js/tests/unit/autocomplete.spec.js
@@ -461,6 +461,22 @@ describe('Autocomplete', () => {
       })
     })
 
+    it('should not show when the show event is prevented', () => {
+      fixtureEl.innerHTML = '<div class="autocomplete"></div>'
+      const autocompleteEl = fixtureEl.querySelector('.autocomplete')
+      const autocomplete = new Autocomplete(autocompleteEl, {
+        options: [{ label: 'Option 1', value: '1' }]
+      })
+      const shown = jasmine.createSpy('shown')
+      autocompleteEl.addEventListener('show.coreui.autocomplete', event => event.preventDefault())
+      autocompleteEl.addEventListener('shown.coreui.autocomplete', shown)
+
+      autocomplete.show()
+
+      expect(autocomplete._isShown()).toBeFalse()
+      expect(shown).not.toHaveBeenCalled()
+    })
+
     it('should not show if disabled', () => {
       fixtureEl.innerHTML = '<div class="autocomplete"></div>'
       const autocompleteEl = fixtureEl.querySelector('.autocomplete')
@@ -602,6 +618,38 @@ describe('Autocomplete', () => {
 
         autocomplete.show()
       })
+    })
+
+    it('should stay open when the hide event is prevented', () => {
+      fixtureEl.innerHTML = '<div class="autocomplete"></div>'
+      const autocompleteEl = fixtureEl.querySelector('.autocomplete')
+      const autocomplete = new Autocomplete(autocompleteEl, {
+        options: [{ label: 'Option 1', value: '1' }]
+      })
+      const hidden = jasmine.createSpy('hidden')
+      autocompleteEl.addEventListener('hide.coreui.autocomplete', event => event.preventDefault())
+      autocompleteEl.addEventListener('hidden.coreui.autocomplete', hidden)
+
+      autocomplete.show()
+      autocomplete.hide()
+
+      expect(autocomplete._isShown()).toBeTrue()
+      expect(hidden).not.toHaveBeenCalled()
+    })
+
+    it('should not fire hide events for a menu that is not shown', () => {
+      fixtureEl.innerHTML = '<div class="autocomplete"></div>'
+      const autocompleteEl = fixtureEl.querySelector('.autocomplete')
+      const autocomplete = new Autocomplete(autocompleteEl, {
+        options: [{ label: 'Option 1', value: '1' }]
+      })
+      const spy = jasmine.createSpy('hide')
+      autocompleteEl.addEventListener('hide.coreui.autocomplete', spy)
+      autocompleteEl.addEventListener('hidden.coreui.autocomplete', spy)
+
+      autocomplete.hide()
+
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should clear input hint element when hiding', () => {

--- a/js/tests/unit/date-input.spec.js
+++ b/js/tests/unit/date-input.spec.js
@@ -812,6 +812,61 @@ describe('DateInput', () => {
       expect(dateInput.getDate()).toEqual(new Date(2026, 6, 14))
       expect(getSections(dateInput._element)[0].textContent).toEqual('14')
     })
+
+    it('should restore the initial date, not the last one set through update()', () => {
+      const dateInput = createDateInput({ date: new Date(2026, 6, 14) })
+
+      dateInput.update({ date: new Date(2026, 6, 20) })
+      dateInput.reset()
+
+      expect(dateInput.getDate()).toEqual(new Date(2026, 6, 14))
+    })
+
+    it('should emit dateChange when the value moves back', () => {
+      const dateInput = createDateInput({ date: new Date(2026, 6, 14) })
+      const spy = jasmine.createSpy('dateChange')
+      dateInput._element.addEventListener('dateChange.coreui.date-input', spy)
+
+      dateInput.clear()
+      dateInput.reset()
+
+      expect(spy).toHaveBeenCalledTimes(2)
+      expect(spy.calls.mostRecent().args[0].date).toEqual(new Date(2026, 6, 14))
+    })
+
+    it('should follow a native form reset', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<form><div id="mydateinput"></div></form>'
+        const dateInput = new DateInput(fixtureEl.querySelector('div'), { format: 'dd.MM.yyyy', date: new Date(2026, 6, 14) })
+
+        dateInput.clear()
+        expect(dateInput.getDate()).toBeNull()
+
+        fixtureEl.querySelector('form').reset()
+
+        setTimeout(() => {
+          expect(dateInput.getDate()).toEqual(new Date(2026, 6, 14))
+          expect(dateInput._element.querySelector('input[type="hidden"]').value).toEqual('14.07.2026')
+          resolve()
+        }, 10)
+      })
+    })
+
+    it('should drop the form listener on dispose', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<form><div id="mydateinput"></div></form>'
+        const dateInput = new DateInput(fixtureEl.querySelector('div'), { format: 'dd.MM.yyyy', date: new Date(2026, 6, 14) })
+        const spy = spyOn(dateInput, 'reset').and.callThrough()
+
+        dateInput.dispose()
+        fixtureEl.querySelector('form').reset()
+
+        setTimeout(() => {
+          expect(spy).not.toHaveBeenCalled()
+          resolve()
+        }, 10)
+      })
+    })
   })
 
   describe('update', () => {

--- a/js/tests/unit/date-picker.spec.js
+++ b/js/tests/unit/date-picker.spec.js
@@ -180,6 +180,34 @@ describe('DatePicker', () => {
       expect(picker._popup.isShown).toBeFalse()
     })
 
+    it('should not open when show is prevented', () => {
+      const picker = buildPicker()
+      const el = fixtureEl.querySelector('#picker')
+      const shown = jasmine.createSpy('shown')
+      el.addEventListener('show.coreui.date-picker', event => event.preventDefault())
+      el.addEventListener('shown.coreui.date-picker', shown)
+
+      picker.show()
+
+      expect(picker._popup.isShown).toBeFalse()
+      expect(el.classList.contains('show')).toBeFalse()
+      expect(shown).not.toHaveBeenCalled()
+    })
+
+    it('should stay open when hide is prevented', () => {
+      const picker = buildPicker()
+      const el = fixtureEl.querySelector('#picker')
+      const hidden = jasmine.createSpy('hidden')
+      el.addEventListener('hide.coreui.date-picker', event => event.preventDefault())
+      el.addEventListener('hidden.coreui.date-picker', hidden)
+
+      picker.show()
+      picker.hide()
+
+      expect(picker._popup.isShown).toBeTrue()
+      expect(hidden).not.toHaveBeenCalled()
+    })
+
     it('should disable the indicator button when the picker is disabled', () => {
       buildPicker({ disabled: true })
 
@@ -193,6 +221,44 @@ describe('DatePicker', () => {
       picker.show()
 
       expect(picker._popup.isShown).toBeFalse()
+    })
+  })
+
+  describe('dateChange payload', () => {
+    it('should carry the same shape whether the day comes from the calendar or the field', () => {
+      const picker = buildPicker({ locale: 'en-US', date: new Date(2026, 6, 14) })
+      const el = fixtureEl.querySelector('#picker')
+      const emitted = []
+      el.addEventListener('dateChange.coreui.date-picker', event => emitted.push(event))
+
+      picker.show()
+      fixtureEl.querySelector('.date-picker-popup .calendar-cell[tabindex="0"]').click()
+      picker.setDate(new Date(2026, 6, 20))
+
+      expect(emitted.length).toBe(2)
+      for (const event of emitted) {
+        expect(event.date).toBeInstanceOf(Date)
+        expect(event.formattedDate).toBeInstanceOf(Date)
+        expect('dateObject' in event).toBeFalse()
+      }
+    })
+
+    it('should report null when the field refuses the calendar selection', () => {
+      const picker = buildPicker({
+        locale: 'en-US', date: new Date(2026, 6, 14),
+        inputOptions: { maxDate: new Date(2026, 6, 14) }, calendarOptions: { maxDate: new Date(2026, 6, 31) }
+      })
+      const el = fixtureEl.querySelector('#picker')
+      let emitted = null
+      el.addEventListener('dateChange.coreui.date-picker', event => {
+        emitted = event
+      })
+
+      picker.show()
+      fixtureEl.querySelector('.date-picker-popup .calendar-cell[data-coreui-date^="Mon Jul 20 2026"]').click()
+
+      expect(emitted.date).toBeNull()
+      expect(picker.getDate()).toBeNull()
     })
   })
 
@@ -240,14 +306,15 @@ describe('DatePicker', () => {
       const el = fixtureEl.querySelector('#picker')
       let emitted = null
       el.addEventListener('dateChange.coreui.date-picker', event => {
-        emitted = event.date
+        emitted = event
       })
 
       picker.show()
       fixtureEl.querySelector('.date-picker-popup .calendar-row[tabindex="0"] .calendar-cell').click()
 
-      expect(emitted).toMatch(/^\d{4}W\d{2}$/)
-      expect(el.querySelector('input[type="hidden"]').value).toEqual(`Week ${emitted.slice(5)}, ${emitted.slice(0, 4)}`)
+      expect(emitted.date).toBeInstanceOf(Date)
+      expect(emitted.formattedDate).toMatch(/^\d{4}W\d{2}$/)
+      expect(el.querySelector('input[type="hidden"]').value).toEqual(`Week ${emitted.formattedDate.slice(5)}, ${emitted.formattedDate.slice(0, 4)}`)
     })
 
     it('should keep the ISO week-numbering year around January 1st', () => {

--- a/js/tests/unit/util/popup.spec.js
+++ b/js/tests/unit/util/popup.spec.js
@@ -50,6 +50,16 @@ describe('Popup', () => {
       expect(calls).toEqual(['show', 'shown'])
     })
 
+    it('should stay hidden when onBeforeShow returns false', () => {
+      const onShow = jasmine.createSpy('onShow')
+      const popup = buildPopup({ onBeforeShow: () => false, onShow })
+
+      popup.show()
+
+      expect(popup.isShown).toBeFalse()
+      expect(onShow).not.toHaveBeenCalled()
+    })
+
     it('should not fire callbacks when already shown', () => {
       const spy = jasmine.createSpy('onShow')
       const popup = buildPopup({ onShow: spy })
@@ -74,6 +84,17 @@ describe('Popup', () => {
   })
 
   describe('hide', () => {
+    it('should stay shown when onBeforeHide returns false', () => {
+      const onHide = jasmine.createSpy('onHide')
+      const popup = buildPopup({ onBeforeHide: () => false, onHide })
+
+      popup.show()
+      popup.hide()
+
+      expect(popup.isShown).toBeTrue()
+      expect(onHide).not.toHaveBeenCalled()
+    })
+
     it('should clear isShown and fire onHide/onHidden in order', () => {
       const calls = []
       const popup = buildPopup({


### PR DESCRIPTION
Three contracts the popup-based components did not share with Modal and Dialog, or with each other. All three change what a listener sees, so they land before the alpha with migration entries.

## 1. `show` / `hide` can be cancelled

- Before: Autocomplete, Multi Select and the four pickers emitted `show`/`hide` after (or while) changing state; `preventDefault()` did nothing. `ComboboxBase.hide()` emitted `hide`/`hidden` even for a closed panel.
- After: Popup gains `onBeforeShow` / `onBeforeHide` hooks that veto the change when they return `false`. The pickers emit `show`/`hide` from them (so Escape, outside click and the indicator are covered, not only the API), ComboboxBase checks `defaultPrevented` before touching the DOM, and `hide()` on a closed panel is silent. `Popup.dispose()` bypasses the veto.

## 2. One `dateChange` payload

- Before: a date typed into the field emitted `{ date: Date }`; a calendar click emitted `{ date: <formatted per selectionType>, dateObject: Date }` and announced the clicked day even when the field refused it (`inputOptions.maxDate` tighter than the calendar's).
- After: both paths emit `{ date, formattedDate }` read from the field after the update. `date` is the validated `Date` or `null`; `formattedDate` is that value in the shape of `selectionType` (`2026-01`, `2026W03`, `2026Q1`, `2026`, or the `Date` for `day`). Date Picker and Date Range Picker; Date Time Picker already reported `getDate()`.

## 3. `reset()` and form reset in the section fields

- Before: `SectionInput.reset()` read `_config.date`, which `update()` overwrites, so create A → `update(B)` → `reset()` gave B. A native form reset left the field untouched.
- After: the field keeps the date it was created with, `reset()` restores it and emits `dateChange` when the value moves, and `reset` on the owning form resets the field (listener removed on dispose). The picker shells keep their own initial value for `reset()` as before.

## Docs

Events tables on Date Picker, Date Range Picker, Autocomplete and Multi Select; `reset` row on Date Input; the range picker snippet; three migration entries (one marked breaking, for the payload).

## Tests

`date-picker.spec.js` (prevented show/hide, uniform payload from calendar and field, `null` when the field refuses the click), `autocomplete.spec.js` (prevented show/hide, silent hide when closed), `date-input.spec.js` (reset after update, `dateChange` on reset, form reset, listener gone after dispose), `popup.spec.js` (before-hooks). Affected suites: 8 files, 772 tests green; typecheck clean.

React and Vue expose none of these payloads or DOM events (callbacks and controlled props instead), so nothing to port.

Ref: `v6-js-scss-bugs-audit-2026-09.md` JS-07, JS-08, JS-09.
