### PR TITLE
refactor(config): $link-color is a global knob, not a theme value

### DIFF
--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -299,6 +299,10 @@ $headings-line-height:        1.2 !default;
 $headings-color:              inherit !default;
 // scss-docs-end headings-variables
 
+// scss-docs-start link-variables
+$link-color:                  light-dark(var(--#{$prefix}primary-base), var(--#{$prefix}primary-fg)) !default;
+// scss-docs-end link-variables
+
 // The type scale
 //
 // One named scale carries every font size the library renders, each stop with

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -3,9 +3,6 @@
 @use "mixins/tokens" as *;
 @use "config" as *;
 
-$link-color:    light-dark(var(--#{$prefix}primary-base), var(--#{$prefix}primary-fg)) !default;
-
-
 // scss-docs-start theme-colors-map
 $theme-colors: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default


### PR DESCRIPTION
`$link-color` was the one value left in `_theme.scss` outside the theme maps. It moves to `_config.scss`, into a `link-variables` block after the headings, next to the other global knobs.

Upstream writes the link colour inline in `_root.scss`, and that was the first shape of this PR. The pre-push gate stopped it: the shared docs engine reads `$link-color` (`_anchor.scss`) through `scss/_variables.scss`, which forwards `config`, `colors` and `theme`, and a partial that emits rules cannot be forwarded. Until the engine reads `var(--cui-link-color)` — which v5 exposes too — the variable has to sit in a rule-free partial, and `_config.scss` is where the engine's other reads live (`$spacer`, `$font-weight-semibold`, `$grid-gutter-width`).

Compiled CSS unchanged: sorted `coreui.css` before and after has zero differing lines. sass-true 116/116, stylelint clean, docs build green, full pre-push gate.