### PR TITLE
test(a11y): put List Box, Transfer and Combobox under the WCAG gate

### DIFF
--- a/build/a11y.config.mjs
+++ b/build/a11y.config.mjs
@@ -14,7 +14,9 @@
  * Entry shape:
  *   component   Logical id; also the default docs path the test renders from,
  *               i.e. docs/src/content/docs/<component>.mdx (its `<Example>`
- *               snippets are the markup under test).
+ *               snippets are the markup under test, each one's `sandboxJs`
+ *               snippet running alongside it so options-driven examples render
+ *               the same as on the page).
  *   criteria[]  { criterion, status?, note? }
  *                 criterion  Key into wcagCriteria (e.g. '4.1.2').
  *                 status     'built-in' | 'partial' | 'author' (default 'author').
@@ -149,6 +151,37 @@ export const a11yComponents = [
         criterion: '3.3.2',
         status: 'author',
         note: 'Associate a visible <label> (or aria-label) with the control; default examples rely on a placeholder.'
+      }
+    ]
+  },
+  {
+    component: 'forms/combobox',
+    // The options live in a popup that starts hidden, so open one before axe
+    // runs — a collapsed combobox hides the listbox from the audit entirely.
+    interactions: [
+      { click: '.combobox-toggle[data-coreui-name="option"]' },
+      { wait: 100 }
+    ],
+    criteria: [
+      {
+        criterion: '4.1.2',
+        status: 'built-in',
+        note: 'The toggle is a <button> carrying aria-haspopup=listbox and aria-expanded, so the state lands on an element whose role supports it; the panel is a role=listbox of role=option items with aria-selected, and the replaced native input stays out of the accessibility tree.'
+      },
+      {
+        criterion: '1.3.1',
+        status: 'built-in',
+        note: 'The opened listbox contains only option and group children — the caret and the hidden input sit outside it.'
+      },
+      {
+        criterion: '2.1.1',
+        status: 'partial',
+        note: 'Arrow keys, Home/End, Enter, Esc and Tab operate the panel; verify manually for full conformance.'
+      },
+      {
+        criterion: '3.3.2',
+        status: 'author',
+        note: 'Name the toggle with a visible <label> or aria-label; the examples rely on a placeholder.'
       }
     ]
   },
