### PR TITLE
refactor: one ready-time initialiser for the data API scans

### DIFF
--- a/js/src/autocomplete.ts
+++ b/js/src/autocomplete.ts
@@ -9,12 +9,13 @@ import ComboboxBase from './combobox-base.js'
 import Data from './dom/data.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import {
   DefaultAllowlist, escapeHtml, type SanitizerAllowList
 } from './util/sanitizer.js'
 import { CLEANER_ICON, INDICATOR_ICON } from './util/icons.js'
-import { defineJQueryPlugin, getUID } from './util/index.js'
+import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
 
 /**
  * ------------------------------------------------------------------------
@@ -43,7 +44,6 @@ const EVENT_KEYUP = `keyup${EVENT_KEY}`
 const EVENT_MOUSEDOWN = `mousedown${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_KEYUP_DATA_API = `keyup${EVENT_KEY}${DATA_API_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_AUTOCOMPLETE = 'autocomplete'
 const CLASS_NAME_CLEANER = 'form-control-cleaner'
@@ -733,9 +733,7 @@ class Autocomplete extends ComboboxBase {
   }
 
   static jQueryInterface(this: any, config: any): any {
-    return this.each(function (this: HTMLElement) {
-      Autocomplete.autocompleteInterface(this, config)
-    })
+    return jQueryDispatch(this, Autocomplete, config)
   }
 
   static clearMenus(event: any): void {
@@ -779,11 +777,7 @@ class Autocomplete extends ComboboxBase {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const autocomplete of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
-    Autocomplete.autocompleteInterface(autocomplete)
-  }
-})
+initializeOnReady(Autocomplete, SELECTOR_DATA_TOGGLE)
 EventHandler.on(document, EVENT_CLICK_DATA_API, Autocomplete.clearMenus)
 EventHandler.on(document, EVENT_KEYUP_DATA_API, Autocomplete.clearMenus)
 

--- a/js/src/calendar.ts
+++ b/js/src/calendar.ts
@@ -7,6 +7,7 @@
  */
 
 import BaseComponent from './base-component.js'
+import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
@@ -76,7 +77,6 @@ const EVENT_SELECT_END_CHANGE = `selectEndChange${EVENT_KEY}`
 const EVENT_START_DATE_CHANGE = `startDateChange${EVENT_KEY}`
 const EVENT_MOUSEENTER = `mouseenter${EVENT_KEY}`
 const EVENT_MOUSELEAVE = `mouseleave${EVENT_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_CALENDAR_CELL = 'calendar-cell'
@@ -1282,11 +1282,7 @@ class Calendar extends BaseComponent {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const element of Array.from(document.querySelectorAll(SELECTOR_DATA_TOGGLE))) {
-    Calendar.calendarInterface(element)
-  }
-})
+initializeOnReady(Calendar, SELECTOR_DATA_TOGGLE)
 
 /**
  * jQuery

--- a/js/src/carousel.ts
+++ b/js/src/carousel.ts
@@ -12,6 +12,7 @@ import BaseComponent from './base-component.js'
 import EventHandler, { type CoreUIEvent } from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { initializeOnReady } from './util/component-functions.js'
 import {
   defineJQueryPlugin, isRTL, isVisible, jQueryDispatch
 } from './util/index.js'
@@ -37,7 +38,6 @@ const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
 const EVENT_MOUSEENTER = `mouseenter${EVENT_KEY}`
 const EVENT_MOUSELEAVE = `mouseleave${EVENT_KEY}`
 const EVENT_POINTERDOWN = `pointerdown${EVENT_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_CAROUSEL = 'carousel'
@@ -941,13 +941,7 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_PLAY_PAUSE, function (e
   Carousel.getOrCreateInstance(target)._togglePlayPause()
 })
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  const carousels = SelectorEngine.find(SELECTOR_DATA_AUTOPLAY)
-
-  for (const carousel of carousels) {
-    Carousel.getOrCreateInstance(carousel)
-  }
-})
+initializeOnReady(Carousel, SELECTOR_DATA_AUTOPLAY)
 
 /**
  * jQuery

--- a/js/src/chip-input.ts
+++ b/js/src/chip-input.ts
@@ -8,6 +8,7 @@
 import ChipSet, { type ChipSetConfig } from './chip-set.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import { getUID, isRTL } from './util/index.js'
 
@@ -18,7 +19,6 @@ import { getUID, isRTL } from './util/index.js'
 const NAME = 'chip-input'
 const DATA_KEY = 'coreui.chip-input'
 const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
 
 const EVENT_BLUR = `blur${EVENT_KEY}`
 const EVENT_CLICK = `click${EVENT_KEY}`
@@ -417,10 +417,6 @@ class ChipInput extends ChipSet {
  * Data API implementation
  */
 
