### PR TITLE
feat(theme): the interaction shade is a runtime knob and keeps its chroma

### DIFF
--- a/docs/src/content/docs/customize/components.mdx
+++ b/docs/src/content/docs/customize/components.mdx
@@ -36,8 +36,8 @@ Themeable components also support a single family of composable `.theme-*` class
 | `--cui-theme-bg-subtle` | Subtle background tint for low-emphasis surfaces |
 | `--cui-theme-bg-muted` | Muted background, between subtle and solid |
 | `--cui-theme-border` | Border color |
-| `--cui-theme-hover` | The theme color shifted in lightness for a hover state |
-| `--cui-theme-active` | The same, one step further, for a pressed state |
+| `--cui-theme-hover` | The theme color shifted for a hover state: lightness times `--cui-theme-hover-lightness`, chroma times `--cui-theme-hover-chroma` |
+| `--cui-theme-active` | The same, one step further, for a pressed state, from the `--cui-theme-active-*` pair |
 | `--cui-theme-focus-ring` | Focus ring color, translucent at `$focus-ring-opacity` |
 
 The `.theme-{name}` classes mirror the keys of the `$theme-colors` map in `scss/_theme.scss` — `.theme-primary`, `.theme-success`, `.theme-danger`, and so on — so adding or renaming a theme color automatically produces a matching class. Each entry defines the tokens for both light and dark mode via `light-dark()`.

--- a/docs/src/content/docs/customize/theme.mdx
+++ b/docs/src/content/docs/customize/theme.mdx
@@ -140,7 +140,7 @@ Four style utilities pair a themed surface with its matching text color — comp
 
 Sass variables set these defaults at build time and are removed in v7. The CSS variables above reach the same values without recompiling, and can be set on a single element.
 
-Each theme class also carries its own interaction shades, computed from the color in the browser, so a component asking for "this color, one step darker" reads a token instead of recomputing it. These two multipliers set how far a shade travels:
+Each theme class also carries its own interaction shades, computed from the color in the browser, so a component asking for "this color, one step darker" reads a token instead of recomputing it. How far a shade travels is set by four `:root` tokens — `--cui-theme-hover-lightness`, `--cui-theme-hover-chroma`, `--cui-theme-active-lightness`, `--cui-theme-active-chroma` — so the strength of every hover and active state is one override, on the page or on a subtree. These variables set their defaults:
 
 <ScssDocs file="scss/_theme.scss" capture="theme-interaction-variables" />
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -3777,6 +3777,14 @@ Upstream v6 does the same, with a `mask-icon()` mixin.
   `$btn-active-lightness` and `$btn-lightness-overrides` are now
   `$theme-hover-lightness`, `$theme-active-lightness` and
   `$theme-state-colors` in `scss/_theme.scss`.
