### PR TITLE
refactor: one sanitizer wrapper for every component

### DIFF
--- a/js/src/calendar.ts
+++ b/js/src/calendar.ts
@@ -13,7 +13,7 @@ import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
 import {
- escapeHtml, sanitizeHtml, type SanitizerAllowList, SVGAllowlist
+ escapeHtml, sanitizeByConfig, type SanitizerAllowList, SVGAllowlist
 } from './util/sanitizer.js'
 import {
  CHEVRON_DOUBLE_LEFT_ICON, CHEVRON_DOUBLE_RIGHT_ICON, CHEVRON_LEFT_ICON, CHEVRON_RIGHT_ICON
@@ -856,7 +856,7 @@ class Calendar extends BaseComponent {
                     data-coreui-date="${date}"
                   >
                     <div class="${CLASS_NAME_CALENDAR_CELL_INNER} day">
-                      ${this._config.renderDayCell ? this._sanitizeHtml(this._config.renderDayCell(date, cellAttributes.meta)) : date.toLocaleDateString(this._config.locale, { day: this._config.dayFormat })}
+                      ${this._config.renderDayCell ? sanitizeByConfig(this._config.renderDayCell(date, cellAttributes.meta), this._config) : date.toLocaleDateString(this._config.locale, { day: this._config.dayFormat })}
                     </div>
                   </td>` :
                   '<td></td>'
@@ -877,7 +877,7 @@ class Calendar extends BaseComponent {
                   data-coreui-date="${date.toDateString()}"
                 >
                   <div class="${CLASS_NAME_CALENDAR_CELL_INNER} month">
-                    ${this._config.renderMonthCell ? this._sanitizeHtml(this._config.renderMonthCell(date, cellAttributes.meta)) : month}
+                    ${this._config.renderMonthCell ? sanitizeByConfig(this._config.renderMonthCell(date, cellAttributes.meta), this._config) : month}
                   </div>
                 </td>`
               )
@@ -897,7 +897,7 @@ class Calendar extends BaseComponent {
                   data-coreui-date="${date.toDateString()}"
                 >
                   <div class="${CLASS_NAME_CALENDAR_CELL_INNER} quarter">
-                    ${this._config.renderQuarterCell ? this._sanitizeHtml(this._config.renderQuarterCell(date, cellAttributes.meta)) : `Q${index + 1}`}
+                    ${this._config.renderQuarterCell ? sanitizeByConfig(this._config.renderQuarterCell(date, cellAttributes.meta), this._config) : `Q${index + 1}`}
                   </div>
                 </td>`
               )
@@ -916,7 +916,7 @@ class Calendar extends BaseComponent {
                   data-coreui-date="${date.toDateString()}"
                 >
                   <div class="${CLASS_NAME_CALENDAR_CELL_INNER} year">
-                    ${this._config.renderYearCell ? this._sanitizeHtml(this._config.renderYearCell(date, cellAttributes.meta)) : date.toLocaleDateString(this._config.locale, { year: this._config.yearFormat })}
+                    ${this._config.renderYearCell ? sanitizeByConfig(this._config.renderYearCell(date, cellAttributes.meta), this._config) : date.toLocaleDateString(this._config.locale, { year: this._config.yearFormat })}
                   </div>
                 </td>`
               )
@@ -1248,15 +1248,7 @@ class Calendar extends BaseComponent {
       navIconPrev: 'navIconNext'
     }
 
-    return this._sanitizeHtml(this._config[this._isRtl() ? (mirrored as Record<string, string>)[name] : name])
-  }
-
-  _sanitizeHtml(html: string): string {
-    if (this._config.sanitize) {
-      return sanitizeHtml(html, this._config.allowList, this._config.sanitizeFn)
-    }
-
-    return html
+    return sanitizeByConfig(this._config[this._isRtl() ? (mirrored as Record<string, string>)[name] : name], this._config)
   }
 
   // Static

