### PR TITLE
fix(Calendar, TimePicker, DateTimePicker): expose the selected cell and the popup state

### DIFF
--- a/build/a11y.config.mjs
+++ b/build/a11y.config.mjs
@@ -155,6 +155,102 @@ export const a11yComponents = [
     ]
   },
   {
+    component: 'forms/date-picker',
+    interactions: [
+      { click: '.picker .form-control-action' },
+      { wait: 200 }
+    ],
+    criteria: [
+      {
+        criterion: '4.1.2',
+        status: 'built-in',
+        note: 'The toggle carries aria-haspopup=dialog, aria-controls pointing at the panel and aria-expanded tracking it; the calendar inside is audited open.'
+      },
+      {
+        criterion: '1.3.1',
+        status: 'built-in',
+        note: 'The open panel is a grid of gridcells; the navigation buttons sit outside it.'
+      },
+      {
+        criterion: '2.1.1',
+        status: 'partial',
+        note: 'Alt+ArrowDown opens the panel, Esc closes it, and the calendar is walked with the arrow keys; verify manually for full conformance.'
+      }
+    ]
+  },
+  {
+    component: 'forms/date-range-picker',
+    interactions: [
+      { click: '.picker .form-control-action' },
+      { wait: 200 }
+    ],
+    criteria: [
+      {
+        criterion: '4.1.2',
+        status: 'built-in',
+        note: 'Both calendars open under one toggle that carries aria-haspopup=dialog, aria-controls and aria-expanded; the range fields and the separator carry their own roles.'
+      },
+      {
+        criterion: '1.3.1',
+        status: 'built-in',
+        note: 'Each calendar in the open panel is a grid of gridcells.'
+      },
+      {
+        criterion: '2.1.1',
+        status: 'partial',
+        note: 'Alt+ArrowDown opens the panel, Esc closes it, and both calendars are walked with the arrow keys; verify manually for full conformance.'
+      }
+    ]
+  },
+  {
+    component: 'forms/date-time-picker',
+    interactions: [
+      { click: '.picker .form-control-action' },
+      { wait: 200 }
+    ],
+    criteria: [
+      {
+        criterion: '4.1.2',
+        status: 'built-in',
+        note: 'The toggle owns the popup state — aria-haspopup=dialog, aria-controls and aria-expanded — instead of the surrounding div, which has no role to support it.'
+      },
+      {
+        criterion: '1.3.1',
+        status: 'built-in',
+        note: 'The open panel holds a calendar grid next to the time selection lists.'
+      },
+      {
+        criterion: '2.1.1',
+        status: 'partial',
+        note: 'Alt+ArrowDown opens the panel, Esc closes it, and Tab moves between the calendar and the time lists; verify manually for full conformance.'
+      }
+    ]
+  },
+  {
+    component: 'forms/time-picker',
+    interactions: [
+      { click: '.picker .form-control-action' },
+      { wait: 200 }
+    ],
+    criteria: [
+      {
+        criterion: '4.1.2',
+        status: 'built-in',
+        note: 'The toggle owns the popup state — aria-haspopup=dialog, aria-controls and aria-expanded — instead of the surrounding div, which has no role to support it.'
+      },
+      {
+        criterion: '1.3.1',
+        status: 'built-in',
+        note: 'The open panel holds the hour, minute and second lists.'
+      },
+      {
+        criterion: '2.1.1',
+        status: 'partial',
+        note: 'Alt+ArrowDown opens the panel, Esc closes it, and the arrow keys walk each time list; verify manually for full conformance.'
+      }
+    ]
+  },
+  {
     component: 'forms/combobox',
     // The options live in a popup that starts hidden, so open one before axe
     // runs — a collapsed combobox hides the listbox from the audit entirely.
@@ -369,6 +465,26 @@ export const a11yComponents = [
   // ---------------------------------------------------------------------------
   // Components
   // ---------------------------------------------------------------------------
+  {
+    component: 'components/calendar',
+    criteria: [
+      {
+        criterion: '4.1.2',
+        status: 'built-in',
+        note: 'The table is a role=grid of role=gridcell cells, which is what makes aria-selected legal on a day, month, quarter or year; the selected cell also carries aria-current=date and an aria-label spelling the full date, and a week row carries aria-selected when whole weeks are selectable.'
+      },
+      {
+        criterion: '1.3.1',
+        status: 'built-in',
+        note: 'Rows and cells keep their grid roles in every panel, so the months, quarters and years views read as a grid rather than a bare table.'
+      },
+      {
+        criterion: '2.1.1',
+        status: 'partial',
+        note: 'Arrow keys walk the grid, Home/End jump to the row edges, PageUp/PageDown change the period and Enter picks; verify manually for full conformance.'
+      }
+    ]
+  },
   {
     component: 'components/list-box',
     criteria: [

--- a/docs/src/content/docs/components/calendar.mdx
+++ b/docs/src/content/docs/components/calendar.mdx
@@ -294,7 +294,7 @@ This example demonstrates advanced usage of custom cell rendering to display pri
 
 ## Accessibility
 
-Keyboard navigation in the grid follows the [date picker dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/). Selected cells carry `aria-selected`, today carries `aria-current="date"`, and every cell announces its full localized date. The months, quarters, and years views answer to the same keys, with arrows moving by cell and row, and no jump ever lands outside `minDate` / `maxDate` — focus stops on the closest date still selectable.
+Keyboard navigation in the grid follows the [date picker dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/). The table is a `grid` of `gridcell` cells, which is what lets a cell report itself as selected: selected cells carry `aria-selected`, today carries `aria-current="date"`, and every cell announces its full localized date. The months, quarters, and years views answer to the same keys, with arrows moving by cell and row, and no jump ever lands outside `minDate` / `maxDate` — focus stops on the closest date still selectable.
 
 ### Keyboard support
 

--- a/docs/src/content/docs/forms/date-time-picker.mdx
+++ b/docs/src/content/docs/forms/date-time-picker.mdx
@@ -128,6 +128,8 @@ The date time picker supports [floating labels](/forms/floating-labels/): set `f
 
 The field and the popup answer to the [same keys as the date picker](/forms/date-picker/#keyboard-support): <kbd>Alt</kbd> + <kbd>Arrow Down</kbd> or <kbd>F4</kbd> opens the panel, <kbd>Escape</kbd> closes it and returns focus, and arrows, <kbd>Home</kbd> / <kbd>End</kbd>, and <kbd>Page Down</kbd> / <kbd>Page Up</kbd> (with <kbd>Shift</kbd> for years) move the focused date.
 
+The toggle button carries the panel's state — `aria-haspopup="dialog"`, `aria-controls` pointing at the popup, and `aria-expanded` tracking whether it is open — so a screen reader announces what the button does and whether the panel is showing.
+
 ## Usage
 
 ### Via data attributes

--- a/docs/src/content/docs/forms/time-picker.mdx
+++ b/docs/src/content/docs/forms/time-picker.mdx
@@ -188,6 +188,19 @@ const picker = new coreui.TimePicker(element, {
     </div>
   </div>`} />
 
+## Accessibility
+
+The toggle button carries the panel's state — `aria-haspopup="dialog"`, `aria-controls` pointing at the popup, and `aria-expanded` tracking whether it is open — so a screen reader announces what the button does and whether the panel is showing. The field itself is a [time input](/forms/time-input/#accessibility), a group of spinbutton sections, so its arrow keys belong to the value and the popup opens on the native dropdown keys.
+
+### Keyboard support
+
+| Key | Action |
+| --- | --- |
+| <kbd>Alt</kbd> + <kbd>Arrow Down</kbd> / <kbd>F4</kbd> | Open the time popup and move focus into it |
+| <kbd>Escape</kbd> | Close the popup and return focus to the field |
+| <kbd>Tab</kbd> / <kbd>Shift</kbd> + <kbd>Tab</kbd> | Cycle between the field, its buttons, and the open popup |
+| <kbd>Arrow Up</kbd> / <kbd>Arrow Down</kbd> | Move through the focused hour, minute or second list |
+
 ## Usage
 
 ### Via data attributes

--- a/js/src/calendar.ts
+++ b/js/src/calendar.ts
@@ -807,6 +807,7 @@ class Calendar extends BaseComponent {
     const weekDays = monthDetails[0].days
 
     const calendarTable = document.createElement('table')
+    calendarTable.setAttribute('role', 'grid')
     calendarTable.innerHTML = `
     ${this._view === 'days' ? `
       <thead>
@@ -849,6 +850,7 @@ class Calendar extends BaseComponent {
                 return month === 'current' || this._config.showAdjacentDays ?
                   `<td
                     class="${cellAttributes.className}"
+                    role="gridcell"
                     tabindex="${cellAttributes.tabIndex}"
                     ${cellAttributes.ariaSelected ? 'aria-selected="true"' : ''}
                     ${cellAttributes.ariaCurrent ? 'aria-current="date"' : ''}
@@ -859,7 +861,7 @@ class Calendar extends BaseComponent {
                       ${this._config.renderDayCell ? sanitizeByConfig(this._config.renderDayCell(date, cellAttributes.meta), this._config) : date.toLocaleDateString(this._config.locale, { day: this._config.dayFormat })}
                     </div>
                   </td>` :
-                  '<td></td>'
+                  '<td role="gridcell"></td>'
               }
             ).join('')}</tr>`
           )
@@ -872,6 +874,7 @@ class Calendar extends BaseComponent {
               return (
                 `<td
                   class="${cellAttributes.className}"
+                  role="gridcell"
                   tabindex="${cellAttributes.tabIndex}"
                   ${cellAttributes.ariaSelected ? 'aria-selected="true"' : ''}
                   data-coreui-date="${date.toDateString()}"
@@ -892,6 +895,7 @@ class Calendar extends BaseComponent {
               return (
                 `<td
                   class="${cellAttributes.className}"
+                  role="gridcell"
                   tabindex="${cellAttributes.tabIndex}"
                   ${cellAttributes.ariaSelected ? 'aria-selected="true"' : ''}
                   data-coreui-date="${date.toDateString()}"
@@ -911,6 +915,7 @@ class Calendar extends BaseComponent {
               return (
                 `<td
                   class="${cellAttributes.className}"
+                  role="gridcell"
                   tabindex="${cellAttributes.tabIndex}"
                   ${cellAttributes.ariaSelected ? 'aria-selected="true"' : ''}
                   data-coreui-date="${date.toDateString()}"

--- a/js/src/date-time-picker.ts
+++ b/js/src/date-time-picker.ts
@@ -20,7 +20,7 @@ import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/
 import type { ComponentConfig } from './util/config.js'
 import { appendControlGroupField, applyControlGroupClasses, createControlGroupAction } from './util/form-control-group.js'
 import { CALENDAR_ICON, CLEANER_ICON } from './util/icons.js'
-import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
+import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -323,7 +323,11 @@ class DateTimePicker extends BaseComponent {
     })
 
     this._menu = document.createElement('div')
+    this._menu.id = getUID(`${this.constructor.NAME}-popup-`)
     this._menu.classList.add(CLASS_NAME_POPUP, CLASS_NAME_DROPDOWN)
+    this._indicatorElement.setAttribute('aria-controls', this._menu.id)
+    this._indicatorElement.setAttribute('aria-expanded', 'false')
+    this._indicatorElement.setAttribute('aria-haspopup', 'dialog')
 
     const body = document.createElement('div')
     body.classList.add(CLASS_NAME_BODY)
@@ -439,7 +443,7 @@ class DateTimePicker extends BaseComponent {
       onHide: () => {
         this._menu.classList.remove(CLASS_NAME_SHOW)
         this._element.classList.remove(CLASS_NAME_SHOW)
-        this._element.setAttribute('aria-expanded', 'false')
+        this._indicatorElement.setAttribute('aria-expanded', 'false')
       },
       onShow: () => {
         // the classes come first: the selection body scrolls the selected cell
@@ -447,7 +451,7 @@ class DateTimePicker extends BaseComponent {
         this._menu.classList.add(CLASS_NAME_SHOW)
         this._element.classList.add(CLASS_NAME_SHOW)
         this._ensureBodies()
-        this._element.setAttribute('aria-expanded', 'true')
+        this._indicatorElement.setAttribute('aria-expanded', 'true')
       },
       onShown: () => EventHandler.trigger(this._element, EVENT_SHOWN)
     })

--- a/js/src/time-picker.ts
+++ b/js/src/time-picker.ts
@@ -18,7 +18,7 @@ import { sanitizeByConfig, type SanitizerAllowList, SVGAllowlist } from './util/
 import type { ComponentConfig } from './util/config.js'
 import { appendControlGroupField, applyControlGroupClasses, createControlGroupAction } from './util/form-control-group.js'
 import { CLEANER_ICON, CLOCK_ICON } from './util/icons.js'
-import { defineJQueryPlugin, jQueryDispatch } from './util/index.js'
+import { defineJQueryPlugin, getUID, jQueryDispatch } from './util/index.js'
 
 /**
  * Constants
@@ -300,7 +300,11 @@ class TimePicker extends BaseComponent {
     })
 
     this._menu = document.createElement('div')
+    this._menu.id = getUID(`${this.constructor.NAME}-popup-`)
     this._menu.classList.add(CLASS_NAME_POPUP, CLASS_NAME_DROPDOWN)
+    this._indicatorElement.setAttribute('aria-controls', this._menu.id)
+    this._indicatorElement.setAttribute('aria-expanded', 'false')
+    this._indicatorElement.setAttribute('aria-haspopup', 'dialog')
 
     this._selectionElement = document.createElement('div')
     this._selectionElement.classList.add(CLASS_NAME_BODY)
@@ -360,7 +364,7 @@ class TimePicker extends BaseComponent {
       onHide: () => {
         this._menu.classList.remove(CLASS_NAME_SHOW)
         this._element.classList.remove(CLASS_NAME_SHOW)
-        this._element.setAttribute('aria-expanded', 'false')
+        this._indicatorElement.setAttribute('aria-expanded', 'false')
       },
       onShow: () => {
         // the classes come first: the selection body scrolls the selected cell
@@ -368,7 +372,7 @@ class TimePicker extends BaseComponent {
         this._menu.classList.add(CLASS_NAME_SHOW)
         this._element.classList.add(CLASS_NAME_SHOW)
         this._ensureSelection()
-        this._element.setAttribute('aria-expanded', 'true')
+        this._indicatorElement.setAttribute('aria-expanded', 'true')
       },
       onShown: () => EventHandler.trigger(this._element, EVENT_SHOWN)
     })


### PR DESCRIPTION
Two confirmed findings from the v6 pre-alpha audit, plus the gate coverage that would have caught both.

## Calendar: the selected cell was never conveyed

`aria-selected` was written onto plain `<td>` cells, where it is not an allowed attribute, so Chromium dropped it. The selected day, month, quarter or year was indistinguishable from any other cell in the accessibility tree. The table is now a `grid` of `gridcell` cells, which makes the attribute legal and restores a cell role in the months, quarters and years panels.

Calendar is the engine behind Date Picker, Date Range Picker and Date Time Picker, so the defect shipped in all three.

## Time Picker and Date Time Picker: the popup state landed nowhere

Both wrote `aria-expanded` onto the component root, a `div` with no role, where it was dropped the same way. Nothing in the tree said the panel was open, and the toggle button announced no state at all. Both now wire the button the way Date Picker already does: `aria-controls` at the popup, `aria-haspopup="dialog"` and `aria-expanded` on the button itself.

## Gate coverage

Calendar and the four pickers join the WCAG conformance gate. Each picker opens its panel before axe runs, so the calendar inside is audited in the state a user actually meets.

The coverage is not decorative. Reverting just the two fixes above turns the gate red on exactly the three components they touch:

```
components/calendar      aria-allowed-attr   9 nodes
forms/date-time-picker   aria-allowed-attr   1 node
forms/time-picker        aria-allowed-attr   1 node
```

Date Picker and Date Range Picker pass either way, which matches the audit: their wiring was already right.

```
before  41 passed, 0 failed, 28 manual, 15 author, 2 n/a
after   51 passed, 0 failed, 33 manual, 15 author, 2 n/a
```

## Docs

The calendar page claimed selected cells carry `aria-selected`, which was not true in practice until now; it now also names the grid roles. Time Picker gained the Accessibility section it was missing, the only picker without one. Every key documented there was checked against the source.

Ports to React and Vue go out alongside this.