@@ -336,6 +369,63 @@ export const a11yComponents = [
   // ---------------------------------------------------------------------------
   // Components
   // ---------------------------------------------------------------------------
+  {
+    component: 'components/list-box',
+    criteria: [
+      {
+        criterion: '4.1.2',
+        status: 'built-in',
+        note: 'The options element is a role=listbox with aria-multiselectable, aria-disabled and aria-busy tracking the config; every option is a role=option with aria-selected and aria-disabled; a companion field gets aria-controls and aria-activedescendant, and the search input is named from ariaSearchLabel.'
+      },
+      {
+        criterion: '1.3.1',
+        status: 'author',
+        note: 'GAP: two listbox children break the required-children rule. A sections-selectable section label is written as role=button inside the listbox (js/src/list-box.ts:757), and the .list-box-empty placeholder stays inside the listbox when a filter hides every option, leaving it with no option or group child.'
+      },
+      {
+        criterion: '2.1.1',
+        status: 'partial',
+        note: 'Arrow keys, Home/End, Space, Shift and Ctrl ranges and Ctrl+A operate the list, and the highlighted option is kept in view; verify manually for full conformance.'
+      }
+    ]
+  },
+  {
+    component: 'components/transfer',
+    criteria: [
+      {
+        criterion: '4.1.2',
+        status: 'built-in',
+        note: 'Each move button is named from its ariaMoveLabel default and points at the list it fills through aria-controls; each side\'s options element is a role=listbox named from the side title when the author gives it no name of its own.'
+      },
+      {
+        criterion: '1.3.1',
+        status: 'built-in',
+        note: 'Both sides are listboxes holding only option and group children; the select-all header and the move buttons sit outside them.'
+      },
+      {
+        criterion: '2.1.1',
+        status: 'partial',
+        note: 'Each list is operated like a standalone list box, and the move buttons are reachable in tab order between them; verify manually for full conformance.'
+      },
+      {
+        criterion: '4.1.3',
+        status: 'built-in',
+        note: 'Moving options updates a visually hidden role=status region with ariaMovedAnnouncement. Verified here: selecting an option and moving it right announces the count and the destination title.'
+      }
+    ],
+    assertions: [
+      {
+        criterion: '4.1.3',
+        label: 'moving an option is announced in the status region',
+        steps: [
+          { click: '#transferItems [data-coreui-transfer-list="source"] .list-box-option' },
+          { click: '#transferItems [data-coreui-transfer-move="target"]' },
+          { wait: 100 }
+        ],
+        run: 'const region = document.querySelector(\'#transferItems .transfer-announcer\'); return Boolean(region && region.textContent.includes(\'moved to\'))'
+      }
+    ]
+  },
   {
     component: 'components/menu',
     html: `<button class="btn btn-primary" type="button" id="a11yMenuToggle" data-coreui-toggle="menu" aria-expanded="false">

--- a/build/test-a11y.mjs
+++ b/build/test-a11y.mjs
@@ -105,9 +105,13 @@ function validateConfig(entries) {
 // Markup resolution
 // ---------------------------------------------------------------------------
 
-// Pull the HTML out of every `<Example code={`...`} />` template literal.
+// Pull the HTML out of every `<Example code={`...`} />` template literal, plus
+// the snippet named by its `sandboxJs` prop. An example whose options come from
+// a snippet renders as inert markup without it — unlabelled buttons, empty
+// listboxes — and axe reports the missing wiring as the component's own defect.
 function extractExamples(src) {
   const examples = []
+  const sandboxIds = []
   const re = /code=\{`([\s\S]*?)`\}/g
   let match
   while ((match = re.exec(src)) !== null) {
@@ -116,32 +120,61 @@ function extractExamples(src) {
     // Components that need a specific rendered state (e.g. for `interactions`)
     // should provide inline `html` in the config instead of relying on docs
     // extraction (see build/a11y.config.mjs).
-    if (!match[1].includes('${')) {
-      examples.push(match[1])
+    if (match[1].includes('${')) {
+      continue
+    }
+
+    examples.push(match[1])
+
+    const tagRest = src.slice(re.lastIndex, src.indexOf('/>', re.lastIndex))
+    const sandbox = /sandboxJs=\{(\w+)\}/.exec(tagRest)
+    if (sandbox) {
+      sandboxIds.push(sandbox[1])
     }
   }
 
-  return examples
+  return { examples, sandboxIds }
+}
+
+// Resolve a `sandboxJs` identifier back to the file its `?raw` import names.
+function readSandboxScripts(src, docFile, ids) {
+  const scripts = []
+  for (const id of ids) {
+    const importRe = new RegExp(`import\\s+${id}\\s+from\\s+'([^']+)'`)
+    const match = importRe.exec(src)
+    if (!match) {
+      continue
+    }
+
+    const file = path.resolve(path.dirname(docFile), match[1].replace(/\?raw$/, ''))
+    if (fs.existsSync(file)) {
+      scripts.push(fs.readFileSync(file, 'utf8'))
+    }
+  }
+
+  return scripts
 }
 
 function resolveExamples(entry) {
   if (Array.isArray(entry.html)) {
-    return entry.html
+    return { examples: entry.html, scripts: [] }
   }
 
   if (typeof entry.html === 'string') {
-    return [entry.html]
+    return { examples: [entry.html], scripts: [] }
   }
 
   const docId = entry.examplesFrom ?? entry.component
   for (const ext of ['.mdx', '.md']) {
     const file = path.join(docsDir, `${docId}${ext}`)
     if (fs.existsSync(file)) {
-      return extractExamples(fs.readFileSync(file, 'utf8'))
+      const src = fs.readFileSync(file, 'utf8')
+      const { examples, sandboxIds } = extractExamples(src)
+      return { examples, scripts: readSandboxScripts(src, file, sandboxIds) }
     }
   }
 
-  return []
+  return { examples: [], scripts: [] }
 }
 
 const configErrors = validateConfig(a11yComponents)
