### PR TITLE
Revert "refactor: one ready-time initialiser for the data API scans (#1240)"

### DIFF
--- a/js/src/autocomplete.ts
+++ b/js/src/autocomplete.ts
@@ -9,13 +9,12 @@ import ComboboxBase from './combobox-base.js'
 import Data from './dom/data.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import {
   DefaultAllowlist, escapeHtml, type SanitizerAllowList
 } from './util/sanitizer.js'
 import { CLEANER_ICON, INDICATOR_ICON } from './util/icons.js'
-import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
+import { defineJQueryPlugin, getUID } from './util/index.js'
 
 /**
  * ------------------------------------------------------------------------
@@ -44,6 +43,7 @@ const EVENT_KEYUP = `keyup${EVENT_KEY}`
 const EVENT_MOUSEDOWN = `mousedown${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_KEYUP_DATA_API = `keyup${EVENT_KEY}${DATA_API_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_AUTOCOMPLETE = 'autocomplete'
 const CLASS_NAME_CLEANER = 'form-control-cleaner'
@@ -733,7 +733,9 @@ class Autocomplete extends ComboboxBase {
   }
 
   static jQueryInterface(this: any, config: any): any {
-    return jQueryDispatch(this, Autocomplete, config)
+    return this.each(function (this: HTMLElement) {
+      Autocomplete.autocompleteInterface(this, config)
+    })
   }
 
   static clearMenus(event: any): void {
@@ -777,7 +779,11 @@ class Autocomplete extends ComboboxBase {
  * Data API implementation
  */
 
-initializeOnReady(Autocomplete, SELECTOR_DATA_TOGGLE)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const autocomplete of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
+    Autocomplete.autocompleteInterface(autocomplete)
+  }
+})
 EventHandler.on(document, EVENT_CLICK_DATA_API, Autocomplete.clearMenus)
 EventHandler.on(document, EVENT_KEYUP_DATA_API, Autocomplete.clearMenus)
 

--- a/js/src/calendar.ts
+++ b/js/src/calendar.ts
@@ -7,7 +7,6 @@
  */
 
 import BaseComponent from './base-component.js'
-import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
@@ -77,6 +76,7 @@ const EVENT_SELECT_END_CHANGE = `selectEndChange${EVENT_KEY}`
 const EVENT_START_DATE_CHANGE = `startDateChange${EVENT_KEY}`
 const EVENT_MOUSEENTER = `mouseenter${EVENT_KEY}`
 const EVENT_MOUSELEAVE = `mouseleave${EVENT_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_CALENDAR_CELL = 'calendar-cell'
@@ -1274,7 +1274,11 @@ class Calendar extends BaseComponent {
  * Data API implementation
  */
 
-initializeOnReady(Calendar, SELECTOR_DATA_TOGGLE)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const element of Array.from(document.querySelectorAll(SELECTOR_DATA_TOGGLE))) {
+    Calendar.calendarInterface(element)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/carousel.ts
+++ b/js/src/carousel.ts
@@ -12,7 +12,6 @@ import BaseComponent from './base-component.js'
 import EventHandler, { type CoreUIEvent } from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { initializeOnReady } from './util/component-functions.js'
 import {
   defineJQueryPlugin, isRTL, isVisible, jQueryDispatch
 } from './util/index.js'
@@ -38,6 +37,7 @@ const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
 const EVENT_MOUSEENTER = `mouseenter${EVENT_KEY}`
 const EVENT_MOUSELEAVE = `mouseleave${EVENT_KEY}`
 const EVENT_POINTERDOWN = `pointerdown${EVENT_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_CAROUSEL = 'carousel'
@@ -941,7 +941,13 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_PLAY_PAUSE, function (e
   Carousel.getOrCreateInstance(target)._togglePlayPause()
 })
 