-EventHandler.on(document, `DOMContentLoaded${EVENT_KEY}${DATA_API_KEY}`, () => {
-  for (const element of SelectorEngine.find(SELECTOR_DATA_CHIP_INPUT)) {
-    ChipInput.getOrCreateInstance(element)
-  }
-})
+initializeOnReady(ChipInput, SELECTOR_DATA_CHIP_INPUT, 'DOMContentLoaded')
 
 export default ChipInput

--- a/js/src/chip-set.ts
+++ b/js/src/chip-set.ts
@@ -6,6 +6,7 @@
  */
 
 import BaseComponent from './base-component.js'
+import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import Chip from './chip.js'
 import EventHandler from './dom/event-handler.js'
@@ -21,9 +22,6 @@ import {
  */
 
 const NAME = 'chip-set'
-const DATA_KEY = 'coreui.chip-set'
-const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
 
 const EVENT_ADD = 'add'
 const EVENT_REMOVE = 'remove'
@@ -578,11 +576,7 @@ class ChipSet extends BaseComponent {
  * Data API implementation
  */
 
-EventHandler.on(document, `DOMContentLoaded${EVENT_KEY}${DATA_API_KEY}`, () => {
-  for (const element of SelectorEngine.find(SELECTOR_DATA_CHIP_SET)) {
-    ChipSet.chipSetInterface(element)
-  }
-})
+initializeOnReady(ChipSet, SELECTOR_DATA_CHIP_SET, 'DOMContentLoaded')
 
 /**
  * jQuery

--- a/js/src/chip.ts
+++ b/js/src/chip.ts
@@ -6,6 +6,7 @@
  */
 
 import BaseComponent from './base-component.js'
+import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
@@ -20,7 +21,6 @@ import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 const NAME = 'chip'
 const DATA_KEY = 'coreui.chip'
 const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
 
 const EVENT_REMOVE = `remove${EVENT_KEY}`
 const EVENT_REMOVED = `removed${EVENT_KEY}`
@@ -388,11 +388,7 @@ class Chip extends BaseComponent {
  * Data API implementation
  */
 
-EventHandler.on(document, `DOMContentLoaded${EVENT_KEY}${DATA_API_KEY}`, () => {
-  for (const element of SelectorEngine.find(SELECTOR_DATA_CHIP)) {
-    Chip.chipInterface(element)
-  }
-})
+initializeOnReady(Chip, SELECTOR_DATA_CHIP, 'DOMContentLoaded')
 
 /**
  * jQuery

--- a/js/src/combobox.ts
+++ b/js/src/combobox.ts
@@ -10,6 +10,7 @@ import Data from './dom/data.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import ListBox, { type ListBoxEntry } from './list-box.js'
+import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import { CARET_ICON } from './util/icons.js'
 import { DefaultAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
@@ -37,7 +38,6 @@ const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
 const EVENT_SEARCH = `search${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_KEYUP_DATA_API = `keyup${EVENT_KEY}${DATA_API_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const EVENT_LIST_BOX = '.coreui.list-box'
 const EVENT_LIST_BOX_SEARCH = `search${EVENT_LIST_BOX}`
@@ -570,11 +570,7 @@ class Combobox extends ComboboxBase {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const toggle of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
-    Combobox.getOrCreateInstance(toggle)
-  }
-})
+initializeOnReady(Combobox, SELECTOR_DATA_TOGGLE)
 
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (this: HTMLElement, event: any) {
   event.preventDefault()

--- a/js/src/date-input.ts
+++ b/js/src/date-input.ts
@@ -5,9 +5,8 @@
  * --------------------------------------------------------------------------
  */
 
-import EventHandler from './dom/event-handler.js'
-import SelectorEngine from './dom/selector-engine.js'
 import SectionInput, { type SectionInputConfig } from './section-input.js'
+import { initializeOnReady } from './util/component-functions.js'
 import { type DateSection, getSectionsFromLocale } from './util/date-sections.js'
 import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
@@ -16,11 +15,6 @@ import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
  */
 
 const NAME = 'date-input'
-const DATA_KEY = 'coreui.date-input'
-const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
-
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_DATA_DATE_INPUT = '[data-coreui-date-input]'
 
@@ -58,11 +52,7 @@ class DateInput extends SectionInput {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const dateInput of SelectorEngine.find(SELECTOR_DATA_DATE_INPUT)) {
-    DateInput.componentInterface(dateInput)
-  }
-})
+initializeOnReady(DateInput, SELECTOR_DATA_DATE_INPUT)
 
 /**
  * jQuery

--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -15,6 +15,7 @@ import Calendar from './calendar.js'
 import DateInput from './date-input.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { initializeOnReady } from './util/component-functions.js'
 import Popup from './util/popup.js'
 import { getDateBySelectionType } from './util/calendar.js'
 import type { ComponentConfig } from './util/config.js'
@@ -31,7 +32,6 @@ import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sani
 const NAME = 'date-picker'
 const DATA_KEY = 'coreui.date-picker'
 const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
 
 const EVENT_CLICK = `click${EVENT_KEY}`
 const EVENT_DATE_CHANGE = `dateChange${EVENT_KEY}`
@@ -39,7 +39,6 @@ const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_HIDE = `hide${EVENT_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_BODY = 'date-picker-body'
 const CLASS_NAME_CALENDAR = 'date-picker-calendar'
@@ -464,11 +463,7 @@ class DatePicker extends BaseComponent {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
-    DatePicker.getOrCreateInstance(element)
-  }
-})
+initializeOnReady(DatePicker, SELECTOR_DATA_TOGGLE)
 
 /**
  * jQuery

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -14,6 +14,7 @@ import Calendar from './calendar.js'
 import DateInput from './date-input.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { initializeOnReady } from './util/component-functions.js'
 import Popup from './util/popup.js'
 import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
 import { getDateBySelectionType } from './util/calendar.js'
@@ -32,7 +33,6 @@ import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sani
 const NAME = 'date-range-picker'
 const DATA_KEY = 'coreui.date-range-picker'
 const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
 
 const EVENT_CLICK = `click${EVENT_KEY}`
 const EVENT_END_DATE_CHANGE = `endDateChange${EVENT_KEY}`
@@ -42,7 +42,6 @@ const EVENT_HIDE = `hide${EVENT_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_START_DATE_CHANGE = `startDateChange${EVENT_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_BODY = 'date-picker-body'
 const CLASS_NAME_CALENDAR = 'date-picker-calendar'
@@ -580,11 +579,7 @@ class DateRangePicker extends BaseComponent {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
-    DateRangePicker.getOrCreateInstance(element)
-  }
-})
+initializeOnReady(DateRangePicker, SELECTOR_DATA_TOGGLE)
 
 /**
  * jQuery

--- a/js/src/date-time-input.ts
+++ b/js/src/date-time-input.ts
@@ -5,10 +5,9 @@
  * --------------------------------------------------------------------------
  */
 
-import EventHandler from './dom/event-handler.js'
-import SelectorEngine from './dom/selector-engine.js'
 import SectionInput, { type SectionInputConfig } from './section-input.js'
 import { convertToDateObject } from './util/calendar.js'
+import { initializeOnReady } from './util/component-functions.js'
 import { type DateSection, getDateTimeSectionsFromLocale } from './util/date-sections.js'
 import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
@@ -17,11 +16,6 @@ import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
  */
 
 const NAME = 'date-time-input'
-const DATA_KEY = 'coreui.date-time-input'
-const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
-
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_DATA_DATE_TIME_INPUT = '[data-coreui-date-time-input]'
 
@@ -84,11 +78,7 @@ class DateTimeInput extends SectionInput {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const dateTimeInput of SelectorEngine.find(SELECTOR_DATA_DATE_TIME_INPUT)) {
-    DateTimeInput.componentInterface(dateTimeInput)
-  }
-})
+initializeOnReady(DateTimeInput, SELECTOR_DATA_DATE_TIME_INPUT)
 
 /**
  * jQuery

--- a/js/src/date-time-picker.ts
+++ b/js/src/date-time-picker.ts
@@ -14,6 +14,7 @@ import Calendar from './calendar.js'
 import DateTimeInput from './date-time-input.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { initializeOnReady } from './util/component-functions.js'
 import Popup from './util/popup.js'
 import TimeSelection from './util/time-selection.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
@@ -29,13 +30,11 @@ import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 const NAME = 'date-time-picker'
 const DATA_KEY = 'coreui.date-time-picker'
 const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
 
 const EVENT_CLICK = `click${EVENT_KEY}`
 const EVENT_DATE_CHANGE = `dateChange${EVENT_KEY}`
 const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_HIDE = `hide${EVENT_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 
@@ -491,11 +490,7 @@ class DateTimePicker extends BaseComponent {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
-    DateTimePicker.getOrCreateInstance(element)
-  }
-})
+initializeOnReady(DateTimePicker, SELECTOR_DATA_TOGGLE)
 
 /**
  * jQuery

--- a/js/src/list-box.ts
+++ b/js/src/list-box.ts
@@ -8,6 +8,7 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import { DefaultAllowlist, sanitizeHtml, type SanitizerAllowList } from './util/sanitizer.js'
 import {
@@ -21,7 +22,6 @@ import {
 const NAME = 'list-box'
 const DATA_KEY = 'coreui.list-box'
 const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
 
 const ARROW_UP_KEY = 'ArrowUp'
 const ARROW_DOWN_KEY = 'ArrowDown'
@@ -1303,11 +1303,7 @@ class ListBox extends BaseComponent {
  * Data API implementation
  */
 
