### PR TITLE
refactor(functions)!: map-slot() goes; map-get-nested() already did the job

### DIFF
--- a/docs/src/content/docs/customize/color.mdx
+++ b/docs/src/content/docs/customize/color.mdx
@@ -454,25 +454,33 @@ instead, so read `var(--cui-primary-300)` where you used to write
 
 <AddedIn version="4.1.0" />
 
-We don't ship `color` and `background-color` utilities for every color in the
-palette, but you can generate them with the [utility API](/utilities/api/).
+We ship `color` and `background-color` utilities for the theme colors, but not
+for every stop of their scales, and not for a color of your own. You can
+generate those with the [utility API](/utilities/api/).
 
 1. Load the color maps and the utilities module in a partial.
 2. Use our `map-merge-multiple()` function to merge several maps into one.
 3. Merge that map into the `values` of any utility group.
 
-Here's an example that generates text color utilities for every palette color and
-every theme color's emphasis tone (e.g., `.text-purple`, `.fg-success`).
+Here's an example that generates text color utilities for two stops of every
+palette color and for one brand color (e.g., `.text-primary-300`, `.text-brand`).
 
 ```scss
 // _my-colors.scss
 @use "sass:map";
 @use "@coreui/coreui/scss/functions/maps" as *;
 @use "@coreui/coreui/scss/colors" as *;
-@use "@coreui/coreui/scss/theme" as *;
 @use "@coreui/coreui/scss/utilities" as *;
 
-$all-colors: map-merge-multiple($colors, map-slot($theme-colors, "fg-emphasis"));
+$scale-colors: ();
+
+@each $color in map.keys($colors) {
+  @each $stop in (300, 700) {
+    $scale-colors: map.set($scale-colors, "#{$color}-#{$stop}", var(--cui-#{$color}-#{$stop}));
+  }
+}
+
+$all-colors: map-merge-multiple($scale-colors, ("brand": #6f42c1));
 
 $utilities: map.merge(
   $utilities,

--- a/docs/src/content/docs/customize/sass.mdx
+++ b/docs/src/content/docs/customize/sass.mdx
@@ -362,19 +362,21 @@ We use the `escape-svg` function to escape the `<`, `>` and `#` characters for S
 
 ### Map helpers
 
-The theme system keeps its definitions nested — one entry per color, holding every slot. `map-slot()` flattens that for consumers that want a single family across all colors:
+The theme system keeps its definitions nested — one entry per color, holding every slot. `map-get-nested()` flattens that for consumers that want a single family across all colors:
 
-<ScssDocs file="scss/functions/_maps.scss" capture="map-slot-function" />
+<ScssDocs file="scss/functions/_maps.scss" capture="map-get-nested-function" />
 
 ```scss
 @use "@coreui/coreui/scss/functions/maps" as *;
 @use "@coreui/coreui/scss/theme" as *;
 
-$subtle-backgrounds: map-slot($theme-colors, "bg-subtle");
+$subtle-backgrounds: map-get-nested($theme-colors, "bg-subtle");
 // => ("primary": …, "secondary": …, "success": …, …)
 ```
 
-`scss/functions/maps` also carries the general-purpose helpers the library uses internally: `map-get-multiple()` (pick several keys), `map-merge-multiple()` (merge several maps), and `map-get-nested()` (pull one sub-key out of every entry).
+Entries without the key are skipped, so a color that drops a slot drops out of the family rather than landing in it as `null`. For the `:root` token behind a slot rather than a copy of its value, reach for `theme-color-refs()` instead — that is what the utilities read.
+
+`scss/functions/maps` also carries `map-get-multiple()` (pick several keys) and `map-merge-multiple()` (merge several maps).
 
 ## Mixins
 

--- a/docs/src/content/docs/migration/v6.mdx
+++ b/docs/src/content/docs/migration/v6.mdx
@@ -3078,9 +3078,9 @@ editing four blocks. It is a map of maps now — one name, eight slots.
   Every `--cui-{color}-*` custom property keeps its name and its value, so
   a runtime override is unaffected.
 - **`$theme-colors` is a map of maps**, so `@each $name, $value in $theme-colors`
-  now yields a map. Use `map-slot($theme-colors, "base")` where a flat
-  `name → colour` map is what you want; the `$theme-colors-*` families in
-  `scss/_theme.scss` are built that way.
+  now yields a map. Use `map-get-nested($theme-colors, "base")` where a flat
+  `name → value` map is what you want, or `theme-color-refs("base")` for the
+  `:root` tokens the utilities read.
 - **New slots:** `fg` (the state colour readable as text, one step lighter than
   `text-emphasis`), `bg-muted` (between `bg-subtle` and the solid colour) and
   `focus-ring` (the hue the `.theme-*` ring mixes from). They emit
