### PR TITLE
refactor(theme): lay the file out the way upstream does

### DIFF
--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -3,6 +3,134 @@
 @use "mixins/tokens" as *;
 @use "config" as *;
 
+// Themes map sub-keys
+//
+// Return var() references to root tokens instead of raw values.
+// Ex: theme-color-refs("bg") => (primary: var(--cui-primary-bg), success: var(--cui-success-bg), ...)
+@function theme-color-refs($slot, $key-suffix: "") {
+  $result: ();
+
+  @each $color in map.keys($theme-colors) {
+    $result: map.set($result, "#{$color}#{$key-suffix}", var(--#{$prefix}#{$color}-#{$slot}));
+  }
+
+  @return $result;
+}
+
+// Theme token to root tokens
+//
+// Returns the global :root token reference for a given a given token map, prefix, and key.
+// Ex: theme-token-refs($theme-bgs, "bg") => (body: var(--cui-bg-body), 1: var(--cui-bg-1), ...)
+// Skips `inherit` since it's a CSS-wide keyword that can't be stored in a custom property.
+@function theme-token-refs($map, $token) {
+  $result: ();
+
+  @each $key, $value in $map {
+    @if $value != inherit {
+      $result: map.merge($result, ($key: var(--#{$prefix}#{$token}-#{$key})));
+    }
+  }
+
+  @return $result;
+}
+
+// Generate opacity values using color-mix()
+// $fallback lets the referenced $color-var fall back to another color (e.g. currentcolor)
+// when it hasn't been set by a companion color utility.
+@function theme-opacity-values($color-var, $fallback: null, $opacities: $util-opacity) {
+  $result: ();
+  // stylelint-disable-next-line scss/at-function-named-arguments, @stylistic/function-whitespace-after
+  $color: if(sass($fallback): var($color-var, $fallback); else: var($color-var));
+
+  @each $key, $value in $opacities {
+    @if $key == 100 {
+      // For 100%, use direct variable reference (more efficient)
+      $result: map.merge($result, ($key: $color));
+    } @else {
+      // For other values, use color-mix()
+      $percentage: $key * 1%;
+      $result: map.merge($result, ($key: color-mix(in oklch, $color $percentage, transparent)));
+    }
+  }
+
+  @return $result;
+}
+
+@function theme-color-tokens() {
+  $tokens: ();
+
+  @each $color, $slots in $theme-colors {
+    @each $slot, $value in $slots {
+      $tokens: map.set($tokens, --#{$prefix}#{$color}-#{$slot}, $value);
+    }
+  }
+
+  @return $tokens;
+}
+
+@mixin theme-color-tokens() {
+  @include tokens(theme-color-tokens());
+}
+
+@mixin theme-tokens($state) {
+  @each $slot in map.keys(map.get($theme-colors, $state)) {
+    --#{$prefix}theme-#{$slot}: var(--#{$prefix}#{$state}-#{$slot});
+  }
+
+  $overrides: map.get($theme-state-colors, $state) or ();
+
+  @each $token in ("hover", "active") {
+    $override: map.get($overrides, $token);
+
+    @if $override {
+      --#{$prefix}theme-#{$token}: #{$override};
+    } @else {
+      --#{$prefix}theme-#{$token}: oklch(from var(--#{$prefix}#{$state}-bg) calc(l * var(--#{$prefix}theme-#{$token}-lightness)) calc(c * var(--#{$prefix}theme-#{$token}-chroma)) h);
+    }
+  }
+}
+
+// Set each --theme-* token to `initial` so descendants drop inherited theme colors.
+// Use `initial`, not `unset`. `unset` inherits from the parent again.
+// scss-docs-start theme-reset
+@mixin theme-reset() {
+  $slots: ();
+
+  @each $slots-of-color in map.values($theme-colors) {
+    @each $slot in map.keys($slots-of-color) {
+      $slots: map.set($slots, $slot, true);
+    }
+  }
+
+  @each $slot in map.keys(map.merge($slots, ("hover": true, "active": true))) {
+    --#{$prefix}theme-#{$slot}: initial;
+  }
+}
+
+@mixin generate-theme-reset() {
+  .theme-reset {
+    @include theme-reset();
+  }
+}
+// scss-docs-end theme-reset
+
+// Generate theme classes dynamically based on the keys in each theme color map
+// scss-docs-start theme-classes
+@mixin generate-theme-classes() {
+  @each $state in map.keys($theme-colors) {
+    .theme-#{$state} {
+      @include theme-tokens($state);
+    }
+  }
+
+  @include generate-theme-reset();
+}
+// scss-docs-end theme-classes
+
+// Theme maps use the `defaults()` pattern so `@use ... with (...)` merges custom
+// values on top of the built-ins instead of replacing the whole map. Set a key
+// to `null` to remove it. See scss/_config.scss for `defaults()`.
+
 // scss-docs-start theme-colors-map
 $theme-colors: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
@@ -146,42 +274,6 @@ $theme-borders: defaults(
 );
 // scss-docs-end theme-borders-map
 
-
-// Contextual theme tokens
-//
-// Components consume colors through the --#{$prefix}theme-* indirection so a
-// single set of component styles works with every theme color. Each slot of a
-// theme color becomes one such token.
-
-// The :root tokens behind one slot, keyed by color name, for utility maps that
-// need to point a whole family at the same slot.
-@function theme-color-refs($slot, $key-suffix: "") {
-  $result: ();
-
-  @each $color in map.keys($theme-colors) {
-    $result: map.set($result, "#{$color}#{$key-suffix}", var(--#{$prefix}#{$color}-#{$slot}));
-  }
-
-  @return $result;
-}
-
-// Theme token to root tokens
-//
-// Returns the global :root token reference for a given a given token map, prefix, and key.
-// Ex: theme-token-refs($theme-bgs, "bg") => (body: var(--bg-body), 1: var(--bg-1), ...)
-// Skips `inherit` since it's a CSS-wide keyword that can't be stored in a custom property.
-@function theme-token-refs($map, $token) {
-  $result: ();
-
-  @each $key, $value in $map {
-    @if $value != inherit {
-      $result: map.merge($result, ($key: var(--#{$prefix}#{$token}-#{$key})));
-    }
-  }
-
-  @return $result;
-}
-
 // scss-docs-start util-opacity-map
 $util-opacity: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
@@ -201,28 +293,6 @@ $util-opacity: defaults(
   $util-opacity
 );
 // scss-docs-end util-opacity-map
-
-// Generate opacity values using color-mix()
-// $fallback lets the referenced $color-var fall back to another color (e.g. currentcolor)
-// when it hasn't been set by a companion color utility.
-@function theme-opacity-values($color-var, $fallback: null, $opacities: $util-opacity) {
-  $result: ();
-  // stylelint-disable-next-line scss/at-function-named-arguments, @stylistic/function-whitespace-after
-  $color: if(sass($fallback): var($color-var, $fallback); else: var($color-var));
-
-  @each $key, $value in $opacities {
-    @if $key == 100 {
-      // For 100%, use direct variable reference (more efficient)
-      $result: map.merge($result, ($key: $color));
-    } @else {
-      // For other values, use color-mix()
-      $percentage: $key * 1%;
-      $result: map.merge($result, ($key: color-mix(in oklch, $color $percentage, transparent)));
-    }
-  }
-
-  @return $result;
-}
 
 // scss-docs-start theme-interaction-variables
 $theme-hover-lightness:   .85 !default;
@@ -251,69 +321,3 @@ $theme-state-colors: defaults(
   $theme-state-colors
 );
 // scss-docs-end theme-state-colors
-
-@mixin theme-tokens($state) {
-  @each $slot in map.keys(map.get($theme-colors, $state)) {
-    --#{$prefix}theme-#{$slot}: var(--#{$prefix}#{$state}-#{$slot});
-  }
-
-  $overrides: map.get($theme-state-colors, $state) or ();
-
-  @each $token in ("hover", "active") {
-    $override: map.get($overrides, $token);
-
-    @if $override {
-      --#{$prefix}theme-#{$token}: #{$override};
-    } @else {
-      --#{$prefix}theme-#{$token}: oklch(from var(--#{$prefix}#{$state}-bg) calc(l * var(--#{$prefix}theme-#{$token}-lightness)) calc(c * var(--#{$prefix}theme-#{$token}-chroma)) h);
-    }
-  }
-}
-
-// scss-docs-start theme-classes
-@mixin generate-theme-classes() {
-  @each $state in map.keys($theme-colors) {
-    .theme-#{$state} {
-      @include theme-tokens($state);
-    }
-  }
-}
-// scss-docs-end theme-classes
-
-// scss-docs-start theme-reset
-@mixin theme-reset() {
-  $slots: ();
-
-  @each $slots-of-color in map.values($theme-colors) {
-    @each $slot in map.keys($slots-of-color) {
-      $slots: map.set($slots, $slot, true);
-    }
-  }
-
-  @each $slot in map.keys(map.merge($slots, ("hover": true, "active": true))) {
-    --#{$prefix}theme-#{$slot}: initial;
-  }
-}
-
-@mixin generate-theme-reset() {
-  .theme-reset {
-    @include theme-reset();
-  }
-}
-// scss-docs-end theme-reset
-
-@function theme-color-tokens() {
-  $tokens: ();
-
-  @each $color, $slots in $theme-colors {
-    @each $slot, $value in $slots {
-      $tokens: map.set($tokens, --#{$prefix}#{$color}-#{$slot}, $value);
-    }
-  }
-
-  @return $tokens;
-}
-
-@mixin theme-color-tokens() {
-  @include tokens(theme-color-tokens());
-}

--- a/scss/helpers/_theme-colors.scss
+++ b/scss/helpers/_theme-colors.scss
@@ -2,5 +2,4 @@
 
 @layer helpers {
   @include generate-theme-classes();
-  @include generate-theme-reset();
 }


### PR DESCRIPTION
## What changes

`_theme.scss` interleaved maps, functions, knobs and mixins: the reader met `$theme-colors` before anything that consumes it, `theme-opacity-values` sat between two maps, and `$util-opacity` split two functions apart. Upstream puts every callable first and every map last. The file now does the same:

| | |
| --- | --- |
| functions | `theme-color-refs`, `theme-token-refs`, `theme-opacity-values`, `theme-color-tokens` |
| mixins | `theme-color-tokens`, `theme-tokens`, `theme-reset`, `generate-theme-reset`, `generate-theme-classes` |
| maps | `$theme-colors` … `$theme-state-colors` |

`generate-theme-classes()` ends with `generate-theme-reset()` the way it does upstream, so one include gives a caller the classes and the escape hatch; `helpers/_theme-colors.scss` drops its second call. The upstream headers on the three shared functions read as they do upstream, with the token names in their examples carrying our prefix. Three narrative comments of ours are gone.

## Not aligned, on purpose

- **`theme-color-values($key)`** exists upstream and feeds `values: theme-color-values("fg")` in their utilities. Ours read `theme-color-refs("fg")`, the runtime tokens, so the function would have no callers here.
- **`theme-tokens()` and `theme-reset()` stay as standalone mixins.** Upstream has neither, because its components never set theme tokens outside a `.theme-*` class; ours are called from `_legacy.scss`, `_range-slider.scss`, `forms/_form-range.scss`, `content/_tables.scss` and the specs.
- **`scss-docs` block names.** Ours are `theme-colors-map`, `theme-reset`, `theme-classes` plus four on maps upstream does not mark at all. Renaming to their `theme-colors` and `generate-theme-reset` would move thirty-odd citations across three editions; worth its own PR if we want it.
- **Signatures.** `theme-color-refs` takes an extra `$key-suffix` the utilities use, and `theme-token-refs` names its parameter `$token` because `$prefix` is the global token prefix here.

## Measured

Sorted `coreui.css` before and after has zero differing lines. sass-true 116/116, visual suite 131/131, stylelint and fusv clean, docs build green, full pre-push gate.