-EventHandler.on(document, `DOMContentLoaded${EVENT_KEY}${DATA_API_KEY}`, () => {
-  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
-    ListBox.getOrCreateInstance(element)
-  }
-})
+initializeOnReady(ListBox, SELECTOR_DATA_TOGGLE, 'DOMContentLoaded')
 
 /**
  * jQuery

--- a/js/src/loading-button.ts
+++ b/js/src/loading-button.ts
@@ -8,7 +8,7 @@
 import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -189,9 +189,7 @@ class LoadingButton extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      LoadingButton.loadingButtonInterface(this, config)
-    })
+    return jQueryDispatch(this, LoadingButton, config)
   }
 }
 

--- a/js/src/multi-select.ts
+++ b/js/src/multi-select.ts
@@ -14,7 +14,7 @@ import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
 import { CLEANER_ICON, INDICATOR_ICON } from './util/icons.js'
 import { DefaultAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
-import { defineJQueryPlugin, getUID } from './util/index.js'
+import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
 
 /**
  * ------------------------------------------------------------------------
@@ -1416,9 +1416,7 @@ class MultiSelect extends ComboboxBase {
   }
 
   static jQueryInterface(this: any, config: any): any {
-    return this.each(function (this: HTMLElement) {
-      MultiSelect.multiSelectInterface(this, config)
-    })
+    return jQueryDispatch(this, MultiSelect, config)
   }
 
   static clearMenus(event: any): void {

--- a/js/src/navigation.ts
+++ b/js/src/navigation.ts
@@ -6,10 +6,11 @@
  */
 
 import BaseComponent from './base-component.js'