+- **The interaction shade is a runtime knob, and it keeps its saturation.**
+  The multipliers are `:root` tokens — `--cui-theme-hover-lightness`,
+  `--cui-theme-hover-chroma`, `--cui-theme-active-lightness`,
+  `--cui-theme-active-chroma` — so the strength of every hover and active
+  state is one override, on the page or on a subtree, where it used to be a
+  Sass value baked into each theme class. The shade also multiplies chroma
+  (1.1 on hover, 1.15 on active) where it used to keep it, so a pressed
+  button no longer fades as it darkens; the lightness steps are unchanged.
 - **The dark-mode button block is gone** (~160 lines of CSS) — variants follow
   the root color tokens, which already switch in dark mode.
 - <span class="badge text-danger-emphasis bg-danger-subtle">Breaking</span>

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -234,6 +234,12 @@ $root-token-defaults: map.merge(
     --#{$prefix}focus-ring-offset: $focus-ring-offset,
     --#{$prefix}focus-ring: var(--#{$prefix}focus-ring-width) solid var(--#{$prefix}focus-ring-color),
     // scss-docs-end root-focus-variables
+    // scss-docs-start root-theme-state-variables
+    --#{$prefix}theme-hover-lightness: $theme-hover-lightness,
+    --#{$prefix}theme-hover-chroma: $theme-hover-chroma,
+    --#{$prefix}theme-active-lightness: $theme-active-lightness,
+    --#{$prefix}theme-active-chroma: $theme-active-chroma,
+    // scss-docs-end root-theme-state-variables
     // scss-docs-start root-backdrop-variables
     --#{$prefix}backdrop-color: $backdrop-color,
     --#{$prefix}backdrop-opacity: $backdrop-opacity,

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -228,9 +228,10 @@ $util-opacity: defaults(
 }
 
 // scss-docs-start theme-interaction-variables
-// Tuned to land near the shade-color() amounts compiled before the states moved into CSS.
 $theme-hover-lightness:   .85 !default;
+$theme-hover-chroma:      1.1 !default;
 $theme-active-lightness:  .8 !default;
+$theme-active-chroma:     1.15 !default;
 // scss-docs-end theme-interaction-variables
 
 // The neutral pair steps along the gray scale instead of shifting lightness: its
@@ -261,13 +262,13 @@ $theme-state-colors: defaults(
 
   $overrides: map.get($theme-state-colors, $state) or ();
 
-  @each $token, $lightness in ("hover": $theme-hover-lightness, "active": $theme-active-lightness) {
+  @each $token in ("hover", "active") {
     $override: map.get($overrides, $token);
 
     @if $override {
       --#{$prefix}theme-#{$token}: #{$override};
     } @else {
-      --#{$prefix}theme-#{$token}: oklch(from var(--#{$prefix}#{$state}-bg) calc(l * #{$lightness}) c h);
+      --#{$prefix}theme-#{$token}: oklch(from var(--#{$prefix}#{$state}-bg) calc(l * var(--#{$prefix}theme-#{$token}-lightness)) calc(c * var(--#{$prefix}theme-#{$token}-chroma)) h);
     }
   }
 }

--- a/scss/_time-picker.scss
+++ b/scss/_time-picker.scss
@@ -20,7 +20,7 @@ $time-picker-roll-cell-hover-bg:              var(--#{$prefix}bg-1) !default;
 $time-picker-roll-cell-selected-color:        var(--#{$prefix}primary-contrast) !default;
 $time-picker-roll-cell-selected-bg:           var(--#{$prefix}primary-base) !default;
 $time-picker-roll-cell-selected-hover-color:  var(--#{$prefix}primary-contrast) !default;
-$time-picker-roll-cell-selected-hover-bg:     oklch(from var(--#{$prefix}primary-base) calc(l * .85) c h) !default;
+$time-picker-roll-cell-selected-hover-bg:     oklch(from var(--#{$prefix}primary-base) calc(l * var(--#{$prefix}theme-hover-lightness)) calc(c * var(--#{$prefix}theme-hover-chroma)) h) !default;
 
 $time-picker-inline-select-font-size:       var(--#{$prefix}btn-input-sm-font-size) !default;
 $time-picker-inline-select-color:           var(--#{$prefix}btn-input-fg) !default;

--- a/scss/tests/mixins/_theme.test.scss
+++ b/scss/tests/mixins/_theme.test.scss
@@ -42,8 +42,8 @@
           --cui-theme-border: var(--cui-primary-border);
           --cui-theme-focus-ring: var(--cui-primary-focus-ring);
           --cui-theme-contrast: var(--cui-primary-contrast);
-          --cui-theme-hover: oklch(from var(--cui-primary-bg) calc(l * .85) c h);
-          --cui-theme-active: oklch(from var(--cui-primary-bg) calc(l * .8) c h);
+          --cui-theme-hover: oklch(from var(--cui-primary-bg) calc(l * var(--cui-theme-hover-lightness)) calc(c * var(--cui-theme-hover-chroma)) h);
+          --cui-theme-active: oklch(from var(--cui-primary-bg) calc(l * var(--cui-theme-active-lightness)) calc(c * var(--cui-theme-active-chroma)) h);
         }
       }
     }


### PR DESCRIPTION
Stacked on #1249; that branch is the base. Merge #1249 first, without deleting its branch, then rebase this one onto `v6-dev` and retarget.

## What changes

The hover and active multipliers move from Sass values baked into every `.theme-*` class to four `:root` tokens:

| token | default |
| --- | --- |
| `--cui-theme-hover-lightness` | `.85` |
| `--cui-theme-hover-chroma` | `1.1` |
| `--cui-theme-active-lightness` | `.8` |
| `--cui-theme-active-chroma` | `1.15` |

The class reads them inside the relative colour, so the strength of every hover and active state is one override, on the page or on a subtree. The shade now multiplies chroma where it kept it, so a pressed button no longer fades as it darkens. The time picker's selected-cell hover reads the same tokens instead of its own `.85`. The neutral pair keeps its gray-scale states from `$theme-state-colors`.

## Why

The derivation already ran in the browser, but its strength was frozen at build time — the `$źródło * .5` shape the v6 rules forbid. Upstream computes the shade per variant inside the button with literal multipliers and no theme-level token at all, so it cannot offer this knob; ours is one place, one override.

## Measured

Chromium, transitions disabled, solid and outline buttons for every role, light and dark:

- lightness of every hover and active state unchanged before and after;
- chroma ×1.1 on hover and ×1.15 on active for the five chromatic roles (`primary` hover: `oklch(.450 .191 278)` → `oklch(.450 .210 278)`);
- `secondary` and `inverse` identical, as they read `$theme-state-colors`;
- the knob works: `--cui-theme-hover-lightness: .5` on `body` moves `primary` hover from L `.450` to `.264`.

Visual suite 131/131, sass-true 116/116, stylelint and fusv clean, docs build green, full pre-push gate.

## Docs

`customize/theme` names the four tokens, `customize/components` says which pair each state token reads, migration carries the knob and the chroma change.