### PR TITLE
refactor: route the last six jQuery interfaces through the dispatcher

### DIFF
--- a/js/src/autocomplete.ts
+++ b/js/src/autocomplete.ts
@@ -14,7 +14,7 @@ import {
   DefaultAllowlist, escapeHtml, type SanitizerAllowList
 } from './util/sanitizer.js'
 import { CLEANER_ICON, INDICATOR_ICON } from './util/icons.js'
-import { defineJQueryPlugin, getUID } from './util/index.js'
+import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
 
 /**
  * ------------------------------------------------------------------------
@@ -733,9 +733,7 @@ class Autocomplete extends ComboboxBase {
   }
 
   static jQueryInterface(this: any, config: any): any {
-    return this.each(function (this: HTMLElement) {
-      Autocomplete.autocompleteInterface(this, config)
-    })
+    return jQueryDispatch(this, Autocomplete, config)
   }
 
   static clearMenus(event: any): void {

--- a/js/src/loading-button.ts
+++ b/js/src/loading-button.ts
@@ -8,7 +8,7 @@
 import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -189,9 +189,7 @@ class LoadingButton extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      LoadingButton.loadingButtonInterface(this, config)
-    })
+    return jQueryDispatch(this, LoadingButton, config)
   }
 }
 

--- a/js/src/multi-select.ts
+++ b/js/src/multi-select.ts
@@ -14,7 +14,7 @@ import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
 import { CLEANER_ICON, INDICATOR_ICON } from './util/icons.js'
 import { DefaultAllowlist, sanitizeByConfig, type SanitizerAllowList } from './util/sanitizer.js'
-import { defineJQueryPlugin, getUID } from './util/index.js'
+import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
 
 /**
  * ------------------------------------------------------------------------
@@ -1416,9 +1416,7 @@ class MultiSelect extends ComboboxBase {
   }
 
   static jQueryInterface(this: any, config: any): any {
-    return this.each(function (this: HTMLElement) {
-      MultiSelect.multiSelectInterface(this, config)
-    })
+    return jQueryDispatch(this, MultiSelect, config)
   }
 
   static clearMenus(event: any): void {

--- a/js/src/navigation.ts
+++ b/js/src/navigation.ts
@@ -9,7 +9,7 @@ import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 import { startSizeTransition, supportsInterpolateSize } from './util/size-transition.js'
 
 /**
@@ -183,9 +183,7 @@ class Navigation extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      Navigation.navigationInterface(this, config)
-    })
+    return jQueryDispatch(this, Navigation, config)
   }
 }
 

--- a/js/src/search-button.ts
+++ b/js/src/search-button.ts
@@ -8,7 +8,7 @@
 import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -337,9 +337,7 @@ class SearchButton extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      SearchButton.searchButtonInterface(this, config)
-    })
+    return jQueryDispatch(this, SearchButton, config)
   }
 
   static _initializeDataApi(): void {

--- a/js/src/sidebar.ts
+++ b/js/src/sidebar.ts
@@ -9,7 +9,7 @@ import BaseComponent from './base-component.js'
 import type { ComponentConfig } from './util/config.js'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
 import Backdrop from './util/backdrop.js'
 import ScrollBarHelper from './util/scrollbar.js'
 
@@ -321,9 +321,7 @@ class Sidebar extends BaseComponent {
   }
 
   static jQueryInterface(this: any, config: any): void {
-    return this.each(function (this: HTMLElement) {
-      Sidebar.sidebarInterface(this, config)
-    })
+    return jQueryDispatch(this, Sidebar, config)
   }
 }
 


### PR DESCRIPTION
The part of #1240 that stays, after the revert in #1242.

## Before / after

- Before: Autocomplete, MultiSelect, LoadingButton, Navigation, SearchButton and Sidebar wrapped their own `xInterface()` in `jQueryInterface`, with the looser `typeof … === 'undefined'` check.
- After: the six delegate to `jQueryDispatch` like the other 40 plugins (#1239), so a private or unknown method name is rejected the same way everywhere. The `xInterface()` statics stay untouched: the data API blocks call them, and those blocks stay written out in each file next to the component's other document-level registrations (mrholek, 2026-09-11).

## Tests

Existing per-plugin jQuery specs unchanged: six suites, 684 tests green; `JQUERY=true` suite green; typecheck clean.