+import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 import { startSizeTransition, supportsInterpolateSize } from './util/size-transition.js'
 
 /**
@@ -41,7 +42,6 @@ const CLASS_NAME_NAV_GROUP = 'nav-group'
 const CLASS_NAME_NAV_GROUP_TOGGLE = 'nav-group-toggle'
 
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_NAV_GROUP = '.nav-group'
 const SELECTOR_NAV_GROUP_ITEMS = '.nav-group-items'
@@ -183,9 +183,7 @@ class Navigation extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      Navigation.navigationInterface(this, config)
-    })
+    return jQueryDispatch(this, Navigation, config)
   }
 }
 
@@ -194,11 +192,7 @@ class Navigation extends BaseComponent {
  * Data Api implementation
  * ------------------------------------------------------------------------
  */
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const element of Array.from(document.querySelectorAll(SELECTOR_DATA_NAVIGATION))) {
-    Navigation.navigationInterface(element)
-  }
-})
+initializeOnReady(Navigation, SELECTOR_DATA_NAVIGATION)
 
 /**
  * ------------------------------------------------------------------------

--- a/js/src/otp-input.ts
+++ b/js/src/otp-input.ts
@@ -8,6 +8,7 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { initializeOnReady } from './util/component-functions.js'
 import {
   defineJQueryPlugin, getNextActiveElement, isRTL, jQueryDispatch
 } from './util/index.js'
@@ -19,7 +20,6 @@ import {
 const NAME = 'otp-input'
 const DATA_KEY = 'coreui.otp-input'
 const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
 
 const ARROW_RIGHT_KEY = 'ArrowRight'
 const ARROW_LEFT_KEY = 'ArrowLeft'
@@ -31,7 +31,6 @@ const EVENT_FOCUS = `focus${EVENT_KEY}`
 const EVENT_INPUT = `input${EVENT_KEY}`
 const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
 const EVENT_PASTE = `paste${EVENT_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_FORM_OTP_CONTROL = '.form-otp-control'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="otp"]'
@@ -525,11 +524,7 @@ class OTPInput extends BaseComponent {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const otp of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
-    OTPInput.otpInputInterface(otp)
-  }
-})
+initializeOnReady(OTPInput, SELECTOR_DATA_TOGGLE)
 
 /**
  * jQuery

--- a/js/src/range-slider.ts
+++ b/js/src/range-slider.ts
@@ -9,6 +9,7 @@ import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import { defineJQueryPlugin, isRTL, jQueryDispatch } from './util/index.js'
 import { DefaultAllowlist, type SanitizerAllowList, sanitizeHtml } from './util/sanitizer.js'
@@ -20,11 +21,9 @@ import { DefaultAllowlist, type SanitizerAllowList, sanitizeHtml } from './util/
 const NAME = 'range-slider'
 const DATA_KEY = 'coreui.range-slider'
 const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
 
 const EVENT_CHANGE = `change${EVENT_KEY}`
 const EVENT_INPUT = `input${EVENT_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_MOUSEDOWN = `mousedown${EVENT_KEY}`
 const EVENT_MOUSEMOVE = `mousemove${EVENT_KEY}`
 const EVENT_MOUSEUP = `mouseup${EVENT_KEY}`
@@ -687,12 +686,7 @@ class RangeSlider extends BaseComponent {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  const ratings = SelectorEngine.find(SELECTOR_DATA_TOGGLE)
-  for (let i = 0, len = ratings.length; i < len; i++) {
-    RangeSlider.rangeSliderInterface(ratings[i])
-  }
-})
+initializeOnReady(RangeSlider, SELECTOR_DATA_TOGGLE)
 
 /**
  * jQuery

--- a/js/src/rating.ts
+++ b/js/src/rating.ts
@@ -6,6 +6,7 @@
  */
 
 import BaseComponent from './base-component.js'
