### PR TITLE
refactor: one jQuery dispatcher for every plugin

### DIFF
--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -204,6 +204,15 @@ alias of the same class, so existing scripts keep working:
 + const offcanvas = new coreui.Offcanvas('#offcanvasExample')
 ```
 
+#### One jQuery dispatcher for every plugin
+
+Every `$(el).plugin('method')` call now goes through the same dispatcher:
+the instance is created or reused, a string argument names a **public**
+method, and anything else throws `TypeError: No method named "…"`. A few
+plugins used to let a private name through (`$(el).tooltip('_getConfig')`
+called it) or skipped the check altogether (`button`, `number-input`,
+`password-input`); they now reject those names like the rest.
+
 #### Lifecycle methods return a promise
 
 `show()`, `hide()`, `toggle()` and `close()` returned before the transition

--- a/js/src/accordion.ts
+++ b/js/src/accordion.ts
@@ -8,7 +8,7 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 import { startSizeTransition, supportsInterpolateSize } from './util/size-transition.js'
 
 /**
@@ -199,19 +199,7 @@ class Accordion extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any, ...args: any[]): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Accordion.getOrCreateInstance(this)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string](...args)
-    })
+    return jQueryDispatch(this, Accordion, config, args)
   }
 }
 

--- a/js/src/alert.ts
+++ b/js/src/alert.ts
@@ -11,7 +11,7 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import { enableDismissTrigger } from './util/component-functions.js'
-import { defineJQueryPlugin, getTransitionDurationFromElement } from './util/index.js'
+import { defineJQueryPlugin, getTransitionDurationFromElement, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -62,19 +62,7 @@ class Alert extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Alert.getOrCreateInstance(this)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string](this)
-    })
+    return jQueryDispatch(this, Alert, config, element => [element])
   }
 }
 

--- a/js/src/button.ts
+++ b/js/src/button.ts
@@ -11,7 +11,7 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { defineJQueryPlugin, setAriaAttribute } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch, setAriaAttribute } from './util/index.js'
 
 /**
  * Constants
@@ -45,13 +45,7 @@ class Button extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Button.getOrCreateInstance(this)
-
-      if (config === 'toggle') {
-        data[config as string]()
-      }
-    })
+    return jQueryDispatch(this, Button, config)
   }
 }
 

--- a/js/src/calendar.ts
+++ b/js/src/calendar.ts
@@ -17,7 +17,7 @@ import {
 import {
  CHEVRON_DOUBLE_LEFT_ICON, CHEVRON_DOUBLE_RIGHT_ICON, CHEVRON_LEFT_ICON, CHEVRON_RIGHT_ICON
 } from './util/icons.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 import {
   convertToDateObject,
   createGroupsInArray,
@@ -1274,19 +1274,7 @@ class Calendar extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): any {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Calendar.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (typeof data[config] === 'undefined') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config]()
-    })
+    return jQueryDispatch(this, Calendar, config)
   }
 }
 

--- a/js/src/carousel.ts
+++ b/js/src/carousel.ts
@@ -12,7 +12,9 @@ import BaseComponent from './base-component.js'
 import EventHandler, { type CoreUIEvent } from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { defineJQueryPlugin, isRTL, isVisible } from './util/index.js'
+import {
+  defineJQueryPlugin, isRTL, isVisible, jQueryDispatch
+} from './util/index.js'
 
 /**
  * Constants
@@ -308,22 +310,13 @@ class Carousel extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Carousel.getOrCreateInstance(this, config)
+    if (typeof config === 'number') {
+      return this.each(function (this: HTMLElement) {
+        Carousel.getOrCreateInstance(this).to(config)
+      })
+    }
 
-      if (typeof config === 'number') {
-        data.to(config)
-        return
-      }
-
-      if (typeof config === 'string') {
-        if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-          throw new TypeError(`No method named "${config}"`)
-        }
-
-        data[config as string]()
-      }
-    })
+    return jQueryDispatch(this, Carousel, config)
   }
 
   // Private

--- a/js/src/chip-set.ts
+++ b/js/src/chip-set.ts
@@ -12,7 +12,9 @@ import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { CHECK_ICON, REMOVE_ICON } from './util/icons.js'
-import { defineJQueryPlugin, getNextActiveElement, isRTL } from './util/index.js'
+import {
+  defineJQueryPlugin, getNextActiveElement, isRTL, jQueryDispatch
+} from './util/index.js'
 
 /**
  * Constants
@@ -568,19 +570,7 @@ class ChipSet extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = ChipSet.getOrCreateInstance(this)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string](this)
-    })
+    return jQueryDispatch(this, ChipSet, config, element => [element])
   }
 }
 

--- a/js/src/chip.ts
+++ b/js/src/chip.ts
@@ -11,7 +11,7 @@ import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { sanitizeHtml, SVGAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
 import { CHECK_ICON, REMOVE_ICON } from './util/icons.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -380,19 +380,7 @@ class Chip extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Chip.getOrCreateInstance(this)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string](this)
-    })
+    return jQueryDispatch(this, Chip, config, element => [element])
   }
 }
 

--- a/js/src/collapse.ts
+++ b/js/src/collapse.ts
@@ -13,9 +13,7 @@ import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import {
-  defineJQueryPlugin,
-  getElement,
-  setAriaAttribute
+  defineJQueryPlugin, getElement, jQueryDispatch, setAriaAttribute
 } from './util/index.js'
 import { startSizeTransition, supportsInterpolateSize } from './util/size-transition.js'
 
@@ -354,17 +352,7 @@ class Collapse extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Collapse.getOrCreateInstance(this)
-
-      if (typeof config === 'string') {
-        if (typeof data[config as string] === 'undefined') {
-          throw new TypeError(`No method named "${config}"`)
-        }
-
-        data[config as string]()
-      }
-    })
+    return jQueryDispatch(this, Collapse, config)
   }
 }
 

--- a/js/src/combobox.ts
+++ b/js/src/combobox.ts
@@ -13,7 +13,7 @@ import ListBox, { type ListBoxEntry } from './list-box.js'
 import type { ComponentConfig } from './util/config.js'
 import { CARET_ICON } from './util/icons.js'
 import { DefaultAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
-import { defineJQueryPlugin, getUID } from './util/index.js'
+import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -562,19 +562,7 @@ class Combobox extends ComboboxBase {
   }
 
   static jQueryInterface(this: any, config: any, ...args: any[]): any {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Combobox.getOrCreateInstance(this, typeof config === 'object' ? config : null)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string](...args)
-    })
+    return jQueryDispatch(this, Combobox, config, args)
   }
 }
 

--- a/js/src/context-menu.ts
+++ b/js/src/context-menu.ts
@@ -10,7 +10,9 @@ import EventHandler, { type CoreUIEvent } from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import Menu, { type MenuConfig } from './menu.js'
 import type { ComponentConfig } from './util/config.js'
-import { defineJQueryPlugin, isDisabled, noop } from './util/index.js'
+import {
+  defineJQueryPlugin, isDisabled, jQueryDispatch, noop
+} from './util/index.js'
 
 /**
  * Constants
@@ -288,19 +290,7 @@ class ContextMenu extends Menu {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = ContextMenu.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (typeof data[config as string] === 'undefined') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string]()
-    })
+    return jQueryDispatch(this, ContextMenu, config)
   }
 }
 

--- a/js/src/date-input.ts
+++ b/js/src/date-input.ts
@@ -9,7 +9,7 @@ import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import SectionInput, { type SectionInputConfig } from './section-input.js'
 import { type DateSection, getSectionsFromLocale } from './util/date-sections.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -50,17 +50,7 @@ class DateInput extends SectionInput {
 
   // Static
   static jQueryInterface(this: any, config: any): any {
-    return this.each(function (this: HTMLElement) {
-      const data: any = DateInput.getOrCreateInstance(this)
-
-      if (typeof config === 'string') {
-        if (typeof data[config] === 'undefined') {
-          throw new TypeError(`No method named "${config}"`)
-        }
-
-        data[config]()
-      }
-    })
+    return jQueryDispatch(this, DateInput, config)
   }
 }
 

--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -21,7 +21,7 @@ import type { ComponentConfig } from './util/config.js'
 import { getWeekSectionsFromLocale } from './util/date-sections.js'
 import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
 import { CALENDAR_ICON, CLEANER_ICON } from './util/icons.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 
 /**
@@ -456,19 +456,7 @@ class DatePicker extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = DatePicker.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config]()
-    })
+    return jQueryDispatch(this, DatePicker, config)
   }
 }
 

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -22,7 +22,7 @@ import { getWeekSectionsFromLocale } from './util/date-sections.js'
 import {
   CALENDAR_ICON, CLEANER_ICON, SEPARATOR_ICON, SEPARATOR_ICON_RTL
 } from './util/icons.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 
 /**
@@ -572,19 +572,7 @@ class DateRangePicker extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = DateRangePicker.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config]()
-    })
+    return jQueryDispatch(this, DateRangePicker, config)
   }
 }
 

--- a/js/src/date-time-input.ts
+++ b/js/src/date-time-input.ts
@@ -10,7 +10,7 @@ import SelectorEngine from './dom/selector-engine.js'
 import SectionInput, { type SectionInputConfig } from './section-input.js'
 import { convertToDateObject } from './util/calendar.js'
 import { type DateSection, getDateTimeSectionsFromLocale } from './util/date-sections.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -76,17 +76,7 @@ class DateTimeInput extends SectionInput {
 
   // Static
   static jQueryInterface(this: any, config: any): any {
-    return this.each(function (this: HTMLElement) {
-      const data: any = DateTimeInput.getOrCreateInstance(this)
-
-      if (typeof config === 'string') {
-        if (typeof data[config] === 'undefined') {
-          throw new TypeError(`No method named "${config}"`)
-        }
-
-        data[config]()
-      }
-    })
+    return jQueryDispatch(this, DateTimeInput, config)
   }
 }
 

--- a/js/src/date-time-picker.ts
+++ b/js/src/date-time-picker.ts
@@ -20,7 +20,7 @@ import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sani
 import type { ComponentConfig } from './util/config.js'
 import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
 import { CALENDAR_ICON, CLEANER_ICON } from './util/icons.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -483,19 +483,7 @@ class DateTimePicker extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = DateTimePicker.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config]()
-    })
+    return jQueryDispatch(this, DateTimePicker, config)
   }
 }
 

--- a/js/src/dialog.ts
+++ b/js/src/dialog.ts
@@ -12,7 +12,7 @@ import DialogBase from './dialog-base.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { enableDismissTrigger } from './util/component-functions.js'
-import { defineJQueryPlugin, isVisible } from './util/index.js'
+import { defineJQueryPlugin, isVisible, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -103,19 +103,7 @@ class Dialog extends DialogBase {
 
   // Static
   static jQueryInterface(this: any, config?: any, relatedTarget?: HTMLElement | null): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Dialog.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (typeof data[config as string] === 'undefined') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string](relatedTarget)
-    })
+    return jQueryDispatch(this, Dialog, config, [relatedTarget])
   }
 }
 

--- a/js/src/drawer.ts
+++ b/js/src/drawer.ts
@@ -13,9 +13,7 @@ import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { enableDismissTrigger } from './util/component-functions.js'
 import {
-  defineJQueryPlugin,
-  isDisabled,
-  isVisible
+  defineJQueryPlugin, isDisabled, isVisible, jQueryDispatch
 } from './util/index.js'
 
 /**
@@ -88,19 +86,7 @@ class Drawer extends DialogBase {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Drawer.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string](this)
-    })
+    return jQueryDispatch(this, Drawer, config, element => [element])
   }
 }
 

--- a/js/src/dropdown.ts
+++ b/js/src/dropdown.ts
@@ -16,7 +16,7 @@ import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
 import Menu, { type MenuConfig } from './menu.js'
 import {
-  defineJQueryPlugin, getNextActiveElement, isRTL, isVisible
+  defineJQueryPlugin, getNextActiveElement, isRTL, isVisible, jQueryDispatch
 } from './util/index.js'
 
 /**
@@ -191,19 +191,7 @@ class Dropdown extends Menu {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Dropdown.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (typeof data[config as string] === 'undefined') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string]()
-    })
+    return jQueryDispatch(this, Dropdown, config)
   }
 }
 

--- a/js/src/list-box.ts
+++ b/js/src/list-box.ts
@@ -11,10 +11,7 @@ import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
 import { DefaultAllowlist, sanitizeHtml, type SanitizerAllowList } from './util/sanitizer.js'
 import {
-  defineJQueryPlugin,
-  getElement,
-  getNextActiveElement,
-  getUID
+  defineJQueryPlugin, getElement, getNextActiveElement, getUID, jQueryDispatch
 } from './util/index.js'
 
 /**
@@ -1298,19 +1295,7 @@ class ListBox extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any, ...args: any[]): any {
-    return this.each(function (this: HTMLElement) {
-      const data: any = ListBox.getOrCreateInstance(this, typeof config === 'object' ? config : null)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string](...args)
-    })
+    return jQueryDispatch(this, ListBox, config, args)
   }
 }
 

--- a/js/src/menu.ts
+++ b/js/src/menu.ts
@@ -31,15 +31,7 @@ import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
 import {
-  defineJQueryPlugin,
-  execute,
-  getElement,
-  getNextActiveElement,
-  isDisabled,
-  isElement,
-  isRTL,
-  isVisible,
-  noop
+  defineJQueryPlugin, execute, getElement, getNextActiveElement, isDisabled, isElement, isRTL, isVisible, jQueryDispatch, noop
 } from './util/index.js'
 import {
   parseResponsivePlacement,
@@ -1102,19 +1094,7 @@ class Menu extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Menu.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (typeof data[config as string] === 'undefined') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string]()
-    })
+    return jQueryDispatch(this, Menu, config)
   }
 }
 

--- a/js/src/modal.ts
+++ b/js/src/modal.ts
@@ -13,7 +13,7 @@ import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { enableDismissTrigger } from './util/component-functions.js'
-import { defineJQueryPlugin, isVisible } from './util/index.js'
+import { defineJQueryPlugin, isVisible, jQueryDispatch } from './util/index.js'
 import { resolveDialogElement } from './util/legacy-markup.js'
 
 /**
@@ -109,19 +109,7 @@ class Modal extends DialogBase {
 
   // Static
   static jQueryInterface(this: any, config?: any, relatedTarget?: HTMLElement | null): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Modal.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (typeof data[config as string] === 'undefined') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string](relatedTarget)
-    })
+    return jQueryDispatch(this, Modal, config, [relatedTarget])
   }
 }
 

--- a/js/src/number-input.ts
+++ b/js/src/number-input.ts
@@ -13,7 +13,7 @@ import {
 } from './util/form-control-group.js'
 import { MINUS_ICON, PLUS_ICON } from './util/icons.js'
 import { sanitizeHtml, SVGAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -304,13 +304,7 @@ class NumberInput extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = NumberInput.getOrCreateInstance(this)
-
-      if (typeof config === 'string') {
-        data[config]()
-      }
-    })
+    return jQueryDispatch(this, NumberInput, config)
   }
 }
 

--- a/js/src/offcanvas.ts
+++ b/js/src/offcanvas.ts
@@ -14,9 +14,7 @@ import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { enableDismissTrigger } from './util/component-functions.js'
 import {
-  defineJQueryPlugin,
-  isDisabled,
-  isVisible
+  defineJQueryPlugin, isDisabled, isVisible, jQueryDispatch
 } from './util/index.js'
 import { resolveDialogElement } from './util/legacy-markup.js'
 
@@ -94,19 +92,7 @@ class Offcanvas extends DialogBase {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Offcanvas.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string](this)
-    })
+    return jQueryDispatch(this, Offcanvas, config, element => [element])
   }
 }
 

--- a/js/src/otp-input.ts
+++ b/js/src/otp-input.ts
@@ -8,7 +8,9 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { defineJQueryPlugin, getNextActiveElement, isRTL } from './util/index.js'
+import {
+  defineJQueryPlugin, getNextActiveElement, isRTL, jQueryDispatch
+} from './util/index.js'
 
 /**
  * Constants
@@ -515,17 +517,7 @@ class OTPInput extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = OTPInput.getOrCreateInstance(this)
-
-      if (typeof config === 'string') {
-        if (typeof data[config as string] === 'undefined') {
-          throw new TypeError(`No method named "${config}"`)
-        }
-
-        data[config as string]()
-      }
-    })
+    return jQueryDispatch(this, OTPInput, config)
   }
 }
 

--- a/js/src/password-input.ts
+++ b/js/src/password-input.ts
@@ -13,7 +13,7 @@ import {
 } from './util/form-control-group.js'
 import { PASSWORD_HIDE_ICON, PASSWORD_SHOW_ICON } from './util/icons.js'
 import { sanitizeHtml, SVGAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -154,11 +154,7 @@ class PasswordInput extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = PasswordInput.getOrCreateInstance(this)
-
-      data[config as string](this)
-    })
+    return jQueryDispatch(this, PasswordInput, config, element => [element])
   }
 }
 

--- a/js/src/password-strength.ts
+++ b/js/src/password-strength.ts
@@ -11,7 +11,7 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -437,11 +437,7 @@ class PasswordStrength extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = PasswordStrength.getOrCreateInstance(this)
-
-      data[config as string](this)
-    })
+    return jQueryDispatch(this, PasswordStrength, config, element => [element])
   }
 }
 

--- a/js/src/popover.ts
+++ b/js/src/popover.ts
@@ -10,7 +10,7 @@
 
 import Tooltip, { type TooltipConfig } from './tooltip.js'
 import type { ComponentConfig } from './util/config.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 import EventHandler, { type CoreUIEvent } from './dom/event-handler.js'
 import type { TemplateContentEntry } from './util/template-factory.js'
 
@@ -94,19 +94,7 @@ class Popover extends Tooltip {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Popover.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (typeof data[config as string] === 'undefined') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string]()
-    })
+    return jQueryDispatch(this, Popover, config)
   }
 }
 

--- a/js/src/progress.ts
+++ b/js/src/progress.ts
@@ -9,7 +9,7 @@ import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -168,19 +168,7 @@ class Progress extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Progress.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string](this)
-    })
+    return jQueryDispatch(this, Progress, config, element => [element])
   }
 }
 

--- a/js/src/range-slider.ts
+++ b/js/src/range-slider.ts
@@ -10,7 +10,7 @@ import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
-import { defineJQueryPlugin, isRTL } from './util/index.js'
+import { defineJQueryPlugin, isRTL, jQueryDispatch } from './util/index.js'
 import { DefaultAllowlist, type SanitizerAllowList, sanitizeHtml } from './util/sanitizer.js'
 
 /**
@@ -679,19 +679,7 @@ class RangeSlider extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): any {
-    return this.each(function (this: HTMLElement) {
-      const data: any = RangeSlider.getOrCreateInstance(this)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config](this)
-    })
+    return jQueryDispatch(this, RangeSlider, config, element => [element])
   }
 }
 

--- a/js/src/range.ts
+++ b/js/src/range.ts
@@ -12,7 +12,7 @@ import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -243,19 +243,7 @@ class Range extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Range.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string](this)
-    })
+    return jQueryDispatch(this, Range, config, element => [element])
   }
 }
 

--- a/js/src/rating.ts
+++ b/js/src/rating.ts
@@ -10,7 +10,7 @@ import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
-import { defineJQueryPlugin, getUID } from './util/index.js'
+import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
 import Tooltip from './tooltip.js'
 
 /**
@@ -485,19 +485,7 @@ class Rating extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Rating.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string](this)
-    })
+    return jQueryDispatch(this, Rating, config, element => [element])
   }
 }
 

--- a/js/src/scrollspy.ts
+++ b/js/src/scrollspy.ts
@@ -13,7 +13,7 @@ import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
 import {
-  defineJQueryPlugin, getElement, isDisabled, isVisible
+  defineJQueryPlugin, getElement, isDisabled, isVisible, jQueryDispatch
 } from './util/index.js'
 
 /**
@@ -585,19 +585,7 @@ class ScrollSpy extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = ScrollSpy.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string]()
-    })
+    return jQueryDispatch(this, ScrollSpy, config)
   }
 }
 

--- a/js/src/stepper.ts
+++ b/js/src/stepper.ts
@@ -11,7 +11,7 @@ import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
 import {
-  defineJQueryPlugin, getNextActiveElement, getUID, isDisabled
+  defineJQueryPlugin, getNextActiveElement, getUID, isDisabled, jQueryDispatch
 } from './util/index.js'
 
 /**
@@ -654,18 +654,7 @@ class Stepper extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Stepper.getOrCreateInstance(this)
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string]()
-    })
+    return jQueryDispatch(this, Stepper, config)
   }
 }
 

--- a/js/src/tab.ts
+++ b/js/src/tab.ts
@@ -12,7 +12,7 @@ import BaseComponent from './base-component.js'
 import EventHandler, { type CoreUIEvent } from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import {
-  defineJQueryPlugin, getNextActiveElement, getTransitionDurationFromElement, isDisabled, setAriaAttribute
+  defineJQueryPlugin, getNextActiveElement, getTransitionDurationFromElement, isDisabled, jQueryDispatch, setAriaAttribute
 } from './util/index.js'
 
 /**
@@ -284,19 +284,7 @@ class Tab extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Tab.getOrCreateInstance(this)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string]()
-    })
+    return jQueryDispatch(this, Tab, config)
   }
 }
 

--- a/js/src/time-input.ts
+++ b/js/src/time-input.ts
@@ -11,7 +11,7 @@ import SectionInput, { type SectionInputConfig } from './section-input.js'
 import { convertToDateObject } from './util/calendar.js'
 import { type DateSection, getTimeSectionsFromLocale } from './util/date-sections.js'
 import { convert12hTo24h } from './util/time.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -85,17 +85,7 @@ class TimeInput extends SectionInput {
 
   // Static
   static jQueryInterface(this: any, config: any): any {
-    return this.each(function (this: HTMLElement) {
-      const data: any = TimeInput.getOrCreateInstance(this)
-
-      if (typeof config === 'string') {
-        if (typeof data[config] === 'undefined') {
-          throw new TypeError(`No method named "${config}"`)
-        }
-
-        data[config]()
-      }
-    })
+    return jQueryDispatch(this, TimeInput, config)
   }
 }
 

--- a/js/src/time-picker.ts
+++ b/js/src/time-picker.ts
@@ -18,7 +18,7 @@ import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sani
 import type { ComponentConfig } from './util/config.js'
 import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
 import { CLEANER_ICON, CLOCK_ICON } from './util/icons.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -404,19 +404,7 @@ class TimePicker extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = TimePicker.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config]()
-    })
+    return jQueryDispatch(this, TimePicker, config)
   }
 }
 

--- a/js/src/toast.ts
+++ b/js/src/toast.ts
@@ -12,7 +12,7 @@ import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler, { type CoreUIEvent } from './dom/event-handler.js'
 import { enableDismissTrigger } from './util/component-functions.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -205,17 +205,7 @@ class Toast extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Toast.getOrCreateInstance(this, config)
-
-      if (typeof config === 'string') {
-        if (typeof data[config as string] === 'undefined') {
-          throw new TypeError(`No method named "${config}"`)
-        }
-
-        data[config as string](this)
-      }
-    })
+    return jQueryDispatch(this, Toast, config, element => [element])
   }
 }
 

--- a/js/src/toaster.ts
+++ b/js/src/toaster.ts
@@ -12,7 +12,7 @@ import Toast, { type ToastConfig } from './toast.js'
 import type { TemplateContentEntry } from './util/template-factory.js'
 import { DefaultAllowlist, sanitizeHtml, type SanitizerAllowList } from './util/sanitizer.js'
 import {
-  defineJQueryPlugin, execute, getElement, getTransitionDurationFromElement, getUID, isElement
+  defineJQueryPlugin, execute, getElement, getTransitionDurationFromElement, getUID, isElement, jQueryDispatch
 } from './util/index.js'
 
 /**
@@ -778,17 +778,7 @@ class Toaster extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Toaster.getOrCreateInstance(this, config)
-
-      if (typeof config === 'string') {
-        if (typeof data[config as string] === 'undefined') {
-          throw new TypeError(`No method named "${config}"`)
-        }
-
-        data[config as string](this)
-      }
-    })
+    return jQueryDispatch(this, Toaster, config, element => [element])
   }
 }
 

--- a/js/src/tooltip.ts
+++ b/js/src/tooltip.ts
@@ -24,7 +24,7 @@ import EventHandler, { type CoreUIEvent } from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import type { ComponentConfig } from './util/config.js'
 import {
-  defineJQueryPlugin, execute, findShadowRoot, getElement, getUID, isRTL, noop
+  defineJQueryPlugin, execute, findShadowRoot, getElement, getUID, isRTL, jQueryDispatch, noop
 } from './util/index.js'
 import { DefaultAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
 import TemplateFactory, { type TemplateContentEntry } from './util/template-factory.js'
@@ -916,19 +916,7 @@ class Tooltip extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Tooltip.getOrCreateInstance(this, config)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (typeof data[config as string] === 'undefined') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string]()
-    })
+    return jQueryDispatch(this, Tooltip, config)
   }
 }
 

--- a/js/src/transfer.ts
+++ b/js/src/transfer.ts
@@ -13,7 +13,7 @@ import type { ComponentConfig } from './util/config.js'
 import {
   CHEVRON_DOUBLE_LEFT_ICON, CHEVRON_DOUBLE_RIGHT_ICON, CHEVRON_LEFT_ICON, CHEVRON_RIGHT_ICON
 } from './util/icons.js'
-import { defineJQueryPlugin, getUID } from './util/index.js'
+import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 
 /**
@@ -679,19 +679,7 @@ class Transfer extends BaseComponent {
 
   // Static
   static jQueryInterface(this: any, config: any, ...args: any[]): any {
-    return this.each(function (this: HTMLElement) {
-      const data: any = Transfer.getOrCreateInstance(this, typeof config === 'object' ? config : null)
-
-      if (typeof config !== 'string') {
-        return
-      }
-
-      if (data[config as string] === undefined || config.startsWith('_') || config === 'constructor') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config as string](...args)
-    })
+    return jQueryDispatch(this, Transfer, config, args)
   }
 }
 

--- a/js/src/util/index.ts
+++ b/js/src/util/index.ts
@@ -250,6 +250,25 @@ const defineJQueryPlugin = (plugin: JQueryPlugin): void => {
   })
 }
 
+type JQueryComponent = { getOrCreateInstance: (element: Element, config?: any) => any }
+
+// A string argument names a public method; private members and misses throw.
+const jQueryDispatch = (collection: any, Component: JQueryComponent, config: any, args: unknown[] | ((element: HTMLElement) => unknown[]) = []): any => {
+  return collection.each(function (this: HTMLElement) {
+    const data = Component.getOrCreateInstance(this, config)
+
+    if (typeof config !== 'string') {
+      return
+    }
+
+    if (data[config] === undefined || config.startsWith('_') || config === 'constructor') {
+      throw new TypeError(`No method named "${config}"`)
+    }
+
+    data[config](...(typeof args === 'function' ? args(this) : args))
+  })
+}
+
 const execute = <T = any>(possibleCallback: T | ((...functionArgs: any[]) => T), args: any[] = [], defaultValue: T | ((...functionArgs: any[]) => T) = possibleCallback): T => {
   return typeof possibleCallback === 'function' ? (possibleCallback as (...functionArgs: any[]) => T).call(...args as [any, ...any[]]) : defaultValue as T
 }
@@ -337,6 +356,7 @@ export {
   isElement,
   isRTL,
   isVisible,
+  jQueryDispatch,
   noop,
   onDOMContentLoaded,
   parseSelector,

--- a/js/tests/unit/util/index.spec.js
+++ b/js/tests/unit/util/index.spec.js
@@ -512,6 +512,58 @@ describe('Util', () => {
     })
   })
 
+  describe('jQueryDispatch', () => {
+    const collection = elements => ({
+      each(callback) {
+        for (const element of elements) {
+          callback.call(element)
+        }
+
+        return collection
+      }
+    })
+
+    const component = () => {
+      const instance = { show: jasmine.createSpy('show'), _private: jasmine.createSpy('_private') }
+      return {
+        instance,
+        getOrCreateInstance: jasmine.createSpy('getOrCreateInstance').and.returnValue(instance)
+      }
+    }
+
+    it('should create or reuse the instance and stop there for a config object', () => {
+      const Component = component()
+      const el = document.createElement('div')
+
+      Util.jQueryDispatch(collection([el]), Component, { a: 1 })
+
+      expect(Component.getOrCreateInstance).toHaveBeenCalledWith(el, { a: 1 })
+      expect(Component.instance.show).not.toHaveBeenCalled()
+    })
+
+    it('should call a public method by name with the given arguments', () => {
+      const Component = component()
+      const el = document.createElement('div')
+
+      Util.jQueryDispatch(collection([el]), Component, 'show', ['x'])
+      Util.jQueryDispatch(collection([el]), Component, 'show', element => [element])
+
+      expect(Component.instance.show).toHaveBeenCalledWith('x')
+      expect(Component.instance.show).toHaveBeenCalledWith(el)
+    })
+
+    it('should throw on an unknown, private or constructor name', () => {
+      const Component = component()
+      const el = document.createElement('div')
+
+      for (const name of ['missing', '_private', 'constructor']) {
+        expect(() => Util.jQueryDispatch(collection([el]), Component, name)).toThrowError(TypeError, `No method named "${name}"`)
+      }
+
+      expect(Component.instance._private).not.toHaveBeenCalled()
+    })
+  })
+
   describe('execute', () => {
     it('should execute if arg is function', () => {
       const spy = jasmine.createSpy('spy')


### PR DESCRIPTION
Stage 1 of the reuse audit (R3, the jQuery adapter half).

## Before / after

- Before: 46 `jQueryInterface` implementations spelled the same ten lines in twelve slightly different ways. Some validated the method name against private members and `constructor`, some only against `undefined`, three (Button, NumberInput, PasswordInput/PasswordStrength) did not validate at all, and the config reached `getOrCreateInstance()` in three different forms.
- After: `util/index.ts` gains `jQueryDispatch(collection, Component, config, args)`. It creates or reuses the instance, returns for a config object, and for a string calls the named **public** method; a private name, `constructor` or a miss throws `TypeError: No method named "…"`. 40 plugins delegate to it and keep only what really differs: the arguments the method receives (none · the element as `relatedTarget` · the caller's rest arguments) and Carousel's numeric `to`. The six plugins whose interface is shared with their data API (Autocomplete, MultiSelect, LoadingButton, Navigation, SearchButton, Sidebar) keep their own for now.

Behaviour change, noted in the migration guide: the plugins that used to let a private name through or skipped the check now reject it like the rest.

## Tests

`util/index.spec.js`: the dispatcher's three behaviours (config object, method with arguments, rejected names). The per-plugin jQuery tests are unchanged and pass. Full unit suite 3819 tests, `JQUERY=true` suite green, typecheck clean.
