### PR TITLE
fix(Popup): let an open panel own Escape so an enclosing dialog stays open

### DIFF
--- a/js/src/autocomplete.ts
+++ b/js/src/autocomplete.ts
@@ -301,6 +301,13 @@ class Autocomplete extends ComboboxBase {
 
     EventHandler.on(this._element, EVENT_KEYDOWN, (event: any) => {
       if (event.key === ESCAPE_KEY) {
+        // An open menu owns the press; a closed one leaves it to whatever
+        // encloses the field, such as a modal dialog.
+        if (this._isShown()) {
+          event.preventDefault()
+          event.stopPropagation()
+        }
+
         this.hide()
         if (this._config.allowOnlyDefinedOptions && this._selected.length === 0) {
           this.search('')
@@ -356,7 +363,7 @@ class Autocomplete extends ComboboxBase {
       // same press must not reopen it or match the value it just wrote.
       const handledByList = event.key === ENTER_KEY && event.defaultPrevented
 
-      if (!handledByList && !this._isShown() && event.key !== TAB_KEY) {
+      if (!handledByList && !this._isShown() && event.key !== TAB_KEY && event.key !== ESCAPE_KEY) {
         this.show()
       }
 

--- a/js/src/combobox.ts
+++ b/js/src/combobox.ts
@@ -517,6 +517,7 @@ class Combobox extends ComboboxBase {
     if (this._isShown()) {
       if (key === ESCAPE_KEY) {
         event.preventDefault()
+        event.stopPropagation()
         this.hide()
       }
 

--- a/js/src/multi-select.ts
+++ b/js/src/multi-select.ts
@@ -416,6 +416,11 @@ class MultiSelect extends ComboboxBase {
 
     EventHandler.on(this._wrapperElement, EVENT_KEYDOWN, (event: any) => {
       if (event.key === ESCAPE_KEY) {
+        if (this._isShown()) {
+          event.preventDefault()
+          event.stopPropagation()
+        }
+
         this.hide()
         return
       }

--- a/js/src/util/popup.ts
+++ b/js/src/util/popup.ts
@@ -147,6 +147,7 @@ class Popup extends Config {
   protected declare _previouslyFocused: HTMLElement | null
   protected declare _clickListener: any
   protected declare _keydownListener: any
+  protected declare _contentKeydownListener: any
   protected declare _anchorKeydownListener: any
   protected declare _focustrap: any
   protected declare _config: PopupConfig
@@ -162,6 +163,7 @@ class Popup extends Config {
     this._previouslyFocused = null
     this._clickListener = null
     this._keydownListener = null
+    this._contentKeydownListener = null
     this._anchorKeydownListener = null
     // The panel now always lives outside the anchor, so the trap has to be told
     // about it unconditionally — otherwise moving into it reads as escaping the
@@ -444,15 +446,32 @@ class Popup extends Config {
       }
     }
 
+    // Focus sits in the panel while it is open, the way it does in a native
+    // date control, so the panel takes Escape for itself: the press must not
+    // reach an enclosing <dialog>, neither as a bubbling keydown nor as the
+    // native `cancel` the browser derives from an unhandled one.
+    this._contentKeydownListener = (event: KeyboardEvent) => {
+      if (event.key === ESCAPE_KEY) {
+        event.preventDefault()
+        event.stopPropagation()
+        this.hide()
+      }
+    }
+
     EventHandler.on(document, EVENT_CLICK, this._clickListener)
     EventHandler.on(document, EVENT_KEYDOWN, this._keydownListener)
+    EventHandler.on(this._content!, EVENT_KEYDOWN, this._contentKeydownListener)
+    EventHandler.on(this._anchor!, EVENT_KEYDOWN, this._contentKeydownListener)
   }
 
   _removeDismissListeners(): void {
     EventHandler.off(document, EVENT_CLICK, this._clickListener)
     EventHandler.off(document, EVENT_KEYDOWN, this._keydownListener)
+    EventHandler.off(this._content, EVENT_KEYDOWN, this._contentKeydownListener)
+    EventHandler.off(this._anchor, EVENT_KEYDOWN, this._contentKeydownListener)
     this._clickListener = null
     this._keydownListener = null
+    this._contentKeydownListener = null
   }
 }
 

--- a/js/tests/unit/autocomplete.spec.js
+++ b/js/tests/unit/autocomplete.spec.js
@@ -1,4 +1,6 @@
+import { userEvent } from '@vitest/browser/context'
 import Autocomplete from '../../src/autocomplete.js'
+import Dialog from '../../src/dialog.js'
 import {
   clearFixture, createEvent, getFixture, jQueryMock
 } from '../helpers/fixture.js'
@@ -459,6 +461,34 @@ describe('Autocomplete', () => {
 
         autocomplete.show()
       })
+    })
+
+    it('should take the first Escape for itself inside a dialog and leave the second to it', async () => {
+      fixtureEl.innerHTML = '<dialog class="dialog dialog-instant" id="dialog"><div class="autocomplete"></div></dialog>'
+      const dialogEl = fixtureEl.querySelector('#dialog')
+      const dialog = new Dialog(dialogEl)
+      const autocomplete = new Autocomplete(fixtureEl.querySelector('.autocomplete'), {
+        options: [{ label: 'Option 1', value: '1' }]
+      })
+      const hidden = new Promise(resolve => {
+        dialogEl.addEventListener('hidden.coreui.dialog', resolve)
+      })
+
+      await dialog.show()
+      autocomplete._inputElement.focus()
+      autocomplete.show()
+      expect(autocomplete._isShown()).toBeTrue()
+
+      await userEvent.keyboard('{Escape}')
+      expect(autocomplete._isShown()).toBeFalse()
+      expect(dialogEl.open).toBeTrue()
+
+      await userEvent.keyboard('{Escape}')
+      await hidden
+      expect(dialogEl.open).toBeFalse()
+
+      autocomplete.dispose()
+      dialog.dispose()
     })
 
     it('should not show when the show event is prevented', () => {

--- a/js/tests/unit/date-picker.spec.js
+++ b/js/tests/unit/date-picker.spec.js
@@ -1,4 +1,6 @@
+import { userEvent } from '@vitest/browser/context'
 import DatePicker from '../../src/date-picker.js'
+import Dialog from '../../src/dialog.js'
 import { clearFixture, getFixture, jQueryMock } from '../helpers/fixture.js'
 
 describe('DatePicker', () => {
@@ -221,6 +223,31 @@ describe('DatePicker', () => {
       picker.show()
 
       expect(picker._popup.isShown).toBeFalse()
+    })
+  })
+
+  describe('inside a dialog', () => {
+    it('should take the first Escape for itself and leave the second to the dialog', async () => {
+      const picker = buildPicker({}, '<dialog class="dialog dialog-instant" id="dialog"><div id="picker"></div></dialog>')
+      const dialogEl = fixtureEl.querySelector('#dialog')
+      const dialog = new Dialog(dialogEl)
+      const hidden = new Promise(resolve => {
+        dialogEl.addEventListener('hidden.coreui.dialog', resolve)
+      })
+
+      await dialog.show()
+      picker.show()
+      expect(picker._popup.isShown).toBeTrue()
+
+      await userEvent.keyboard('{Escape}')
+      expect(picker._popup.isShown).toBeFalse()
+      expect(dialogEl.open).toBeTrue()
+
+      await userEvent.keyboard('{Escape}')
+      await hidden
+      expect(dialogEl.open).toBeFalse()
+
+      dialog.dispose()
     })
   })
 

--- a/js/tests/unit/util/popup.spec.js
+++ b/js/tests/unit/util/popup.spec.js
@@ -447,6 +447,21 @@ describe('Popup', () => {
       expect(popup.isShown).toBeTrue()
     })
 
+    it('should consume Escape pressed inside the panel', () => {
+      const popup = buildPopup()
+      const reachedDocument = jasmine.createSpy('document keydown')
+      document.addEventListener('keydown', reachedDocument)
+      popup.show()
+
+      const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+      fixtureEl.querySelector('#option').dispatchEvent(event)
+      document.removeEventListener('keydown', reachedDocument)
+
+      expect(popup.isShown).toBeFalse()
+      expect(event.defaultPrevented).toBeTrue()
+      expect(reachedDocument).not.toHaveBeenCalled()
+    })
+
     it('should hide on Escape', () => {
       const popup = buildPopup()
       popup.show()


### PR DESCRIPTION
## Before / after

- Before: a picker (or an Autocomplete / Multi Select menu) open inside a `<dialog>` closed together with the dialog on Escape. The panel's listener on `document` only called `hide()`; the same press bubbled on and, left unprevented, made the browser fire the dialog's native `cancel`. For a non-modal dialog its own `keydown` listener even ran first.
- After: focus already lives in the panel while it is open, the way it does in a native `<input type="date">`, so the panel owns the press. Popup listens on its content and anchor and calls `preventDefault()` (no native `cancel`) and `stopPropagation()` (no bubbling keydown) before hiding. Autocomplete, Multi Select and Combobox do the same on their field while the menu is shown, and leave a press on a closed menu alone so it reaches the dialog. First Escape closes the panel, second closes the dialog. No overlay stack needed.

Also fixed on the way: Escape reopened a closed Autocomplete menu (every key but Tab did), which swallowed the second press.

## Tests

Real key presses via `userEvent.keyboard` in Chromium, so the dialog's native `cancel` fires as for a user:

- `date-picker.spec.js`: picker inside a modal Dialog, first Escape closes the picker and leaves the dialog open, second closes the dialog.
- `autocomplete.spec.js`: same with the menu.
- `popup.spec.js`: Escape dispatched inside the panel is default-prevented and never reaches `document`.

Affected suites: 6 files, 707 tests green; typecheck clean.

Ref: `v6-js-scss-bugs-audit-2026-09.md` JS-04. React/Vue `useDropdownWithFloating` shares the pattern; port follows.