--- a/js/src/chip.ts
+++ b/js/src/chip.ts
@@ -10,7 +10,7 @@ import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { sanitizeHtml, SVGAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
+import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 import { CHECK_ICON, REMOVE_ICON } from './util/icons.js'
 import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
@@ -288,7 +288,7 @@ class Chip extends BaseComponent {
     const check = document.createElement('span')
     check.className = CLASS_NAME_CHIP_CHECK
     check.setAttribute('aria-hidden', 'true')
-    check.innerHTML = this._sanitizeIcon(this._config.selectedIcon)
+    check.innerHTML = sanitizeByConfig(this._config.selectedIcon, this._config)
     this._element.prepend(check)
   }
 
@@ -298,7 +298,7 @@ class Chip extends BaseComponent {
     button.className = CLASS_NAME_CHIP_REMOVE
     button.setAttribute('aria-label', this._config.ariaRemoveLabel)
     button.setAttribute('tabindex', '-1') // Not in tab order, chips handle keyboard
-    button.innerHTML = this._sanitizeIcon(this._config.removeIcon)
+    button.innerHTML = sanitizeByConfig(this._config.removeIcon, this._config)
     return button
   }
 
@@ -360,10 +360,6 @@ class Chip extends BaseComponent {
     EventHandler.trigger(this._element, EVENT_REMOVED)
     this._element.remove()
     this.dispose()
-  }
-
-  _sanitizeIcon(icon: string): string {
-    return this._config.sanitize ? sanitizeHtml(icon, this._config.allowList, this._config.sanitizeFn) : icon
   }
 
   // Static

--- a/js/src/combobox-base.ts
+++ b/js/src/combobox-base.ts
@@ -11,7 +11,7 @@ import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { createAnchoredPosition } from './util/floating-ui.js'
 import { resolvePopupContainer } from './util/popup.js'
-import { escapeHtml, sanitizeHtml } from './util/sanitizer.js'
+import { escapeHtml } from './util/sanitizer.js'
 import { executeAfterTransition, getElement } from './util/index.js'
 
 /**
@@ -494,12 +494,6 @@ class ComboboxBase extends BaseComponent {
   }
 
   // Templates
-
-  _maybeSanitize(content: string): string {
-    return this._config.sanitize ?
-      sanitizeHtml(content, this._config.allowList, this._config.sanitizeFn) :
-      content
-  }
 
   // Config normalization shared by every combobox surface
 

--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -23,7 +23,7 @@ import { getWeekSectionsFromLocale } from './util/date-sections.js'
 import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
 import { CALENDAR_ICON, CLEANER_ICON } from './util/icons.js'
 import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
-import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
+import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 
 /**
  * Constants
@@ -284,10 +284,6 @@ class DatePicker extends BaseComponent {
     return (byType as Record<string, any>)[this._config.selectionType] ?? null
   }
 
-  _sanitizeIcon(icon: string): string {
-    return this._config.sanitize ? sanitizeHtml(icon, this._config.allowList, this._config.sanitizeFn) : icon
-  }
-
   _createDatePicker(): void {
     this._element.classList.add(CLASS_NAME_DATE_PICKER, CLASS_NAME_PICKER)
 
@@ -306,7 +302,7 @@ class DatePicker extends BaseComponent {
     this._fieldElement = appendControlGroupField(inputGroup, inputEl, this._config.floatingLabel, `${this.constructor.NAME}-`)
 
     const action = (className: string, icon: string, label: string) => createControlGroupAction({
-      className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => this._sanitizeIcon(value)
+      className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => sanitizeByConfig(value, this._config)
     })
 
     if (this._config.cleaner) {

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -24,7 +24,7 @@ import {
   CALENDAR_ICON, CLEANER_ICON, SEPARATOR_ICON, SEPARATOR_ICON_RTL
 } from './util/icons.js'
 import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
-import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
+import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 
 /**
  * Constants
@@ -330,10 +330,6 @@ class DateRangePicker extends BaseComponent {
     this._calendar?.update({ selectEndDate: value })
   }
 
-  _sanitizeIcon(icon: string): string {
-    return this._config.sanitize ? sanitizeHtml(icon, this._config.allowList, this._config.sanitizeFn) : icon
-  }
-
   // The separator is a directional arrow, so it has an RTL counterpart (v1 did
   // the same with two icon variables, swapped in CSS). Read the element's
   // computed direction rather than isRTL(): the document can be LTR while an
@@ -396,7 +392,7 @@ class DateRangePicker extends BaseComponent {
     const separator = document.createElement('span')
     separator.classList.add(CLASS_NAME_SEPARATOR)
     separator.setAttribute('aria-hidden', 'true')
-    separator.innerHTML = this._sanitizeIcon(this._resolveSeparatorIcon())
+    separator.innerHTML = sanitizeByConfig(this._resolveSeparatorIcon(), this._config)
     inputGroup.append(separator)
     this._separatorElement = separator
 
@@ -421,7 +417,7 @@ class DateRangePicker extends BaseComponent {
     })
 
     const action = (className: string, icon: string, label: string) => createControlGroupAction({
-      className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => this._sanitizeIcon(value)
+      className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => sanitizeByConfig(value, this._config)
     })
 
     if (this._config.cleaner) {

--- a/js/src/date-time-picker.ts
+++ b/js/src/date-time-picker.ts
@@ -17,7 +17,7 @@ import SelectorEngine from './dom/selector-engine.js'
 import { initializeOnReady } from './util/component-functions.js'
 import Popup from './util/popup.js'
 import TimeSelection from './util/time-selection.js'
-import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
+import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 import type { ComponentConfig } from './util/config.js'
 import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
 import { CALENDAR_ICON, CLEANER_ICON } from './util/icons.js'
@@ -273,10 +273,6 @@ class DateTimePicker extends BaseComponent {
     return { ...forwarded, ...overrides, ...extra }
   }
 
-  _sanitizeIcon(icon: string): string {
-    return this._config.sanitize ? sanitizeHtml(icon, this._config.allowList, this._config.sanitizeFn) : icon
-  }
-
   _createDateTimePicker(): void {
     this._element.classList.add(
       CLASS_NAME_DATE_PICKER, CLASS_NAME_DATE_TIME_PICKER, CLASS_NAME_PICKER
@@ -297,7 +293,7 @@ class DateTimePicker extends BaseComponent {
     this._fieldElement = appendControlGroupField(inputGroup, inputEl, this._config.floatingLabel, `${this.constructor.NAME}-`)
 
     const action = (className: string, icon: string, label: string) => createControlGroupAction({
-      className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => this._sanitizeIcon(value)
+      className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => sanitizeByConfig(value, this._config)
     })
 
     if (this._config.cleaner) {

--- a/js/src/list-box.ts
+++ b/js/src/list-box.ts
@@ -10,7 +10,7 @@ import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
-import { DefaultAllowlist, sanitizeHtml, type SanitizerAllowList } from './util/sanitizer.js'
+import { DefaultAllowlist, sanitizeByConfig, type SanitizerAllowList } from './util/sanitizer.js'
 import {
   defineJQueryPlugin, getElement, getNextActiveElement, getUID, jQueryDispatch
 } from './util/index.js'
@@ -706,7 +706,7 @@ class ListBox extends BaseComponent {
 
   _setContent(target: HTMLElement, content: string): void {
     if (this._config.html) {
-      target.innerHTML = this._config.sanitize ? sanitizeHtml(content, this._config.allowList, this._config.sanitizeFn) : content
+      target.innerHTML = sanitizeByConfig(content, this._config)
       return
     }
 

--- a/js/src/multi-select.ts
+++ b/js/src/multi-select.ts
@@ -13,7 +13,7 @@ import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
 import { CLEANER_ICON, INDICATOR_ICON } from './util/icons.js'
-import { DefaultAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
+import { DefaultAllowlist, sanitizeByConfig, type SanitizerAllowList } from './util/sanitizer.js'
 import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
 
 /**
@@ -1321,7 +1321,7 @@ class MultiSelect extends ComboboxBase {
     if (result instanceof Node) {
       this._headerElement.replaceChildren(result)
     } else {
-      this._headerElement.innerHTML = this._maybeSanitize(result)
+      this._headerElement.innerHTML = sanitizeByConfig(result, this._config)
     }
   }
 

--- a/js/src/number-input.ts
+++ b/js/src/number-input.ts
@@ -12,7 +12,7 @@ import {
   createControlGroupAction, ensureControlGroup, releaseControlGroup, type ControlGroup
 } from './util/form-control-group.js'
 import { MINUS_ICON, PLUS_ICON } from './util/icons.js'
-import { sanitizeHtml, SVGAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
+import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
@@ -203,14 +203,14 @@ class NumberInput extends BaseComponent {
       className: CLASS_NAME_ACTION,
       icon: this._config.decrementIcon,
       label: this._config.ariaDecrementLabel,
-      sanitizeIcon: (icon: string) => this._sanitizeIcon(icon)
+      sanitizeIcon: (icon: string) => sanitizeByConfig(icon, this._config)
     })
 
     this._incrementElement = createControlGroupAction({
       className: CLASS_NAME_ACTION,
       icon: this._config.incrementIcon,
       label: this._config.ariaIncrementLabel,
-      sanitizeIcon: (icon: string) => this._sanitizeIcon(icon)
+      sanitizeIcon: (icon: string) => sanitizeByConfig(icon, this._config)
     })
 
     // A number field already steps with the up and down arrows, so putting the
@@ -290,10 +290,6 @@ class NumberInput extends BaseComponent {
     if (this._incrementElement) {
       this._incrementElement.disabled = max !== '' && value !== '' && Number(value) >= Number(max)
     }
-  }
-
-  _sanitizeIcon(icon: string): string {
-    return this._config.sanitize ? sanitizeHtml(icon, this._config.allowList, this._config.sanitizeFn) : icon
   }
 
   // Static

--- a/js/src/password-input.ts
+++ b/js/src/password-input.ts
@@ -12,7 +12,7 @@ import {
   createControlGroupAction, ensureControlGroup, releaseControlGroup, type ControlGroup
 } from './util/form-control-group.js'
 import { PASSWORD_HIDE_ICON, PASSWORD_SHOW_ICON } from './util/icons.js'
-import { sanitizeHtml, SVGAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
+import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
@@ -121,7 +121,7 @@ class PasswordInput extends BaseComponent {
       disabled: this._element.disabled,
       icon: this._config.showIcon,
       label: this._config.ariaToggleLabel,
-      sanitizeIcon: (icon: string) => this._sanitizeIcon(icon)
+      sanitizeIcon: (icon: string) => sanitizeByConfig(icon, this._config)
     })
 
     EventHandler.on(this._toggleElement, EVENT_CLICK, () => this.toggle())
@@ -138,11 +138,7 @@ class PasswordInput extends BaseComponent {
     const visible = this._element.type === 'text'
 
     this._toggleElement.setAttribute('aria-pressed', visible ? 'true' : 'false')
-    this._toggleElement.innerHTML = this._sanitizeIcon(visible ? this._config.hideIcon : this._config.showIcon)
-  }
-
-  _sanitizeIcon(icon: string): string {
-    return this._config.sanitize ? sanitizeHtml(icon, this._config.allowList, this._config.sanitizeFn) : icon
+    this._toggleElement.innerHTML = sanitizeByConfig(visible ? this._config.hideIcon : this._config.showIcon, this._config)
   }
 
   // Static

--- a/js/src/range-slider.ts
+++ b/js/src/range-slider.ts
@@ -12,7 +12,7 @@ import SelectorEngine from './dom/selector-engine.js'
 import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import { defineJQueryPlugin, isRTL, jQueryDispatch } from './util/index.js'
-import { DefaultAllowlist, type SanitizerAllowList, sanitizeHtml } from './util/sanitizer.js'
+import { DefaultAllowlist, sanitizeByConfig, type SanitizerAllowList } from './util/sanitizer.js'
 
 /**
  * Constants
@@ -435,7 +435,7 @@ class RangeSlider extends BaseComponent {
       const tooltipInnerElement = this._createElement('span', CLASS_NAME_TOOLTIP_INNER)
 
       tooltipInnerElement.innerHTML = this._config.tooltipsFormat ?
-        (this._config.sanitize ? sanitizeHtml(this._config.tooltipsFormat(input.value), this._config.allowList, this._config.sanitizeFn) : this._config.tooltipsFormat(input.value)) :
+        sanitizeByConfig(this._config.tooltipsFormat(input.value), this._config) :
         input.value
       tooltipElement.append(tooltipArrowElement, tooltipInnerElement)
 
@@ -458,8 +458,8 @@ class RangeSlider extends BaseComponent {
 
     if (this._tooltips[index]) {
       this._tooltips[index].children[1].innerHTML = this._config.tooltipsFormat ?
-        (this._config.sanitize ? sanitizeHtml(this._config.tooltipsFormat(value), this._config.allowList, this._config.sanitizeFn) : this._config.tooltipsFormat(value)) :
-        value
+        sanitizeByConfig(this._config.tooltipsFormat(value), this._config) :
+        String(value)
       const input = SelectorEngine.find(SELECTOR_RANGE_SLIDER_INPUT, this._element as ParentNode)[index] as HTMLInputElement
       this._positionTooltip(this._tooltips[index], input)
     }

--- a/js/src/rating.ts
+++ b/js/src/rating.ts
@@ -10,7 +10,7 @@ import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
+import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
 import Tooltip from './tooltip.js'
 
@@ -412,7 +412,7 @@ class Rating extends BaseComponent {
       if (this._config.icon) {
         const ratingItemIconElement = document.createElement('div')
         ratingItemIconElement.classList.add(CLASS_NAME_RATING_ITEM_CUSTOM_ICON)
-        ratingItemIconElement.innerHTML = this._sanitizeIcon(typeof this._config.icon === 'object' ? this._config.icon[index + 1] : this._config.icon)
+        ratingItemIconElement.innerHTML = sanitizeByConfig(typeof this._config.icon === 'object' ? this._config.icon[index + 1] : this._config.icon, this._config)
 
         ratingItemLabelElement.append(ratingItemIconElement)
       } else {
@@ -425,7 +425,7 @@ class Rating extends BaseComponent {
       if (this._config.icon && this._config.activeIcon) {
         const ratingItemIconActiveElement = document.createElement('div')
         ratingItemIconActiveElement.classList.add(CLASS_NAME_RATING_ITEM_CUSTOM_ICON_ACTIVE)
-        ratingItemIconActiveElement.innerHTML = this._sanitizeIcon(typeof this._config.activeIcon === 'object' ? this._config.activeIcon[index + 1] : this._config.activeIcon)
+        ratingItemIconActiveElement.innerHTML = sanitizeByConfig(typeof this._config.activeIcon === 'object' ? this._config.activeIcon[index + 1] : this._config.activeIcon, this._config)
 
         ratingItemLabelElement.append(ratingItemIconActiveElement)
       }
@@ -464,10 +464,6 @@ class Rating extends BaseComponent {
     })
 
     this._element.append(ratingItemElement)
-  }
-
-  _sanitizeIcon(icon: any): any {
-    return this._config.sanitize ? sanitizeHtml(icon, this._config.allowList, this._config.sanitizeFn) : icon
   }
 
   // Static

--- a/js/src/time-picker.ts
+++ b/js/src/time-picker.ts
@@ -15,7 +15,7 @@ import TimeInput from './time-input.js'
 import { initializeOnReady } from './util/component-functions.js'
 import Popup from './util/popup.js'
 import TimeSelection from './util/time-selection.js'
-import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
+import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 import type { ComponentConfig } from './util/config.js'
 import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
 import { CLEANER_ICON, CLOCK_ICON } from './util/icons.js'
@@ -253,10 +253,6 @@ class TimePicker extends BaseComponent {
     return { ...forwarded, ...overrides, ...extra }
   }
 
-  _sanitizeIcon(icon: string): string {
-    return this._config.sanitize ? sanitizeHtml(icon, this._config.allowList, this._config.sanitizeFn) : icon
-  }
-
   _createTimePicker(): void {
     this._element.classList.add(CLASS_NAME_TIME_PICKER, CLASS_NAME_PICKER)
 
@@ -275,7 +271,7 @@ class TimePicker extends BaseComponent {
     this._fieldElement = appendControlGroupField(inputGroup, inputEl, this._config.floatingLabel, `${this.constructor.NAME}-`)
 
     const action = (className: string, icon: string, label: string) => createControlGroupAction({
-      className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => this._sanitizeIcon(value)
+      className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => sanitizeByConfig(value, this._config)
     })
 
     if (this._config.cleaner) {

--- a/js/src/toaster.ts
+++ b/js/src/toaster.ts
@@ -10,7 +10,7 @@ import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import Toast, { type ToastConfig } from './toast.js'
 import type { TemplateContentEntry } from './util/template-factory.js'
-import { DefaultAllowlist, sanitizeHtml, type SanitizerAllowList } from './util/sanitizer.js'
+import { DefaultAllowlist, sanitizeByConfig, type SanitizerAllowList } from './util/sanitizer.js'
 import {
   defineJQueryPlugin, execute, getElement, getTransitionDurationFromElement, getUID, isElement, jQueryDispatch
 } from './util/index.js'
@@ -522,7 +522,7 @@ class Toaster extends BaseComponent {
     }
 
     if (this._config.html) {
-      target.innerHTML = this._config.sanitize ? sanitizeHtml(resolved, this._config.allowList, this._config.sanitizeFn) : resolved
+      target.innerHTML = sanitizeByConfig(resolved, this._config)
       return
     }
 

--- a/js/src/transfer.ts
+++ b/js/src/transfer.ts
@@ -15,7 +15,7 @@ import {
   CHEVRON_DOUBLE_LEFT_ICON, CHEVRON_DOUBLE_RIGHT_ICON, CHEVRON_LEFT_ICON, CHEVRON_RIGHT_ICON
 } from './util/icons.js'
 import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
-import { sanitizeHtml, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
+import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 
 /**
  * Constants
@@ -365,7 +365,7 @@ class Transfer extends BaseComponent {
       }
 
       if (button.innerHTML.trim() === '') {
-        button.innerHTML = this._sanitizeIcon(this._moveIcon(kind))
+        button.innerHTML = sanitizeByConfig(this._moveIcon(kind), this._config)
       }
 
       button.setAttribute('aria-controls', this._sides[side].options.id)
@@ -403,10 +403,6 @@ class Transfer extends BaseComponent {
     }
 
     return this._moveSide(kind) === SIDE_TARGET ? this._config.moveToTargetIcon : this._config.moveToSourceIcon
-  }
-
-  _sanitizeIcon(icon: string): string {
-    return this._config.sanitize ? sanitizeHtml(icon, this._config.allowList, this._config.sanitizeFn) : icon
   }
 
   _moveButtons(): HTMLButtonElement[] {

--- a/js/src/util/sanitizer.ts
+++ b/js/src/util/sanitizer.ts
@@ -170,4 +170,10 @@ export function sanitizeHtml(unsafeHtml: string, allowList: SanitizerAllowList, 
   return createdDocument.body.innerHTML
 }
 
-export type { SanitizerAllowList }
+type SanitizerConfig = { allowList?: SanitizerAllowList, sanitize?: boolean, sanitizeFn?: ((unsafeHtml: string) => string) | null }
+
+export function sanitizeByConfig(unsafeHtml: string, config: SanitizerConfig): string {
+  return config.sanitize ? sanitizeHtml(unsafeHtml, config.allowList ?? DefaultAllowlist, config.sanitizeFn) : unsafeHtml
+}
+
+export type { SanitizerAllowList, SanitizerConfig }

--- a/js/tests/unit/util/sanitizer.spec.js
+++ b/js/tests/unit/util/sanitizer.spec.js
@@ -1,5 +1,5 @@
 import {
-  DefaultAllowlist, escapeHtml, sanitizeHtml, SVGAllowlist
+  DefaultAllowlist, escapeHtml, sanitizeByConfig, sanitizeHtml, SVGAllowlist
 } from '../../../src/util/sanitizer.js'
 
 describe('Sanitizer', () => {
@@ -20,6 +20,23 @@ describe('Sanitizer', () => {
       expect(SVGAllowlist.svg).toContain('viewbox')
       expect(SVGAllowlist.path).toContain('d')
       expect(SVGAllowlist.line).toContain('x1')
+    })
+  })
+
+  describe('sanitizeByConfig', () => {
+    it('should sanitize with the allow list and function from the config', () => {
+      const html = '<img src="x" onerror="alert(1)"><b>ok</b>'
+      const sanitizeFn = jasmine.createSpy('sanitizeFn').and.returnValue('<i>fn</i>')
+
+      expect(sanitizeByConfig(html, { sanitize: true, allowList: DefaultAllowlist })).toEqual('<img src="x"><b>ok</b>')
+      expect(sanitizeByConfig(html, { sanitize: true, allowList: DefaultAllowlist, sanitizeFn })).toEqual('<i>fn</i>')
+      expect(sanitizeFn).toHaveBeenCalledWith(html)
+    })
+
+    it('should return the html untouched when sanitize is off', () => {
+      const html = '<img src="x" onerror="alert(1)">'
+
+      expect(sanitizeByConfig(html, { sanitize: false, allowList: DefaultAllowlist })).toBe(html)
     })
   })
 


### PR DESCRIPTION
Stage 2 of the reuse audit, R4 (the sanitizer half; the config half landed in #1226/#1227).

## Before / after

- Before: sixteen call sites in fourteen components spelled the same guard, `config.sanitize ? sanitizeHtml(html, config.allowList, config.sanitizeFn) : html`, as nine private `_sanitizeIcon()`, a `_maybeSanitize()` (ComboboxBase), a `_sanitizeHtml()` (Calendar) and four inline ternaries (ListBox, Toaster, RangeSlider ×2).
- After: `util/sanitizer.ts` exports `sanitizeByConfig(html, config)`; the components call it directly and the private copies are gone (16 files, 47 insertions, 91 deletions). `allowList` falls back to `DefaultAllowlist` only when a config has none, which no component does. `TemplateFactory` keeps its `_maybeSanitize`, as the file tracks upstream and its specs spy on the method.

No behaviour change. RangeSlider's tooltip fallback is written as `String(value)` now that the sanitized branch is typed as a string.

## Tests

`sanitizer.spec.js`: the wrapper with the allow list, with a `sanitizeFn`, and with `sanitize: false`. Full unit suite 3823 tests, typecheck clean.