+import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
@@ -20,14 +21,12 @@ import Tooltip from './tooltip.js'
 const NAME = 'rating'
 const DATA_KEY = 'coreui.rating'
 const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
 
 const EVENT_CHANGE = `change${EVENT_KEY}`
 const EVENT_CLICK = `click${EVENT_KEY}`
 const EVENT_FOCUSIN = `focusin${EVENT_KEY}`
 const EVENT_FOCUSOUT = `focusout${EVENT_KEY}`
 const EVENT_HOVER = `hover${EVENT_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_MOUSEENTER = `mouseenter${EVENT_KEY}`
 const EVENT_MOUSELEAVE = `mouseleave${EVENT_KEY}`
 
@@ -493,12 +492,7 @@ class Rating extends BaseComponent {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  const ratings = SelectorEngine.find(SELECTOR_DATA_TOGGLE)
-  for (let i = 0, len = ratings.length; i < len; i++) {
-    Rating.ratingInterface(ratings[i])
-  }
-})
+initializeOnReady(Rating, SELECTOR_DATA_TOGGLE)
 
 /**
  * jQuery

--- a/js/src/scrollspy.ts
+++ b/js/src/scrollspy.ts
@@ -11,6 +11,7 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import {
   defineJQueryPlugin, getElement, isDisabled, isVisible, jQueryDispatch
@@ -23,14 +24,12 @@ import {
 const NAME = 'scrollspy'
 const DATA_KEY = 'coreui.scrollspy'
 const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
 
 const EVENT_ACTIVATE = `activate${EVENT_KEY}`
 const EVENT_CLICK = `click${EVENT_KEY}`
 const EVENT_SCROLL = `scroll${EVENT_KEY}`
 const EVENT_SCROLLEND = `scrollend${EVENT_KEY}`
 const EVENT_RESIZE = `resize${EVENT_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_MENU_ITEM = 'menu-item'
 const CLASS_NAME_DROPDOWN_ITEM = 'dropdown-item'
@@ -602,11 +601,7 @@ function decodeFragment(hash: string): string {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const spy of SelectorEngine.find(SELECTOR_DATA_SPY)) {
-    ScrollSpy.getOrCreateInstance(spy)
-  }
-})
+initializeOnReady(ScrollSpy, SELECTOR_DATA_SPY)
 
 /**
  * jQuery

--- a/js/src/search-button.ts
+++ b/js/src/search-button.ts
@@ -8,7 +8,7 @@
 import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -337,9 +337,7 @@ class SearchButton extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      SearchButton.searchButtonInterface(this, config)
-    })
+    return jQueryDispatch(this, SearchButton, config)
   }
 
   static _initializeDataApi(): void {

--- a/js/src/sidebar.ts
+++ b/js/src/sidebar.ts
@@ -6,10 +6,11 @@
  */
 
 import BaseComponent from './base-component.js'
