### PR TITLE
fix(docs): restore the theme colour labels the examples read

### DIFF
--- a/docs/src/data/theme-colors.yml
+++ b/docs/src/data/theme-colors.yml
@@ -1,10 +1,18 @@
-# The v6 theme colours, overriding the engine's v5-shaped list. Names only: the
-# contrast pairing comes from `.text-bg-*` at runtime, so nothing here can drift
-# out of step with the stylesheet. Order matches `$theme-colors` in _theme.scss.
+# The v6 theme colours, overriding the engine's v5-shaped list. Name and label
+# only: the contrast pairing comes from `.text-bg-*` at runtime, so nothing here
+# can drift out of step with the stylesheet. Order matches `$theme-colors` in
+# _theme.scss.
 - name: primary
+  title: Primary
 - name: secondary
+  title: Secondary
 - name: success
+  title: Success
 - name: info
+  title: Info
 - name: warning
+  title: Warning
 - name: danger
+  title: Danger
 - name: inverse
+  title: Inverse


### PR DESCRIPTION
The v6 theme-colours data file lists names only, so every example built from `getData('theme-colors')` renders `undefined` where the colour label should be. 23 call sites across 26 pages, including the range slider, where it reaches the `aria-labels` attribute and ships to assistive technology.

`title` is a display label, not a colour value, so it cannot drift out of step with the stylesheet the way `hex` and `contrast_color` could. Those two stay out, which is what the file's comment was protecting.

Verified against a full `docs-build`: no `undefined` anywhere in `_site`, and the range slider's ARIA labels render as written.

Same fix lands in the React edition (#363) and the Vue edition (#299), where the file was missing entirely.