@@ -3694,7 +3694,7 @@ now, and the two neutrals swap ends of the gray scale between schemes.
   `color-contrast()` or the tint/shade functions — read `$gray-*` for that.
 - **`$utilities-colors` is removed.** It was a flat `name → colour` copy of the
   map's `base` slot, and no utility reads the raw colour for every family any
-  more. Call `map-slot($theme-colors, "base")` where you need one, or
+  more. Call `map-get-nested($theme-colors, "base")` where you need one, or
   `theme-color-refs("fg")` for the slot a text utility uses.
 - **`$theme-lightness-overrides` is now `$theme-state-colors`** and carries
   ready values rather than lightness multipliers. A single multiplier cannot

--- a/scss/functions/_maps.scss
+++ b/scss/functions/_maps.scss
@@ -6,6 +6,7 @@
 // It prefixes the keys with `n` and makes the value negative.
 // Pull one sub-key out of every entry of a nested map.
 // map-get-nested(("lg": ("font-size": 1.25rem, ...)), "font-size") => ("lg": 1.25rem, ...)
+// scss-docs-start map-get-nested-function
 @function map-get-nested($map, $key) {
   $result: ();
   @each $name, $values in $map {
@@ -15,6 +16,7 @@
   }
   @return $result;
 }
+// scss-docs-end map-get-nested-function
 
 // Get multiple keys from a sass map
 @function map-get-multiple($map, $values) {
@@ -36,16 +38,3 @@
   }
   @return $merged-maps;
 }
-
-// scss-docs-start map-slot-function
-// Pull one slot out of a map of maps: map-slot($theme-colors, "bg-subtle")
-// returns ("primary": …, "secondary": …, …). Lets the nested definition stay
-// the single source while consumers that want one flat family keep working.
-@function map-slot($map, $slot) {
-  $result: ();
-  @each $key, $slots in $map {
-    $result: map.set($result, $key, map.get($slots, $slot));
-  }
-  @return $result;
-}
-// scss-docs-end map-slot-function

--- a/scss/tests/functions/_maps.test.scss
+++ b/scss/tests/functions/_maps.test.scss
@@ -1,15 +1,6 @@
 @use "../../functions/maps" as *;
 
-$sizes: (
-  "sm": ("font-size": .875rem, "padding": .25rem),
-  "lg": ("font-size": 1.25rem, "padding": .5rem)
-);
-
 @include describe("maps functions") {
-  @include it("map-slot pulls one slot out of every entry") {
-    @include assert-equal(map-slot($sizes, "font-size"), ("sm": .875rem, "lg": 1.25rem));
-  }
-
   @include it("map-get-nested skips entries without the key") {
     @include assert-equal(map-get-nested(("sm": ("padding": .25rem), "lg": ("font-size": 1.25rem)), "font-size"), ("lg": 1.25rem));
   }


### PR DESCRIPTION
## What changes

`map-slot()` is removed. `map-get-nested()` flattens a map of maps the same way and has been sitting ten lines above it in the same file:

```scss
// both return ("primary": …, "success": …, …)
map-slot($theme-colors, "bg-subtle")
map-get-nested($theme-colors, "bg-subtle")
```

The difference is a guard: `map-get-nested()` skips an entry that lacks the key, where `map-slot()` writes `null` into the result.

## Why now

`map-slot()` lost its last caller when #1249 removed the seven `$theme-colors-{slot}` maps. What was left was a duplicate with no internal user that the docs still pointed people at, in four places.

## Docs

- **Sass usage** documents `map-get-nested()` under Map helpers, with its own `scss-docs` block, and says when to reach for `theme-color-refs()` instead — the `:root` token behind a slot rather than a copy of its value.
- **Migration** swaps its two `map-slot()` calls.
- **Color** had an example that stopped being true when the palette became the theme colours: it merged `$colors` with `map-slot($theme-colors, "fg-emphasis")`, two maps with the same keys since #1249, and promised a `.text-purple` that no longer exists. It now generates two stops of every palette colour plus a brand colour of its own.

## Not in this PR

The React and Vue docs cite `capture="map-slot-function"` and build against the published `@coreui/coreui-pro` 5.27.0, which still has that block and does not yet have `map-get-nested-function`. Their pages describe the version they document correctly until the library ships, so they move with the release.

## Measured

Sorted `coreui.css` before and after has zero differing lines. sass-true 115/115 (the `map-slot` spec and its now-unused fixture go with it), stylelint and fusv clean, docs build green, full pre-push gate.