+import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 import Backdrop from './util/backdrop.js'
 import ScrollBarHelper from './util/scrollbar.js'
 
@@ -41,7 +42,6 @@ const EVENT_RESIZE = `resize${EVENT_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_DATA_CLOSE = '[data-coreui-close="sidebar"]'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="narrow"], [data-coreui-toggle="unfoldable"]'
@@ -321,9 +321,7 @@ class Sidebar extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      Sidebar.sidebarInterface(this, config)
-    })
+    return jQueryDispatch(this, Sidebar, config)
   }
 }
 
@@ -333,11 +331,7 @@ class Sidebar extends BaseComponent {
  * ------------------------------------------------------------------------
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const element of Array.from(document.querySelectorAll(SELECTOR_SIDEBAR))) {
-    Sidebar.sidebarInterface(element)
-  }
-})
+initializeOnReady(Sidebar, SELECTOR_SIDEBAR)
 
 /**
  * ------------------------------------------------------------------------

--- a/js/src/stepper.ts
+++ b/js/src/stepper.ts
@@ -6,6 +6,7 @@
  */
 
 import BaseComponent from './base-component.js'
+import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
@@ -29,7 +30,6 @@ const EVENT_STEP_VALIDATION_COMPLETE = `stepValidationComplete${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}`
 const EVENT_INPUT = `input${EVENT_KEY}`
 const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}`
 
 const CLASS_NAME_ACTIVE = 'active'
 const CLASS_NAME_COMPLETE = 'complete'
@@ -692,11 +692,7 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEPPER_ACTION, functio
   }
 })
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
-    Stepper.getOrCreateInstance(element)
-  }
-})
+initializeOnReady(Stepper, SELECTOR_DATA_TOGGLE)
 
 /**
  * jQuery integration

--- a/js/src/tab.ts
+++ b/js/src/tab.ts
@@ -11,6 +11,7 @@
 import BaseComponent from './base-component.js'
 import EventHandler, { type CoreUIEvent } from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { initializeOnReady } from './util/component-functions.js'
 import {
   defineJQueryPlugin, getNextActiveElement, getTransitionDurationFromElement, isDisabled, jQueryDispatch, setAriaAttribute
 } from './util/index.js'
@@ -29,7 +30,6 @@ const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}`
 const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}`
 
 const ARROW_LEFT_KEY = 'ArrowLeft'
 const ARROW_RIGHT_KEY = 'ArrowRight'
@@ -307,11 +307,7 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
 /**
  * Initialize on focus
  */
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE_ACTIVE)) {
-    Tab.getOrCreateInstance(element)
-  }
-})
+initializeOnReady(Tab, SELECTOR_DATA_TOGGLE_ACTIVE)
 /**
  * jQuery
  */

--- a/js/src/time-input.ts
+++ b/js/src/time-input.ts
@@ -5,10 +5,9 @@
  * --------------------------------------------------------------------------
  */
 
-import EventHandler from './dom/event-handler.js'
-import SelectorEngine from './dom/selector-engine.js'
 import SectionInput, { type SectionInputConfig } from './section-input.js'
 import { convertToDateObject } from './util/calendar.js'
+import { initializeOnReady } from './util/component-functions.js'
 import { type DateSection, getTimeSectionsFromLocale } from './util/date-sections.js'
 import { convert12hTo24h } from './util/time.js'
 import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
@@ -18,11 +17,6 @@ import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
  */
 
 const NAME = 'time-input'
-const DATA_KEY = 'coreui.time-input'
-const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
-
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_DATA_TIME_INPUT = '[data-coreui-time-input]'
 