-initializeOnReady(Carousel, SELECTOR_DATA_AUTOPLAY)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  const carousels = SelectorEngine.find(SELECTOR_DATA_AUTOPLAY)
+
+  for (const carousel of carousels) {
+    Carousel.getOrCreateInstance(carousel)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/chip-input.ts
+++ b/js/src/chip-input.ts
@@ -8,7 +8,6 @@
 import ChipSet, { type ChipSetConfig } from './chip-set.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import { getUID, isRTL } from './util/index.js'
 
@@ -19,6 +18,7 @@ import { getUID, isRTL } from './util/index.js'
 const NAME = 'chip-input'
 const DATA_KEY = 'coreui.chip-input'
 const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
 
 const EVENT_BLUR = `blur${EVENT_KEY}`
 const EVENT_CLICK = `click${EVENT_KEY}`
@@ -417,6 +417,10 @@ class ChipInput extends ChipSet {
  * Data API implementation
  */
 
-initializeOnReady(ChipInput, SELECTOR_DATA_CHIP_INPUT, 'DOMContentLoaded')
+EventHandler.on(document, `DOMContentLoaded${EVENT_KEY}${DATA_API_KEY}`, () => {
+  for (const element of SelectorEngine.find(SELECTOR_DATA_CHIP_INPUT)) {
+    ChipInput.getOrCreateInstance(element)
+  }
+})
 
 export default ChipInput

--- a/js/src/chip-set.ts
+++ b/js/src/chip-set.ts
@@ -6,7 +6,6 @@
  */
 
 import BaseComponent from './base-component.js'
-import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import Chip from './chip.js'
 import EventHandler from './dom/event-handler.js'
@@ -22,6 +21,9 @@ import {
  */
 
 const NAME = 'chip-set'
+const DATA_KEY = 'coreui.chip-set'
+const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
 
 const EVENT_ADD = 'add'
 const EVENT_REMOVE = 'remove'
@@ -576,7 +578,11 @@ class ChipSet extends BaseComponent {
  * Data API implementation
  */
 
-initializeOnReady(ChipSet, SELECTOR_DATA_CHIP_SET, 'DOMContentLoaded')
+EventHandler.on(document, `DOMContentLoaded${EVENT_KEY}${DATA_API_KEY}`, () => {
+  for (const element of SelectorEngine.find(SELECTOR_DATA_CHIP_SET)) {
+    ChipSet.chipSetInterface(element)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/chip.ts
+++ b/js/src/chip.ts
@@ -6,7 +6,6 @@
  */
 
 import BaseComponent from './base-component.js'
-import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
@@ -21,6 +20,7 @@ import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 const NAME = 'chip'
 const DATA_KEY = 'coreui.chip'
 const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
 
 const EVENT_REMOVE = `remove${EVENT_KEY}`
 const EVENT_REMOVED = `removed${EVENT_KEY}`
@@ -384,7 +384,11 @@ class Chip extends BaseComponent {
  * Data API implementation
  */
 
-initializeOnReady(Chip, SELECTOR_DATA_CHIP, 'DOMContentLoaded')
+EventHandler.on(document, `DOMContentLoaded${EVENT_KEY}${DATA_API_KEY}`, () => {
+  for (const element of SelectorEngine.find(SELECTOR_DATA_CHIP)) {
+    Chip.chipInterface(element)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/combobox.ts
+++ b/js/src/combobox.ts
@@ -10,7 +10,6 @@ import Data from './dom/data.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import ListBox, { type ListBoxEntry } from './list-box.js'
-import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import { CARET_ICON } from './util/icons.js'
 import { DefaultAllowlist, type SanitizerAllowList } from './util/sanitizer.js'
@@ -38,6 +37,7 @@ const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
 const EVENT_SEARCH = `search${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_KEYUP_DATA_API = `keyup${EVENT_KEY}${DATA_API_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const EVENT_LIST_BOX = '.coreui.list-box'
 const EVENT_LIST_BOX_SEARCH = `search${EVENT_LIST_BOX}`
@@ -570,7 +570,11 @@ class Combobox extends ComboboxBase {
  * Data API implementation
  */
 
-initializeOnReady(Combobox, SELECTOR_DATA_TOGGLE)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const toggle of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
+    Combobox.getOrCreateInstance(toggle)
+  }
+})
 
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (this: HTMLElement, event: any) {
   event.preventDefault()

--- a/js/src/date-input.ts
+++ b/js/src/date-input.ts
@@ -5,8 +5,9 @@
  * --------------------------------------------------------------------------
  */
 
+import EventHandler from './dom/event-handler.js'
+import SelectorEngine from './dom/selector-engine.js'
 import SectionInput, { type SectionInputConfig } from './section-input.js'
-import { initializeOnReady } from './util/component-functions.js'
 import { type DateSection, getSectionsFromLocale } from './util/date-sections.js'
 import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
@@ -15,6 +16,11 @@ import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
  */
 
 const NAME = 'date-input'
+const DATA_KEY = 'coreui.date-input'
+const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
+
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_DATA_DATE_INPUT = '[data-coreui-date-input]'
 
@@ -52,7 +58,11 @@ class DateInput extends SectionInput {
  * Data API implementation
  */
 
-initializeOnReady(DateInput, SELECTOR_DATA_DATE_INPUT)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const dateInput of SelectorEngine.find(SELECTOR_DATA_DATE_INPUT)) {
+    DateInput.componentInterface(dateInput)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -15,7 +15,6 @@ import Calendar from './calendar.js'
 import DateInput from './date-input.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { initializeOnReady } from './util/component-functions.js'
 import Popup from './util/popup.js'
 import { getDateBySelectionType } from './util/calendar.js'
 import type { ComponentConfig } from './util/config.js'
@@ -32,6 +31,7 @@ import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/
 const NAME = 'date-picker'
 const DATA_KEY = 'coreui.date-picker'
 const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
 
 const EVENT_CLICK = `click${EVENT_KEY}`
 const EVENT_DATE_CHANGE = `dateChange${EVENT_KEY}`
@@ -39,6 +39,7 @@ const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_HIDE = `hide${EVENT_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_BODY = 'date-picker-body'
 const CLASS_NAME_CALENDAR = 'date-picker-calendar'
@@ -459,7 +460,11 @@ class DatePicker extends BaseComponent {
  * Data API implementation
  */
 
-initializeOnReady(DatePicker, SELECTOR_DATA_TOGGLE)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
+    DatePicker.getOrCreateInstance(element)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/date-range-picker.ts
+++ b/js/src/date-range-picker.ts
@@ -14,7 +14,6 @@ import Calendar from './calendar.js'
 import DateInput from './date-input.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { initializeOnReady } from './util/component-functions.js'
 import Popup from './util/popup.js'
 import { appendControlGroupField, createControlGroupAction } from './util/form-control-group.js'
 import { getDateBySelectionType } from './util/calendar.js'
@@ -33,6 +32,7 @@ import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/
 const NAME = 'date-range-picker'
 const DATA_KEY = 'coreui.date-range-picker'
 const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
 
 const EVENT_CLICK = `click${EVENT_KEY}`
 const EVENT_END_DATE_CHANGE = `endDateChange${EVENT_KEY}`
@@ -42,6 +42,7 @@ const EVENT_HIDE = `hide${EVENT_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_START_DATE_CHANGE = `startDateChange${EVENT_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_BODY = 'date-picker-body'
 const CLASS_NAME_CALENDAR = 'date-picker-calendar'
@@ -575,7 +576,11 @@ class DateRangePicker extends BaseComponent {
  * Data API implementation
  */
 
-initializeOnReady(DateRangePicker, SELECTOR_DATA_TOGGLE)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
+    DateRangePicker.getOrCreateInstance(element)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/date-time-input.ts
+++ b/js/src/date-time-input.ts
@@ -5,9 +5,10 @@
  * --------------------------------------------------------------------------
  */
 
+import EventHandler from './dom/event-handler.js'
+import SelectorEngine from './dom/selector-engine.js'
 import SectionInput, { type SectionInputConfig } from './section-input.js'
 import { convertToDateObject } from './util/calendar.js'
-import { initializeOnReady } from './util/component-functions.js'
 import { type DateSection, getDateTimeSectionsFromLocale } from './util/date-sections.js'
 import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
@@ -16,6 +17,11 @@ import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
  */
 
 const NAME = 'date-time-input'
+const DATA_KEY = 'coreui.date-time-input'
+const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
+
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_DATA_DATE_TIME_INPUT = '[data-coreui-date-time-input]'
 
@@ -78,7 +84,11 @@ class DateTimeInput extends SectionInput {
  * Data API implementation
  */
 
-initializeOnReady(DateTimeInput, SELECTOR_DATA_DATE_TIME_INPUT)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const dateTimeInput of SelectorEngine.find(SELECTOR_DATA_DATE_TIME_INPUT)) {
+    DateTimeInput.componentInterface(dateTimeInput)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/date-time-picker.ts
+++ b/js/src/date-time-picker.ts
@@ -14,7 +14,6 @@ import Calendar from './calendar.js'
 import DateTimeInput from './date-time-input.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { initializeOnReady } from './util/component-functions.js'
 import Popup from './util/popup.js'
 import TimeSelection from './util/time-selection.js'
 import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
@@ -30,11 +29,13 @@ import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 const NAME = 'date-time-picker'
 const DATA_KEY = 'coreui.date-time-picker'
 const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
 
 const EVENT_CLICK = `click${EVENT_KEY}`
 const EVENT_DATE_CHANGE = `dateChange${EVENT_KEY}`
 const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_HIDE = `hide${EVENT_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 
@@ -486,7 +487,11 @@ class DateTimePicker extends BaseComponent {
  * Data API implementation
  */
 
-initializeOnReady(DateTimePicker, SELECTOR_DATA_TOGGLE)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
+    DateTimePicker.getOrCreateInstance(element)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/list-box.ts
+++ b/js/src/list-box.ts
@@ -8,7 +8,6 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import { DefaultAllowlist, sanitizeByConfig, type SanitizerAllowList } from './util/sanitizer.js'
 import {
@@ -22,6 +21,7 @@ import {
 const NAME = 'list-box'
 const DATA_KEY = 'coreui.list-box'
 const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
 
 const ARROW_UP_KEY = 'ArrowUp'
 const ARROW_DOWN_KEY = 'ArrowDown'
@@ -1303,7 +1303,11 @@ class ListBox extends BaseComponent {
  * Data API implementation
  */
 
-initializeOnReady(ListBox, SELECTOR_DATA_TOGGLE, 'DOMContentLoaded')
+EventHandler.on(document, `DOMContentLoaded${EVENT_KEY}${DATA_API_KEY}`, () => {
+  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
+    ListBox.getOrCreateInstance(element)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/loading-button.ts
+++ b/js/src/loading-button.ts
@@ -8,7 +8,7 @@
 import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
-import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
+import { defineJQueryPlugin } from './util/index.js'
 
 /**
  * Constants
@@ -189,7 +189,9 @@ class LoadingButton extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return jQueryDispatch(this, LoadingButton, config)
+    return this.each(function (this: HTMLElement) {
+      LoadingButton.loadingButtonInterface(this, config)
+    })
   }
 }
 

--- a/js/src/multi-select.ts
+++ b/js/src/multi-select.ts
@@ -14,7 +14,7 @@ import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
 import { CLEANER_ICON, INDICATOR_ICON } from './util/icons.js'
 import { DefaultAllowlist, sanitizeByConfig, type SanitizerAllowList } from './util/sanitizer.js'
-import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
+import { defineJQueryPlugin, getUID } from './util/index.js'
 
 /**
  * ------------------------------------------------------------------------
@@ -1416,7 +1416,9 @@ class MultiSelect extends ComboboxBase {
   }
 
   static jQueryInterface(this: any, config: any): any {
-    return jQueryDispatch(this, MultiSelect, config)
+    return this.each(function (this: HTMLElement) {
+      MultiSelect.multiSelectInterface(this, config)
+    })
   }
 
   static clearMenus(event: any): void {

--- a/js/src/navigation.ts
+++ b/js/src/navigation.ts
@@ -6,11 +6,10 @@
  */
 
 import BaseComponent from './base-component.js'
-import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
+import { defineJQueryPlugin } from './util/index.js'
 import { startSizeTransition, supportsInterpolateSize } from './util/size-transition.js'
 
 /**
@@ -42,6 +41,7 @@ const CLASS_NAME_NAV_GROUP = 'nav-group'
 const CLASS_NAME_NAV_GROUP_TOGGLE = 'nav-group-toggle'
 
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_NAV_GROUP = '.nav-group'
 const SELECTOR_NAV_GROUP_ITEMS = '.nav-group-items'
@@ -183,7 +183,9 @@ class Navigation extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return jQueryDispatch(this, Navigation, config)
+    return this.each(function (this: HTMLElement) {
+      Navigation.navigationInterface(this, config)
+    })
   }
 }
 
@@ -192,7 +194,11 @@ class Navigation extends BaseComponent {
  * Data Api implementation
  * ------------------------------------------------------------------------
  */
-initializeOnReady(Navigation, SELECTOR_DATA_NAVIGATION)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const element of Array.from(document.querySelectorAll(SELECTOR_DATA_NAVIGATION))) {
+    Navigation.navigationInterface(element)
+  }
+})
 
 /**
  * ------------------------------------------------------------------------

--- a/js/src/otp-input.ts
+++ b/js/src/otp-input.ts
@@ -8,7 +8,6 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { initializeOnReady } from './util/component-functions.js'
 import {
   defineJQueryPlugin, getNextActiveElement, isRTL, jQueryDispatch
 } from './util/index.js'
@@ -20,6 +19,7 @@ import {
 const NAME = 'otp-input'
 const DATA_KEY = 'coreui.otp-input'
 const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
 
 const ARROW_RIGHT_KEY = 'ArrowRight'
 const ARROW_LEFT_KEY = 'ArrowLeft'
@@ -31,6 +31,7 @@ const EVENT_FOCUS = `focus${EVENT_KEY}`
 const EVENT_INPUT = `input${EVENT_KEY}`
 const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
 const EVENT_PASTE = `paste${EVENT_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_FORM_OTP_CONTROL = '.form-otp-control'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="otp"]'
@@ -524,7 +525,11 @@ class OTPInput extends BaseComponent {
  * Data API implementation
  */
 
-initializeOnReady(OTPInput, SELECTOR_DATA_TOGGLE)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const otp of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
+    OTPInput.otpInputInterface(otp)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/range-slider.ts
+++ b/js/src/range-slider.ts
@@ -9,7 +9,6 @@ import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import { defineJQueryPlugin, isRTL, jQueryDispatch } from './util/index.js'
 import { DefaultAllowlist, sanitizeByConfig, type SanitizerAllowList } from './util/sanitizer.js'
@@ -21,9 +20,11 @@ import { DefaultAllowlist, sanitizeByConfig, type SanitizerAllowList } from './u
 const NAME = 'range-slider'
 const DATA_KEY = 'coreui.range-slider'
 const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
 
 const EVENT_CHANGE = `change${EVENT_KEY}`
 const EVENT_INPUT = `input${EVENT_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_MOUSEDOWN = `mousedown${EVENT_KEY}`
 const EVENT_MOUSEMOVE = `mousemove${EVENT_KEY}`
 const EVENT_MOUSEUP = `mouseup${EVENT_KEY}`
@@ -686,7 +687,12 @@ class RangeSlider extends BaseComponent {
  * Data API implementation
  */
 
-initializeOnReady(RangeSlider, SELECTOR_DATA_TOGGLE)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  const ratings = SelectorEngine.find(SELECTOR_DATA_TOGGLE)
+  for (let i = 0, len = ratings.length; i < len; i++) {
+    RangeSlider.rangeSliderInterface(ratings[i])
+  }
+})
 
 /**
  * jQuery

--- a/js/src/rating.ts
+++ b/js/src/rating.ts
@@ -6,7 +6,6 @@
  */
 
 import BaseComponent from './base-component.js'
-import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
@@ -21,12 +20,14 @@ import Tooltip from './tooltip.js'
 const NAME = 'rating'
 const DATA_KEY = 'coreui.rating'
 const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
 
 const EVENT_CHANGE = `change${EVENT_KEY}`
 const EVENT_CLICK = `click${EVENT_KEY}`
 const EVENT_FOCUSIN = `focusin${EVENT_KEY}`
 const EVENT_FOCUSOUT = `focusout${EVENT_KEY}`
 const EVENT_HOVER = `hover${EVENT_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_MOUSEENTER = `mouseenter${EVENT_KEY}`
 const EVENT_MOUSELEAVE = `mouseleave${EVENT_KEY}`
 
@@ -488,7 +489,12 @@ class Rating extends BaseComponent {
  * Data API implementation
  */
 
-initializeOnReady(Rating, SELECTOR_DATA_TOGGLE)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  const ratings = SelectorEngine.find(SELECTOR_DATA_TOGGLE)
+  for (let i = 0, len = ratings.length; i < len; i++) {
+    Rating.ratingInterface(ratings[i])
+  }
+})
 
 /**
  * jQuery

--- a/js/src/scrollspy.ts
+++ b/js/src/scrollspy.ts
@@ -11,7 +11,6 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import {
   defineJQueryPlugin, getElement, isDisabled, isVisible, jQueryDispatch
@@ -24,12 +23,14 @@ import {
 const NAME = 'scrollspy'
 const DATA_KEY = 'coreui.scrollspy'
 const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
 
 const EVENT_ACTIVATE = `activate${EVENT_KEY}`
 const EVENT_CLICK = `click${EVENT_KEY}`
 const EVENT_SCROLL = `scroll${EVENT_KEY}`
 const EVENT_SCROLLEND = `scrollend${EVENT_KEY}`
 const EVENT_RESIZE = `resize${EVENT_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_MENU_ITEM = 'menu-item'
 const CLASS_NAME_DROPDOWN_ITEM = 'dropdown-item'
@@ -601,7 +602,11 @@ function decodeFragment(hash: string): string {
  * Data API implementation
  */
 
-initializeOnReady(ScrollSpy, SELECTOR_DATA_SPY)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const spy of SelectorEngine.find(SELECTOR_DATA_SPY)) {
+    ScrollSpy.getOrCreateInstance(spy)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/search-button.ts
+++ b/js/src/search-button.ts
@@ -8,7 +8,7 @@
 import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
-import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
+import { defineJQueryPlugin } from './util/index.js'
 
 /**
  * Constants
@@ -337,7 +337,9 @@ class SearchButton extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return jQueryDispatch(this, SearchButton, config)
+    return this.each(function (this: HTMLElement) {
+      SearchButton.searchButtonInterface(this, config)
+    })
   }
 
   static _initializeDataApi(): void {

--- a/js/src/sidebar.ts
+++ b/js/src/sidebar.ts
@@ -6,11 +6,10 @@
  */
 
 import BaseComponent from './base-component.js'
-import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
-import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
+import { defineJQueryPlugin } from './util/index.js'
 import Backdrop from './util/backdrop.js'
 import ScrollBarHelper from './util/scrollbar.js'
 
@@ -42,6 +41,7 @@ const EVENT_RESIZE = `resize${EVENT_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_DATA_CLOSE = '[data-coreui-close="sidebar"]'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="narrow"], [data-coreui-toggle="unfoldable"]'
@@ -321,7 +321,9 @@ class Sidebar extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return jQueryDispatch(this, Sidebar, config)
+    return this.each(function (this: HTMLElement) {
+      Sidebar.sidebarInterface(this, config)
+    })
   }
 }
 
@@ -331,7 +333,11 @@ class Sidebar extends BaseComponent {
  * ------------------------------------------------------------------------
  */
 
-initializeOnReady(Sidebar, SELECTOR_SIDEBAR)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const element of Array.from(document.querySelectorAll(SELECTOR_SIDEBAR))) {
+    Sidebar.sidebarInterface(element)
+  }
+})
 
 /**
  * ------------------------------------------------------------------------

--- a/js/src/stepper.ts
+++ b/js/src/stepper.ts
@@ -6,7 +6,6 @@
  */
 
 import BaseComponent from './base-component.js'
-import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
@@ -30,6 +29,7 @@ const EVENT_STEP_VALIDATION_COMPLETE = `stepValidationComplete${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}`
 const EVENT_INPUT = `input${EVENT_KEY}`
 const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}`
 
 const CLASS_NAME_ACTIVE = 'active'
 const CLASS_NAME_COMPLETE = 'complete'
@@ -692,7 +692,11 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEPPER_ACTION, functio
   }
 })
 
-initializeOnReady(Stepper, SELECTOR_DATA_TOGGLE)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
+    Stepper.getOrCreateInstance(element)
+  }
+})
 
 /**
  * jQuery integration

--- a/js/src/tab.ts
+++ b/js/src/tab.ts
@@ -11,7 +11,6 @@
 import BaseComponent from './base-component.js'
 import EventHandler, { type CoreUIEvent } from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { initializeOnReady } from './util/component-functions.js'
 import {
   defineJQueryPlugin, getNextActiveElement, getTransitionDurationFromElement, isDisabled, jQueryDispatch, setAriaAttribute
 } from './util/index.js'
@@ -30,6 +29,7 @@ const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}`
 const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}`
 
 const ARROW_LEFT_KEY = 'ArrowLeft'
 const ARROW_RIGHT_KEY = 'ArrowRight'
@@ -307,7 +307,11 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
 /**
  * Initialize on focus
  */
-initializeOnReady(Tab, SELECTOR_DATA_TOGGLE_ACTIVE)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE_ACTIVE)) {
+    Tab.getOrCreateInstance(element)
+  }
+})
 /**
  * jQuery
  */

--- a/js/src/time-input.ts
+++ b/js/src/time-input.ts
@@ -5,9 +5,10 @@
  * --------------------------------------------------------------------------
  */
 
+import EventHandler from './dom/event-handler.js'
+import SelectorEngine from './dom/selector-engine.js'
 import SectionInput, { type SectionInputConfig } from './section-input.js'
 import { convertToDateObject } from './util/calendar.js'
-import { initializeOnReady } from './util/component-functions.js'
 import { type DateSection, getTimeSectionsFromLocale } from './util/date-sections.js'
 import { convert12hTo24h } from './util/time.js'
 import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
@@ -17,6 +18,11 @@ import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
  */
 
 const NAME = 'time-input'
+const DATA_KEY = 'coreui.time-input'
+const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
+
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_DATA_TIME_INPUT = '[data-coreui-time-input]'
 
@@ -87,7 +93,11 @@ class TimeInput extends SectionInput {
  * Data API implementation
  */
 
-initializeOnReady(TimeInput, SELECTOR_DATA_TIME_INPUT)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const timeInput of SelectorEngine.find(SELECTOR_DATA_TIME_INPUT)) {
+    TimeInput.componentInterface(timeInput)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/time-picker.ts
+++ b/js/src/time-picker.ts
@@ -12,7 +12,6 @@ import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import TimeInput from './time-input.js'
-import { initializeOnReady } from './util/component-functions.js'
 import Popup from './util/popup.js'
 import TimeSelection from './util/time-selection.js'
 import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
@@ -28,10 +27,12 @@ import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 const NAME = 'time-picker'
 const DATA_KEY = 'coreui.time-picker'
 const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
 
 const EVENT_CLICK = `click${EVENT_KEY}`
 const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_HIDE = `hide${EVENT_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_TIME_CHANGE = `timeChange${EVENT_KEY}`
@@ -407,7 +408,11 @@ class TimePicker extends BaseComponent {
  * Data API implementation
  */
 
-initializeOnReady(TimePicker, SELECTOR_DATA_TOGGLE)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
+    TimePicker.getOrCreateInstance(element)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/transfer.ts
+++ b/js/src/transfer.ts
@@ -9,7 +9,6 @@ import BaseComponent from './base-component.js'
 import ListBox, { type ListBoxEntry, type ListBoxGroup, type ListBoxItem } from './list-box.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { initializeOnReady } from './util/component-functions.js'
 import type { ComponentConfig } from './util/config.js'
 import {
   CHEVRON_DOUBLE_LEFT_ICON, CHEVRON_DOUBLE_RIGHT_ICON, CHEVRON_LEFT_ICON, CHEVRON_RIGHT_ICON
@@ -24,6 +23,7 @@ import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/
 const NAME = 'transfer'
 const DATA_KEY = 'coreui.transfer'
 const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
 
 const EVENT_CHANGE = 'change'
 const EVENT_MOVE = 'move'
@@ -683,7 +683,11 @@ class Transfer extends BaseComponent {
  * Data API implementation
  */
 
-initializeOnReady(Transfer, SELECTOR_DATA_TOGGLE, 'DOMContentLoaded')
+EventHandler.on(document, `DOMContentLoaded${EVENT_KEY}${DATA_API_KEY}`, () => {
+  for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
+    Transfer.getOrCreateInstance(element)
+  }
+})
 
 /**
  * jQuery

--- a/js/src/util/component-functions.ts
+++ b/js/src/util/component-functions.ts
@@ -34,15 +34,6 @@ const enableDismissTrigger = (component: typeof BaseComponent, method = 'hide', 
   })
 }
 
-const initializeOnReady = (component: typeof BaseComponent, selector: string, event: 'DOMContentLoaded' | 'load' = 'load'): void => {
-  EventHandler.on(event === 'load' ? window : document, `${event}${component.EVENT_KEY}.data-api`, () => {
-    for (const element of SelectorEngine.find(selector)) {
-      component.getOrCreateInstance(element)
-    }
-  })
-}
-
 export {
-  enableDismissTrigger,
-  initializeOnReady
+  enableDismissTrigger
 }

--- a/js/tests/unit/navigation.spec.js
+++ b/js/tests/unit/navigation.spec.js
@@ -80,23 +80,23 @@ describe('Navigation', () => {
     it('should initialize navigation on elements with data-coreui-navigation', () => {
       fixtureEl.innerHTML = '<nav data-coreui-navigation></nav>'
       const navEl = fixtureEl.querySelector('nav')
-      spyOn(Navigation, 'getOrCreateInstance')
+      spyOn(Navigation, 'navigationInterface')
 
       const loadEvent = new Event('load')
       window.dispatchEvent(loadEvent)
 
-      expect(Navigation.getOrCreateInstance).toHaveBeenCalledWith(navEl)
+      expect(Navigation.navigationInterface).toHaveBeenCalledWith(navEl)
     })
 
     it('should initialize navigation on elements with legacy data-coreui="navigation"', () => {
       fixtureEl.innerHTML = '<nav data-coreui="navigation"></nav>'
       const navEl = fixtureEl.querySelector('nav')
-      spyOn(Navigation, 'getOrCreateInstance')
+      spyOn(Navigation, 'navigationInterface')
 
       const loadEvent = new Event('load')
       window.dispatchEvent(loadEvent)
 
-      expect(Navigation.getOrCreateInstance).toHaveBeenCalledWith(navEl)
+      expect(Navigation.navigationInterface).toHaveBeenCalledWith(navEl)
     })
   })
 

--- a/js/tests/unit/sidebar.spec.js
+++ b/js/tests/unit/sidebar.spec.js
@@ -716,7 +716,7 @@ describe('Sidebar', () => {
     it('should initialize sidebar on elements with .sidebar class on window load', () => {
       fixtureEl.innerHTML = '<div class="sidebar"></div>'
       const sidebarEl = fixtureEl.querySelector('.sidebar')
-      const spySidebarInterface = spyOn(Sidebar, 'getOrCreateInstance')
+      const spySidebarInterface = spyOn(Sidebar, 'sidebarInterface')
 
       const loadEvent = new Event('load')
       window.dispatchEvent(loadEvent)
@@ -773,7 +773,7 @@ describe('Sidebar', () => {
       fixtureEl.innerHTML = '<div class="sidebar"></div>'
       const sidebarEl = fixtureEl.querySelector('.sidebar')
       const sidebar = new Sidebar(sidebarEl)
-      const spySidebarInterface = spyOn(Sidebar, 'getOrCreateInstance')
+      const spySidebarInterface = spyOn(Sidebar, 'sidebarInterface')
 
       sidebar.dispose()
       window.dispatchEvent(new Event('load'))

--- a/js/tests/unit/util/component-functions.spec.js
+++ b/js/tests/unit/util/component-functions.spec.js
@@ -1,6 +1,5 @@
 import BaseComponent from '../../../src/base-component.js'
-import EventHandler from '../../../src/dom/event-handler.js'
-import { enableDismissTrigger, initializeOnReady } from '../../../src/util/component-functions.js'
+import { enableDismissTrigger } from '../../../src/util/component-functions.js'
 import { clearFixture, createEvent, getFixture } from '../../helpers/fixture.js'
 
 class DummyClass2 extends BaseComponent {
@@ -26,35 +25,6 @@ describe('Plugin functions', () => {
 
   afterEach(() => {
     clearFixture()
-  })
-
-  describe('initializeOnReady', () => {
-    const component = () => ({
-      EVENT_KEY: '.coreui.probe',
-      getOrCreateInstance: jasmine.createSpy('getOrCreateInstance')
-    })
-
-    it('should initialise every match on load by default', () => {
-      fixtureEl.innerHTML = '<div class="probe"></div><div class="probe"></div>'
-      const Probe = component()
-
-      initializeOnReady(Probe, '.probe')
-      EventHandler.trigger(window, 'load')
-
-      expect(Probe.getOrCreateInstance).toHaveBeenCalledTimes(2)
-      EventHandler.off(window, 'load.coreui.probe.data-api')
-    })
-
-    it('should initialise on DOMContentLoaded when asked', () => {
-      fixtureEl.innerHTML = '<div class="probe"></div>'
-      const Probe = component()
-
-      initializeOnReady(Probe, '.probe', 'DOMContentLoaded')
-      EventHandler.trigger(document, 'DOMContentLoaded')
-
-      expect(Probe.getOrCreateInstance).toHaveBeenCalledWith(fixtureEl.querySelector('.probe'))
-      EventHandler.off(document, 'DOMContentLoaded.coreui.probe.data-api')
-    })
   })
 
   describe('data-coreui-dismiss functionality', () => {


### PR DESCRIPTION
Reverts #1240 at mrholek's request, pending a decision on whether the shared ready-time initialiser is the right shape.

Restores the per-plugin `load` / `DOMContentLoaded` handlers, the six plugins' `xInterface`-based `jQueryInterface`, and the constants and imports #1240 removed. The one conflict with #1241 (the `multi-select.ts` import line) is resolved by keeping `sanitizeByConfig` and dropping `jQueryDispatch`. Full unit suite and `JQUERY=true` suite green, typecheck clean.

The change stays recoverable from `42074b52e`.