@@ -160,7 +193,7 @@ const components = a11yComponents
     criteria: entry.criteria,
     interactions: entry.interactions ?? [],
     assertions: entry.assertions ?? [],
-    examples: resolveExamples(entry)
+    ...resolveExamples(entry)
   }))
   .toSorted((a, b) => a.id.localeCompare(b.id))
 
@@ -170,7 +203,8 @@ const components = a11yComponents
 
 const ROOT_ID = 'a11y-root'
 
-function pageHtml(examplesHtml) {
+function pageHtml(examplesHtml, scripts = []) {
+  const sandbox = scripts.map(script => `<script type="module">${script}</script>`).join('\n    ')
   return `<!doctype html>
 <html lang="en">
   <head>
@@ -181,6 +215,7 @@ function pageHtml(examplesHtml) {
   <body>
     <main id="${ROOT_ID}">${examplesHtml}</main>
     <script src="${jsHref}"></script>
+    ${sandbox}
   </body>
 </html>`
 }
@@ -259,7 +294,7 @@ async function runAssertions(page, assertions = []) {
 }
 
 async function evaluateComponent(page, component, ruleIds) {
-  const html = pageHtml(component.examples.join('\n'))
+  const html = pageHtml(component.examples.join('\n'), component.scripts)
   const file = path.join(tmpDir, `${component.id.replace(/\//g, '__')}.html`)
   fs.writeFileSync(file, html)
 
@@ -388,6 +423,12 @@ for (const component of components) {
     const statusLabel = c.dim(a11yStatusLabels[item.status ?? 'author'])
 
     console.log(`  ${badge} ${id} ${level} ${meta.title} ${c.dim('·')} ${statusLabel}`)
+
+    // A criterion the component itself does not satisfy reads as the app's
+    // problem otherwise — the status vocabulary has no word for "ours, open".
+    if (item.note?.includes('GAP:')) {
+      console.log(`         ${c.warn('gap')} ${item.note.slice(item.note.indexOf('GAP:') + 5)}`)
+    }
 
     if (verdict === 'fail') {
       for (const violation of violations ?? []) {


### PR DESCRIPTION
The WCAG conformance gate covered 21 components and none of the three newest ones, which happen to carry the densest ARIA in the library. It reported `0 failed` while six list boxes shipped a required-children violation.

## Coverage added

| component | 4.1.2 | 1.3.1 | 2.1.1 | 4.1.3 |
| --- | --- | --- | --- | --- |
| List Box | pass | gap | manual | — |
| Transfer | pass | pass | manual | pass |
| Combobox | pass | pass | manual | — |

Transfer's status criterion is asserted, not assumed: the check selects an option, moves it right and reads the announcement back out of the live region. Combobox opens its popup before axe runs, because a collapsed panel keeps the listbox out of the audit entirely.

## One open gap, named rather than hidden

List Box keeps 1.3.1 unasserted. Two of its children are not allowed inside a listbox: a sections-selectable section label is written as `role="button"`, and the empty placeholder stays inside the listbox when a filter hides every option, leaving it with no option child. Both are filed separately in the pre-alpha audit and both need a cross-framework pass, so neither is fixed here.

## Two runner changes

An example whose options come from a `sandboxJs` snippet rendered as inert markup, so axe saw unlabelled buttons and empty listboxes and reported the missing wiring as the component's own defect. **18 of the 21 violations this PR first surfaced were that artifact.** Snippets now run alongside their example, each in its own module scope, because two of them declare the same top-level name and the second was throwing.

A criterion carrying a `GAP:` note now prints it. The status vocabulary has no word for "ours, still open", so such a criterion was reading as `Your responsibility` in the report. This also surfaces the gaps already recorded on Navs & Tabs and Tooltips.

## Result

```
before  35 passed, 0 failed, 25 manual, 13 author, 2 n/a
after   41 passed, 0 failed, 28 manual, 15 author, 2 n/a
```

No verdict changed for any previously covered component.