@@ -93,11 +87,7 @@ class TimeInput extends SectionInput {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const timeInput of SelectorEngine.find(SELECTOR_DATA_TIME_INPUT)) {
-    TimeInput.componentInterface(timeInput)
-  }
-})
+initializeOnReady(TimeInput, SELECTOR_DATA_TIME_INPUT)
 
 /**
  * jQuery

--- a/js/src/time-picker.ts
+++ b/js/src/time-picker.ts
@@ -12,6 +12,7 @@ import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import TimeInput from './time-input.js'
+import { initializeOnReady } from './util/component-functions.js'
 import Popup from './util/popup.js'
 import TimeSelection from './util/time-selection.js'
 import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
@@ -27,12 +28,10 @@ import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 const NAME = 'time-picker'
 const DATA_KEY = 'coreui.time-picker'
 const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
 
 const EVENT_CLICK = `click${EVENT_KEY}`
 const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_HIDE = `hide${EVENT_KEY}`
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_TIME_CHANGE = `timeChange${EVENT_KEY}`
@@ -412,11 +411,7 @@ class TimePicker extends BaseComponent {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
-    TimePicker.getOrCreateInstance(element)
-  }
-})
+initializeOnReady(TimePicker, SELECTOR_DATA_TOGGLE)
 
 /**
  * jQuery

--- a/js/src/transfer.ts
+++ b/js/src/transfer.ts
@@ -9,6 +9,7 @@ import BaseComponent from './base-component.js'
 import ListBox, { type ListBoxEntry, type ListBoxGroup, type ListBoxItem } from './list-box.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import {
   CHEVRON_DOUBLE_LEFT_ICON, CHEVRON_DOUBLE_RIGHT_ICON, CHEVRON_LEFT_ICON, CHEVRON_RIGHT_ICON
@@ -23,7 +24,6 @@ import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sani
 const NAME = 'transfer'
 const DATA_KEY = 'coreui.transfer'
 const EVENT_KEY = `.${DATA_KEY}`
-const DATA_API_KEY = '.data-api'
 
 const EVENT_CHANGE = 'change'
 const EVENT_MOVE = 'move'
@@ -687,11 +687,7 @@ class Transfer extends BaseComponent {
  * Data API implementation
  */
 
