### PR TITLE
feat(DatePicker): compose from the markup and own the date

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -58,27 +58,27 @@
     },
     {
       "path": "./dist/js/coreui.bundle.js",
-      "maxSize": "146.5KB"
+      "maxSize": "147KB"
     },
     {
       "path": "./dist/js/coreui.bundle.min.js",
-      "maxSize": "96.5KB"
+      "maxSize": "97KB"
     },
     {
       "path": "./dist/js/coreui.esm.js",
-      "maxSize": "135.5KB"
+      "maxSize": "136KB"
     },
     {
       "path": "./dist/js/coreui.esm.min.js",
-      "maxSize": "99.5KB"
+      "maxSize": "100KB"
     },
     {
       "path": "./dist/js/coreui.js",
-      "maxSize": "136.5KB"
+      "maxSize": "137KB"
     },
     {
       "path": "./dist/js/coreui.min.js",
-      "maxSize": "90KB"
+      "maxSize": "90.5KB"
     }
   ],
   "ci": {

--- a/docs/src/content/docs/forms/date-picker.mdx
+++ b/docs/src/content/docs/forms/date-picker.mdx
@@ -158,6 +158,31 @@ Wrap the control in [`.form-field`](/forms/field/) to lay it out with its label 
     <div class="form-text">We deliver on working days only.</div>
   </div>`} />
 
+## Composing the markup
+
+The picker is built from other components — the [date input](/forms/date-input/) field, the [calendar](/components/calendar/) and a popup — held together by the date it owns. The markup is where you choose the parts: mark an element with a role attribute and the picker adopts it instead of building its own; leave a part out and it is generated as in the examples above.
+
+| Role | Element | What the picker does with it |
+| --- | --- | --- |
+| `data-coreui-picker-field` | a `div` | Hosts the date input's sections. Without it the field is generated (and wrapped in `.form-floating` when `floatingLabel` is set). |
+| `data-coreui-picker-toggle` | a `button` or any element | Opens and closes the calendar. Gets `aria-expanded`, `aria-controls` and `aria-haspopup`, and `ariaToggleLabel` as its name unless it has one. |
+| `data-coreui-picker-cleaner` | a `button` | Clears the value. Gets `ariaCleanerLabel` as its name unless it has one. |
+
+A decorative `<svg>` inside an adopted button is marked `aria-hidden` for you. So a trigger can be a regular button with its own text and icon, the way a combobox has one:
+
+<Example pro code={`<div data-coreui-locale="en-US" data-coreui-toggle="date-picker">
+    <div data-coreui-picker-field></div>
+    <button type="button" class="btn btn-subtle btn-sm" data-coreui-picker-cleaner>
+      <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 3l10 10M13 3L3 13"/></svg>
+    </button>
+    <button type="button" class="btn btn-subtle btn-sm" data-coreui-picker-toggle>
+      <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1.5" y="2.5" width="13" height="12" rx="1.5"/><path d="M1.5 6.5h13M5 1v3M11 1v3"/></svg>
+      Pick a date
+    </button>
+  </div>`} />
+
+The `cleanerIcon` and `indicatorIcon` options only feed the generated buttons; with your own markup the icon is whatever you put in the HTML, and nothing is sanitized because nothing is rendered from a string.
+
 ## Floating labels
 
 The date picker supports [floating labels](/forms/floating-labels/): set `floatingLabel` and the component renders the label itself — no wrapper markup needed — and the text also becomes the field's accessible name. The mask placeholders stay hidden while the label rests inside the field; focusing any part of the field — the sections or the picker button — floats the label and reveals the mask.
@@ -342,6 +367,8 @@ Add `data-coreui-toggle="date-picker"` to a `div` element.
 <div data-coreui-toggle="date-picker"></div>
 ```
 
+Inside it, `data-coreui-picker-field`, `data-coreui-picker-toggle` and `data-coreui-picker-cleaner` name the parts you supply yourself — see [Composing the markup](#composing-the-markup).
+
 ### Via JavaScript
 
 ```html
@@ -373,12 +400,12 @@ attributes work on the picker element too.
 | `ariaLabel` | string | `'Date input'` | Accessible name of the field. It lands on the `role="group"` container the sections sit in, so it names the whole control rather than one part of it. |
 | `ariaToggleLabel` | string | `'Toggle the calendar'` | Accessible label of the indicator button. |
 | `cleaner` | boolean | `true` | Renders a button that clears the value. It appears only once the field holds one. |
-| `cleanerIcon` | string | cross SVG | Inline SVG rendered by the component (sanitized). |
+| `cleanerIcon` | string | cross SVG | Inline SVG of the generated cleaner (sanitized). Not used for a `data-coreui-picker-cleaner` you wrote. |
 | `calendarOptions` | object | `{}` | Programmatic escape hatch for calendar options. |
 | `container` | string, element, false | `false` | Teleport target for the dropdown. |
 | `date` | date, string, null | `null` | Initial value. |
 | `disabled` | boolean | `false` | Disables the field and the popup. |
-| `indicatorIcon` | string | calendar SVG | Inline SVG rendered by the component (sanitized). |
+| `indicatorIcon` | string | calendar SVG | Inline SVG of the generated toggle (sanitized). Not used for a `data-coreui-picker-toggle` you wrote. |
 | `inputOptions` | object | `{}` | Programmatic escape hatch for date input options. |
 | `locale` | string | browser locale | Drives section order, separators, and calendar labels. |
 | `maxDate` | date, string, null | `null` | Upper bound, enforced by both layers. |

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -946,6 +946,21 @@ behaviour, v5 is the reference. Mapping:
   calendar is built then); later opens are unchanged. Code reaching into the
   private `picker._calendar` before the first open now finds `null`.
 
+#### The date picker adopts the markup you write
+
+The date picker is composed from the date input, the calendar and a popup,
+joined by the one date it owns. Mark a `div` with `data-coreui-picker-field`,
+a button with `data-coreui-picker-toggle` or `data-coreui-picker-cleaner`
+inside the picker element and it uses them instead of generating its own —
+a trigger can be a regular button with text, the icons can be plain `<svg>`
+in the HTML. Nothing changes for the bare `<div data-coreui-toggle="date-picker">`.
+
+<span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>
+`aria-expanded` moved from the picker's root element to the toggle button,
+where it describes the control that opens the calendar; the toggle also
+carries `aria-controls` and `aria-haspopup="dialog"`. Styles keyed to the
+root's `.show` class are unaffected.
+
 #### The date range picker is built on the date range input
 
 <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/js/src/date-picker.ts
+++ b/js/src/date-picker.ts
@@ -3,10 +3,13 @@
  * CoreUI PRO date-picker.js
  * License (https://coreui.io/pro/license/)
  *
- * Composed from existing primitives — DateInput (section field), Calendar, and
- * the Popup anchored-overlay util — rather than one monolith. Projected regions
- * (footer) come from a <template> child and act through the slot context, not
- * through configuration props.
+ * Composed from existing components — DateInput (section field), Calendar and
+ * the Popup — joined by one piece of state, the date, that the picker owns.
+ * The markup is the composition surface: a field, a toggle and a cleaner the
+ * author wrote (by role attribute) are adopted; whatever is missing is
+ * generated, so a bare `<div data-coreui-toggle="date-picker">` keeps working.
+ * Projected regions (footer) come from a <template> child and act through the
+ * slot context, not through configuration props.
  * --------------------------------------------------------------------------
  */
 
@@ -16,12 +19,12 @@ import DateInput from './date-input.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import Popup from './util/popup.js'
-import { getDateBySelectionType } from './util/calendar.js'
+import { getDateBySelectionType, isSameDateAs } from './util/calendar.js'
 import type { ComponentConfig } from './util/config.js'
 import { getWeekSectionsFromLocale } from './util/date-sections.js'
 import { appendControlGroupField, applyControlGroupClasses, createControlGroupAction } from './util/form-control-group.js'
 import { CALENDAR_ICON, CLEANER_ICON } from './util/icons.js'
-import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
+import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
 import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/sanitizer.js'
 
 /**
@@ -58,11 +61,14 @@ const CLASS_NAME_SHOW = 'show'
 const SELECTOR_DATA_TOGGLE = '[data-coreui-toggle="date-picker"]'
 const SELECTOR_TEMPLATE_FOOTER = 'template[data-coreui-template="footer"]'
 const SELECTOR_ACTION = '[data-coreui-picker-action]'
+const SELECTOR_ROLE_CLEANER = '[data-coreui-picker-cleaner]'
+const SELECTOR_ROLE_FIELD = '[data-coreui-picker-field]'
+const SELECTOR_ROLE_TOGGLE = '[data-coreui-picker-toggle]'
+const SELECTOR_SVG = 'svg'
 const SELECTOR_ACTION_TODAY = '[data-coreui-picker-action="today"]'
 
-// Icons live in JavaScript, not in CSS masks — the chips pattern: inline SVG on
-// currentColor, swappable through an option, sanitized like any user-provided
-// markup.
+// Icons live in JavaScript only as the fallback for the minimal markup: an
+// author who writes the toggle or the cleaner puts the SVG in the HTML.
 
 type DatePickerConfig = {
   allowList: SanitizerAllowList
@@ -137,14 +143,16 @@ const DefaultType: Record<string, string> = {
 class DatePicker extends BaseComponent {
   protected declare _footerTemplate: any
   protected declare _cleanerElement: HTMLElement | null
-  protected declare _indicatorElement: HTMLElement
+  protected declare _toggleElement: HTMLElement
   protected declare _fieldElement: HTMLElement
+  protected declare _created: { cleaner: boolean, field: boolean, toggle: boolean }
   protected declare _initialDate: any
+  protected declare _date: Date | null
   protected declare _input: any
   protected declare _calendar: any
   protected declare _calendarElement: any
   protected declare _menu: any
-  protected declare _syncingFromPanel: boolean
+  protected declare _applying: boolean
   protected declare _addedGroupClass: boolean
   protected declare _popup: any
 
@@ -152,18 +160,18 @@ class DatePicker extends BaseComponent {
     super(element, config)
 
     this._footerTemplate = SelectorEngine.findOne(SELECTOR_TEMPLATE_FOOTER, this._element)
-    // setDate() goes through the field's update(), which rewrites its config —
-    // so the shell keeps the initial value for reset() itself
     this._initialDate = config?.date ?? this._config.date
     this._cleanerElement = null
+    this._created = { cleaner: false, field: false, toggle: false }
     this._input = null
     this._calendar = null
-    this._syncingFromPanel = false
+    this._applying = false
     this._calendarElement = null
     this._menu = null
     this._popup = null
 
     this._createDatePicker()
+    this._date = this._input.getDate()
     this._createPopup()
     this._addEventListeners()
   }
@@ -199,25 +207,25 @@ class DatePicker extends BaseComponent {
   }
 
   getDate(): Date | null {
-    return this._input.getDate()
+    return this._date
   }
 
   // The field validates the date against min/max — the emitted value and the
   // calendar selection follow the validation outcome, not the argument.
   setDate(date: Date | null): void {
-    this._input.update({ date })
+    this._applyDate(date)
   }
 
   clear(): void {
-    this._input.clear()
+    this._applyDate(null)
   }
 
   reset(): void {
-    this.setDate(this._initialDate)
+    this._applyDate(this._initialDate)
   }
 
   today(): void {
-    this.setDate(new Date())
+    this._applyDate(new Date())
   }
 
   getContext(): Record<string, any> {
@@ -234,16 +242,25 @@ class DatePicker extends BaseComponent {
   }
 
   override dispose(): void {
-    for (const element of [this._menu, this._indicatorElement, this._cleanerElement]) {
+    for (const element of [this._menu, this._toggleElement, this._cleanerElement]) {
       EventHandler.off(element, EVENT_KEY)
     }
 
     this._popup.dispose()
     this._input.dispose()
     this._calendar?.dispose()
-    this._fieldElement.remove()
-    this._cleanerElement?.remove()
-    this._indicatorElement.remove()
+
+    if (this._created.field) {
+      this._fieldElement.remove()
+    }
+
+    if (this._created.cleaner) {
+      this._cleanerElement?.remove()
+    }
+
+    if (this._created.toggle) {
+      this._toggleElement.remove()
+    }
 
     if (this._addedGroupClass) {
       this._element.classList.remove(CLASS_NAME_INPUT_GROUP)
@@ -299,21 +316,35 @@ class DatePicker extends BaseComponent {
       inputGroup.classList.add(`${CLASS_NAME_FORM_CONTROL}-${this._config.size}`)
     }
 
-    const inputEl = document.createElement('div')
-    this._fieldElement = appendControlGroupField(inputGroup, inputEl, this._config.floatingLabel, `${this.constructor.NAME}-`)
+    // Markup first: a part the author wrote is adopted, a missing one is built.
+    const ownField = SelectorEngine.findOne(SELECTOR_ROLE_FIELD, inputGroup)
+    const inputEl = ownField ?? document.createElement('div')
+    this._created.field = !ownField
+    this._fieldElement = ownField ?? appendControlGroupField(inputGroup, inputEl, this._config.floatingLabel, `${this.constructor.NAME}-`)
 
     const action = (className: string, icon: string, label: string) => createControlGroupAction({
       className, disabled: this._config.disabled, icon, label, sanitizeIcon: (value: string) => sanitizeByConfig(value, this._config)
     })
 
-    if (this._config.cleaner) {
+    const ownCleaner = SelectorEngine.findOne(SELECTOR_ROLE_CLEANER, inputGroup)
+
+    if (ownCleaner) {
+      this._cleanerElement = this._adoptAction(ownCleaner, this._config.ariaCleanerLabel)
+    } else if (this._config.cleaner) {
       this._cleanerElement = action(CLASS_NAME_CLEANER, this._config.cleanerIcon, this._config.ariaCleanerLabel)
+      this._created.cleaner = true
       inputGroup.append(this._cleanerElement)
     }
 
-    const indicator = action(CLASS_NAME_INDICATOR, this._config.indicatorIcon, this._config.ariaToggleLabel)
-    inputGroup.append(indicator)
-    this._indicatorElement = indicator
+    const ownToggle = SelectorEngine.findOne(SELECTOR_ROLE_TOGGLE, inputGroup)
+
+    if (ownToggle) {
+      this._toggleElement = this._adoptAction(ownToggle, this._config.ariaToggleLabel)
+    } else {
+      this._toggleElement = action(CLASS_NAME_INDICATOR, this._config.indicatorIcon, this._config.ariaToggleLabel)
+      this._created.toggle = true
+      inputGroup.append(this._toggleElement)
+    }
 
     this._input = new DateInput(inputEl, this._forwardConfig(DateInput, {
       date: this._config.date,
@@ -323,19 +354,16 @@ class DatePicker extends BaseComponent {
       ...(this._resolveFormat() ? { format: this._resolveFormat() } : {})
     }, { ...(this._config.floatingLabel ? { ariaLabel: this._config.floatingLabel } : {}), ...this._config.inputOptions }))
 
-    // Selection flows panel → field; this is the only bridge back, so a date
-    // typed into the field reaches the calendar too. The guard stops the echo
-    // of the panel's own updates — without it, picking a range start would
-    // re-render the calendar mid-interaction.
     EventHandler.on(inputEl, DateInput.eventName(DateInput.CHANGE_EVENT_NAME), (event: any) => {
-      if (!this._syncingFromPanel) {
-        this._calendar?.update({ startDate: event.date })
-        this._triggerDateChange()
-      }
+      this._applyDate(event.date, { field: false })
     })
 
     this._menu = document.createElement('div')
+    this._menu.id = getUID(`${this.constructor.NAME}-popup-`)
     this._menu.classList.add(CLASS_NAME_POPUP, CLASS_NAME_DROPDOWN)
+    this._toggleElement.setAttribute('aria-controls', this._menu.id)
+    this._toggleElement.setAttribute('aria-expanded', 'false')
+    this._toggleElement.setAttribute('aria-haspopup', 'dialog')
 
     const body = document.createElement('div')
     body.classList.add(CLASS_NAME_BODY)
@@ -387,20 +415,59 @@ class DatePicker extends BaseComponent {
     }, this._config.calendarOptions))
 
     EventHandler.on(this._calendar._element, 'startDateChange.coreui.calendar', event => {
-      this._syncingFromPanel = true
-      this._input.update({ date: event.dateObject })
-      this._syncingFromPanel = false
-      this._triggerDateChange()
+      this._applyDate(event.dateObject, { calendar: false })
       this.hide()
     })
   }
 
-  // The field validates the date, so the event reports what the field holds —
-  // a selection the field refused (min/max) is announced as null, not as the
-  // day that was clicked.
-  _triggerDateChange(): void {
-    const date = this.getDate()
-    EventHandler.trigger(this._element, EVENT_DATE_CHANGE, { date, formattedDate: getDateBySelectionType(date, this._config.selectionType) })
+  // The one place the date changes. The field validates it, so what the
+  // picker keeps and announces is what the field holds — a selection the
+  // field refused (min/max) becomes null, not the day that was clicked. The
+  // side that reported the change is not written back to.
+  _applyDate(date: Date | null, { calendar = true, field = true }: { calendar?: boolean, field?: boolean } = {}): void {
+    if (this._applying) {
+      return
+    }
+
+    this._applying = true
+
+    if (field) {
+      this._input.update({ date })
+    }
+
+    const applied = field ? this._input.getDate() : date
+    this._applying = false
+
+    const changed = !isSameDateAs(applied, this._date)
+    this._date = applied
+
+    if (calendar) {
+      this._calendar?.update({ startDate: applied })
+    }
+
+    if (changed) {
+      EventHandler.trigger(this._element, EVENT_DATE_CHANGE, { date: applied, formattedDate: getDateBySelectionType(applied, this._config.selectionType) })
+    }
+  }
+
+  // An element the author wrote gets the accessibility the component would
+  // have given its own: a name when it has none, hidden decoration.
+  _adoptAction(element: HTMLElement, label: string): HTMLElement {
+    if (!element.hasAttribute('aria-label') && !element.hasAttribute('aria-labelledby')) {
+      element.setAttribute('aria-label', label)
+    }
+
+    for (const svg of SelectorEngine.find(SELECTOR_SVG, element)) {
+      if (!svg.hasAttribute('aria-hidden')) {
+        svg.setAttribute('aria-hidden', 'true')
+      }
+    }
+
+    if (this._config.disabled && 'disabled' in element) {
+      (element as HTMLButtonElement).disabled = true
+    }
+
+    return element
   }
 
   _createPopup(): void {
@@ -414,13 +481,13 @@ class DatePicker extends BaseComponent {
       onHide: () => {
         this._menu.classList.remove(CLASS_NAME_SHOW)
         this._element.classList.remove(CLASS_NAME_SHOW)
-        this._element.setAttribute('aria-expanded', 'false')
+        this._toggleElement.setAttribute('aria-expanded', 'false')
       },
       onShow: () => {
         this._ensureCalendar()
         this._menu.classList.add(CLASS_NAME_SHOW)
         this._element.classList.add(CLASS_NAME_SHOW)
-        this._element.setAttribute('aria-expanded', 'true')
+        this._toggleElement.setAttribute('aria-expanded', 'true')
       },
       onShown: () => EventHandler.trigger(this._element, EVENT_SHOWN)
     })
@@ -434,7 +501,7 @@ class DatePicker extends BaseComponent {
       })
     }
 
-    EventHandler.on(this._indicatorElement, EVENT_CLICK, () => {
+    EventHandler.on(this._toggleElement, EVENT_CLICK, () => {
       if (!this._config.disabled) {
         this.toggle()
       }

--- a/js/tests/unit/date-picker.spec.js
+++ b/js/tests/unit/date-picker.spec.js
@@ -174,7 +174,8 @@ describe('DatePicker', () => {
 
       el.querySelector('.form-control-action').click()
       expect(el.classList.contains('show')).toBeTrue()
-      expect(el.getAttribute('aria-expanded')).toEqual('true')
+      expect(el.querySelector('.form-control-action').getAttribute('aria-expanded')).toEqual('true')
+      expect(el.querySelector('.form-control-action').getAttribute('aria-controls')).toEqual(picker._menu.id)
 
       el.querySelector('.form-control-action').click()
       expect(el.classList.contains('show')).toBeFalse()
@@ -223,6 +224,95 @@ describe('DatePicker', () => {
       picker.show()
 
       expect(picker._popup.isShown).toBeFalse()
+    })
+  })
+
+  describe('markup roles', () => {
+    const OWN_MARKUP = `<div id="picker" data-coreui-locale="en-US">
+        <div data-coreui-picker-field></div>
+        <button type="button" class="btn btn-subtle btn-sm" data-coreui-picker-cleaner><svg viewBox="0 0 16 16"><path d="M0 0h16"/></svg></button>
+        <button type="button" class="btn btn-subtle btn-sm" data-coreui-picker-toggle>Pick a date <svg viewBox="0 0 16 16"><path d="M0 0h16"/></svg></button>
+      </div>`
+
+    it('should adopt the field, toggle and cleaner the author wrote instead of building its own', () => {
+      const picker = buildPicker({ date: new Date(2026, 6, 14) }, OWN_MARKUP)
+      const el = fixtureEl.querySelector('#picker')
+
+      expect(el.querySelector('.form-control-action')).toBeNull()
+      expect(el.querySelector('.form-control-cleaner')).toBeNull()
+      expect(el.querySelector('[data-coreui-picker-field] .form-date-time-section')).not.toBeNull()
+      expect(el.querySelector('input[type="hidden"]').value).toEqual('07/14/2026')
+
+      el.querySelector('[data-coreui-picker-toggle]').click()
+      expect(picker._popup.isShown).toBeTrue()
+      el.querySelector('[data-coreui-picker-toggle]').click()
+      expect(picker._popup.isShown).toBeFalse()
+
+      el.querySelector('[data-coreui-picker-cleaner]').click()
+      expect(picker.getDate()).toBeNull()
+    })
+
+    it('should give an adopted toggle the accessibility it would have given its own', () => {
+      const picker = buildPicker({}, OWN_MARKUP)
+      const el = fixtureEl.querySelector('#picker')
+      const toggle = el.querySelector('[data-coreui-picker-toggle]')
+
+      expect(toggle.getAttribute('aria-label')).toEqual('Toggle the calendar')
+      expect(toggle.getAttribute('aria-haspopup')).toEqual('dialog')
+      expect(toggle.getAttribute('aria-controls')).toEqual(picker._menu.id)
+      expect(toggle.getAttribute('aria-expanded')).toEqual('false')
+      expect(el.querySelector('[data-coreui-picker-cleaner]').getAttribute('aria-label')).toEqual('Clear the value')
+
+      for (const svg of el.querySelectorAll('svg')) {
+        expect(svg.getAttribute('aria-hidden')).toEqual('true')
+      }
+
+      picker.show()
+      expect(toggle.getAttribute('aria-expanded')).toEqual('true')
+    })
+
+    it('should keep the name the author gave the toggle', () => {
+      buildPicker({}, '<div id="picker"><div data-coreui-picker-field></div><button type="button" aria-label="Open" data-coreui-picker-toggle></button></div>')
+
+      expect(fixtureEl.querySelector('[data-coreui-picker-toggle]').getAttribute('aria-label')).toEqual('Open')
+    })
+
+    it('should disable an adopted toggle and cleaner when the picker is disabled', () => {
+      buildPicker({ disabled: true }, OWN_MARKUP)
+
+      expect(fixtureEl.querySelector('[data-coreui-picker-toggle]').disabled).toBeTrue()
+      expect(fixtureEl.querySelector('[data-coreui-picker-cleaner]').disabled).toBeTrue()
+    })
+
+    it('should leave the author\'s elements in place on dispose', () => {
+      const picker = buildPicker({}, OWN_MARKUP)
+      const el = fixtureEl.querySelector('#picker')
+
+      picker.dispose()
+      pickers.length = 0
+
+      expect(el.querySelector('[data-coreui-picker-field]')).not.toBeNull()
+      expect(el.querySelector('[data-coreui-picker-toggle]')).not.toBeNull()
+      expect(el.querySelector('[data-coreui-picker-cleaner]')).not.toBeNull()
+    })
+
+    it('should keep the field and the calendar on the one date the picker owns', () => {
+      const picker = buildPicker({ locale: 'en-US', date: new Date(2026, 6, 14) })
+      const emitted = []
+      fixtureEl.querySelector('#picker').addEventListener('dateChange.coreui.date-picker', event => emitted.push(event.date))
+
+      picker.show()
+      fixtureEl.querySelector('.date-picker-popup .calendar-cell[data-coreui-date^="Mon Jul 20 2026"]').click()
+      expect(picker.getDate()).toEqual(new Date(2026, 6, 20))
+      expect(picker._calendar._startDate).toEqual(new Date(2026, 6, 20))
+
+      picker.setDate(new Date(2026, 6, 20))
+      expect(emitted.length).toBe(1)
+
+      picker.setDate(new Date(2026, 6, 21))
+      expect(fixtureEl.querySelector('#picker input[type="hidden"]').value).toEqual('07/21/2026')
+      expect(picker._calendar._startDate).toEqual(new Date(2026, 6, 21))
+      expect(emitted.length).toBe(2)
     })
   })
 


### PR DESCRIPTION
Pilot of the composition direction (`plans/pickers-v2-rewrite.md`, section of 2026-09-11). **Left open on purpose — mrholek wants to play with it before it lands.**

## What changes

**One owner of the date.** `_applyDate()` is the only place the date changes: it writes to the field, reads back what the field kept after validation, updates the calendar and emits `dateChange` once, when the value moved. The side that reported a change (field or calendar) is not written back to, which replaces the `_syncingFromPanel` echo guard. `setDate`, `clear`, `reset`, `today` and both child events go through it. Consequence to note: `dateChange` no longer fires when the calendar click lands on the already-selected day.

**The markup is the composition surface.** Inside the picker element:

| Role | Adopted as |
| --- | --- |
| `<div data-coreui-picker-field>` | host of the date input's sections |
| `data-coreui-picker-toggle` (button or anything) | opens/closes the calendar |
| `<button data-coreui-picker-cleaner>` | clears the value |

A missing part is generated as before, so `<div data-coreui-toggle="date-picker">` is unchanged. With your own markup the trigger can be a `btn btn-subtle` with text, and the icons are `<svg>` in the HTML — `indicatorIcon`/`cleanerIcon` and the sanitizer only feed the generated fallbacks.

**A11y stays the component's job.** An adopted element gets `ariaToggleLabel` / `ariaCleanerLabel` as its name unless it already has one, `aria-hidden` on its decorative `<svg>`, and `disabled` with the picker. `aria-expanded` moves from the root to the toggle (where it describes the control), which also carries `aria-controls` → popup id and `aria-haspopup="dialog"`. Migration guide has the breaking note; root `.show` class is unchanged. `dispose()` removes only what the picker built.

## Not in this PR

Promoting `Popup`, `TimeSelection` and the frame parts to public components, and the same treatment for TimePicker / DateRangePicker / DateTimePicker. React/Vue: the structure already matches; nothing to port for this step.

## Tests

`date-picker.spec.js` (+6): adopted field/toggle/cleaner replace the generated ones and work; adopted toggle gets the ARIA set and keeps an author's `aria-label`; adopted buttons follow `disabled`; dispose leaves the author's elements; field and calendar follow the one date with a single `dateChange` per real change. Full unit suite 3827 tests, visual suites for floating labels and field components green, typecheck clean; docs build in the pre-push gate.