-EventHandler.on(document, `DOMContentLoaded${EVENT_KEY}${DATA_API_KEY}`, () => {
-  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
-    Transfer.getOrCreateInstance(element)
-  }
-})
+initializeOnReady(Transfer, SELECTOR_DATA_TOGGLE, 'DOMContentLoaded')
 
 /**
  * jQuery

--- a/js/src/util/component-functions.ts
+++ b/js/src/util/component-functions.ts
@@ -34,6 +34,15 @@ const enableDismissTrigger = (component: typeof BaseComponent, method = 'hide', 
   })
 }
 
+const initializeOnReady = (component: typeof BaseComponent, selector: string, event: 'DOMContentLoaded' | 'load' = 'load'): void => {
+  EventHandler.on(event === 'load' ? window : document, `${event}${component.EVENT_KEY}.data-api`, () => {
+    for (const element of SelectorEngine.find(selector)) {
+      component.getOrCreateInstance(element)
+    }
+  })
+}
+
 export {
-  enableDismissTrigger
+  enableDismissTrigger,
+  initializeOnReady
 }

--- a/js/tests/unit/navigation.spec.js
+++ b/js/tests/unit/navigation.spec.js
@@ -80,23 +80,23 @@ describe('Navigation', () => {
     it('should initialize navigation on elements with data-coreui-navigation', () => {
       fixtureEl.innerHTML = '<nav data-coreui-navigation></nav>'
       const navEl = fixtureEl.querySelector('nav')
-      spyOn(Navigation, 'navigationInterface')
+      spyOn(Navigation, 'getOrCreateInstance')
 
       const loadEvent = new Event('load')
       window.dispatchEvent(loadEvent)
 
-      expect(Navigation.navigationInterface).toHaveBeenCalledWith(navEl)
+      expect(Navigation.getOrCreateInstance).toHaveBeenCalledWith(navEl)
     })
 
     it('should initialize navigation on elements with legacy data-coreui="navigation"', () => {
       fixtureEl.innerHTML = '<nav data-coreui="navigation"></nav>'
       const navEl = fixtureEl.querySelector('nav')
-      spyOn(Navigation, 'navigationInterface')
+      spyOn(Navigation, 'getOrCreateInstance')
 
       const loadEvent = new Event('load')
       window.dispatchEvent(loadEvent)
 
-      expect(Navigation.navigationInterface).toHaveBeenCalledWith(navEl)
+      expect(Navigation.getOrCreateInstance).toHaveBeenCalledWith(navEl)
     })
   })
 

--- a/js/tests/unit/sidebar.spec.js
+++ b/js/tests/unit/sidebar.spec.js
@@ -716,7 +716,7 @@ describe('Sidebar', () => {
     it('should initialize sidebar on elements with .sidebar class on window load', () => {
       fixtureEl.innerHTML = '<div class="sidebar"></div>'
       const sidebarEl = fixtureEl.querySelector('.sidebar')
-      const spySidebarInterface = spyOn(Sidebar, 'sidebarInterface')
+      const spySidebarInterface = spyOn(Sidebar, 'getOrCreateInstance')
 
       const loadEvent = new Event('load')
       window.dispatchEvent(loadEvent)
@@ -773,7 +773,7 @@ describe('Sidebar', () => {
       fixtureEl.innerHTML = '<div class="sidebar"></div>'
       const sidebarEl = fixtureEl.querySelector('.sidebar')
       const sidebar = new Sidebar(sidebarEl)
-      const spySidebarInterface = spyOn(Sidebar, 'sidebarInterface')
+      const spySidebarInterface = spyOn(Sidebar, 'getOrCreateInstance')
 
       sidebar.dispose()
       window.dispatchEvent(new Event('load'))

--- a/js/tests/unit/util/component-functions.spec.js
+++ b/js/tests/unit/util/component-functions.spec.js
@@ -1,5 +1,6 @@
 import BaseComponent from '../../../src/base-component.js'
-import { enableDismissTrigger } from '../../../src/util/component-functions.js'
+import EventHandler from '../../../src/dom/event-handler.js'
+import { enableDismissTrigger, initializeOnReady } from '../../../src/util/component-functions.js'
 import { clearFixture, createEvent, getFixture } from '../../helpers/fixture.js'
 
 class DummyClass2 extends BaseComponent {
@@ -25,6 +26,35 @@ describe('Plugin functions', () => {
 
   afterEach(() => {
     clearFixture()
+  })
+
+  describe('initializeOnReady', () => {
+    const component = () => ({
+      EVENT_KEY: '.coreui.probe',
+      getOrCreateInstance: jasmine.createSpy('getOrCreateInstance')
+    })
+
+    it('should initialise every match on load by default', () => {
+      fixtureEl.innerHTML = '<div class="probe"></div><div class="probe"></div>'
+      const Probe = component()
+
+      initializeOnReady(Probe, '.probe')
+      EventHandler.trigger(window, 'load')
+
+      expect(Probe.getOrCreateInstance).toHaveBeenCalledTimes(2)
+      EventHandler.off(window, 'load.coreui.probe.data-api')
+    })
+
+    it('should initialise on DOMContentLoaded when asked', () => {
+      fixtureEl.innerHTML = '<div class="probe"></div>'
+      const Probe = component()
+
+      initializeOnReady(Probe, '.probe', 'DOMContentLoaded')
+      EventHandler.trigger(document, 'DOMContentLoaded')
+
+      expect(Probe.getOrCreateInstance).toHaveBeenCalledWith(fixtureEl.querySelector('.probe'))
+      EventHandler.off(document, 'DOMContentLoaded.coreui.probe.data-api')
+    })
   })
 
   describe('data-coreui-dismiss functionality', () => {


### PR DESCRIPTION
Stage 1 of the reuse audit, second half of R3 (after #1239).

## Before / after

- Before: 24 plugins each registered their own `load` / `DOMContentLoaded` handler whose whole job was "find every element matching my selector and create an instance", spelled in five ways (`SelectorEngine.find` vs `querySelectorAll`, `for…of` vs indexed loop, `getOrCreateInstance` vs the plugin's own `xInterface`). Six plugins still wrapped their `xInterface` in `jQueryInterface`.
- After: `util/component-functions.ts` gains `initializeOnReady(Component, selector, event = 'load')`. It keeps each plugin's choice of `load` (window) or `DOMContentLoaded` (document) and the event name `<event><EVENT_KEY>.data-api`, so init order and the events consumers can hook are unchanged. The six jQuery wrappers delegate to `jQueryDispatch`; the `xInterface` statics stay for the data API and direct callers. Orphaned constants and imports are gone: 28 files, 70 insertions, 201 deletions.

Left alone on purpose: Collapse (gated on `hidden="until-found"` support), MultiSelect (two selectors and a tabindex filter), Drawer/Offcanvas (open on load), and the four `_initializeDataApi` statics the specs call directly.

## Tests

`component-functions.spec.js`: the initialiser on `load` and on `DOMContentLoaded`. Navigation and Sidebar data-API specs now spy on `getOrCreateInstance` instead of the plugin interface they used to route through. Full unit suite 3821 tests, `JQUERY=true` suite green, typecheck clean.
